### PR TITLE
Fixed a alias name when exporting a certificate

### DIFF
--- a/scripts/apiml_cm.sh
+++ b/scripts/apiml_cm.sh
@@ -193,7 +193,7 @@ function import_external_certificate {
 
 function export_service_certificate {
     echo "Export service certificate to the PEM format"
-    pkeytool -exportcert -alias localhost -keystore ${SERVICE_KEYSTORE}.p12 -storetype PKCS12 -storepass ${SERVICE_PASSWORD} -rfc -file ${SERVICE_KEYSTORE}.cer
+    pkeytool -exportcert -alias ${SERVICE_ALIAS} -keystore ${SERVICE_KEYSTORE}.p12 -storetype PKCS12 -storepass ${SERVICE_PASSWORD} -rfc -file ${SERVICE_KEYSTORE}.cer
 
     if [ `uname` = "OS/390" ]; then
         iconv -f ISO8859-1 -t IBM-1047 ${SERVICE_KEYSTORE}.cer > ${SERVICE_KEYSTORE}.cer-ebcdic


### PR DESCRIPTION
Found and fixed a small bug in the certificate management script