### PR TITLE
Support for HTTPS in Discovery Service for Plain Java Enabler

### DIFF
--- a/docs/local-configuration.md
+++ b/docs/local-configuration.md
@@ -48,6 +48,7 @@ java -jar api-catalog-services/build/libs/api-catalog-services.jar --spring.conf
 java -jar discoverable-client/build/libs/discoverable-client.jar --spring.config.additional-location=file:./config/local/discoverable-client.yml
 ```
 
+
 ### Default Discovery Timing Settings 
 
 Default timings can require up to 3 minutes for service startup discovery and shutdown to be registered.

--- a/docs/local-configuration.md
+++ b/docs/local-configuration.md
@@ -48,12 +48,6 @@ java -jar api-catalog-services/build/libs/api-catalog-services.jar --spring.conf
 java -jar discoverable-client/build/libs/discoverable-client.jar --spring.config.additional-location=file:./config/local/discoverable-client.yml
 ```
 
-### Sample Application - Hello World Spring
-
-```shell
-./gradlew :helloworld-spring:tomcatRun
-```
-
 ### Default Discovery Timing Settings 
 
 Default timings can require up to 3 minutes for service startup discovery and shutdown to be registered.

--- a/docs/local-configuration.md
+++ b/docs/local-configuration.md
@@ -48,6 +48,11 @@ java -jar api-catalog-services/build/libs/api-catalog-services.jar --spring.conf
 java -jar discoverable-client/build/libs/discoverable-client.jar --spring.config.additional-location=file:./config/local/discoverable-client.yml
 ```
 
+### Sample Application - Hello World Spring
+
+```shell
+./gradlew :helloworld-spring:tomcatRun
+```
 
 ### Default Discovery Timing Settings 
 

--- a/gateway-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
@@ -101,23 +101,24 @@ public class HttpConfig {
 
     @Bean
     public SslContextFactory jettySslContextFactory() {
-        if (verifySslCertificatesOfServices) {
-            SslContextFactory sslContextFactory = new SslContextFactory(HttpsFactory.replaceFourSlashes(keyStore));
-            sslContextFactory.setProtocol(protocol);
-            sslContextFactory.setKeyStorePassword(keyStorePassword);
-            sslContextFactory.setKeyStoreType(keyStoreType);
-            sslContextFactory.setCertAlias(keyAlias);
-            if (trustStore != null) {
-                sslContextFactory.setTrustStorePath(HttpsFactory.replaceFourSlashes(trustStore));
-                sslContextFactory.setTrustStoreType(trustStoreType);
-                sslContextFactory.setTrustStorePassword(trustStorePassword);
-            }
-            log.debug("jettySslContextFactory: {}", sslContextFactory.dump());
-            return sslContextFactory;
+        SslContextFactory sslContextFactory = new SslContextFactory(HttpsFactory.replaceFourSlashes(keyStore));
+        sslContextFactory.setProtocol(protocol);
+        sslContextFactory.setKeyStorePassword(keyStorePassword);
+        sslContextFactory.setKeyStoreType(keyStoreType);
+        sslContextFactory.setCertAlias(keyAlias);
+
+        if (trustStore != null) {
+            sslContextFactory.setTrustStorePath(HttpsFactory.replaceFourSlashes(trustStore));
+            sslContextFactory.setTrustStoreType(trustStoreType);
+            sslContextFactory.setTrustStorePassword(trustStorePassword);
         }
-        else {
-            return new SslContextFactory(true);
+        log.debug("jettySslContextFactory: {}", sslContextFactory.dump());
+
+        if (!verifySslCertificatesOfServices) {
+            sslContextFactory.setTrustAll(true);
         }
+
+        return sslContextFactory;
     }
 
     @Bean

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/ws/WebSocketProxyServerHandler.java
@@ -105,7 +105,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
             WebSocketRoutedSession session = new WebSocketRoutedSession(webSocketSession, targetUrl, jettySslContextFactory);
             routedSessions.put(webSocketSession.getId(), session);
         } catch (WebSocketProxyError e) {
-            log.debug("Error opening WebSocket connection to {}: {}", targetUrl, e.getMessage(), e);
+            log.error("Error opening WebSocket connection to {}: {}", targetUrl, e.getMessage(), e);
             webSocketSession.close(CloseStatus.NOT_ACCEPTABLE.withReason(e.getMessage()));
         }
     }

--- a/helloworld-spring/src/main/resources/service-configuration.yml
+++ b/helloworld-spring/src/main/resources/service-configuration.yml
@@ -6,7 +6,18 @@ homePageRelativeUrl:
 statusPageRelativeUrl: /application/info
 healthCheckRelativeUrl: /application/health
 discoveryServiceUrls:
-    - http://eureka:password@localhost:10011/eureka
+    - https://localhost:10011/eureka
+ssl:
+    enabled: false
+    protocol: TLSv1.2
+    keyAlias: localhost
+    keyPassword: password
+    keyStore: ../keystore/localhost/localhost.keystore.p12
+    keyStorePassword: password
+    keyStoreType: PKCS12
+    trustStore: ../keystore/localhost/localhost.truststore.p12
+    trustStorePassword: password
+    trustStoreType: PKCS12
 routes:
     - gatewayUrl: api/v1
       serviceUrl: /hellospring/api/v1

--- a/helloworld-spring/src/main/resources/service-configuration.yml
+++ b/helloworld-spring/src/main/resources/service-configuration.yml
@@ -12,10 +12,10 @@ ssl:
     protocol: TLSv1.2
     keyAlias: localhost
     keyPassword: password
-    keyStore: ../keystore/localhost/localhost.keystore.p12
+    keyStore: keystore/localhost/localhost.keystore.p12
     keyStorePassword: password
     keyStoreType: PKCS12
-    trustStore: ../keystore/localhost/localhost.truststore.p12
+    trustStore: keystore/localhost/localhost.truststore.p12
     trustStorePassword: password
     trustStoreType: PKCS12
 routes:

--- a/helloworld-spring/src/main/resources/service-configuration.yml
+++ b/helloworld-spring/src/main/resources/service-configuration.yml
@@ -8,7 +8,7 @@ healthCheckRelativeUrl: /application/health
 discoveryServiceUrls:
     - https://localhost:10011/eureka
 ssl:
-    enabled: false
+    verifySslCertificatesOfServices: true
     protocol: TLSv1.2
     keyAlias: localhost
     keyPassword: password

--- a/helloworld-spring/src/main/resources/service-configuration.yml
+++ b/helloworld-spring/src/main/resources/service-configuration.yml
@@ -12,10 +12,10 @@ ssl:
     protocol: TLSv1.2
     keyAlias: localhost
     keyPassword: password
-    keyStore: keystore/localhost/localhost.keystore.p12
+    keyStore: ../keystore/localhost/localhost.keystore.p12
     keyStorePassword: password
     keyStoreType: PKCS12
-    trustStore: keystore/localhost/localhost.truststore.p12
+    trustStore: ../keystore/localhost/localhost.truststore.p12
     trustStorePassword: password
     trustStoreType: PKCS12
 routes:

--- a/integration-enabler-java/build.gradle
+++ b/integration-enabler-java/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    compileOnly libraries.lombok
-
     compile(project(':common-service-core'))
 
     compile libraries.jackson_annotations
     compile libraries.jackson_dataformat_yaml
     compile libraries.eureka_client
+
+    compileOnly libraries.lombok
 
     testCompile libraries.junit
     testCompile libraries.logback_classic

--- a/integration-enabler-java/build.gradle
+++ b/integration-enabler-java/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     compileOnly libraries.lombok
 
+    compile(project(':common-service-core'))
+
     compile libraries.jackson_annotations
     compile libraries.jackson_dataformat_yaml
     compile libraries.eureka_client

--- a/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/ApiMediationServiceConfig.java
+++ b/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/ApiMediationServiceConfig.java
@@ -31,4 +31,5 @@ public class ApiMediationServiceConfig {
     private List<Route> routes;
     private ApiInfo apiInfo;
     private CatalogUiTile catalogUiTile;
+    private Ssl ssl;
 }

--- a/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/Ssl.java
+++ b/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/Ssl.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package com.ca.mfaas.eurekaservice.client.config;
 
 import lombok.AllArgsConstructor;
@@ -8,7 +17,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Ssl {
-    private String enabled;
+    private boolean verifySslCertificatesOfServices;
+    private String protocol;
     private String keyAlias;
     private String keyPassword;
     private String keyStore;

--- a/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/Ssl.java
+++ b/integration-enabler-java/src/main/java/com/ca/mfaas/eurekaservice/client/config/Ssl.java
@@ -1,0 +1,20 @@
+package com.ca.mfaas.eurekaservice.client.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Ssl {
+    private String enabled;
+    private String keyAlias;
+    private String keyPassword;
+    private String keyStore;
+    private String keyStorePassword;
+    private String keyStoreType;
+    private String trustStore;
+    private String trustStorePassword;
+    private String trustStoreType;
+}

--- a/integration-enabler-java/src/test/java/com/ca/mfaas/eurekaservice/client/ApiMediationClientImplTest.java
+++ b/integration-enabler-java/src/test/java/com/ca/mfaas/eurekaservice/client/ApiMediationClientImplTest.java
@@ -10,6 +10,7 @@
 package com.ca.mfaas.eurekaservice.client;
 
 import com.ca.mfaas.eurekaservice.client.config.ApiMediationServiceConfig;
+import com.ca.mfaas.eurekaservice.client.config.Ssl;
 import com.ca.mfaas.eurekaservice.client.impl.ApiMediationClientImpl;
 import com.ca.mfaas.eurekaservice.client.util.ApiMediationServiceConfigReader;
 import org.junit.Rule;
@@ -22,6 +23,9 @@ public class ApiMediationClientImplTest {
 
     @Test
     public void startEurekaClient() {
+        Ssl ssl = new Ssl(false, "TLSv1.2", "localhost", "password",
+            "../keystore/localhost/localhost.keystore.p12", "password", "PKCS12",
+            "../keystore/localhost/localhost.truststore.p12","password", "PKCS12");
         ApiMediationClient client = new ApiMediationClientImpl();
         ApiMediationServiceConfig config = ApiMediationServiceConfig.builder()
             .serviceId("service")
@@ -29,7 +33,8 @@ public class ApiMediationClientImplTest {
             .healthCheckRelativeUrl("")
             .homePageRelativeUrl("")
             .statusPageRelativeUrl("")
-            .discoveryServiceUrl("http://eureka:password@localhost:10011/eureka")
+            .discoveryServiceUrl("https://localhost:10011/eureka")
+            .ssl(ssl)
             .build();
 
         client.register(config);

--- a/integration-enabler-java/src/test/resources/https-service-configuration.yml
+++ b/integration-enabler-java/src/test/resources/https-service-configuration.yml
@@ -8,6 +8,17 @@ healthCheckRelativeUrl: /application/health
 discoveryServiceUrls:
     - http://eureka:password@localhost:10011/eureka
     - http://eureka:password@localhost:10011/eureka
+ssl:
+    verifySslCertificatesOfServices: true
+    protocol: TLSv1.2
+    keyAlias: localhost
+    keyPassword: password
+    keyStore: ../keystore/localhost/localhost.keystore.p12
+    keyStorePassword: password
+    keyStoreType: PKCS12
+    trustStore: ../keystore/localhost/localhost.truststore.p12
+    trustStorePassword: password
+    trustStoreType: PKCS12
 routes:
     - gatewayUrl: api/v1
       serviceUrl: /hellospring/api/v1


### PR DESCRIPTION
This pull request adds the support of HTTPS in Discovery Service into the Plain Java Enabler.

This one of the PRs that resolve #75.