### PR TITLE
Do not restore loadingReducer state after page reload

### DIFF
--- a/api-catalog-ui/frontend/.gitignore
+++ b/api-catalog-ui/frontend/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 debug.log
 /report
+test-results/
+

--- a/api-catalog-ui/frontend/src/components/Login/Login.jsx
+++ b/api-catalog-ui/frontend/src/components/Login/Login.jsx
@@ -40,19 +40,19 @@ export default class Login extends React.Component {
         ) {
             switch (error.messageNumber) {
                 case 'SEC0001':
-                    messageText = `Authentication is required. (${error.messageNumber})`;
+                    messageText = `Authentication is required (${error.messageNumber})`;
                     break;
                 case 'SEC0004':
-                    messageText = `Session has expired, please login again. (${error.messageNumber})`;
+                    messageText = `Session has expired, please login again (${error.messageNumber})`;
                     break;
                 case 'SEC0005':
-                    messageText = `Username or password is invalid. (${error.messageNumber})`;
+                    messageText = `Username or password is invalid (${error.messageNumber})`;
                     break;
                 case 'MFS0104':
-                    messageText = `The request is taking too long. Please try again later. (${error.messageNumber})`;
+                    messageText = `The request is taking too long, please try again later (${error.messageNumber})`;
                     break;
                 default:
-                    messageText = `Authentication Error: ${error.messageNumber}. Try to log in again.`;
+                    messageText = `Unexpected Error: ${error.messageNumber}, plase try to log in again later`;
                     break;
             }
         }

