### PR TITLE
Call API Doc through gateway

### DIFF
--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIDocRetrievalService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIDocRetrievalService.java
@@ -19,7 +19,6 @@ import com.ca.mfaas.product.model.ApiInfo;
 import com.netflix.appinfo.InstanceInfo;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.client.utils.URIBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.http.HttpEntity;
@@ -41,8 +40,6 @@ import java.util.stream.Collectors;
 @DependsOn("instanceRetrievalService")
 public class APIDocRetrievalService {
 
-    private final String HTTPS = "https";
-    private final String HTTP = "http";
     private String gatewayUrl;
 
     private final RestTemplate restTemplate;
@@ -143,17 +140,8 @@ public class APIDocRetrievalService {
             HttpEntity<?> entity = createRequest();
             ResponseEntity<String> response;
 
-            // construct the endpoint based on the instance details
-            String baseUrl;
-            String hostName = instance.getHostName();
-            if (instance.isPortEnabled(InstanceInfo.PortType.SECURE)) {
-                baseUrl = new URIBuilder().setHost(hostName)
-                    .setScheme(HTTPS).setPort(instance.getSecurePort()).build().toString();
-            } else {
-                baseUrl = new URIBuilder().setHost(hostName)
-                    .setScheme(HTTP).setPort(instance.getPort()).build().toString();
-            }
-            String instanceApiDocEndpoint = baseUrl + getLocalApiDocEndPoint(instance);
+            // Always retrieve api doc via the gateway
+            String instanceApiDocEndpoint = getGatewayUrl() + "/api/" + apiVersion + "/" + instance.getAppName().toLowerCase() + "/api-doc";
 
             log.info("Sending API Doc info request to: " + instanceApiDocEndpoint);
             response = restTemplate.exchange(

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIServiceStatusService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIServiceStatusService.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.ca.mfaas.product.constants.ApimConstants.API_DOC_NORMALISED;
+
 @Slf4j
 @Service
 public class APIServiceStatusService {
@@ -148,7 +150,7 @@ public class APIServiceStatusService {
     private HttpHeaders createHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
-        headers.set("Api-Doc-Normalised", "true");
+        headers.set(API_DOC_NORMALISED, "true");
         return headers;
     }
 }

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIServiceStatusService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/status/APIServiceStatusService.java
@@ -148,6 +148,7 @@ public class APIServiceStatusService {
     private HttpHeaders createHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
+        headers.set("Api-Doc-Normalised", "true");
         return headers;
     }
 }

--- a/gateway-common/src/main/java/com/ca/mfaas/product/constants/ApimConstants.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/constants/ApimConstants.java
@@ -1,0 +1,16 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package com.ca.mfaas.product.constants;
+
+public class ApimConstants {
+
+    // custom REST response header to signify that this API Doc has already been normalised
+    public static final String API_DOC_NORMALISED = "Api-Doc-Normalised";
+}

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.ca.mfaas.product.constants.ApimConstants.API_DOC_NORMALISED;
 import static com.netflix.zuul.context.RequestContext.getCurrentContext;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.*;
 
@@ -113,7 +114,7 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
             List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
             if (zuulResponseHeaders != null) {
                 for (Pair<String, String> it : zuulResponseHeaders) {
-                    if (it.first().contains("Api-Doc-Normalised")) {
+                    if (it.first().contains(API_DOC_NORMALISED)) {
                         if (Boolean.valueOf(it.second())) {
                             log.debug("Api Doc is already normalised for: " + requestPath + ", transformation not required.");
                             return false;

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
@@ -32,6 +32,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,15 +114,22 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
             && (context.getResponseDataStream() != null || context.getResponseBody() != null)) {
             List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
             if (zuulResponseHeaders != null) {
+                boolean shouldNormalise = true;
+                List<Pair<String, String>> filteredResponseHeaders = new ArrayList<>();
                 for (Pair<String, String> it : zuulResponseHeaders) {
                     if (it.first().contains(API_DOC_NORMALISED)) {
                         if (Boolean.valueOf(it.second())) {
                             log.debug("Api Doc is already normalised for: " + requestPath + ", transformation not required.");
-                            return false;
+                            shouldNormalise = false;
                         }
                         break;
+                    } else {
+                        filteredResponseHeaders.add(it);
                     }
                 }
+                // remove "Api-Doc-Normalised" from response
+                context.put("zuulResponseHeaders", filteredResponseHeaders);
+                return shouldNormalise;
             }
             log.debug("Normalising endpoints for: " + requestPath);
             return true;

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
@@ -130,11 +130,25 @@ public class PostFilterApiDocTransformTest {
     @Test
     public void whenRequestIsAnApiDocRequestButAlreadyNormalised_thenDoNotFilter() {
         final RequestContext ctx = RequestContext.getCurrentContext();
-        ctx.set(REQUEST_URI_KEY, "/hello");
+        ctx.set(REQUEST_URI_KEY, "/api-doc");
         ctx.set(PROXY_KEY, "/hello");
-        ctx.set(API_DOC_NORMALISED, "true");
+        ctx.addZuulResponseHeader(API_DOC_NORMALISED, "true");
         String body = "do not normalise me";
         ctx.setResponseBody(body);
         assertFalse(this.filter.shouldFilter());
+    }
+
+    @Test
+    public void whenRequestIsAnApiDocRequestButAlreadyNormalised_thenDoNotFilterAndRemoveZuulHeader() {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(REQUEST_URI_KEY, "/api-doc");
+        ctx.set(PROXY_KEY, "/hello");
+        ctx.addZuulResponseHeader(API_DOC_NORMALISED, "true");
+        ctx.addZuulResponseHeader("Leave-Me-Alone", "true");
+        String body = "do not normalise me";
+        ctx.setResponseBody(body);
+        assertFalse(this.filter.shouldFilter());
+        assertFalse(ctx.getZuulResponseHeaders().contains(API_DOC_NORMALISED));
+
     }
 }


### PR DESCRIPTION
Avoid duplicate route prefixes in API catalog API Doc.
Main change is to ALWAYS call the pia-doc via the gateway, never directly to the serv ice.
Any api-doc which is cached by the API Catalog will set the Api-Doc-Normalised flag to true so the POST filter will now re-normalise it.
Any api-doc which does not have this flag set will go through the usual checks.
Also, remove the zuul header if it exists and do not pass it to the client

This is the story: https://rally1.rallydev.com/#/72725828452ud/detail/userstory/f32a1b01-f885-4f90-8222-061a7ec1b4a2