### PR TITLE
Example for Node.js and Express API service that works with HTTPS in Discovery Service

### DIFF
--- a/helloworld-expressjs/.gitignore
+++ b/helloworld-expressjs/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/helloworld-expressjs/README.md
+++ b/helloworld-expressjs/README.md
@@ -1,0 +1,43 @@
+# Hello World API Service in Express
+
+This is an example how an API service implemented using [Node.js](https://nodejs.org/en/) and [Express](https://expressjs.com/) can be registered to the API Mediation Layer. 
+
+There are following files:
+ 
+ - [index.js](index.js) - starts the API service implemented in Express and registers it to the Discovery service
+
+ - [apiLayerService.js](apiLayerService.js) - a module that does the registration to the Discovery Service using [eureka-js-client](https://www.npmjs.com/package/eureka-js-client)
+
+ This example contains the full HTTPS validation of both Discovery Service and the Hello World service.
+
+ The certicate, private key for the service, and the local CA certificate are loaded from `keystore/localhost/localhost.keystore.p12`.
+
+ You can start the service using:
+
+    cd helloworld-expressjs
+    node index.js
+
+If the APIML is already running then you should see following messages:
+
+    hwexpress service listening on port 10020
+    registered with eureka:  hwexpress/localhost:hwexpress:10020
+
+The you can access it via gateway it by:
+
+    http --verify=../keystore/local_ca/localca.cer GET https://localhost:10010/api/v1/hwexpress/hello
+
+## APIML Service Metadata
+
+The function `registerServiceToDiscoveryService()` in `index.js` does the registration to the Discovery Service by calling `registerService(options)` from the `apiLayerService.js` module.
+
+The `options` argument contains the options that are used to define the application to the Discovery Service and additional metadata for the API Catalog.
+
+The fields are following:
+
+- `tlsOptions` the options that are used for the [request](https://github.com/request/request#tlsssl-protocol) library to setup HTTPS connection (both server and client validation is done). The `pfx` with PKCS12 keystore and `passphrase` with the keystore passwords are recommended
+- `discoveryServiceUrl` - the URL of the APIML Discovery Service - for the APIML running on your workstatition it is by default: `https://localhost:10011/eureka/apps/`
+- `hostName` - the hostname of the service that is accesible by the API Gateway
+- `ipAddr` - the IP address of the service that is accessible by the API Gateway
+- `port` - the port on which the service is listening
+- `serviceId`, `title`, `description`, 
+`homePageUrl`, `statusPageUrl`, `healthCheckUrl`, `routes` - see [Configuration Parameters](https://zowe.github.io/docs-site/latest/guides/api-mediation-onboard-an-existing-rest-api-service-without-code-changes.html#configuration-parameters)

--- a/helloworld-expressjs/apiLayerService.js
+++ b/helloworld-expressjs/apiLayerService.js
@@ -1,0 +1,63 @@
+const eureka = require("eureka-js-client");
+
+function apiLayerServiceModule() {
+    this.registerService = function(options) {
+        const metadata = {
+            "apiml.apiInfo.0.apiId": options.apiInfo[0].apiId,
+            "apiml.apiInfo.0.gatewayUrl": options.apiInfo[0].gatewayUrl,
+            "apiml.apiInfo.0.swaggerUrl": options.apiInfo[0].swaggerUrl,
+            "mfaas.discovery.catalogUiTile.description": options.catalogUiTile.description,
+            "mfaas.discovery.catalogUiTile.id": options.catalogUiTile.tileId,
+            "mfaas.discovery.catalogUiTile.title": options.catalogUiTile.title,
+            "mfaas.discovery.catalogUiTile.version": options.catalogUiTile.version,
+            "mfaas.discovery.service.title": options.title,
+            "mfaas.discovery.service.description": options.description,
+            "routed-services.0.gateway-url": options.routes[0].gatewayUrl,
+            "routed-services.0.service-url": options.routes[0].serviceRelativeUrl
+        };
+
+        const client = new eureka.Eureka({
+            instance: {
+                app: options.serviceId,
+                instanceId: `${options.hostName}:${options.serviceId}:${options.port}`,
+                hostName: options.hostName,
+                ipAddr: options.ipAddr,
+                homePageUrl: options.homePageUrl,
+                statusPageUrl: options.statusPageUrl,
+                healthCheckUrl: options.healthCheckUrl,
+                secureHealthCheckUrl: options.healthCheckUrl,
+                port: {
+                    $: options.port,
+                    "@enabled": "false"
+                },
+                securePort: {
+                    $: options.port,
+                    "@enabled": "true"
+                },
+                vipAddress: options.serviceId,
+                secureVipAddress: options.serviceId,
+                dataCenterInfo: {
+                    "@class": "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
+                    name: "MyOwn"
+                },
+                metadata: metadata
+            },
+            eureka: {
+                ssl: true,
+                serviceUrls: {
+                    default: [options.discoveryServiceUrl]
+                }
+            },
+            requestMiddleware: (requestOpts, done) => {
+                requestOpts.pfx = options.tlsOptions.pfx;
+                requestOpts.passphrase = options.tlsOptions.passphrase;
+                done(requestOpts);
+            }
+        });
+
+        client.start();
+        return client;
+    };
+}
+
+module.exports = apiLayerServiceModule;

--- a/helloworld-expressjs/index.js
+++ b/helloworld-expressjs/index.js
@@ -1,0 +1,101 @@
+const express = require("express");
+const https = require("https");
+const fs = require("fs");
+const apiLayerService = require("./apiLayerService");
+
+// Command-line arguments:
+const args = {
+    port: process.argv[2] || 10020,
+    hostName: process.argv[3] || "localhost",
+    ipAddr: process.argv[4] || "127.0.0.1",
+    serviceId: process.argv[5] || "hwexpress",
+    discoveryServiceUrl: process.argv[6] || "https://localhost:10011/eureka/apps/",
+    pfx: process.argv[7] || "../keystore/localhost/localhost.keystore.p12",
+    passphrase: process.argv[8] || "password"
+};
+
+// Options for TLS (shared by the HTTPS server and Eureka client):
+const tlsOptions = {
+    pfx: fs.readFileSync(args.pfx),
+    passphrase: args.passphrase,
+    secureProtocol: "TLSv1_2_method",
+    rejectUnauthorized: true
+};
+
+/**
+ * Registers the service to the APIML Discovery service
+ */
+function registerServiceToDiscoveryService() {
+    new apiLayerService().registerService({
+        // See README.md for more details about following options
+        tlsOptions: tlsOptions,
+        discoveryServiceUrl: args.discoveryServiceUrl,
+        serviceId: args.serviceId,
+        title: "Hello World API Service in Express",
+        description: "Hello World REST API Service implemented in Express and Node.js",
+        hostName: args.hostName,
+        ipAddr: args.ipAddr,
+        port: args.port,
+        homePageUrl: `https://${args.hostName}:${args.port}/`,
+        statusPageUrl: `https://${args.hostName}:${args.port}/info`,
+        healthCheckUrl: `https://${args.hostName}:${args.port}/status`,
+        routes: [
+            {
+                gatewayUrl: "api/v1",
+                serviceRelativeUrl: "/api/v1"
+            }
+        ],
+        apiInfo: [
+            {
+                apiId: "org.zowe.hwexpress",
+                gatewayUrl: "api/v1",
+                swaggerUrl: `https://${args.hostName}:${args.port}/swagger.json`
+            }
+        ],
+        catalogUiTile: {
+            tileId: "cademoapps",
+            title: "Sample API Mediation Layer Applications",
+            description:
+                "Applications which demonstrate how to make a service integrated to the API Mediation Layer ecosystem",
+            version: "1.0.0"
+        }
+    });
+}
+
+/**
+ * Starts the REST API service as an HTTPS server
+ */
+function startHttpsService() {
+    const app = express();
+
+    // Index page with a link to the REST API endpoint:
+    app.get("/", (req, res) =>
+        res.json({
+            links: [
+                {
+                    rel: "hello",
+                    href: `${req.protocol}://${req.get("Host")}/api/v1/hello`
+                }
+            ]
+        })
+    );
+
+    // REST API endopint:
+    app.get("/api/v1/hello", (req, res) => res.json({ greeting: "Hello World!" }));
+
+    // Status and health endpoints for Eureka:
+    app.get("/info", (req, res) => res.json({ serviceId: serviceId, nodeJsVersion: process.version }));
+    app.get("/status", (req, res) => res.json({ status: "UP" }));
+
+    // Static resoures (contains Swagger JSON document with API documentation):
+    app.use(express.static("static"));
+
+    // Start HTTPS server:
+    const httpsServer = https.createServer(tlsOptions, app);
+    httpsServer.listen(args.port, function () {
+        console.log(`${args.serviceId} service listening on port ${args.port}`);
+        registerServiceToDiscoveryService();
+    });
+}
+
+startHttpsService();

--- a/helloworld-expressjs/package.json
+++ b/helloworld-expressjs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "helloworld-expressjs",
+  "version": "0.2.0",
+  "description": "Hello World Service in Express",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zowe/api-layer/helloworld-expressjs"
+  },
+  "author": "",
+  "license": "EPL-2.0",
+  "dependencies": {
+    "eureka-js-client": "^4.4.2",
+    "express": "^4.16.4"
+  }
+}

--- a/helloworld-expressjs/static/swagger.json
+++ b/helloworld-expressjs/static/swagger.json
@@ -1,0 +1,61 @@
+
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Sample API showing how to use an Express application in the API Mediation Layer ecosystem",
+        "version": "1.0.0",
+        "title": "Helloworld in Express"
+    },
+    "basePath": "/api/v1",
+    "tags": [
+        {
+            "name": "hello",
+            "description": "Hello World!",
+            "externalDocs": {
+                "description": "Find out more",
+                "url": "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program"
+            }
+        }
+    ],
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/hello": {
+            "get": {
+                "tags": [
+                    "hello"
+                ],
+                "summary": "Retrieve a Hello world greeting",
+                "description": "A **\"Hello, World!\" program** is a [computer program](https://en.wikipedia.org/wiki/Computer_program) that outputs or displays \"Hello, World!\" to a user. Being a very simple program in most [programming languages](https://en.wikipedia.org/wiki/Programming_language), it is often used to illustrate the basic [syntax](https://en.wikipedia.org/wiki/Syntax) of a programming language for a working program, and as such is often the very first program people write",
+                "operationId": "hello",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Greeting"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Greeting": {
+            "type": "object",
+            "properties": {
+                "greeting": {
+                    "type": "string",
+                    "example": "Hello world!"
+                }
+            }
+        }
+    },
+    "externalDocs": {
+        "description": "Find out more about Hello World!",
+        "url": "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program"
+    }
+}


### PR DESCRIPTION
This pull request shows an example of how an API service developer using Node.js and Express
can be registered with Discovery Service that requires HTTPS certificate of the Eureka client
(ie. the service that is registering).

No changes were required in the APIML certificate management. The Node.js is able to read the
PKCS12 key stores.

The example is in [helloworld-expressjs](/helloworld-expressjs/) folder.

The instructions are in the [helloworld-expressjs/README.md](/helloworld-expressjs/README.md) file.

This is the first step for story #92. Changes in the Zowe installation scripts will follow.