### PR TITLE
API Catalog listens on all network interfaces

### DIFF
--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -78,7 +78,7 @@ mfaas:
 ##############################################################################################
 
 server:
-    address: ${mfaas.service.hostname}
+    address: ${mfaas.service.ipAddress}
     port: ${mfaas.server.port}
     servlet:
         contextPath: ${mfaas.server.contextPath}

--- a/zowe-install/src/main/resources/scripts/api-mediation-start-catalog-template.sh
+++ b/zowe-install/src/main/resources/scripts/api-mediation-start-catalog-template.sh
@@ -23,6 +23,9 @@ java -Xms16m -Xmx512m -Dibm.serversocket.recover=true -Dfile.encoding=UTF-8 \
     -Denvironment.preferIpAddress=true -Denvironment.gatewayHostname=**HOSTNAME** \
     -Denvironment.eurekaUserId=eureka \
     -Denvironment.eurekaPassword=password \
+    -Dapiml.security.verifySslCertificatesOfServices=true \
+    -Dspring.profiles.include= \
+    -Dserver.address=0.0.0.0 \
     -Dserver.ssl.enabled=true \
     -Dserver.ssl.keyStore=$DIR/../keystore/localhost/localhost.keystore.p12 \
     -Dserver.ssl.keyStoreType=PKCS12 \

--- a/zowe-install/src/main/resources/scripts/api-mediation-start-discovery-template.sh
+++ b/zowe-install/src/main/resources/scripts/api-mediation-start-discovery-template.sh
@@ -23,6 +23,7 @@ java -Xms32m -Xmx256m -Xquickstart \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=/tmp \
     -Dspring.profiles.active=https \
+    -Dspring.profiles.include= \
     -Dserver.address=0.0.0.0 \
     -Dapiml.discovery.userid=eureka \
     -Dapiml.discovery.password=password \

--- a/zowe-install/src/main/resources/scripts/api-mediation-start-gateway-template.sh
+++ b/zowe-install/src/main/resources/scripts/api-mediation-start-gateway-template.sh
@@ -21,12 +21,15 @@ java -Xms32m -Xmx256m -Xquickstart \
     -Dibm.serversocket.recover=true \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=/tmp \
+    -Dspring.profiles.include= \
     -Dapiml.service.hostname=**HOSTNAME** \
     -Dapiml.service.port=**GATEWAY_PORT** \
     -Dapiml.service.discoveryServiceUrls=https://**HOSTNAME**:**DISCOVERY_PORT**/eureka/ \
     -Dapiml.service.preferIpAddress=true \
     -Dapiml.service.ipAddress=**IPADDRESS** \
     -Dapiml.gateway.timeoutMillis=30000 \
+    -Dapiml.security.verifySslCertificatesOfServices=true \
+    -Dserver.address=0.0.0.0 \
     -Dserver.ssl.enabled=true \
     -Dserver.ssl.keyStore=$DIR/../keystore/localhost/localhost.keystore.p12 \
     -Dserver.ssl.keyStoreType=PKCS12 \


### PR DESCRIPTION
The Zowe installation script can automatically assign hostname that is resolved to different IP address so the API catalog needs to listen on all IP addresses.