### PR TITLE
Integration test to check application/routes content

### DIFF
--- a/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.ca.mfaas.gatewayservice;
+
+import com.ca.mfaas.utils.config.ConfigReader;
+import com.ca.mfaas.utils.config.GatewayServiceConfiguration;
+import com.ca.mfaas.utils.http.HttpRequestUtils;
+import io.restassured.RestAssured;
+import lombok.extern.slf4j.Slf4j;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+
+@Slf4j
+public class RoutesIntegrationTest {
+
+    private final static String APPLICATION_ROUTES_ENDPOINT = "/application/routes";
+    private String token;
+    private GatewayServiceConfiguration serviceConfiguration;
+    private String scheme;
+    private String host;
+    private int port;
+    private String basePath;
+    @Before
+    public void setUp() {
+        serviceConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
+        scheme = serviceConfiguration.getScheme();
+        host = serviceConfiguration.getHost();
+        port = serviceConfiguration.getPort();
+        basePath = "/api/v1/gateway";
+
+        RestAssured.port = port;
+        RestAssured.basePath = basePath;
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @Test
+    public void shouldNotContainSuperfluousEndpoints() {
+        URI uri = HttpRequestUtils.getUriFromGateway(APPLICATION_ROUTES_ENDPOINT);
+        Map<String, Object> expected = new HashMap<String, Object>();
+        expected.put("/api/v1/api-doc/gateway/**", "apicatalog");
+        given()
+            .expect()
+                .body("$",  Matchers.hasItem(expected))
+            .when()
+            .get(uri);
+    }
+        // Given
+}

--- a/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package com.ca.mfaas.gatewayservice;
 
 import com.ca.mfaas.utils.http.HttpRequestUtils;

--- a/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/gatewayservice/RoutesIntegrationTest.java
@@ -1,57 +1,31 @@
 package com.ca.mfaas.gatewayservice;
 
-import com.ca.mfaas.utils.config.ConfigReader;
-import com.ca.mfaas.utils.config.GatewayServiceConfiguration;
 import com.ca.mfaas.utils.http.HttpRequestUtils;
-import io.restassured.RestAssured;
 import lombok.extern.slf4j.Slf4j;
-import org.hamcrest.Matchers;
-import org.junit.Before;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
-import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.core.Is.is;
+import static org.apache.http.HttpStatus.SC_OK;
 
 @Slf4j
 public class RoutesIntegrationTest {
 
     private final static String APPLICATION_ROUTES_ENDPOINT = "/application/routes";
-    private String token;
-    private GatewayServiceConfiguration serviceConfiguration;
-    private String scheme;
-    private String host;
-    private int port;
-    private String basePath;
-    @Before
-    public void setUp() {
-        serviceConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
-        scheme = serviceConfiguration.getScheme();
-        host = serviceConfiguration.getHost();
-        port = serviceConfiguration.getPort();
-        basePath = "/api/v1/gateway";
-
-        RestAssured.port = port;
-        RestAssured.basePath = basePath;
-        RestAssured.useRelaxedHTTPSValidation();
-    }
 
     @Test
-    public void shouldNotContainSuperfluousEndpoints() {
-        URI uri = HttpRequestUtils.getUriFromGateway(APPLICATION_ROUTES_ENDPOINT);
-        Map<String, Object> expected = new HashMap<String, Object>();
-        expected.put("/api/v1/api-doc/gateway/**", "apicatalog");
-        given()
-            .expect()
-                .body("$",  Matchers.hasItem(expected))
-            .when()
-            .get(uri);
+    public void shouldNotContainSuperfluousEndpoints()  throws Exception{
+        final HttpResponse response = HttpRequestUtils.getResponse(APPLICATION_ROUTES_ENDPOINT, SC_OK);
+        final String jsonResponse = EntityUtils.toString(response.getEntity());
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/app/"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/gateway/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/staticclient/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/zosmfca32/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/apicatalog/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/discoverableclient/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/cadbmds01/**"));
+        Assert.assertEquals(false, jsonResponse.toLowerCase().contains("\"/discovery/**"));
     }
-        // Given
 }


### PR DESCRIPTION
This PR is related to [https://rally1.rallydev.com/#/72725828452d/detail/userstory/278438244612](https://rally1.rallydev.com/#/72725828452d/detail/userstory/278438244612). The defect was already fixed in the past. The purpose of the PR is to have now an integration test to check that superfluous endpoints like `/gateway/**: "gateway` or `/app/helloworld/**: "helloworld"` are not present in the `/application/routes`.