### PR TITLE
TransformService defects

### DIFF
--- a/gateway-common/src/main/java/com/ca/mfaas/product/routing/RoutedServices.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/routing/RoutedServices.java
@@ -50,7 +50,7 @@ public class RoutedServices {
         int maxSize = 0;
 
         for (String key : routedService.keySet()) {
-            if (type.equals(ServiceType.ALL) || !key.toLowerCase().startsWith(type.name().toLowerCase())) {
+            if (!type.equals(ServiceType.ALL) && !key.toLowerCase().startsWith(type.name().toLowerCase())) {
                 continue;
             }
 

--- a/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
@@ -21,6 +21,8 @@ import java.net.URI;
 @Slf4j
 public class TransformService {
 
+    private static final String SEPARATOR = "/";
+
     private final GatewayConfigProperties gatewayConfigProperties;
 
     public TransformService(GatewayConfigProperties gatewayConfigProperties) {
@@ -50,16 +52,14 @@ public class TransformService {
             throw new URLTransformationException(message);
         }
 
-        String pathToReplace;
 
+        String pathToReplace = serviceUri.getPath();
         if (serviceUri.getQuery() != null) {
-            pathToReplace = serviceUri.getPath() + "?" + serviceUri.getQuery();
+            pathToReplace += "?" + serviceUri.getQuery();
         }
-        else pathToReplace = serviceUri.getPath();
 
-        String path = pathToReplace.replace(route.getServiceUrl(), "");
-
-        if (!path.isEmpty() && !path.startsWith("/")) {
+        String endPoint = getShortEndPoint(route.getServiceUrl(), pathToReplace);
+        if (!endPoint.isEmpty() && !endPoint.startsWith("/")) {
             throw new URLTransformationException("The path " + serviceUri.getPath() + " of the service URL " + serviceUri + " is not valid.");
         }
 
@@ -68,6 +68,22 @@ public class TransformService {
             gatewayConfigProperties.getHostname(),
             route.getGatewayUrl(),
             serviceId,
-            path);
+            endPoint);
+    }
+
+
+    /**
+     * Get short endpoint
+     *
+     * @param routeServiceUrl service url of route
+     * @param endPoint        the endpoint of method
+     * @return short endpoint
+     */
+    private String getShortEndPoint(String routeServiceUrl, String endPoint) {
+        String shortEndPoint = endPoint;
+        if (!routeServiceUrl.equals(SEPARATOR)) {
+            shortEndPoint = shortEndPoint.replaceFirst(routeServiceUrl, "");
+        }
+        return shortEndPoint;
     }
 }

--- a/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
@@ -44,8 +44,12 @@ public class TransformService {
                                String serviceUrl,
                                RoutedServices routes) throws URLTransformationException {
         URI serviceUri = URI.create(serviceUrl);
+        String serviceUriPath = serviceUri.getPath();
+        if (serviceUriPath == null) {
+            throw new URLTransformationException("The URI " + serviceUri.toString() + " is not valid.");
+        }
 
-        RoutedService route = routes.getBestMatchingServiceUrl(serviceUri.getPath(), type);
+        RoutedService route = routes.getBestMatchingServiceUrl(serviceUriPath, type);
         if (route == null) {
             String message = String.format("Not able to select route for url %s of the service %s. Original url used.", serviceUri, serviceId);
             log.warn(message);
@@ -53,12 +57,11 @@ public class TransformService {
         }
 
 
-        String pathToReplace = serviceUri.getPath();
         if (serviceUri.getQuery() != null) {
-            pathToReplace += "?" + serviceUri.getQuery();
+            serviceUriPath += "?" + serviceUri.getQuery();
         }
 
-        String endPoint = getShortEndPoint(route.getServiceUrl(), pathToReplace);
+        String endPoint = getShortEndPoint(route.getServiceUrl(), serviceUriPath);
         if (!endPoint.isEmpty() && !endPoint.startsWith("/")) {
             throw new URLTransformationException("The path " + serviceUri.getPath() + " of the service URL " + serviceUri + " is not valid.");
         }

--- a/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
+++ b/gateway-common/src/main/java/com/ca/mfaas/product/routing/transform/TransformService.java
@@ -50,7 +50,15 @@ public class TransformService {
             throw new URLTransformationException(message);
         }
 
-        String path = serviceUri.getPath().replace(route.getServiceUrl(), "");
+        String pathToReplace;
+
+        if (serviceUri.getQuery() != null) {
+            pathToReplace = serviceUri.getPath() + "?" + serviceUri.getQuery();
+        }
+        else pathToReplace = serviceUri.getPath();
+
+        String path = pathToReplace.replace(route.getServiceUrl(), "");
+
         if (!path.isEmpty() && !path.startsWith("/")) {
             throw new URLTransformationException("The path " + serviceUri.getPath() + " of the service URL " + serviceUri + " is not valid.");
         }

--- a/gateway-common/src/test/java/com/ca/mfaas/product/routing/RoutedServicesTest.java
+++ b/gateway-common/src/test/java/com/ca/mfaas/product/routing/RoutedServicesTest.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 public class RoutedServicesTest {
 
@@ -48,13 +48,29 @@ public class RoutedServicesTest {
 
 
     @Test
-    public void testNotFoundBestMatchingServiceUrl() {
-        RoutedService routedService = routedServices.getBestMatchingServiceUrl("/apicatalo", ServiceType.ALL);
-        assertNull(routedService);
+    public void testBestMatchingServiceUrlByAllServiceTypes() {
+        RoutedService routedService = routedServices.getBestMatchingServiceUrl("/apicatalog", ServiceType.ALL);
+        assertNotNull(routedService);
+
+        assertEquals("api_v1", routedService.getSubServiceId());
+        assertEquals("api/v1", routedService.getGatewayUrl());
+        assertEquals("/apicatalog", routedService.getServiceUrl());
+
+
+        routedServices.addRoutedService(new RoutedService("api_v1", "api/v1", "/apicatalog"));
+        routedServices.addRoutedService(new RoutedService("ui_v1", "ui/v1", "/apicatalog/test"));
+
+
+        routedService = routedServices.getBestMatchingServiceUrl("/apicatalog/test/param1", ServiceType.ALL);
+        assertNotNull(routedService);
+
+        assertEquals("ui_v1", routedService.getSubServiceId());
+        assertEquals("ui/v1", routedService.getGatewayUrl());
+        assertEquals("/apicatalog/test", routedService.getServiceUrl());
     }
 
     @Test
-    public void testBestMatchingServiceUrl() {
+    public void testBestMatchingServiceUrlBySpecificServiceTypes() {
         RoutedService routedService = routedServices.getBestMatchingServiceUrl("/apicatalog", ServiceType.API);
 
         assertEquals("api_v1", routedService.getSubServiceId());
@@ -71,18 +87,9 @@ public class RoutedServicesTest {
         assertEquals("api_v2", routedService.getSubServiceId());
         assertEquals("api/v2", routedService.getGatewayUrl());
         assertEquals("/apicatalog2", routedService.getServiceUrl());
-    }
 
 
-
-    @Test
-    public void testBestMatchingServiceUrlForNotOnlyApi() {
-        RoutedService routedService3 = new RoutedService("api_v2", "api/v2", "/apicatalog");
-        RoutedService routedService4 = new RoutedService("ui_v2", "ui/v2", "/apicatalog2");
-        routedServices.addRoutedService(routedService3);
-        routedServices.addRoutedService(routedService4);
-
-        RoutedService routedService = routedServices.getBestMatchingServiceUrl("/apicatalog2", ServiceType.UI);
+        routedService = routedServices.getBestMatchingServiceUrl("/apicatalog2", ServiceType.UI);
 
         assertEquals("ui_v2", routedService.getSubServiceId());
         assertEquals("ui/v2", routedService.getGatewayUrl());

--- a/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
+++ b/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
@@ -124,6 +124,18 @@ public class TransformServiceTest {
 
 
     @Test
+    public void givenInvalidHomePage_thenThrowException() throws URLTransformationException {
+        String url = "https:localhost:8080/wss";
+
+        TransformService transformService = new TransformService(gatewayConfigProperties);
+
+        exception.expect(URLTransformationException.class);
+        exception.expectMessage("The URI " + url + " is not valid.");
+        transformService.transformURL(null, null, url, null);
+    }
+
+
+    @Test
     public void givenHomePage_whenPathIsNotValid_thenThrowException() throws URLTransformationException {
         String url = "https://localhost:8080/wss";
 

--- a/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
+++ b/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
@@ -161,5 +161,27 @@ public class TransformServiceTest {
         assertEquals(expectedUrl, actualUrl);
     }
 
+    @Test
+    public void givenUrlContainingPathAndQuery_whenTransform_thenKeepQueryPartInTheNewUrl() throws URLTransformationException {
+        String url = "https://locahost:8080/ui/service/login.do?action=secure";
+        String path = "/login.do?action=secure";
+        RoutedServices routedServices = new RoutedServices();
+        RoutedService routedService1 = new RoutedService(SERVICE_ID, UI_PREFIX, "/ui/service");
+        RoutedService routedService2 = new RoutedService(SERVICE_ID, "api/v1", "/");
+        routedServices.addRoutedService(routedService1);
+        routedServices.addRoutedService(routedService2);
+
+        TransformService transformService = new TransformService(gatewayConfigProperties);
+
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+        String expectedUrl = String.format("%s://%s/%s/%s%s",
+            gatewayConfigProperties.getScheme(),
+            gatewayConfigProperties.getHostname(),
+            UI_PREFIX,
+            SERVICE_ID,
+            path);
+        assertEquals(expectedUrl, actualUrl);
+    }
+
 
 }

--- a/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
+++ b/gateway-common/src/test/java/com/ca/mfaas/product/routing/transform/TransformServiceTest.java
@@ -153,11 +153,33 @@ public class TransformServiceTest {
         TransformService transformService = new TransformService(gatewayConfigProperties);
 
         String actualUrl = transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices);
-        String expectedUrl = String.format("%s://%s/%s/%s",
+        String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayConfigProperties.getScheme(),
             gatewayConfigProperties.getHostname(),
             WS_PREFIX,
-            SERVICE_ID);
+            SERVICE_ID,
+            "/");
+        assertEquals(expectedUrl, actualUrl);
+    }
+
+    @Test
+    public void givenServiceUrl_whenItsRoot_thenKeepHomePagePathSame() throws URLTransformationException {
+        String url = "https://locahost:8080/test";
+        RoutedServices routedServices = new RoutedServices();
+        RoutedService routedService1 = new RoutedService(SERVICE_ID, UI_PREFIX, "/");
+        RoutedService routedService2 = new RoutedService(SERVICE_ID, "api/v1", "/");
+        routedServices.addRoutedService(routedService1);
+        routedServices.addRoutedService(routedService2);
+
+        TransformService transformService = new TransformService(gatewayConfigProperties);
+
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+        String expectedUrl = String.format("%s://%s/%s/%s%s",
+            gatewayConfigProperties.getScheme(),
+            gatewayConfigProperties.getHostname(),
+            UI_PREFIX,
+            SERVICE_ID,
+            "/test");
         assertEquals(expectedUrl, actualUrl);
     }
 


### PR DESCRIPTION
This PR cover the defects about TransformService.
1. ServiceType.All was considered as a case when client don't use ServiceType.UI,ServiceType.API or ServiceType.WS.
2. When the URL path was containing also query part (e.g. `service/login.do?action=secure`) the query part was lost during the URL transformation. Now it is kept.
3. When serviceUrl is "/", all slashes were removed from the path. Now the replacing process is skipped when serviceUrl is "/".