### PR TITLE
Try out & authorize buttons

### DIFF
--- a/api-catalog-ui/frontend/package-lock.json
+++ b/api-catalog-ui/frontend/package-lock.json
@@ -4917,6 +4917,12 @@
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
+        "dateformat": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.2.tgz",
+            "integrity": "sha1-mk30v/FYrC80vGN6vbFUcWB+Flk=",
+            "dev": true
+        },
         "debug": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -10164,6 +10170,18 @@
                 "jest-worker": "^23.2.0",
                 "micromatch": "^2.3.11",
                 "sane": "^2.0.0"
+            }
+        },
+        "jest-html-reporter": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-2.4.2.tgz",
+            "integrity": "sha512-pQ3FQIauOEu8pi6TIJkizXgk7aTOsAfp9bCu7CWgtBThGqI1/w0VLQiOc/DBra2fIaym6tEoqug0gT3DpbVkLA==",
+            "dev": true,
+            "requires": {
+                "dateformat": "3.0.2",
+                "mkdirp": "0.5.1",
+                "strip-ansi": "3.0.1",
+                "xmlbuilder": "8.2.2"
             }
         },
         "jest-jasmine2": {
@@ -22279,6 +22297,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+        },
+        "xmlbuilder": {
+            "version": "8.2.2",
+            "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+            "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+            "dev": true
         },
         "xmlchars": {
             "version": "1.3.1",

--- a/api-catalog-ui/frontend/package.json
+++ b/api-catalog-ui/frontend/package.json
@@ -41,7 +41,7 @@
     "scripts": {
         "start": "react-scripts start",
         "start:dev": "concurrently -c blue,green -n Backend,UI \"npm run start:mocked-backend\" \"cross-env REACT_APP_GATEWAY_URL=http://localhost:8000 npm start\"",
-        "start:mocked-backend": "cross-env REACT_APP_GATEWAY_URL=http://localhost:8000 nodemon mocked-backend/server.js",
+        "start:mock": "cross-env REACT_APP_GATEWAY_URL=http://localhost:8000 nodemon mocked-backend/server.js",
         "build": "react-scripts build",
         "analyze": "source-map-explorer build/static/js/main.*",
         "postbuild": "rimraf build/**/*.map",

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.css
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.css
@@ -8,3 +8,11 @@ a.nav-tab > svg {
     margin-left: .3rem;
     padding-top: .3rem;
 }
+
+section.schemes.wrapper.block.col-12 > label {
+    display: none;
+}
+
+/*label[for="schemes"] {*/
+    /*display: none;*/
+/*}*/

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -1,25 +1,31 @@
-import { Link, Text, Tooltip } from "mineral-ui";
-import React, { Component } from "react";
-import Shield from "../ErrorBoundary/Shield/Shield";
-import "../Swagger/Swagger.css";
-import SwaggerContainer from "../Swagger/SwaggerContainer";
-import "./ServiceTab.css";
+import { Link, Text, Tooltip } from 'mineral-ui';
+import React, { Component } from 'react';
+import Shield from '../ErrorBoundary/Shield/Shield';
+import '../Swagger/Swagger.css';
+import SwaggerContainer from '../Swagger/SwaggerContainer';
+import './ServiceTab.css';
 
 export default class ServiceTab extends Component {
     render() {
-        const message = "The API documentation was retrieved but could not be displayed.";
+        const message = 'The API documentation was retrieved but could not be displayed.';
         const {
             match: {
-                params: { tileID, serviceId }
+                params: { tileID, serviceId },
             },
-            tiles, selectService, selectedService, selectedTile
+            tiles,
+            selectService,
+            selectedService,
+            selectedTile,
         } = this.props;
         let currentService = null;
         let invalidService = true;
-        const hasHomepage = selectedService.homePageUrl !== null && selectedService.homePageUrl !== undefined && selectedService.homePageUrl.length > 0;
+        const hasHomepage =
+            selectedService.homePageUrl !== null &&
+            selectedService.homePageUrl !== undefined &&
+            selectedService.homePageUrl.length > 0;
 
         if (tiles === null || tiles === undefined || tiles.length === 0) {
-            throw new Error("No tile is selected.");
+            throw new Error('No tile is selected.');
         }
         tiles[0].services.forEach(service => {
             if (service.serviceId === serviceId) {
@@ -33,42 +39,50 @@ export default class ServiceTab extends Component {
         return (
             <React.Fragment>
                 {invalidService && (
-                    <Text element="h3" style={{ margin: "0 auto", "background": "#ffff", width: "100%" }}>
-                        <br/>
-                        <br/>
-                        <p style={{ marginLeft: "122px" }}>This tile does not contain service "{serviceId}"</p>
+                    <Text element="h3" style={{ margin: '0 auto', background: '#ffff', width: '100%' }}>
+                        <br />
+                        <br />
+                        <p style={{ marginLeft: '122px' }}>This tile does not contain service "{serviceId}"</p>
                     </Text>
                 )}
                 <Shield title={message}>
                     {selectedService !== null && (
                         <React.Fragment>
-                            <div style={{ "background": "#ffff" }}>
-                                <div style={{ margin: "20px 0px 0px 55px", "background": "#ffff", width: "100%" }}>
-                                    <Text element="h2" color="#3b4151" fontWeight="bold">{selectedService.title}</Text>
+                            <div style={{ background: '#ffff' }}>
+                                <div style={{ margin: '20px 0px 0px 55px', background: '#ffff' }}>
+                                    <Text element="h2" color="#3b4151" fontWeight="bold">
+                                        {selectedService.title}
+                                    </Text>
                                     {hasHomepage && (
                                         <React.Fragment>
-                                            {
-                                                selectedService.status === "UP" && (
-                                                    <Tooltip key={selectedService.serviceId} content="Open API Homepage"
-                                                             placement="bottom">
-                                                        <Link href={selectedService.homePageUrl}><strong>API
-                                                            Homepage</strong></Link>
-                                                    </Tooltip>
-                                                )
-                                            }
-                                            {selectedService.status === "DOWN" && (
-                                                <Tooltip key={selectedService.serviceId}
-                                                         content="API Homepage navigation is disabled as the service is not running"
-                                                         placement="bottom">
-                                                    <Link variant="danger"><strong>API Homepage</strong></Link>
+                                            {selectedService.status === 'UP' && (
+                                                <Tooltip
+                                                    key={selectedService.serviceId}
+                                                    content="Open API Homepage"
+                                                    placement="bottom"
+                                                >
+                                                    <Link href={selectedService.homePageUrl}>
+                                                        <strong>API Homepage</strong>
+                                                    </Link>
+                                                </Tooltip>
+                                            )}
+                                            {selectedService.status === 'DOWN' && (
+                                                <Tooltip
+                                                    key={selectedService.serviceId}
+                                                    content="API Homepage navigation is disabled as the service is not running"
+                                                    placement="bottom"
+                                                >
+                                                    <Link variant="danger">
+                                                        <strong>API Homepage</strong>
+                                                    </Link>
                                                 </Tooltip>
                                             )}
                                         </React.Fragment>
                                     )}
-                                    <Text style={{ marginTop: "15px" }}>{selectedService.description}</Text>
+                                    <Text style={{ marginTop: '15px' }}>{selectedService.description}</Text>
                                 </div>
                             </div>
-                            <SwaggerContainer/>
+                            <SwaggerContainer />
                         </React.Fragment>
                     )}
                 </Shield>

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -58,11 +58,11 @@ export default class ServiceTab extends Component {
                                             {selectedService.status === 'UP' && (
                                                 <Tooltip
                                                     key={selectedService.serviceId}
-                                                    content="Open API Homepage"
+                                                    content="Open service homepage"
                                                     placement="bottom"
                                                 >
                                                     <Link href={selectedService.homePageUrl}>
-                                                        <strong>API Homepage</strong>
+                                                        <strong>Service Homepage</strong>
                                                     </Link>
                                                 </Tooltip>
                                             )}

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.css
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.css
@@ -30,7 +30,7 @@
 
 .swagger-ui .wrapper {
     width: 100%;
-    max-width: 1460px;
+    /* max-width: 1460px; */
     margin: 0 0 0 40px;
 }
 

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.css
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.css
@@ -3,8 +3,13 @@
     box-sizing: border-box
 }
 
-.swagger-ui .scheme-container {
-    display: none;
+.modal-btn {
+    max-width: 20vh;
+    margin: 1rem;
+}
+
+.try-out {
+    padding-left: 1rem;
 }
 
 #swaggerContainer {
@@ -487,10 +492,6 @@
     color: #fff !important
 }
 
-.swagger-ui .scheme-container {
-    display: none;
-}
-
 .swagger-ui .scheme-container .schemes {
     display: -webkit-box;
     display: -ms-flexbox;
@@ -915,7 +916,7 @@
     left: 50%;
     width: 100%;
     min-width: 300px;
-    max-width: 650px;
+    max-width: 70vh;
     -webkit-transform: translate(-50%, -50%);
     transform: translate(-50%, -50%);
     border: 1px solid #ebebeb;

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -1,16 +1,19 @@
 import React, { Component } from 'react';
 import SwaggerUi, { presets } from 'swagger-ui';
 import './Swagger.css';
+import * as Sswagger from'./endoverswagger';
 
 export default class SwaggerUI extends Component {
-
     componentDidMount() {
         this.retrieveSwagger();
     }
 
     componentDidUpdate(prevProps) {
         const { selectedService } = this.props;
-        if (selectedService.serviceId !== prevProps.selectedService.serviceId || selectedService.tileId !== prevProps.selectedService.tileId) {
+        if (
+            selectedService.serviceId !== prevProps.selectedService.serviceId ||
+            selectedService.tileId !== prevProps.selectedService.tileId
+        ) {
             this.retrieveSwagger();
         }
     }
@@ -18,9 +21,6 @@ export default class SwaggerUI extends Component {
     customPlugins = () => ({
         statePlugins: {
             spec: {
-                wrapSelectors: {
-                    allowTryItOutFor: () => () => false,
-                },
                 wrapActions: {
                     updateLoadingStatus: ori => (...args) => {
                         const [loadingStatus] = args;
@@ -36,12 +36,17 @@ export default class SwaggerUI extends Component {
     retrieveSwagger = () => {
         const { selectedService } = this.props;
 
-        if (selectedService.apiDoc !== null && selectedService.apiDoc !== undefined && selectedService.apiDoc.length !== 0) {
+        if (
+            selectedService.apiDoc !== null &&
+            selectedService.apiDoc !== undefined &&
+            selectedService.apiDoc.length !== 0
+        ) {
             try {
-                const swagger = JSON.parse(selectedService.apiDoc);
+                // const swagger = JSON.parse(selectedService.apiDoc);
+                console.log(Sswagger.default);
                 SwaggerUi({
                     dom_id: '#swaggerContainer',
-                    spec: swagger,
+                    spec: Sswagger.default,
                     presets: [presets.apis],
                     plugins: [this.customPlugins],
                 });
@@ -54,22 +59,25 @@ export default class SwaggerUI extends Component {
     render() {
         const { selectedService } = this.props;
         let error = false;
-        if (selectedService.apiDoc === undefined || selectedService.apiDoc === null || selectedService.apiDoc.length === 0) {
+        if (
+            selectedService.apiDoc === undefined ||
+            selectedService.apiDoc === null ||
+            selectedService.apiDoc.length === 0
+        ) {
             error = true;
         }
         return (
             <div style={{ width: '100%', background: '#ffffff' }}>
                 {error && (
                     <div style={{ width: '100%', background: '#ffffff', paddingLeft: 50, paddingTop: 30 }}>
-                        <h2 style={{ color: '#de1b1b' }}>Api Documentation for
-                            service "{selectedService.title}" (Service Id: {selectedService.serviceId}) could not be retrieved or is
-                            not defined.</h2>
+                        <h2 style={{ color: '#de1b1b' }}>
+                            Api Documentation for service "{selectedService.title}" (Service Id:{' '}
+                            {selectedService.serviceId}) could not be retrieved or is not defined.
+                        </h2>
                         <h5 style={{ color: '#de1b1b' }}>See console for details</h5>
                     </div>
                 )}
-                {!error && (
-                    <div id="swaggerContainer" data-testid="swagger"/>
-                )}
+                {!error && <div id="swaggerContainer" data-testid="swagger" />}
             </div>
         );
     }

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import SwaggerUi, { presets } from 'swagger-ui';
 import './Swagger.css';
-import * as Sswagger from'./endoverswagger';
 
 export default class SwaggerUI extends Component {
     componentDidMount() {
@@ -42,11 +41,10 @@ export default class SwaggerUI extends Component {
             selectedService.apiDoc.length !== 0
         ) {
             try {
-                // const swagger = JSON.parse(selectedService.apiDoc);
-                console.log(Sswagger.default);
+                const swagger = JSON.parse(selectedService.apiDoc);
                 SwaggerUi({
                     dom_id: '#swaggerContainer',
-                    spec: Sswagger.default,
+                    spec: swagger,
                     presets: [presets.apis],
                     plugins: [this.customPlugins],
                 });


### PR DESCRIPTION
Enables the funtionality of 'authorize' and 'try-it-out' buttons for swagger-ui.

Also rename 'API Homepage' to 'Service homepage'.