### PR TITLE
Add z/OSMF filter to change JWT token to LTPA

### DIFF
--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/pre/ZosmfFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/pre/ZosmfFilter.java
@@ -15,17 +15,19 @@ import com.netflix.zuul.context.RequestContext;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_DECORATION_FILTER_ORDER;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SERVICE_ID_KEY;
 
 public class ZosmfFilter extends ZuulFilter {
     private static final String ZOSMF = "zosmf";
+
+    private static final String COOKIE_HEADER = "cookie";
 
     private final TokenService tokenService;
 
     @Autowired
     public ZosmfFilter(TokenService tokenService) {
         this.tokenService = tokenService;
-
     }
 
     @Override
@@ -38,7 +40,7 @@ public class ZosmfFilter extends ZuulFilter {
 
     @Override
     public String filterType() {
-        return "pre";
+        return PRE_TYPE;
     }
 
     @Override
@@ -53,7 +55,14 @@ public class ZosmfFilter extends ZuulFilter {
         String jwtToken = tokenService.getToken(context.getRequest());
         String ltpaToken = tokenService.getLtpaToken(jwtToken);
 
-        context.addZuulRequestHeader("Cookie", ltpaToken);
+        String cookie = context.getZuulRequestHeaders().get(COOKIE_HEADER);
+        if (cookie != null) {
+            cookie += "; " + ltpaToken;
+        }
+        else {
+            cookie = ltpaToken;
+        }
+        context.addZuulRequestHeader(COOKIE_HEADER, cookie);
         return null;
     }
 }

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/routing/MfaasRoutingConfig.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/routing/MfaasRoutingConfig.java
@@ -13,9 +13,11 @@ import com.ca.mfaas.gateway.filters.post.ConvertAuthTokenInUriToCookieFilter;
 import com.ca.mfaas.gateway.filters.post.TransformApiDocEndpointsFilter;
 import com.ca.mfaas.gateway.filters.pre.LocationFilter;
 import com.ca.mfaas.gateway.filters.pre.SlashFilter;
+import com.ca.mfaas.gateway.filters.pre.ZosmfFilter;
 import com.ca.mfaas.gateway.services.routing.RoutedServicesUser;
 import com.ca.mfaas.gateway.ws.WebSocketProxyServerHandler;
 import com.ca.mfaas.security.config.SecurityConfigurationProperties;
+import com.ca.mfaas.security.token.TokenService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -39,6 +41,11 @@ public class MfaasRoutingConfig {
     @Bean
     public SlashFilter slashFilter() {
         return new SlashFilter();
+    }
+
+    @Bean
+    public ZosmfFilter zosmfFilter(TokenService tokenService) {
+        return new ZosmfFilter(tokenService);
     }
 
     @Bean

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/pre/ZosmfFilterTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/pre/ZosmfFilterTest.java
@@ -1,0 +1,110 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package com.ca.mfaas.gateway.filters.pre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SERVICE_ID_KEY;
+
+import com.ca.mfaas.security.token.TokenService;
+import com.netflix.zuul.context.RequestContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ZosmfFilterTest {
+
+    private static final String TOKEN = "token";
+    private static final String LTPA_TOKEN = "ltpaToken";
+    private static final String MY_COOKIE = "myCookie=MYCOOKIE";
+
+    private ZosmfFilter filter;
+    private TokenService tokenService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.tokenService = mock(TokenService.class);
+        this.filter = new ZosmfFilter(tokenService);
+        RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.clear();
+        ctx.setResponse(new MockHttpServletResponse());
+    }
+
+    @Test
+    public void shouldFilterZosmfRequests() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "zosmftest");
+
+        assertTrue(this.filter.shouldFilter());
+    }
+
+    @Test
+    public void shouldNotFilterOtherServiceRequests() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "testservice");
+
+        assertFalse(this.filter.shouldFilter());
+    }
+
+    @Test
+    public void shouldAddLtpaTokenToZosmfRequests() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "zosmftest");
+        when(tokenService.getToken(ctx.getRequest())).thenReturn(TOKEN);
+        when(tokenService.getLtpaToken(TOKEN)).thenReturn(LTPA_TOKEN);
+
+        this.filter.run();
+
+        assertTrue(ctx.getZuulRequestHeaders().get("cookie").contains(LTPA_TOKEN));
+    }
+
+    @Test
+    public void shouldPassWhenLtpaTokenIsMissing() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "zosmftest");
+        when(tokenService.getToken(ctx.getRequest())).thenReturn(TOKEN);
+        when(tokenService.getLtpaToken(TOKEN)).thenReturn(null);
+
+        this.filter.run();
+
+        assertEquals(null, ctx.getZuulRequestHeaders().get("cookie"));
+    }
+
+    @Test
+    public void shouldPassWhenJwtTokenIsMissing() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "zosmftest");
+        when(tokenService.getToken(ctx.getRequest())).thenReturn(null);
+        when(tokenService.getLtpaToken(null)).thenReturn(null);
+
+        this.filter.run();
+
+        assertEquals(null, ctx.getZuulRequestHeaders().get("cookie"));
+    }
+
+    @Test
+    public void shouldKeepExistingCookies() throws Exception {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(SERVICE_ID_KEY, "zosmftest");
+        ctx.addZuulRequestHeader("Cookie", MY_COOKIE);
+
+        when(tokenService.getToken(ctx.getRequest())).thenReturn(TOKEN);
+        when(tokenService.getLtpaToken(TOKEN)).thenReturn(LTPA_TOKEN);
+
+        this.filter.run();
+
+        assertTrue(ctx.getZuulRequestHeaders().get("cookie").contains(LTPA_TOKEN));
+        assertTrue(ctx.getZuulRequestHeaders().get("cookie").contains(MY_COOKIE));
+    }    
+}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -18,7 +18,7 @@ completely and ready for tests to start.
 
 2. Run
     ```shell
-    ./gradlew runIntegrationTests ./gradlew runIntegrationTests -Dapicatalog.user=<MAINFRAME_USERID> -Dapicatalog.password=<PASSWORD>
+    ./gradlew runIntegrationTests -Dapicatalog.user=<MAINFRAME_USERID> -Dapicatalog.password=<PASSWORD>
     ``` 
 
 3. (Optional) Change host/port/scheme for gateway-service and discovery-service. You can also set the number of instances for discovery service

