### PR TITLE
Fix API doc translation

### DIFF
--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/filters/post/TransformApiDocEndpointsFilter.java
@@ -24,6 +24,7 @@ import io.swagger.models.Swagger;
 import io.swagger.util.Json;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 import javax.validation.UnexpectedTypeException;
@@ -224,7 +225,7 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
                 log.trace("Base Path: " + swagger.getBasePath());
 
                 // Retrieve route which matches endpoint
-                String endPoint = swagger.getBasePath() + originalEndpoint;
+                String endPoint = swagger.getBasePath().equals(SEPARATOR) ? originalEndpoint : swagger.getBasePath() + originalEndpoint;
                 RoutedService route = getRouteServiceForEndpoint(endPoint, finalServiceId);
 
                 String updatedShortEndPoint = null;
@@ -256,9 +257,9 @@ public class TransformApiDocEndpointsFilter extends ZuulFilter implements Routed
         }
 
         // update scheme and host
-        String scheme = context.getZuulRequestHeaders().get(X_FORWARDED_PROTO_HEADER.toLowerCase());
+        String scheme = context.getRequest().getScheme();
         swagger.setSchemes(Collections.singletonList(Scheme.forValue(scheme)));
-        swagger.setHost(context.getZuulRequestHeaders().get(X_FORWARDED_HOST_HEADER.toLowerCase()));
+        swagger.setHost(context.getRequest().getHeader(HttpHeaders.HOST.toLowerCase()));
 
         // Convert to JSON and set content body
         try {

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -58,6 +58,7 @@ server:
 
 zuul:
     sslHostnameValidationEnabled: false
+    addProxyHeaders: false
     traceRequestBody: true
     ignoreSecurityHeaders: false
     includeDebugHeader: false

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ApiDocController.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/ApiDocController.java
@@ -241,8 +241,236 @@ public class ApiDocController {
         "  }\n" +
         "}";
 
+    public static String apiDocResultWithNoContextPath = "{\n" +
+        "  \"swagger\": \"2.0\",\n" +
+        "  \"info\": {\n" +
+        "    \"version\": \"1.0.0\",\n" +
+        "    \"title\": \"Swagger Petstore\",\n" +
+        "    \"description\": \"A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification\",\n" +
+        "    \"termsOfService\": \"http://swagger.io/terms/\",\n" +
+        "    \"contact\": {\n" +
+        "      \"name\": \"Swagger API Team\"\n" +
+        "    },\n" +
+        "    \"license\": {\n" +
+        "      \"name\": \"MIT\"\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"host\": \"petstore.swagger.io\",\n" +
+        "  \"basePath\": \"/\",\n" +
+        "  \"schemes\": [\n" +
+        "    \"http\"\n" +
+        "  ],\n" +
+        "  \"consumes\": [\n" +
+        "    \"application/json\"\n" +
+        "  ],\n" +
+        "  \"produces\": [\n" +
+        "    \"application/json\"\n" +
+        "  ],\n" +
+        "  \"paths\": {\n" +
+        "    \"/v1/pets\": {\n" +
+        "      \"get\": {\n" +
+        "        \"description\": \"Returns all pets from the system that the user has access to\",\n" +
+        "        \"operationId\": \"findPets\",\n" +
+        "        \"produces\": [\n" +
+        "          \"application/json\",\n" +
+        "          \"application/xml\",\n" +
+        "          \"text/xml\",\n" +
+        "          \"text/html\"\n" +
+        "        ],\n" +
+        "        \"parameters\": [\n" +
+        "          {\n" +
+        "            \"name\": \"tags\",\n" +
+        "            \"in\": \"query\",\n" +
+        "            \"description\": \"tags to filter by\",\n" +
+        "            \"required\": false,\n" +
+        "            \"type\": \"array\",\n" +
+        "            \"items\": {\n" +
+        "              \"type\": \"string\"\n" +
+        "            },\n" +
+        "            \"collectionFormat\": \"csv\"\n" +
+        "          },\n" +
+        "          {\n" +
+        "            \"name\": \"limit\",\n" +
+        "            \"in\": \"query\",\n" +
+        "            \"description\": \"maximum number of results to return\",\n" +
+        "            \"required\": false,\n" +
+        "            \"type\": \"integer\",\n" +
+        "            \"format\": \"int32\"\n" +
+        "          }\n" +
+        "        ],\n" +
+        "        \"responses\": {\n" +
+        "          \"200\": {\n" +
+        "            \"description\": \"pet response\",\n" +
+        "            \"schema\": {\n" +
+        "              \"type\": \"array\",\n" +
+        "              \"items\": {\n" +
+        "                \"$ref\": \"#/definitions/Pet\"\n" +
+        "              }\n" +
+        "            }\n" +
+        "          },\n" +
+        "          \"default\": {\n" +
+        "            \"description\": \"unexpected error\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/ErrorModel\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      },\n" +
+        "      \"post\": {\n" +
+        "        \"description\": \"Creates a new pet in the store.  Duplicates are allowed\",\n" +
+        "        \"operationId\": \"addPet\",\n" +
+        "        \"produces\": [\n" +
+        "          \"application/json\"\n" +
+        "        ],\n" +
+        "        \"parameters\": [\n" +
+        "          {\n" +
+        "            \"name\": \"pet\",\n" +
+        "            \"in\": \"body\",\n" +
+        "            \"description\": \"Pet to add to the store\",\n" +
+        "            \"required\": true,\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/NewPet\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        ],\n" +
+        "        \"responses\": {\n" +
+        "          \"200\": {\n" +
+        "            \"description\": \"pet response\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/Pet\"\n" +
+        "            }\n" +
+        "          },\n" +
+        "          \"default\": {\n" +
+        "            \"description\": \"unexpected error\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/ErrorModel\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      }\n" +
+        "    },\n" +
+        "    \"/v2/pets/{id}\": {\n" +
+        "      \"get\": {\n" +
+        "        \"description\": \"Returns a user based on a single ID, if the user does not have access to the pet\",\n" +
+        "        \"operationId\": \"findPetById\",\n" +
+        "        \"produces\": [\n" +
+        "          \"application/json\",\n" +
+        "          \"application/xml\",\n" +
+        "          \"text/xml\",\n" +
+        "          \"text/html\"\n" +
+        "        ],\n" +
+        "        \"parameters\": [\n" +
+        "          {\n" +
+        "            \"name\": \"id\",\n" +
+        "            \"in\": \"path\",\n" +
+        "            \"description\": \"ID of pet to fetch\",\n" +
+        "            \"required\": true,\n" +
+        "            \"type\": \"integer\",\n" +
+        "            \"format\": \"int64\"\n" +
+        "          }\n" +
+        "        ],\n" +
+        "        \"responses\": {\n" +
+        "          \"200\": {\n" +
+        "            \"description\": \"pet response\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/Pet\"\n" +
+        "            }\n" +
+        "          },\n" +
+        "          \"default\": {\n" +
+        "            \"description\": \"unexpected error\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/ErrorModel\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      },\n" +
+        "      \"delete\": {\n" +
+        "        \"description\": \"deletes a single pet based on the ID supplied\",\n" +
+        "        \"operationId\": \"deletePet\",\n" +
+        "        \"parameters\": [\n" +
+        "          {\n" +
+        "            \"name\": \"id\",\n" +
+        "            \"in\": \"path\",\n" +
+        "            \"description\": \"ID of pet to delete\",\n" +
+        "            \"required\": true,\n" +
+        "            \"type\": \"integer\",\n" +
+        "            \"format\": \"int64\"\n" +
+        "          }\n" +
+        "        ],\n" +
+        "        \"responses\": {\n" +
+        "          \"204\": {\n" +
+        "            \"description\": \"pet deleted\"\n" +
+        "          },\n" +
+        "          \"default\": {\n" +
+        "            \"description\": \"unexpected error\",\n" +
+        "            \"schema\": {\n" +
+        "              \"$ref\": \"#/definitions/ErrorModel\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      }\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"definitions\": {\n" +
+        "    \"Pet\": {\n" +
+        "      \"type\": \"object\",\n" +
+        "      \"allOf\": [\n" +
+        "        {\n" +
+        "          \"$ref\": \"#/definitions/NewPet\"\n" +
+        "        },\n" +
+        "        {\n" +
+        "          \"required\": [\n" +
+        "            \"id\"\n" +
+        "          ],\n" +
+        "          \"properties\": {\n" +
+        "            \"id\": {\n" +
+        "              \"type\": \"integer\",\n" +
+        "              \"format\": \"int64\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      ]\n" +
+        "    },\n" +
+        "    \"NewPet\": {\n" +
+        "      \"type\": \"object\",\n" +
+        "      \"required\": [\n" +
+        "        \"name\"\n" +
+        "      ],\n" +
+        "      \"properties\": {\n" +
+        "        \"name\": {\n" +
+        "          \"type\": \"string\"\n" +
+        "        },\n" +
+        "        \"tag\": {\n" +
+        "          \"type\": \"string\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    },\n" +
+        "    \"ErrorModel\": {\n" +
+        "      \"type\": \"object\",\n" +
+        "      \"required\": [\n" +
+        "        \"code\",\n" +
+        "        \"message\"\n" +
+        "      ],\n" +
+        "      \"properties\": {\n" +
+        "        \"code\": {\n" +
+        "          \"type\": \"integer\",\n" +
+        "          \"format\": \"int32\"\n" +
+        "        },\n" +
+        "        \"message\": {\n" +
+        "          \"type\": \"string\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    }\n" +
+        "  }\n" +
+        "}";
+
     @GetMapping(value = "/api-doc", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getApiDoc(@RequestParam(value = "group", required = false) String apiDocGroup) throws JsonProcessingException {
         return apiDocResult;
+    }
+
+    @GetMapping(value = "/no-context-path/api-doc", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getApiDocWithoutContextPath(@RequestParam(value = "group", required = false) String apiDocGroup) throws JsonProcessingException {
+        return apiDocResultWithNoContextPath;
     }
 }

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
@@ -76,6 +76,7 @@ public class PostFilterApiDocTransformTest {
             statusCode(200).
             body("swagger", equalTo("2.0"));
     }
+
     @Test
     public void whenPostFilterApplied_thenSwaggerVersionModified_oneGWUrl() throws IOException {
         final RequestContext ctx = RequestContext.getCurrentContext();

--- a/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
+++ b/gateway-service/src/test/java/com/ca/mfaas/gateway/filters/post/PostFilterApiDocTransformTest.java
@@ -18,6 +18,7 @@ import io.swagger.util.Json;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.validation.UnexpectedTypeException;
@@ -53,8 +54,10 @@ public class PostFilterApiDocTransformTest {
         ctx.set(SERVICE_ID_KEY, SERVICE_ID);
         ctx.setResponseBody(ApiDocController.apiDocResult);
         ctx.setResponseDataStream(IOUtils.toInputStream(ApiDocController.apiDocResult));
+        MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         response.setStatus(200);
+        ctx.setRequest(request);
         ctx.setResponse(response);
         RoutedServices routedServices = new RoutedServices();
         routedServices.addRoutedService(
@@ -73,7 +76,6 @@ public class PostFilterApiDocTransformTest {
             statusCode(200).
             body("swagger", equalTo("2.0"));
     }
-
     @Test
     public void whenPostFilterApplied_thenSwaggerVersionModified_oneGWUrl() throws IOException {
         final RequestContext ctx = RequestContext.getCurrentContext();
@@ -87,7 +89,30 @@ public class PostFilterApiDocTransformTest {
         Swagger swagger = Json.mapper().readValue(body, Swagger.class);
         assertEquals("Base path for only one Gateway Url is not correct.", BASE_PATH, swagger.getBasePath());
         swagger.getPaths().forEach((endPoint, path) -> {
-            assertTrue(endPoint + " does not contains 'pets'.", endPoint.contains(ENDPOINT));
+            assertTrue(endPoint + " does not equal '/pets'", endPoint.equals("/" + ENDPOINT));
+            assertFalse(endPoint + " contains base path '" + BASE_PATH + "'.", endPoint.contains(SERVICE_ID));
+        });
+    }
+
+    @Test
+    public void whenPostFilterApplied_thenSwaggerVersionModified_oneGWUrl_noContextPath() throws IOException {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ctx.setResponseBody(ApiDocController.apiDocResultWithNoContextPath);
+        response.setStatus(200);
+        ctx.setResponse(response);
+        assertTrue(this.filter.shouldFilter());
+        RoutedServices routedServices = new RoutedServices();
+        routedServices.addRoutedService(
+            new RoutedService("noContextPath", "api/v1", "/v1"));
+        this.filter.addRoutedServices(SERVICE_ID, routedServices);
+        this.filter.run();
+        String body = ctx.getResponseBody();
+        assertEquals(apiDocEndpoint, ctx.get(REQUEST_URI_KEY));
+        Swagger swagger = Json.mapper().readValue(body, Swagger.class);
+        assertEquals("Base path for only one Gateway Url is not correct.", BASE_PATH, swagger.getBasePath());
+        swagger.getPaths().forEach((endPoint, path) -> {
+            assertTrue(endPoint + " does not equal '/pets'.", endPoint.equals("/" + ENDPOINT));
             assertFalse(endPoint + " contains base path '" + BASE_PATH + "'.", endPoint.contains(SERVICE_ID));
         });
     }


### PR DESCRIPTION
Resolves bug when some services had incorrect api-doc. Difficult to recreate. 

Note: These services was using GW headers to populates some fields in swagger. These fields were not populated correctly.