### PR TITLE
Fix instance creation defect in DS

### DIFF
--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessor.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessor.java
@@ -141,9 +141,9 @@ public class ServiceDefinitionProcessor {
                     try {
                         URL url = new URL(instanceBaseUrl);
                         if (url.getHost().isEmpty()) {
-                            errors.add(String.format("The URL %s does not contain a hostname. The instance will not be created", instanceBaseUrl));
+                            errors.add(String.format("The URL %s does not contain a hostname. The instance of %s will not be created", instanceBaseUrl, service.getServiceId()));
                         } else if (url.getPort() == -1) {
-                            errors.add(String.format("The URL %s does not contain a port number. The instance will not be created", instanceBaseUrl));
+                            errors.add(String.format("The URL %s does not contain a port number. The instance of %s will not be created", instanceBaseUrl, service.getServiceId()));
                         } else {
                             InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder();
                             String instanceId = String.format("%s%s:%s:%s", STATIC_INSTANCE_ID_PREFIX, url.getHost(), serviceId, url.getPort());

--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessor.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessor.java
@@ -19,7 +19,6 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import javax.validation.constraints.Null;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -200,5 +200,27 @@ public class ServiceDefinitionProcessorTest {
         assertEquals(1, instances.size());
         assertEquals(6, result.getInstances().get(0).getMetadata().size());
     }
+
+    @Test
+    public void testCreateInstancesWithUndefinedInstanceBaseUrl() {
+        ServiceDefinitionProcessor serviceDefinitionProcessor = new ServiceDefinitionProcessor();
+        String yaml =
+            "services:\n" +
+                "    - serviceId: casamplerestapiservice\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "catalogUiTiles:\n" +
+                "    tileid:\n" +
+                "        title: Tile Title\n" +
+                "        description: Tile Description\n";
+        ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
+            Collections.singletonList(yaml));
+        List<InstanceInfo> instances = result.getInstances();
+        System.out.println("testProcessServicesDataWithWrongUrlMissingPort - result.getErrors():" + result.getErrors());
+        assertThat(instances.size(), is(0));
+        assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice is not defined. The instance will not be created: null"));
+    }
 }
 

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -256,6 +257,57 @@ public class ServiceDefinitionProcessorTest {
         System.out.println("testCreateInstancesWithMultipleStaticDefinitions - result.getErrors():" + result.getErrors());
         assertThat(instances.size(), is(2));
         assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice2 is not defined. The instance will not be created: null"));
+
+    }
+
+    @Test
+    public void testCreateInstancesWithMultipleYmls() {
+        ServiceDefinitionProcessor serviceDefinitionProcessor = new ServiceDefinitionProcessor();
+        String yaml =
+            "services:\n" +
+                "    - serviceId: casamplerestapiservice\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "       - https://localhost:10012/casamplerestapiservice\n" +
+                "catalogUiTiles:\n" +
+                "    tileid:\n" +
+                "        title: Tile Title\n" +
+                "        description: Tile Description\n";
+        String yaml2 =
+            "services:\n" +
+                "    - serviceId: casamplerestapiservice2\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "       - \n" +
+                "catalogUiTiles:\n" +
+                "    tileid:\n" +
+                "        title: Tile Title\n" +
+                "        description: Tile Description\n";
+        String yaml3 =
+            "services:\n" +
+                "    - serviceId: casamplerestapiservice3\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "       - https://localhost:10012/casamplerestapiservice3\n" +
+                "catalogUiTiles:\n" +
+                "    tileid:\n" +
+                "        title: Tile Title\n" +
+                "        description: Tile Description\n";
+
+
+        List<String> yamlList = Arrays.asList(yaml, yaml2, yaml3);
+
+        ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
+            yamlList);
+        List<InstanceInfo> instances = result.getInstances();
+        System.out.println("testCreateInstancesWithMultipleYmls - result.getErrors():" + result.getErrors());
+        assertThat(instances.size(), is(2));
 
     }
 }

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -218,9 +218,45 @@ public class ServiceDefinitionProcessorTest {
         ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
             Collections.singletonList(yaml));
         List<InstanceInfo> instances = result.getInstances();
-        System.out.println("testProcessServicesDataWithWrongUrlMissingPort - result.getErrors():" + result.getErrors());
+        System.out.println("testCreateInstancesWithUndefinedInstanceBaseUrl - result.getErrors():" + result.getErrors());
         assertThat(instances.size(), is(0));
         assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice is not defined. The instance will not be created: null"));
