### PR TITLE
Use local CA signed certificate for discoverable-client on localhost

### DIFF
--- a/config/local/discoverable-client.yml
+++ b/config/local/discoverable-client.yml
@@ -16,11 +16,13 @@ server:
     ssl:
         keyAlias: localhost
         keyPassword: password
-        keyStore: keystore/selfsigned/localhost.keystore.p12
+        keyStore: keystore/localhost/localhost.keystore.p12
+        # keyStore: keystore/selfsigned/localhost.keystore.p12        
         # keyStore: keystore/selfsigned/localhost-untrusted.keystore.p12
         keyStorePassword: password
         keyStoreType: PKCS12
-        trustStore: keystore/selfsigned/localhost.truststore.p12
+        trustStore: keystore/localhost/localhost.truststore.p12
+        # trustStore: keystore/selfsigned/localhost.truststore.p12
         # trustStore: keystore/selfsigned/localhost-untrusted.truststore.p12
         trustStorePassword: password
         trustStoreType: PKCS12


### PR DESCRIPTION
Uses the original keystore `keystore/localhost/localhost.keystore.p12` for `discoverable-client` instead of a self-signed certificate. 

The reason is to make it easier to create new local CA and truststore for the APIML without additional steps to trust the self-signed certificate.