### PR TITLE
Support mixed case service ID

### DIFF
--- a/config/local/api-defs/staticclient.yml
+++ b/config/local/api-defs/staticclient.yml
@@ -5,7 +5,7 @@
 # It is loaded by the Discovery Service during its startup.
 #
 services:
-    - serviceId: staticclient  # unique lowercase ID of the service
+    - serviceId: StaticClient  # unique lowercase ID of the service
       catalogUiTileId: static  # ID of the API Catalog UI tile (visual grouping of the services)
       title: Statically Defined API Service  # Title of the service in the API catalog
       description: Sample to demonstrate how to add an API service with Swagger to API Catalog using a static YAML definition  # Description of the service in the API catalog
@@ -27,7 +27,7 @@ services:
           gatewayUrl: api/v1
           swaggerUrl: https://localhost:10012/discoverableclient/api-doc
 
-    - serviceId: staticclient2  # unique lowercase ID of the service
+    - serviceId: staticclient2  # unique ID of the service
       catalogUiTileId: static  # ID of the API Catalog UI tile (visual grouping of the services)
       title: Staticaly Defined Service 2  # Title of the service in the API catalog
       description: Sample to demonstrate how to add an API service without Swagger documentation to API Catalog using a static YAML definition  # Description of the service in the API catalog
@@ -48,28 +48,6 @@ services:
         - apiId: org.zowe.discoverableclient
           gatewayUrl: api/v1
           version: 1.0.0
-
-    - serviceId: StaticClient3  # unique lowercase ID of the service
-      catalogUiTileId: static  # ID of the API Catalog UI tile (visual grouping of the services)
-      title: Staticaly Defined Service 3  # Title of the service in the API catalog
-      description: Sample to demonstrate how to add an API service with mixed case service ID   # Description of the service in the API catalog
-      instanceBaseUrls:  # list of base URLs for each instance
-          - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
-      statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
-      healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
-      routes:
-          - gatewayUrl: api/v1  # [api/ui/ws]/v{majorVersion}
-            serviceRelativeUrl: /api/v1 # relativePath that is added to baseUrl of an instance
-          - gatewayUrl: ui/v1
-            serviceRelativeUrl: /
-          - gatewayUrl: ws/v1
-            serviceRelativeUrl: /ws
-        # List of APIs provided by the service (currenly only one is supported):
-      apiInfo:
-          - apiId: org.zowe.discoverableclient
-            gatewayUrl: api/v1
-            version: 1.0.0
 
 # List of tiles that can be used by services defined in the YAML file:
 catalogUiTiles:

--- a/config/local/api-defs/staticclient.yml
+++ b/config/local/api-defs/staticclient.yml
@@ -49,6 +49,28 @@ services:
           gatewayUrl: api/v1
           version: 1.0.0
 
+    - serviceId: StaticClient3  # unique lowercase ID of the service
+      catalogUiTileId: static  # ID of the API Catalog UI tile (visual grouping of the services)
+      title: Staticaly Defined Service 3  # Title of the service in the API catalog
+      description: Sample to demonstrate how to add an API service with mixed case service ID   # Description of the service in the API catalog
+      instanceBaseUrls:  # list of base URLs for each instance
+          - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
+      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
+      healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
+      routes:
+          - gatewayUrl: api/v1  # [api/ui/ws]/v{majorVersion}
+            serviceRelativeUrl: /api/v1 # relativePath that is added to baseUrl of an instance
+          - gatewayUrl: ui/v1
+            serviceRelativeUrl: /
+          - gatewayUrl: ws/v1
+            serviceRelativeUrl: /ws
+        # List of APIs provided by the service (currenly only one is supported):
+      apiInfo:
+          - apiId: org.zowe.discoverableclient
+            gatewayUrl: api/v1
+            version: 1.0.0
+
 # List of tiles that can be used by services defined in the YAML file:
 catalogUiTiles:
     static:

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ artifactoryPublishingMavenRepo=https://gizaartifactory.jfrog.io/gizaartifactory/
 artifactoryPublishingMavenSnapshotRepo=https://gizaartifactory.jfrog.io/gizaartifactory/libs-snapshot-local
 
 # Artifacts version
-version=1.1.0
+version=1.1.0-SNAPSHOT
 
 defaultSpringBootVersion=2.0.2.RELEASE
 defaultSpringBootCloudVersion=2.0.0.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ artifactoryPublishingMavenRepo=https://gizaartifactory.jfrog.io/gizaartifactory/
 artifactoryPublishingMavenSnapshotRepo=https://gizaartifactory.jfrog.io/gizaartifactory/libs-snapshot-local
 
 # Artifacts version
-version=1.0.1
+version=1.1.0
 
 defaultSpringBootVersion=2.0.2.RELEASE
 defaultSpringBootCloudVersion=2.0.0.RELEASE