+    }
+
+    @Test
+    public void TestCreateInstancesWithMultipleStaticDefinitions() {
+        ServiceDefinitionProcessor serviceDefinitionProcessor = new ServiceDefinitionProcessor();
+        String yaml =
+            "services:\n" +
+                "    - serviceId: casamplerestapiservice\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "       - https://localhost:10012/casamplerestapiservice2\n" +
+                "    - serviceId: casamplerestapiservice2\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "    - serviceId: casamplerestapiservice3\n" +
+                "      title: Title\n" +
+                "      description: Description\n" +
+                "      catalogUiTileId: tileid\n" +
+                "      instanceBaseUrls:\n" +
+                "       - https://localhost:10012/casamplerestapiservice3\n" +
+                "catalogUiTiles:\n" +
+                "    tileid:\n" +
+                "        title: Tile Title\n" +
+                "        description: Tile Description\n";
+
+        ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
+            Collections.singletonList(yaml));
+        List<InstanceInfo> instances = result.getInstances();
+        System.out.println("TestCreateInstancesWithMultipleStaticDefinitions - result.getErrors():" + result.getErrors());
+        assertThat(instances.size(), is(2));
+        assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice2 is not defined. The instance will not be created: null"));
+
     }
 }
 

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -282,7 +282,7 @@ public class ServiceDefinitionProcessorTest {
                 "      description: Description\n" +
                 "      catalogUiTileId: tileid\n" +
                 "      instanceBaseUrls:\n" +
-                "       - \n" +
+                "        \n" +
                 "catalogUiTiles:\n" +
                 "    tileid:\n" +
                 "        title: Tile Title\n" +
@@ -302,12 +302,13 @@ public class ServiceDefinitionProcessorTest {
 
 
         List<String> yamlList = Arrays.asList(yaml, yaml2, yaml3);
-
-        ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
+        List<String> yamlNameList = Arrays.asList("yaml", "yaml1", "yaml2");
+        ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(yamlNameList,
             yamlList);
         List<InstanceInfo> instances = result.getInstances();
         System.out.println("testCreateInstancesWithMultipleYmls - result.getErrors():" + result.getErrors());
         assertThat(instances.size(), is(2));
+        assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice2 is not defined. The instance will not be created: null"));
 
     }
 }

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -158,7 +158,7 @@ public class ServiceDefinitionProcessorTest {
         System.out.println("testProcessServicesDataWithWrongUrlMissingHostname - result.getErrors():" + result.getErrors());
         assertEquals(0, instances.size());
         assertEquals(1, result.getErrors().size());
-        assertTrue(result.getErrors().get(0).contains("The URL https:///casamplerestapiservice/ does not contain a hostname"));
+        assertTrue(result.getErrors().get(0).contains("The URL https:///casamplerestapiservice/ does not contain a hostname. The instance of casamplerestapiservice will not be created"));
     }
 
     @Test
@@ -174,7 +174,7 @@ public class ServiceDefinitionProcessorTest {
         System.out.println("testProcessServicesDataWithWrongUrlMissingPort - result.getErrors():" + result.getErrors());
         assertEquals(0, instances.size());
         assertEquals(1, result.getErrors().size());
-        assertTrue(result.getErrors().get(0).contains("The URL https://host/casamplerestapiservice/ does not contain a port number"));
+        assertTrue(result.getErrors().get(0).contains("The URL https://host/casamplerestapiservice/ does not contain a port number. The instance of casamplerestapiservice will not be created"));
     }
 
     @Test

--- a/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
+++ b/discovery-service/src/test/java/com/ca/mfaas/discovery/staticdef/ServiceDefinitionProcessorTest.java
@@ -224,7 +224,7 @@ public class ServiceDefinitionProcessorTest {
     }
 
     @Test
-    public void TestCreateInstancesWithMultipleStaticDefinitions() {
+    public void testCreateInstancesWithMultipleStaticDefinitions() {
         ServiceDefinitionProcessor serviceDefinitionProcessor = new ServiceDefinitionProcessor();
         String yaml =
             "services:\n" +
@@ -253,7 +253,7 @@ public class ServiceDefinitionProcessorTest {
         ServiceDefinitionProcessor.ProcessServicesDataResult result = serviceDefinitionProcessor.processServicesData(Collections.singletonList("test"),
             Collections.singletonList(yaml));
         List<InstanceInfo> instances = result.getInstances();
-        System.out.println("TestCreateInstancesWithMultipleStaticDefinitions - result.getErrors():" + result.getErrors());
+        System.out.println("testCreateInstancesWithMultipleStaticDefinitions - result.getErrors():" + result.getErrors());
         assertThat(instances.size(), is(2));
         assertTrue(result.getErrors().get(0).contains("The instanceBaseUrl of casamplerestapiservice2 is not defined. The instance will not be created: null"));
 


### PR DESCRIPTION
Related to this defect [https://rally1.rallydev.com/#/72725828452d/detail/defect/281247246244](https://rally1.rallydev.com/#/72725828452d/detail/defect/281247246244)
The defect was preventing zosmfca32 instance to be created and this was causing the authentication failure
Signed-off-by: Andrea Tabone <andrea.tabone@ca.com>