--- a/security-module/src/main/java/com/ca/mfaas/security/token/TokenService.java
+++ b/security-module/src/main/java/com/ca/mfaas/security/token/TokenService.java
@@ -24,7 +24,8 @@ import java.util.UUID;
 @Service
 @Slf4j
 public class TokenService {
-    private static final String BEARER_HEADER = "Bearer ";
+    static final String LTPA_CLAIM_NAME = "ltpa";
+    static final String BEARER_TYPE_PREFIX = "Bearer ";
 
     private final SecurityConfigurationProperties securityConfigurationProperties;
 
@@ -43,7 +44,7 @@ public class TokenService {
         return Jwts.builder()
             .setSubject(username)
             .claim("dom", domain)
-            .claim("ltpa", ltpaToken)
+            .claim(LTPA_CLAIM_NAME, ltpaToken)
             .setIssuedAt(new Date(now))
             .setExpiration(new Date(expiration))
             .setIssuer(securityConfigurationProperties.getTokenProperties().getIssuer())
@@ -80,9 +81,9 @@ public class TokenService {
         Claims claims = Jwts.parser()
             .setSigningKey(securityConfigurationProperties.getTokenProperties().getSecret())
             .parseClaimsJws(jwtToken)
-            .getBody();
+                .getBody();
 
-        return claims.get("ltpa", String.class);
+        return claims.get(LTPA_CLAIM_NAME, String.class);
     }
 
     public String getToken(HttpServletRequest request) {
@@ -99,8 +100,8 @@ public class TokenService {
     }
 
     private String extractTokenFromAuthoritationHeader(String header) {
-        if (header != null && header.startsWith(BEARER_HEADER)) {
-            return header.replaceFirst(BEARER_HEADER, "");
+        if (header != null && header.startsWith(BEARER_TYPE_PREFIX)) {
+            return header.replaceFirst(BEARER_TYPE_PREFIX, "");
         }
 
         return null;

--- a/security-module/src/main/java/com/ca/mfaas/security/token/TokenService.java
+++ b/security-module/src/main/java/com/ca/mfaas/security/token/TokenService.java
@@ -95,10 +95,10 @@ public class TokenService {
             }
         }
 
-        return extractToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+        return extractTokenFromAuthoritationHeader(request.getHeader(HttpHeaders.AUTHORIZATION));
     }
 
-    private String extractToken(String header) {
+    private String extractTokenFromAuthoritationHeader(String header) {
         if (header != null && header.startsWith(BEARER_HEADER)) {
             return header.replaceFirst(BEARER_HEADER, "");
         }

--- a/security-module/src/test/java/com/ca/mfaas/security/token/TokenServiceTest.java
+++ b/security-module/src/test/java/com/ca/mfaas/security/token/TokenServiceTest.java
@@ -17,8 +17,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import javax.servlet.http.Cookie;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 
@@ -129,4 +133,29 @@ public class TokenServiceTest {
         tokenService.validateToken(authentication);
     }
 
+    @Test
+    public void getTokenReturnsTokenInCookie() {
+        TokenService tokenService = new TokenService(securityConfigurationProperties);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("apimlAuthenticationToken", "token"));
+
+        assertEquals("token", tokenService.getToken(request));
+    }
+
+    @Test
+    public void getTokenReturnsTokenInAuthorizationHeader() {
+        TokenService tokenService = new TokenService(securityConfigurationProperties);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer token");
+
+        assertEquals("token", tokenService.getToken(request));        
+    }
+
+    @Test
+    public void getTokenReturnsNullIfTokenIsMissing() {
+        TokenService tokenService = new TokenService(securityConfigurationProperties);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertEquals(null, tokenService.getToken(request));
+    }    
 }

--- a/security-module/src/test/java/com/ca/mfaas/security/token/TokenServiceTest.java
+++ b/security-module/src/test/java/com/ca/mfaas/security/token/TokenServiceTest.java
@@ -161,11 +161,20 @@ public class TokenServiceTest {
     }
 
     @Test
-    public void getLtpaToken() {
+    public void getLtpaTokenReturnsTokenFromJwt() {
         TokenService tokenService = new TokenService(securityConfigurationProperties);
         String jwtToken = Jwts.builder().claim(LTPA_CLAIM_NAME, TEST_TOKEN)
                 .signWith(SignatureAlgorithm.HS512, securityConfigurationProperties.getTokenProperties().getSecret())
                 .compact();
         assertEquals(TEST_TOKEN, tokenService.getLtpaToken(jwtToken));
+    }
+
+    @Test
+    public void getLtpaTokenReturnsNullIfLtpaIsMissing() {
+        TokenService tokenService = new TokenService(securityConfigurationProperties);
+        String jwtToken = Jwts.builder().claim("dom", "test")
+                .signWith(SignatureAlgorithm.HS512, securityConfigurationProperties.getTokenProperties().getSecret())
+                .compact();
+        assertEquals(null, tokenService.getLtpaToken(jwtToken));
     }
 }


### PR DESCRIPTION
Add z/OSMF filter to change JWT token to LTPA

Status:
* working
* **tests are in progress**

Try out:
* Obtain JWT token:

		http -v -j --verify=False POST https://localhost:10010/api/v1/gateway/auth/login username=<userid> password=<password>

* Set variable:
		
		set token=<jwt_token>
		
		# Mac: 
		export token=<jwt_token>

* Access zOSMF - bearer:

		http https://localhost:10010/api/zosmfca32/zosmf/restfiles/ds?dslevel=mfaas.* "Authorization:Bearer %token%" "X-CSRF-ZOSMF-HEADER;" --verify=no

* Access zOSMF - cookie:

		http -v https://localhost:10010/api/zosmfca32/zosmf/restfiles/ds?dslevel=mfaas.* "Cookie:apimlAuthenticationToken=%token%" "X-CSRF-ZOSMF-HEADER;" --verify=no