### PR TITLE
Convert security token in query parameter to cookie

### DIFF
--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/ConvertAuthTokenInUriToCookieFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/ConvertAuthTokenInUriToCookieFilter.java
@@ -1,0 +1,73 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package com.ca.mfaas.gateway.filters.post;
+
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SEND_RESPONSE_FILTER_ORDER;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ca.mfaas.security.config.SecurityConfigurationProperties;
+import com.ca.mfaas.security.config.SecurityConfigurationProperties.CookieProperties;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+
+/**
+ * Uses the authentication token provided as a query parameter and puts it to
+ * the expected place (cookie).
+ */
+public class ConvertAuthTokenInUriToCookieFilter extends ZuulFilter {
+    final static String TOKEN_KEY = "apimlAuthenticationToken";
+
+    private final SecurityConfigurationProperties securityConfigurationProperties;
+
+    public ConvertAuthTokenInUriToCookieFilter(SecurityConfigurationProperties securityConfigurationProperties) {
+        this.securityConfigurationProperties = securityConfigurationProperties;
+    }
+
+    public String filterType() {
+        return POST_TYPE;
+    }
+
+    public int filterOrder() {
+        return SEND_RESPONSE_FILTER_ORDER - 1;
+    }
+
+    public boolean shouldFilter() {
+        return true;
+    }
+
+    public Object run() {
+        RequestContext context = RequestContext.getCurrentContext();
+        if ((context.getRequestQueryParams() != null) && context.getRequestQueryParams().containsKey(TOKEN_KEY)) {
+            HttpServletResponse servletResponse = context.getResponse();
+            CookieProperties cp = securityConfigurationProperties.getCookieProperties();
+            Cookie cookie = new Cookie(cp.getCookieName(), context.getRequestQueryParams().get(TOKEN_KEY).get(0));
+            cookie.setPath(cp.getCookiePath());
+            cookie.setSecure(true);
+            cookie.setHttpOnly(true);
+            cookie.setMaxAge(cp.getCookieMaxAge());
+            cookie.setComment(cp.getCookieComment());
+            servletResponse.addCookie(cookie);
+
+            String url = context.getRequest().getRequestURL().toString();
+            String newUrl;
+            if (url.endsWith("/apicatalog/")) {
+                newUrl = url + "#/dashboard";
+            } else {
+                newUrl = url;
+            }
+            context.addZuulResponseHeader("Location", newUrl);
+            context.setResponseStatusCode(HttpServletResponse.SC_MOVED_TEMPORARILY);
+        }
+        return null;
+    }
+}

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/routing/MfaasRoutingConfig.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/routing/MfaasRoutingConfig.java
@@ -9,11 +9,14 @@
  */
 package com.ca.mfaas.gateway.routing;
 
+import com.ca.mfaas.gateway.filters.post.ConvertAuthTokenInUriToCookieFilter;
 import com.ca.mfaas.gateway.filters.post.TransformApiDocEndpointsFilter;
 import com.ca.mfaas.gateway.filters.pre.LocationFilter;
 import com.ca.mfaas.gateway.filters.pre.SlashFilter;
 import com.ca.mfaas.gateway.services.routing.RoutedServicesUser;
 import com.ca.mfaas.gateway.ws.WebSocketProxyServerHandler;
+import com.ca.mfaas.security.config.SecurityConfigurationProperties;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
@@ -41,6 +44,12 @@ public class MfaasRoutingConfig {
     @Bean
     public TransformApiDocEndpointsFilter transformApiDocEndpointsFilter() {
         return new TransformApiDocEndpointsFilter();
+    }
+
+    @Bean
+    @Autowired
+    public ConvertAuthTokenInUriToCookieFilter convertAuthTokenInUriToCookieFilter(SecurityConfigurationProperties securityConfigurationProperties) {
+        return new ConvertAuthTokenInUriToCookieFilter(securityConfigurationProperties);
     }
 
     @Bean

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ConvertAuthTokenInUriToCookieFilterTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ConvertAuthTokenInUriToCookieFilterTest.java
@@ -1,0 +1,84 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package com.ca.mfaas.gateway.filters.post;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.ca.mfaas.security.config.SecurityConfigurationProperties;
+import com.netflix.zuul.context.RequestContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ConvertAuthTokenInUriToCookieFilterTest {
+
+    private ConvertAuthTokenInUriToCookieFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        SecurityConfigurationProperties securityConfigurationProperties = new SecurityConfigurationProperties();
+        this.filter = new ConvertAuthTokenInUriToCookieFilter(securityConfigurationProperties);
+        RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.clear();
+        ctx.setResponse(new MockHttpServletResponse());
+    }
+
+    @Test
+    public void doesNotDoAnythingWhenThereIsNoParam() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        this.filter.run();
+        assertFalse(ctx.getResponse().getHeaderNames().contains("Set-Cookie"));
+    }
+
+    @Test
+    public void doesNotDoAnythingWhenThereIsAnotherParam() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        Map<String, List<String>> params = new HashMap<>();
+        params.put("someParameter", Arrays.asList("value"));
+        ctx.setRequestQueryParams(params);
+        this.filter.run();
+        assertFalse(ctx.getResponse().getHeaderNames().contains("Set-Cookie"));
+    }
+
+    @Test
+    public void setsCookieForCorrectParameter() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.setRequest(new MockHttpServletRequest("GET", "/api/v1/service"));
+        Map<String, List<String>> params = new HashMap<>();
+        params.put(ConvertAuthTokenInUriToCookieFilter.TOKEN_KEY, Arrays.asList("token"));
+        ctx.setRequestQueryParams(params);
+        this.filter.run();
+        assertTrue(ctx.getResponse().getHeaders("Set-Cookie").toString().contains("apimlAuthenticationToken=token"));
+        assertEquals("Location", ctx.getZuulResponseHeaders().get(0).first());
+        assertEquals("http://localhost/api/v1/service", ctx.getZuulResponseHeaders().get(0).second());
+    }
+
+    @Test
+    public void setsLocationToDashboardForApiCatalog() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.setRequest(new MockHttpServletRequest("GET", "/api/v1/apicatalog/"));
+        Map<String, List<String>> params = new HashMap<>();
+        params.put(ConvertAuthTokenInUriToCookieFilter.TOKEN_KEY, Arrays.asList("token"));
+        ctx.setRequestQueryParams(params);
+        this.filter.run();
+        assertTrue(ctx.getResponse().getHeaders("Set-Cookie").toString().contains("apimlAuthenticationToken=token"));
+        assertEquals("Location", ctx.getZuulResponseHeaders().get(0).first());
+        assertEquals("http://localhost/api/v1/apicatalog/#/dashboard", ctx.getZuulResponseHeaders().get(0).second());
+    }
+}


### PR DESCRIPTION
This allows the correct token to be passed from a different location (e.g. zLUX iframe) to any endpoint in APIML as a cookie.

E.g.: `https://localhost:10010/ui/v1/apicatalog/?apimlAuthenticationToken=<correct_token>`

The request is then redirected to the URL without the parameter so it is not stored in the browser history.

In case of API catalog, it also redirects to the Dashboard because a request with empty path goes to log in even if the token is present.