### PR TITLE
Use the default Java encoding on z/OS in certificate management script

### DIFF
--- a/scripts/apiml_cm.sh
+++ b/scripts/apiml_cm.sh
@@ -10,6 +10,8 @@
 # https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/keytoolDocs/keytool_overview.html
 #
 
+export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047"
+
 BASE_DIR=$(dirname "$0")
 PARAMS="$@"
 PWD=`pwd`


### PR DESCRIPTION
Signed-off-by: Petr Plavjanik <petr.plavjanik@broadcom.com>

Resolves https://github.com/zowe/api-layer/issues/156	