--- a/api-catalog-ui/frontend/src/components/Login/Login.jsx
+++ b/api-catalog-ui/frontend/src/components/Login/Login.jsx
@@ -40,13 +40,16 @@ export default class Login extends React.Component {
         ) {
             switch (error.messageNumber) {
                 case 'SEC0001':
-                    messageText = 'Authentication is required.';
+                    messageText = `Authentication is required. (${error.messageNumber})`;
                     break;
                 case 'SEC0004':
-                    messageText = 'Session has expired, please login again.';
+                    messageText = `Session has expired, please login again. (${error.messageNumber})`;
                     break;
                 case 'SEC0005':
-                    messageText = 'Username or password is invalid.';
+                    messageText = `Username or password is invalid. (${error.messageNumber})`;
+                    break;
+                case 'MFS0104':
+                    messageText = `The request is taking too long. Please try again later. (${error.messageNumber})`;
                     break;
                 default:
                     messageText = `Authentication Error: ${error.messageNumber}. Try to log in again.`;

--- a/api-catalog-ui/frontend/src/components/Login/Login.jsx
+++ b/api-catalog-ui/frontend/src/components/Login/Login.jsx
@@ -49,10 +49,10 @@ export default class Login extends React.Component {
                     messageText = `Username or password is invalid (${error.messageNumber})`;
                     break;
                 case 'MFS0104':
-                    messageText = `The request is taking too long, please try again later (${error.messageNumber})`;
+                    messageText = `Request timeout, please try again later (${error.messageNumber})`;
                     break;
                 default:
-                    messageText = `Unexpected Error: ${error.messageNumber}, plase try to log in again later`;
+                    messageText = `Unexpected error, please try again later (${error.messageNumber})`;
                     break;
             }
         }

--- a/api-catalog-ui/frontend/src/components/Login/Login.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Login/Login.test.jsx
@@ -112,7 +112,7 @@ describe('>>> Login page component tests', () => {
                 "Authentication problem: 'Username or password are invalid.' for URL '/apicatalog/auth/login'",
             messageKey: 'com.ca.mfaas.security.otherError',
         });
-        expect(messageText).toEqual('Unexpected Error: SEC00099, plase try to log in again later');
+        expect(messageText).toContain(`SEC00099`);
     });
 
     it('should disable button and show spinner when request is being resolved', () => {

--- a/api-catalog-ui/frontend/src/components/Login/Login.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Login/Login.test.jsx
@@ -73,7 +73,7 @@ describe('>>> Login page component tests', () => {
                 "Authentication problem: 'Username or password are invalid.' for URL '/apicatalog/auth/login'",
             messageKey: 'com.ca.mfaas.security.invalidUsername',
         });
-        expect(messageText).toEqual('Username or password is invalid.');
+        expect(messageText).toEqual('Username or password is invalid (SEC0005)');
     });
 
     it('should display authetication required', () => {
@@ -86,7 +86,7 @@ describe('>>> Login page component tests', () => {
                 "Authentication problem: 'Username or password are invalid.' for URL '/apicatalog/auth/login'",
             messageKey: 'com.ca.mfaas.security.authenticationRequired',
         });
-        expect(messageText).toEqual('Authentication is required.');
+        expect(messageText).toEqual('Authentication is required (SEC0001)');
     });
 
     it('should display session has expired', () => {
@@ -99,7 +99,7 @@ describe('>>> Login page component tests', () => {
                 "Authentication problem: 'Username or password are invalid.' for URL '/apicatalog/auth/login'",
             messageKey: 'com.ca.mfaas.security.sessionExpired',
         });
-        expect(messageText).toEqual('Session has expired, please login again.');
+        expect(messageText).toEqual('Session has expired, please login again (SEC0004)');
     });
 
     it('should display server generated failure message', () => {
@@ -112,7 +112,7 @@ describe('>>> Login page component tests', () => {
                 "Authentication problem: 'Username or password are invalid.' for URL '/apicatalog/auth/login'",
             messageKey: 'com.ca.mfaas.security.otherError',
         });
-        expect(messageText).toEqual(`Authentication Error: SEC00099. Try to log in again.`);
+        expect(messageText).toEqual('Unexpected Error: SEC00099, plase try to log in again later');
     });
 
     it('should disable button and show spinner when request is being resolved', () => {

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -3,14 +3,16 @@ import SwaggerUi, { presets } from 'swagger-ui';
 import './Swagger.css';
 
 export default class SwaggerUI extends Component {
-
     componentDidMount() {
         this.retrieveSwagger();
     }
 
     componentDidUpdate(prevProps) {
         const { selectedService } = this.props;
-        if (selectedService.serviceId !== prevProps.selectedService.serviceId || selectedService.tileId !== prevProps.selectedService.tileId) {
+        if (
+            selectedService.serviceId !== prevProps.selectedService.serviceId ||
+            selectedService.tileId !== prevProps.selectedService.tileId
+        ) {
             this.retrieveSwagger();
         }
     }
@@ -36,7 +38,11 @@ export default class SwaggerUI extends Component {
     retrieveSwagger = () => {
         const { selectedService } = this.props;
 
-        if (selectedService.apiDoc !== null && selectedService.apiDoc !== undefined && selectedService.apiDoc.length !== 0) {
+        if (
+            selectedService.apiDoc !== null &&
+            selectedService.apiDoc !== undefined &&
+            selectedService.apiDoc.length !== 0
+        ) {
             try {
                 const swagger = JSON.parse(selectedService.apiDoc);
                 SwaggerUi({
@@ -54,22 +60,21 @@ export default class SwaggerUI extends Component {
     render() {
         const { selectedService } = this.props;
         let error = false;
-        if (selectedService.apiDoc === undefined || selectedService.apiDoc === null || selectedService.apiDoc.length === 0) {
+        if (
+            selectedService.apiDoc === undefined ||
+            selectedService.apiDoc === null ||
+            selectedService.apiDoc.length === 0
+        ) {
             error = true;
         }
         return (
             <div style={{ width: '100%', background: '#ffffff' }}>
                 {error && (
-                    <div style={{ width: '100%', background: '#ffffff', paddingLeft: 50, paddingTop: 30 }}>
-                        <h2 style={{ color: '#de1b1b' }}>Api Documentation for
-                            service "{selectedService.title}" (Service Id: {selectedService.serviceId}) could not be retrieved or is
-                            not defined.</h2>
-                        <h5 style={{ color: '#de1b1b' }}>See console for details</h5>
+                    <div style={{ width: '100%', background: '#ffffff', paddingLeft: 55 }}>
+                        <h3 style={{ color: '#de1b1b' }}>API documentation could not be retrieved</h3>
                     </div>
                 )}
-                {!error && (
-                    <div id="swaggerContainer" data-testid="swagger"/>
-                )}
+                {!error && <div id="swaggerContainer" data-testid="swagger" />}
             </div>
         );
     }

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -71,7 +71,7 @@ export default class SwaggerUI extends Component {
             <div style={{ width: '100%', background: '#ffffff' }}>
                 {error && (
                     <div style={{ width: '100%', background: '#ffffff', paddingLeft: 55 }}>
-                        <h3 style={{ color: '#de1b1b' }}>API documentation could not be retrieved</h3>
+                        <h4 style={{ color: '#de1b1b' }}>API documentation could not be retrieved</h4>
                     </div>
                 )}
                 {!error && <div id="swaggerContainer" data-testid="swagger" />}

--- a/api-catalog-ui/frontend/src/index.js
+++ b/api-catalog-ui/frontend/src/index.js
@@ -36,7 +36,7 @@ const authenticationReducerBlacklistFilter = createBlacklistFilter('authenticati
 const persistConfig = {
     key: 'root',
     storage: storageSession,
-    blacklist: ['filtersReducer'],
+    blacklist: ['filtersReducer', 'loadingReducer'],
     transforms: [authenticationReducerBlacklistFilter],
 };
 


### PR DESCRIPTION
**Problem:** If you were to refresh the page while login request still wasn't resolved, the UI would still indicate a loading state and therefor prevent you from trying to sign in again.

**Cause:** Redux state was rehydrated after page refresh which includes the state of the loadingReducer.

**Solution:** Exclude loadingReducer from rehydration.