### PR TITLE
Service still displayed as UP and API doc available in the catalog even if stopped

### DIFF
--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CacheRefreshService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CacheRefreshService.java
@@ -11,6 +11,7 @@ package com.ca.mfaas.apicatalog.services.cached;
 
 import com.ca.mfaas.apicatalog.model.APIContainer;
 import com.ca.mfaas.apicatalog.services.initialisation.InstanceRetrievalService;
+import com.ca.mfaas.apicatalog.services.status.APIServiceStatusService;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
@@ -43,6 +44,7 @@ public class CacheRefreshService {
     @Autowired
     public CacheRefreshService(CachedProductFamilyService cachedProductFamilyService,
                                CachedServicesService cachedServicesService,
+                               APIServiceStatusService apiServiceStatusService,
                                InstanceRetrievalService instanceRetrievalService) {
         this.cachedProductFamilyService = cachedProductFamilyService;
         this.cachedServicesService = cachedServicesService;
@@ -91,6 +93,7 @@ public class CacheRefreshService {
     private Set<String> compareServices() {
         // Updated containers
         Set<String> containersUpdated = new HashSet<>();
+        Applications cachedServices = cachedServicesService.getAllCachedServices();
         Applications deltaFromDiscovery = instanceRetrievalService.extractDeltaFromDiscovery();
 
         if (deltaFromDiscovery != null && !deltaFromDiscovery.getRegisteredApplications().isEmpty()) {
@@ -98,7 +101,7 @@ public class CacheRefreshService {
             // newer identifier is provided by Netflix
             // if getVersion is removed then the process will be slightly more inefficient but will not need to change
             if (cachedServicesService.getVersionDelta() != deltaFromDiscovery.getVersion()) {
-                containersUpdated = processServiceInstances(deltaFromDiscovery);
+                containersUpdated = processServiceInstances(cachedServices, deltaFromDiscovery);
             }
             cachedServicesService.setVersionDelta(deltaFromDiscovery.getVersion());
         }
@@ -107,16 +110,16 @@ public class CacheRefreshService {
 
     /**
      * Check each delta instance and consider it for processing
-     *
+     * @param cachedServices the collection of cached services
      * @param deltaFromDiscovery changed instances
      */
-    private Set<String> processServiceInstances(Applications deltaFromDiscovery) {
+    private Set<String> processServiceInstances(Applications cachedServices, Applications deltaFromDiscovery) {
         Set<String> containersUpdated = new HashSet<>();
         Set<InstanceInfo> updatedServices = updateDelta(deltaFromDiscovery);
         updatedServices.forEach(instance -> {
             try {
                 // check if this instance should be processed/updated
-                processServiceInstance(containersUpdated, deltaFromDiscovery, instance);
+                processServiceInstance(containersUpdated, cachedServices, deltaFromDiscovery, instance);
             } catch (Exception e) {
                 log.error("could not update cache for service: " + instance + ", processing will continue.", e);
             }
@@ -126,20 +129,26 @@ public class CacheRefreshService {
 
     /**
      * Get this instance service details and check if it should be processed
-     *
-     * @param containersUpdated  which containers were updated
+     * @param containersUpdated which containers were updated
+     * @param cachedServices existing services
      * @param deltaFromDiscovery changed service instances
-     * @param instance           this instance
+     * @param instance this instance
      */
-    private void processServiceInstance(Set<String> containersUpdated,
-                                        Applications deltaFromDiscovery,
-                                        InstanceInfo instance) {
-        deltaFromDiscovery.getRegisteredApplications()
-            .stream()
-            .filter(service -> service.getName().equalsIgnoreCase(instance.getAppName()))
-            .findFirst()
-            .ifPresent(application -> processInstance(containersUpdated, instance, application));
+    private void processServiceInstance(Set<String> containersUpdated, Applications cachedServices,
+                                        Applications deltaFromDiscovery, InstanceInfo instance) {
+        Application application = null;
+        // Get the application which this instance belongs to
+        if (cachedServices != null && cachedServices.getRegisteredApplications() != null) {
+            application = cachedServices.getRegisteredApplications().stream()
+                .filter(service -> service.getName().equalsIgnoreCase(instance.getAppName())).findFirst().orElse(null);
+        }
+        // if its new then it will only be in the delta
+        if (application == null || application.getInstances().isEmpty()) {
+            application = deltaFromDiscovery.getRegisteredApplications().stream()
+                .filter(service -> service.getName().equalsIgnoreCase(instance.getAppName())).findFirst().orElse(null);
+        }
 
+        processInstance(containersUpdated, instance, application);
     }
 
     /**
@@ -152,13 +161,13 @@ public class CacheRefreshService {
     private void processInstance(Set<String> containersUpdated, InstanceInfo instance, Application application) {
         if (InstanceInfo.InstanceStatus.DOWN.equals(instance.getStatus())) {
             application.removeInstance(instance);
+        } else {
+            // update any containers which contain this service
+            updateContainers(containersUpdated, instance);
         }
 
         // Update the service cache
         updateService(instance.getAppName(), application);
-
-        // update any containers which contain this service
-        updateContainers(containersUpdated, instance, application);
     }
 
 
@@ -194,36 +203,21 @@ public class CacheRefreshService {
 
     private void updateService(String serviceId, Application application) {
         if (application == null) {
-            log.error("Could not find Application object for serviceId: {} cache not updated with " +
-                "current values.", serviceId);
+            log.error("Could not find Application object for serviceId: " + serviceId + " cache not updated with " +
+                "current values.");
         } else {
-            if (application.getInstances() == null || application.getInstances().isEmpty()) {
-                cachedServicesService.removeService(serviceId);
-                log.debug("Removed service cache for service: {}", serviceId);
-            } else {
-                cachedServicesService.updateService(serviceId, application);
-                log.debug("Updated service cache for service: {}", serviceId);
-            }
+            cachedServicesService.updateService(serviceId, application);
+            log.debug("Updated service cache for service: " + serviceId);
         }
     }
 
     private void updateContainers(Set<String> containersUpdated,
-                                  InstanceInfo instanceInfo,
-                                  Application application) {
-        if (application == null) {
-            log.error("Cannot create a tile for an empty instance");
-        } else {
-            if (application.getInstances() == null || application.getInstances().isEmpty()) {
-                //should be removed from cache
-                checkIfServiceShouldBeRemoved(containersUpdated, instanceInfo);
-            } else {
-                String apiEnabled = instanceInfo.getMetadata().get(API_ENABLED_METADATA_KEY);
+                                  InstanceInfo instanceInfo) {
+        String apiEnabled = instanceInfo.getMetadata().get(API_ENABLED_METADATA_KEY);
 
-                // only register API enabled services
-                if (apiEnabled == null || Boolean.valueOf(apiEnabled)) {
-                    updateContainer(containersUpdated, instanceInfo.getAppName(), instanceInfo);
-                }
-            }
+        // only register API enabled services
+        if (apiEnabled == null || Boolean.valueOf(apiEnabled)) {
+            updateContainer(containersUpdated, instanceInfo.getAppName(), instanceInfo);
         }
     }
 
@@ -242,19 +236,6 @@ public class CacheRefreshService {
         } else {
             APIContainer container = cachedProductFamilyService.saveContainerFromInstance(productFamilyId, instanceInfo);
             log.info("Created/Updated tile and updated cache for container: " + container.getId() + " @ " + container.getLastUpdatedTimestamp().getTime());
-            containersUpdated.add(productFamilyId);
-        }
-    }
-
-    private void checkIfServiceShouldBeRemoved(Set<String> containersUpdated, InstanceInfo instanceInfo) {
-        String serviceId = instanceInfo.getAppName();
-        String productFamilyId = instanceInfo.getMetadata().get("mfaas.discovery.catalogUiTile.id");
-        if (productFamilyId == null) {
-            log.error("Cannot create a tile without a parent id, the metadata for service: " + serviceId +
-                " must contain an entry for mfaas.discovery.catalogUiTile.id");
-        } else {
-            cachedProductFamilyService.removeContainerFromInstance(productFamilyId, serviceId);
-            log.info("Removed service {} from container {}", serviceId, productFamilyId);
             containersUpdated.add(productFamilyId);
         }
     }

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
@@ -52,7 +52,10 @@ public class CachedApiDocService {
                 CachedApiDocService.serviceApiDocs.put(new ApiDocCacheKey(serviceId, apiVersion), apiDoc);
             }
         } catch (Exception e) {
-            log.warn("ApiDoc retrieving problem. {}", e.getMessage());
+            //if there's not apiDoc in cache
+            if (apiDoc == null) {
+                log.warn("ApiDoc retrieving problem. {}", e.getMessage());
+            }
         }
         return apiDoc;
     }

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
@@ -44,21 +44,16 @@ public class CachedApiDocService {
      * @return api doc info for the requested service id
      */
     public String getApiDocForService(final String serviceId, final String apiVersion) {
-        String apiDoc;
-
+        String apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
         try {
             ApiDocInfo apiDocInfo = apiDocRetrievalService.retrieveApiDoc(serviceId, apiVersion);
-            if (apiDocInfo == null || apiDocInfo.getApiDocContent() == null) {
-                apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
-            } else {
+            if (apiDocInfo != null && apiDocInfo.getApiDocContent() != null) {
                 apiDoc = transformApiDocService.transformApiDoc(serviceId, apiDocInfo);
                 CachedApiDocService.serviceApiDocs.put(new ApiDocCacheKey(serviceId, apiVersion), apiDoc);
             }
         } catch (Exception e) {
             log.warn("ApiDoc retrieving problem. {}", e.getMessage());
-            apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
         }
-
         return apiDoc;
     }
 

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
@@ -44,16 +44,21 @@ public class CachedApiDocService {
      * @return api doc info for the requested service id
      */
     public String getApiDocForService(final String serviceId, final String apiVersion) {
-        String apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
-        if (apiDoc == null) {
+        String apiDoc;
+
+        try {
             ApiDocInfo apiDocInfo = apiDocRetrievalService.retrieveApiDoc(serviceId, apiVersion);
-            if (apiDocInfo.getApiDocContent() == null) {
-                return null;
+            if (apiDocInfo == null || apiDocInfo.getApiDocContent() == null) {
+                apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
             } else {
                 apiDoc = transformApiDocService.transformApiDoc(serviceId, apiDocInfo);
                 CachedApiDocService.serviceApiDocs.put(new ApiDocCacheKey(serviceId, apiVersion), apiDoc);
             }
+        } catch (Exception e) {
+            log.warn("ApiDoc retrieving problem. {}", e.getMessage());
+            apiDoc = CachedApiDocService.serviceApiDocs.get(new ApiDocCacheKey(serviceId, apiVersion));
         }
+
         return apiDoc;
     }
 

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedApiDocService.java
@@ -54,7 +54,7 @@ public class CachedApiDocService {
         } catch (Exception e) {
             //if there's not apiDoc in cache
             if (apiDoc == null) {
-                log.warn("ApiDoc retrieving problem. {}", e.getMessage());
+                log.warn("ApiDoc retrieving problem for {}. {}", serviceId, e.getMessage());
             }
         }
         return apiDoc;

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedProductFamilyService.java
@@ -344,29 +344,6 @@ public class CachedProductFamilyService {
 
         return container;
     }
-
-    /**
-     * Remove a container
-     *
-     * @param productFamilyId the product family id of the container
-     * @param serviceId       check for this service
-     */
-    @CacheEvict(key = "#productFamilyId")
-    public void removeContainerFromInstance(String productFamilyId, String serviceId) {
-        APIContainer container = products.get(productFamilyId);
-        if (container != null) {
-            Set<APIService> apiServices = container.getServices();
-            apiServices.remove(new APIService(serviceId));
-
-            if (apiServices.isEmpty()) {
-                products.remove(productFamilyId);
-            } else {
-                container.setServices(apiServices);
-                products.put(container.getId(), container);
-            }
-        }
-    }
-
     /**
      * Update the summary totals for a container based on it's running services
      *

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedServicesService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/cached/CachedServicesService.java
@@ -56,15 +56,6 @@ public class CachedServicesService {
     public void updateService(@NonNull final String serviceId, final Application application) {
         services.put(serviceId.toLowerCase(), application);
     }
-
-    /**
-     * Remove this service with the application object
-     * @param serviceId the service name (lowercase)
-     */
-    public void removeService(@NonNull final String serviceId) {
-        services.remove(serviceId.toLowerCase());
-    }
-
     /**
      * Clear the cache and remove all entries from the map
      */

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/initialisation/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/services/initialisation/InstanceRetrievalService.java
@@ -161,7 +161,7 @@ public class InstanceRetrievalService {
             }
         } catch (Exception e) {
             String msg = "An error occurred when trying to get instance info for:  " + serviceId;
-            log.error(msg, e);
+            log.warn(msg, e.getMessage());
             throw new RetryException(msg);
         }
 


### PR DESCRIPTION
Issue #283 
Hi Reviewers!
In this PR, I have implemented 2 things.
1) The first problem is service still displayed as UP even if stopped. Actually, it had been working before, it was broken after #262 implementation. I grabbed old implementation codes and I made refactoring a little bit.
2) The second part is totally new. When service is down, api-doc should be gotten from the URL otherwise it should be from the cache.

I apologize for what you see as changes. It was hard to decide a better design. I hope you will enjoy!
