### PR TITLE
Missing step to get the gradle wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Following tools are required to build and develop API Mediation Layer:
   
 
 ## Quick start
+Bootstrap gradle to get wrapper:
+
+    UNIX
+    ./bootstrap_gradlew.sh
+    
+    Windows
+    ./bootstrap_gradlew.bat
 
 Build all modules:
 


### PR DESCRIPTION
The gradle wrapper is missing from the project upon cloning. The bootstrap_gradlew script needs to be run before ./gradlew build otherwise the build fails