### PR TITLE
Change Base URL and endpoints in API doc

### DIFF
--- a/api-catalog-ui/frontend/src/e2e/e2e.test.jsx
+++ b/api-catalog-ui/frontend/src/e2e/e2e.test.jsx
@@ -113,7 +113,9 @@ describe('>>> e2e tests', async () => {
         const tabTitleText = await page.evaluate(el => el.innerText, tab);
         const descriptionText = await page.evaluate(el => el.innerText, description);
         expect(tabTitleText).toBe('API Mediation Layer API');
-        expect(descriptionText).toBe('The API Mediation Layer for z/OS internal API services. The API Mediation Layer provides a single point of access to mainframe REST APIs and offers enterprise cloud-like features such as high-availability, scalability, dynamic API discovery, and documentation.');
+        expect(descriptionText).toBe(
+            'The API Mediation Layer for z/OS internal API services. The API Mediation Layer provides a single point of access to mainframe REST APIs and offers enterprise cloud-like features such as high-availability, scalability, dynamic API discovery, and documentation.'
+        );
     });
 
     it('Should display the back button', async () => {
@@ -133,23 +135,25 @@ describe('>>> e2e tests', async () => {
         await page.waitForSelector(
             '#swaggerContainer > div > div:nth-child(2) > div.information-container.wrapper > section > div > div > div > div > p'
         );
+        await page.waitForSelector('pre.base-url');
         const serviceTitle = await page.$(
             '#swaggerContainer > div > div:nth-child(2) > div.information-container.wrapper > section > div > div > hgroup > h2'
         );
         await page.waitFor(2000);
-        const serviceUrl = await page.$(
-            '#swaggerContainer > div > div:nth-child(2) > div.information-container.wrapper > section > div > div > hgroup > a > span'
-        );
+        const serviceUrl = await page.$('pre.base-url');
         const serviceDescription = await page.$(
             '#swaggerContainer > div > div:nth-child(2) > div.information-container.wrapper > section > div > div > div > div > p'
         );
         const serviceTitleText = await page.evaluate(el => el.innerText, serviceTitle);
         const serviceDescriptionText = await page.evaluate(el => el.innerText, serviceDescription);
+        const serviceUrlText = await page.evaluate(el => el.innerText, serviceUrl);
         const expectedTitleValue = 'API Catalog\n' + ' 1.0.0 ';
+        const expectedUrl = `[ Base URL: ${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/api/v1/apicatalog ]`;
         const expectedDescriptionValue =
             'REST API for the API Catalog service which is a component of the API Mediation Layer. Use this API to retrieve information regarding catalog dashboard tiles, tile contents and its status, API documentation and status for the registered services.';
         expect(serviceTitleText).toBe(expectedTitleValue);
         expect(serviceDescriptionText).toBe(expectedDescriptionValue);
+        expect(serviceUrlText).toBe(expectedUrl);
     });
 
     it('Should go back to the dashboard page, check the URL and check if the search bar works', async () => {

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
@@ -19,11 +19,11 @@ import com.netflix.util.Pair;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import io.swagger.models.Path;
+import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
 import io.swagger.util.Json;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.springframework.http.HttpStatus;
 
 import javax.validation.UnexpectedTypeException;
@@ -31,11 +31,7 @@ import javax.validation.UnexpectedTypeException;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.ca.mfaas.product.constants.ApimConstants.API_DOC_NORMALISED;
 import static com.netflix.zuul.context.RequestContext.getCurrentContext;
@@ -49,6 +45,7 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 @Slf4j
 public class TransformApiDocEndpointsFilter extends ZuulFilter implements RoutedServicesUser {
 
+    private static final String SEPARATOR = "/";
     private final Map<String, RoutedServices> routedServicesMap = new HashMap<>();
 
     /**
@@ -97,7 +94,7 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
      *
      * @param serviceId   the service id
      * @param requestPath the request path
-     * @param context request context
+     * @param context     request context
      * @return true if this can be processed
      */
     private boolean isRequestThatCanBeProcessed(String serviceId, String requestPath, RequestContext context) {
@@ -140,6 +137,7 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
 
     /**
      * Retrieve the body as a String from the data stream
+     *
      * @param responseStream the data stream
      * @return a string
      * @throws IOException body could not be retrieved
@@ -184,7 +182,8 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
             throw new UnexpectedTypeException("Response is not a Swagger type object. Http Response: " + context.getResponseStatusCode());
         }
 
-        Map<String, Path> updatedPaths = new HashMap<>();
+        Map<String, Path> updatedShortPaths = new HashMap<>();
+        Map<String, Path> updatedLongPaths = new HashMap<>();
         String serviceId = (String) context.get(SERVICE_ID_KEY);
         String requestUri = (String) context.get(REQUEST_URI_KEY);
 
@@ -212,6 +211,7 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
         }
 
         // Update all paths to gateway format
+        Set<String> prefixes = new HashSet<>();
         if (swagger.getPaths() != null && !swagger.getPaths().isEmpty()) {
 
             // Check each path
@@ -224,33 +224,41 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
                 log.trace("Base Path: " + swagger.getBasePath());
 
                 // Retrieve route which matches endpoint
+                String endPoint = swagger.getBasePath() + originalEndpoint;
+                RoutedService route = getRouteServiceForEndpoint(endPoint, finalServiceId);
 
-                String updatedEndPoint = getGatewayURLForEndPoint(swagger.getBasePath() + originalEndpoint, finalServiceId);
-                log.trace("Final Endpoint: " + updatedEndPoint);
+                String updatedShortEndPoint = null;
+                String updatedLongEndPoint = null;
+                if (route != null) {
+                    prefixes.add(route.getGatewayUrl());
+                    updatedShortEndPoint = endPoint.replace(route.getServiceUrl(), "");
+                    updatedLongEndPoint = SEPARATOR + route.getGatewayUrl() + SEPARATOR + finalServiceId + updatedShortEndPoint;
+                }
+                log.trace("Final Endpoint: " + updatedLongEndPoint);
+
                 // If endpoint not converted, then use original
-                if (updatedEndPoint != null) {
-                    updatedPaths.put(updatedEndPoint, path);
+                if (updatedLongEndPoint != null) {
+                    updatedShortPaths.put(updatedShortEndPoint, path);
+                    updatedLongPaths.put(updatedLongEndPoint, path);
                 } else {
                     log.debug("Could not transform endpoint: " + originalEndpoint + ", original used");
                 }
             });
-
-            // update the original swagger object with the new paths
-            swagger.setPaths(updatedPaths);
         }
 
-        // update host and base path
-        swagger.setBasePath("");
-        String baseHost;
-        try {
-            baseHost = new URIBuilder()
-                .setHost(context.getZuulRequestHeaders().get(X_FORWARDED_HOST_HEADER.toLowerCase()))
-                .setScheme(context.getZuulRequestHeaders().get(X_FORWARDED_PROTO_HEADER.toLowerCase())).build().toString();
-        } catch (URISyntaxException e) {
-            log.warn("An error occurred when setting host in the Api Doc, setting it to fallback value", e);
-            baseHost = context.getZuulRequestHeaders().get(X_FORWARDED_HOST_HEADER.toLowerCase());
+        // update basePath and the original swagger object with the new paths
+        if (prefixes.size() == 1) {
+            swagger.setBasePath(SEPARATOR + prefixes.iterator().next() + SEPARATOR + serviceId);
+            swagger.setPaths(updatedShortPaths);
+        } else {
+            swagger.setBasePath("");
+            swagger.setPaths(updatedLongPaths);
         }
-        swagger.setHost(baseHost);
+
+        // update scheme and host
+        String scheme = context.getZuulRequestHeaders().get(X_FORWARDED_PROTO_HEADER.toLowerCase());
+        swagger.setSchemes(Collections.singletonList(Scheme.forValue(scheme)));
+        swagger.setHost(context.getZuulRequestHeaders().get(X_FORWARDED_HOST_HEADER.toLowerCase()));
 
         // Convert to JSON and set content body
         try {
@@ -263,38 +271,18 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
     }
 
     /**
-     * Get the base path for this Api Version
+     * Get the transformation routes for the endpoint
      *
-     * @return the base path
-     * @param endPoint the REST endpoint (relative to service)
+     * @param endPoint the endpoint
      * @param serviceId the service id
+     * @return modified content
      */
-    private String getGatewayURLForEndPoint(String endPoint, String serviceId) {
-        String updatedEndPoint = null;
-        String basePath = null;
-
-        // Get the transformation routes for this service
+    private RoutedService getRouteServiceForEndpoint(String endPoint, String serviceId) {
         RoutedServices routedServices = routedServicesMap.get(serviceId);
-        if (routedServices != null) {
-            RoutedService route = routedServices.findGatewayUrlThatMatchesServiceUrl(endPoint, true);
-            if (route != null) {
-                String separator = "/";
-                basePath = separator + route.getGatewayUrl();
-                updatedEndPoint = separator + serviceId + endPoint.replace(route.getServiceUrl(), "");
-
-                log.trace("Updated Endpoint: " + updatedEndPoint);
-
-                // remove any prefixes where the base path may also contain the service Id
-                String duplicatePrefix = "/" + serviceId + "/" + serviceId;
-                if (updatedEndPoint.startsWith(duplicatePrefix)) {
-                    updatedEndPoint = updatedEndPoint.replace(duplicatePrefix, "/" + serviceId);
-                    log.debug("Duplicate Modified Endpoint: " + updatedEndPoint);
-                }
-            } else {
-                // if no route found then do not update endpoint, use original
-                return null;
-            }
+        if (routedServices == null) {
+            return null;
+        } else {
+            return routedServices.findGatewayUrlThatMatchesServiceUrl(endPoint, true);
         }
-        return basePath + updatedEndPoint;
     }
 }

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ApiDocController.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ApiDocController.java
@@ -126,7 +126,7 @@ public class ApiDocController {
         "        }\n" +
         "      }\n" +
         "    },\n" +
-        "    \"/v1/pets/{id}\": {\n" +
+        "    \"/v2/pets/{id}\": {\n" +
         "      \"get\": {\n" +
         "        \"description\": \"Returns a user based on a single ID, if the user does not have access to the pet\",\n" +
         "        \"operationId\": \"findPetById\",\n" +

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
@@ -88,12 +88,12 @@ public class PostFilterApiDocTransformTest {
         assertEquals("Base path for only one Gateway Url is not correct.", BASE_PATH, swagger.getBasePath());
         swagger.getPaths().forEach((endPoint, path) -> {
             assertTrue(endPoint + " does not contains 'pets'.", endPoint.contains(ENDPOINT));
-            assertFalse(endPoint + " contains base path '" + BASE_PATH +"'.", endPoint.contains(SERVICE_ID));
+            assertFalse(endPoint + " contains base path '" + BASE_PATH + "'.", endPoint.contains(SERVICE_ID));
         });
     }
 
     @Test
-    public void  whenPostFilterApplied_thenSwaggerVersionModified_twoGWUrls() throws IOException {
+    public void whenPostFilterApplied_thenSwaggerVersionModified_twoGWUrls() throws IOException {
         RoutedServices routedServices = new RoutedServices();
         routedServices.addRoutedService(
             new RoutedService("v1", "api/v1", "/discovered-service/v1"));
@@ -112,7 +112,7 @@ public class PostFilterApiDocTransformTest {
         assertTrue("Base path for two Gateway Urls is not empty.", swagger.getBasePath().isEmpty());
         swagger.getPaths().forEach((endPoint, path) -> {
             assertTrue(endPoint + " does not contains 'pets'.", endPoint.contains(ENDPOINT));
-            assertTrue(endPoint + " does not contains base path '" + BASE_PATH +"'.", endPoint.contains(SERVICE_ID));
+            assertTrue(endPoint + " does not contains base path '" + BASE_PATH + "'.", endPoint.contains(SERVICE_ID));
         });
     }
 

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
@@ -36,21 +36,21 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 
 public class PostFilterApiDocTransformTest {
 
+    private static final String SERVICE_ID = "discovered-service";
+    private static final String BASE_PATH = "/api/v1/discovered-service";
+    private static final String ENDPOINT = "pets";
+
     private final String apiDocEndpoint = "/api-doc";
     private TransformApiDocEndpointsFilter filter;
-    private RequestContext ctx;
-
-    private String BASE_PATH  = "/api/v1/discovered-service";
 
     @Before
     public void setUp() {
         this.filter = new TransformApiDocEndpointsFilter();
-        ctx = RequestContext.getCurrentContext();
+        RequestContext ctx = RequestContext.getCurrentContext();
         ctx.clear();
         ctx.set(REQUEST_URI_KEY, apiDocEndpoint);
         ctx.set(PROXY_KEY, "/api/v1/discovered-service");
-        String serviceId = "discovered-service";
-        ctx.set(SERVICE_ID_KEY, serviceId);
+        ctx.set(SERVICE_ID_KEY, SERVICE_ID);
         ctx.setResponseBody(ApiDocController.apiDocResult);
         ctx.setResponseDataStream(IOUtils.toInputStream(ApiDocController.apiDocResult));
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -58,8 +58,8 @@ public class PostFilterApiDocTransformTest {
         ctx.setResponse(response);
         RoutedServices routedServices = new RoutedServices();
         routedServices.addRoutedService(
-            new RoutedService(serviceId, "api/v1", "/discovered-service/v1"));
-        this.filter.addRoutedServices(serviceId, routedServices);
+            new RoutedService("v1", "api/v1", "/discovered-service/v1"));
+        this.filter.addRoutedServices(SERVICE_ID, routedServices);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class PostFilterApiDocTransformTest {
     }
 
     @Test
-    public void whenPostFilterApplied_thenSwaggerVersion2UnModified() throws IOException {
+    public void whenPostFilterApplied_thenSwaggerVersionModified_oneGWUrl() throws IOException {
         final RequestContext ctx = RequestContext.getCurrentContext();
         MockHttpServletResponse response = new MockHttpServletResponse();
         response.setStatus(200);
@@ -85,7 +85,35 @@ public class PostFilterApiDocTransformTest {
         String body = ctx.getResponseBody();
         assertEquals(apiDocEndpoint, ctx.get(REQUEST_URI_KEY));
         Swagger swagger = Json.mapper().readValue(body, Swagger.class);
-        swagger.getPaths().forEach((endPoint, path) -> assertTrue(endPoint + " does not start with " + BASE_PATH, endPoint.startsWith(BASE_PATH)));
+        assertEquals("Base path for only one Gateway Url is not correct.", BASE_PATH, swagger.getBasePath());
+        swagger.getPaths().forEach((endPoint, path) -> {
+            assertTrue(endPoint + " does not contains 'pets'.", endPoint.contains(ENDPOINT));
+            assertFalse(endPoint + " contains base path '" + BASE_PATH +"'.", endPoint.contains(SERVICE_ID));
+        });
+    }
+
+    @Test
+    public void  whenPostFilterApplied_thenSwaggerVersionModified_twoGWUrls() throws IOException {
+        RoutedServices routedServices = new RoutedServices();
+        routedServices.addRoutedService(
+            new RoutedService("v1", "api/v1", "/discovered-service/v1"));
+        routedServices.addRoutedService(
+            new RoutedService("v2", "api/v2", "/discovered-service/v2"));
+        this.filter.addRoutedServices(SERVICE_ID, routedServices);
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+        ctx.setResponse(response);
+        assertTrue(this.filter.shouldFilter());
+        this.filter.run();
+        String body = ctx.getResponseBody();
+        assertEquals(apiDocEndpoint, ctx.get(REQUEST_URI_KEY));
+        Swagger swagger = Json.mapper().readValue(body, Swagger.class);
+        assertTrue("Base path for two Gateway Urls is not empty.", swagger.getBasePath().isEmpty());
+        swagger.getPaths().forEach((endPoint, path) -> {
+            assertTrue(endPoint + " does not contains 'pets'.", endPoint.contains(ENDPOINT));
+            assertTrue(endPoint + " does not contains base path '" + BASE_PATH +"'.", endPoint.contains(SERVICE_ID));
+        });
     }
 
     @Test

--- a/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -21,7 +21,6 @@ import net.minidev.json.JSONArray;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;

--- a/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -62,7 +62,7 @@ public class ApiCatalogEndpointIntegrationTest {
         scheme = gatewayServiceConfiguration.getScheme();
         host = gatewayServiceConfiguration.getHost();
         port = gatewayServiceConfiguration.getPort();
-        baseHost = new URIBuilder().setScheme(scheme).setHost(host).setPort(port).build().toString();
+        baseHost = host + ":" + port;
     }
 
     @Test
@@ -103,11 +103,11 @@ public class ApiCatalogEndpointIntegrationTest {
         assertFalse(apiCatalogSwagger, paths.isEmpty());
         assertFalse(apiCatalogSwagger, definitions.isEmpty());
         assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "", swaggerBasePath);
-        assertNull(apiCatalogSwagger, paths.get("/api/v1/apicatalog/status/updates"));
-        assertNotNull(apiCatalogSwagger, paths.get("/api/v1/apicatalog/containers/{id}"));
-        assertNotNull(apiCatalogSwagger, paths.get("/api/v1/apicatalog/containers"));
-        assertNotNull(apiCatalogSwagger, paths.get("/api/v1/apicatalog/apidoc/{service-id}/{api-version}"));
+        assertEquals(apiCatalogSwagger, "/api/v1/apicatalog", swaggerBasePath);
+        assertNull(apiCatalogSwagger, paths.get("/status/updates"));
+        assertNotNull(apiCatalogSwagger, paths.get("/containers/{id}"));
+        assertNotNull(apiCatalogSwagger, paths.get("/containers"));
+        assertNotNull(apiCatalogSwagger, paths.get("/apidoc/{service-id}/{api-version}"));
         assertNotNull(apiCatalogSwagger, definitions.get("APIContainer"));
         assertNotNull(apiCatalogSwagger, definitions.get("APIService"));
         assertNotNull(apiCatalogSwagger, definitions.get("TimeZone"));
@@ -139,11 +139,12 @@ public class ApiCatalogEndpointIntegrationTest {
 
     /**
      * Execute the endpoint and check the response for a return code
-     * @param endpoint execute thus
+     *
+     * @param endpoint   execute thus
      * @param returnCode check for this
      * @return response
      * @throws URISyntaxException oops
-     * @throws IOException oops
+     * @throws IOException        oops
      */
     private HttpResponse getResponse(String endpoint, int returnCode) throws IOException {
         HttpGet request = HttpRequestUtils.getRequest(endpoint);

--- a/integration-tests/src/test/java/com/ca/mfaas/startup/impl/ApiDocFormatStartupChecker.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/startup/impl/ApiDocFormatStartupChecker.java
@@ -44,7 +44,7 @@ public class ApiDocFormatStartupChecker {
             jsonResponse = EntityUtils.toString(response.getEntity());
         } catch (Exception ignore) { }
 
-        if (jsonResponse.contains("/api/v1/apicatalog/containers")) {
+        if (jsonResponse.contains("/api/v1/apicatalog")) {
             result = true;
         } else {
             log.info("Did not find correct endpoints");


### PR DESCRIPTION
Base URL and endpoints were changed to the following format:

* One prefix - should be api/v1

**Swagger example:**
host: "localhost:10010",
basePath: "/api/v1/discoverableclient",
schemes: [
"https"
]
,paths: {
/greeting: {

* Multiple prefixes

**Swagger example:**
host: "localhost:10010",
basePath: "",
schemes: [
"https"
]
,paths: {
/api/v1/discoverableclient/greeting: {