### PR TITLE
dashboard home button fix

### DIFF
--- a/api-catalog-ui/frontend/src/components/Header/Header.jsx
+++ b/api-catalog-ui/frontend/src/components/Header/Header.jsx
@@ -12,7 +12,7 @@ export default class Header extends Component {
 
     render() {
         const iconLogout = <IconPowerSettingsNew />;
-        const dashboard = '/#/dashboard';
+        const dashboard = '/ui/v1/apicatalog/#/dashboard';
         return (
             <div className="header">
                 <div className="product-name">

--- a/api-catalog-ui/frontend/src/components/Header/Header.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Header/Header.test.jsx
@@ -12,7 +12,7 @@ describe('>>> Header component tests', () => {
 
     it('should have link href to itself', () => {
         const sample = enzyme.shallow(<Header />);
-        expect(sample.find('Link').props().href).toEqual('/#/dashboard');
+        expect(sample.find('Link').props().href).toEqual('/ui/v1/apicatalog/#/dashboard');
     });
 
     it('should handle a Logout button click', () => {


### PR DESCRIPTION
fix for API Catalog defect: The link in the API Catalog title does not go the API Catalog title

Signed-off-by: Zikos, Christos <Christos.Zikos@ca.com>