--- a/integration-tests/src/test/java/com/ca/mfaas/discoveryservice/staticdef/StaticClientEndpointsTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/discoveryservice/staticdef/StaticClientEndpointsTest.java
@@ -19,8 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 public class StaticClientEndpointsTest {
     private static final String GREET = "/api/v1/discoverableclient/greeting";
-    private static final String STATIC_GREET = "/api/v1/staticclient/greeting";
-    private static final String MIXED_CASE_GREET = "/api/v1/StaticClient3/greeting";
+    private static final String STATIC_GREET = "/api/v1/StaticClient/greeting";
 
     @Test
     public void shouldSameResponseAsDynamicService() throws Exception {
@@ -34,15 +33,5 @@ public class StaticClientEndpointsTest {
         // Then
         assertEquals(response.getStatusLine().getStatusCode(), staticResponse.getStatusLine().getStatusCode());
         assertEquals(hello, staticHello);
-    }
-
-    /**
-     * Test service with mixed case service ID
-     * Depends on service StaticClient3 to be defined in staticclient.yml
-     * @throws Exception
-     */
-    @Test
-    public void shouldMixedCaseServiceIdWork() throws Exception {
-        HttpRequestUtils.getResponse(MIXED_CASE_GREET, SC_OK);
     }
 }

--- a/integration-tests/src/test/java/com/ca/mfaas/discoveryservice/staticdef/StaticClientEndpointsTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/discoveryservice/staticdef/StaticClientEndpointsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 public class StaticClientEndpointsTest {
     private static final String GREET = "/api/v1/discoverableclient/greeting";
     private static final String STATIC_GREET = "/api/v1/staticclient/greeting";
+    private static final String MIXED_CASE_GREET = "/api/v1/StaticClient3/greeting";
 
     @Test
     public void shouldSameResponseAsDynamicService() throws Exception {
@@ -33,5 +34,15 @@ public class StaticClientEndpointsTest {
         // Then
         assertEquals(response.getStatusLine().getStatusCode(), staticResponse.getStatusLine().getStatusCode());
         assertEquals(hello, staticHello);
+    }
+
+    /**
+     * Test service with mixed case service ID
+     * Depends on service StaticClient3 to be defined in staticclient.yml
+     * @throws Exception
+     */
+    @Test
+    public void shouldMixedCaseServiceIdWork() throws Exception {
+        final HttpResponse staticResponse = HttpRequestUtils.getResponse(MIXED_CASE_GREET, SC_OK);
     }
 }

--- a/integration-tests/src/test/java/com/ca/mfaas/ws/WebSocketProxyTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/ws/WebSocketProxyTest.java
@@ -32,6 +32,7 @@ public class WebSocketProxyTest {
 
     private final static int WAIT_TIMEOUT_MS = 10000;
     private final static String UPPERCASE_URL = "/ws/v1/discoverableclient/uppercase";
+    private final static String STATIC_UPPERCASE_URL = "/ws/v1/StaticClient/uppercase";
 
     @Before
     public void setUp() {
@@ -93,6 +94,20 @@ public class WebSocketProxyTest {
     }
 
     @Test
+    public void shouldRouteWebSocketSessionForStaticClient() throws Exception {
+        final StringBuilder response = new StringBuilder();
+        WebSocketSession session = appendingWebSocketSession(discoverableClientGatewayUrl(STATIC_UPPERCASE_URL), response, 1);
+
+        session.sendMessage(new TextMessage("hello world!"));
+        synchronized (response) {
+            response.wait(WAIT_TIMEOUT_MS);
+        }
+
+        assertEquals("HELLO WORLD!", response.toString());
+        session.close();
+    }
+
+    @Test
     public void shouldCloseSessionAfterClientServerCloses() throws Exception {
         final StringBuilder response = new StringBuilder();
         WebSocketSession session = appendingWebSocketSession(discoverableClientGatewayUrl(UPPERCASE_URL), response, 2);
@@ -121,8 +136,7 @@ public class WebSocketProxyTest {
     @Test
     public void shouldFailIfServiceIsNotCorrect() throws Exception {
         final StringBuilder response = new StringBuilder();
-        WebSocketSession session = appendingWebSocketSession(
-                discoverableClientGatewayUrl("/ws/v1/wrong-service/uppercase"), response, 1);
+        appendingWebSocketSession(discoverableClientGatewayUrl("/ws/v1/wrong-service/uppercase"), response, 1);
 
         synchronized (response) {
             response.wait(WAIT_TIMEOUT_MS);


### PR DESCRIPTION
This PR is to address issue https://github.com/zowe/api-layer/issues/215. Prior to this PR, gateway url with mixed case service ID can not be routed. The reason is that, service ID is converted to lower cases in Discovery Service

I modified MfaasRouteLocator.java, recover serviceId by setting it to be VIPAdress. Because when service instance is created, VIPAddress is set to serviceId, and it is not converted to lower case by Discovery Service.
```
     builder.setAppName(serviceId).setInstanceId(instanceId).setHostName(url.getHost()).setIPAddr(ipAddress)
            .setDataCenterInfo(DEFAULT_INFO).setVIPAddress(serviceId).setSecureVIPAddress(serviceId)
            .setLeaseInfo(LeaseInfo.Builder.newBuilder()
```
I also created integration test for it. The case is put into StaticClientEndpointsTest.java. And to facilitate the integration test, I also modified staticclient.yml file, add a service with mixed case service Id

Signed-off-by: zhuxun <zhuxun@cn.ibm.com>

