### PR TITLE
Fix for non verifying sslcontext to use specific protocol

### DIFF
--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/ApiCatalogApplication.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/ApiCatalogApplication.java
@@ -30,7 +30,7 @@ import org.springframework.web.reactive.config.EnableWebFlux;
 @EnableEurekaClient
 @EnableWebFlux
 @EnableApiDiscovery
-@ComponentScan({ "com.ca.mfaas.enable", "com.ca.mfaas.apicatalog", "com.ca.mfaas.product.config",
+@ComponentScan({ "com.ca.mfaas.enable", "com.ca.mfaas.apicatalog", "com.ca.mfaas.product.security", "com.ca.mfaas.product.config",
         "com.ca.mfaas.product.web" })
 @EnableScheduling
 @EnableRetry

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 apiml:
     security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
         zosmfServiceId: zosmfca32
 
 spring:
@@ -66,7 +67,7 @@ mfaas:
         esmEnabled: ${environment.esmEnabled:false}
         sslEnabled: true
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         trustStore: ${environment.truststore}
         trustStoreType: ${environment.truststoreType}
         trustStorePassword: ${environment.truststorePassword}

--- a/common-service-core/src/main/java/com/ca/mfaas/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/com/ca/mfaas/security/HttpsFactory.java
@@ -91,7 +91,7 @@ public class HttpsFactory {
 
     private SSLContext createIgnoringSslContext() {
         try {
-            return new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build();
+            return new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).setProtocol(config.getProtocol()).build();
         } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
             throw new HttpsConfigError("Error initializing SSL/TLS context: " + e.getMessage(), e,
                     ErrorCode.SSL_CONTEXT_INITIALIZATION_FAILED, config);

--- a/discoverable-client/src/main/java/com/ca/mfaas/client/DiscoverableClientSampleApplication.java
+++ b/discoverable-client/src/main/java/com/ca/mfaas/client/DiscoverableClientSampleApplication.java
@@ -25,7 +25,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 @EnableApiDiscovery
 @EnableConfigurationProperties
 @EnableWebSocket
-@ComponentScan(value = { "com.ca.mfaas.client", "com.ca.mfaas.enable", "com.ca.mfaas.product.web" })
+@ComponentScan(value = { "com.ca.mfaas.client", "com.ca.mfaas.enable", "com.ca.mfaas.product.security", "com.ca.mfaas.product.web" })
 public class DiscoverableClientSampleApplication implements ApplicationListener<ApplicationReadyEvent> {
 
     public static void main(String[] args) {

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -12,6 +12,8 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
 
 apiml:
+    security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
     # The `apiml` node contains API Mediation Layer specific configuration
     service:
         # The `apiml.service` node contains information required by any APIML service
@@ -19,7 +21,7 @@ apiml:
         hostname: localhost  # Hostname that is advertised in Eureka. Default is valid only for localhost
         port: 10012  # Default port name for discoverable-clinet service
         ipAddress: 127.0.0.1  # IP address that is advertised in Eureka. Default is valid only for localhost
-        preferIpAddress: false
+        preferIpAddress: false        
 
 spring:
     application:
@@ -42,7 +44,7 @@ server:
     ssl:
         enabled: true
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         keyStoreType: PKCS12
         trustStoreType: PKCS12
 

--- a/discoverable-client/src/test/resources/application.yml
+++ b/discoverable-client/src/test/resources/application.yml
@@ -12,6 +12,8 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
 
 apiml:
+    security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
     # The `apiml` node contains API Mediation Layer specific configuration
     service:
         # The `apiml.service` node contains information required by any APIML service
@@ -42,7 +44,7 @@ server:
     ssl:
         enabled: true
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         keyStoreType: PKCS12
         trustStoreType: PKCS12
 

--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/DiscoveryServiceApplication.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/DiscoveryServiceApplication.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.ComponentScan;
 @EnableEurekaServer
 @SpringBootApplication(exclude = HystrixAutoConfiguration.class)
 @EnableConfigurationProperties
-@ComponentScan({"com.ca.mfaas.discovery", "com.ca.mfaas.product.config", "com.ca.mfaas.product.discovery", "com.ca.mfaas.product.web"})
+@ComponentScan({"com.ca.mfaas.discovery", "com.ca.mfaas.product.config", "com.ca.mfaas.product.security", "com.ca.mfaas.product.discovery", "com.ca.mfaas.product.web"})
 public class DiscoveryServiceApplication implements ApplicationListener<ApplicationReadyEvent> {
 
     public static void main(String[] args) {

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -13,6 +13,8 @@ logging:
         com.sun.jersey.server.impl.application.WebApplicationImpl: WARN
 
 apiml:
+    security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
     # The `apiml` node contains API Mediation Layer specific configuration
     service:
         # The `apiml.service` node contains information required by any APIML service
@@ -83,7 +85,7 @@ server:
         enabled: true
         clientAuth: want
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         keyStoreType: PKCS12
         trustStoreType: PKCS12
         trustStoreRequired: true

--- a/docs/ciphers.md
+++ b/docs/ciphers.md
@@ -1,0 +1,19 @@
+## How to set ciphers used in API ML services
+
+To set ciphers supported by the HTTPS servers in API ML services you need to set following property
+for all services (gateway, discovery service, and API catalog):
+
+    -Dapiml.security.ciphers=<cipher-list>
+
+The default value is in the `application.yml` files, for example: [gateway-service/src/main/resources/application.yml](/gateway-service/src/main/resources/application.yml). The default configuration is in the resulting JAR files.
+
+On z/OS, this can be overridden in `$ZOWE_ROOT_DIR/api-mediation/scripts/api-mediation-start-*.sh` where `*` expands to `gateway`, `catalog`, and `discovery`.
+
+On localhost, the default configuration can be overridden on [config/local/gateway-service.yml](/config/local/gateway-service.yml) and other YAML files for development purposes without rebuilding the JAR files.
+
+The default cipher list is:
+
+    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+
+The IANA ciphers names are supported.
+The names of ciphers are available at https://wiki.mozilla.org/Security/Server_Side_TLS#Cipher_suites.

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -20,6 +20,8 @@ logging:
         org.springframework.web.servlet.PageNotFound: ERROR
 
 apiml:
+    security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
     # The `apiml` node contains API Mediation Layer specific configuration
     service:
         # The `apiml.service` node contains information required by any APIML service
@@ -55,7 +57,7 @@ server:
     ssl:
         enabled: true
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         keyStoreType: PKCS12
         trustStoreType: PKCS12
 

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -19,6 +19,8 @@ logging:
         org.eclipse.jetty: WARN
 
 apiml:
+    security:
+        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
     # The `apiml` node contains API Mediation Layer specific configuration
     service:
         # The `apiml.service` node contains information required by any APIML service
@@ -50,7 +52,7 @@ server:
     ssl:
         enabled: true
         protocol: TLSv1.2
-        ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        ciphers: ${apiml.security.ciphers}
         keyStoreType: PKCS12
         trustStore: keystore/localhost/localhost.truststore.p12
         trustStorePassword: password
@@ -160,5 +162,3 @@ logging:
         org.apache.catalina: INFO
         com.netflix: INFO
         org.hibernate: INFO
-
-

--- a/security-module/src/main/java/com/ca/mfaas/security/config/SecurityConfigurationProperties.java
+++ b/security-module/src/main/java/com/ca/mfaas/security/config/SecurityConfigurationProperties.java
@@ -34,6 +34,7 @@ public class SecurityConfigurationProperties {
     private CookieProperties cookieProperties;
     private String zosmfServiceId;
     private boolean verifySslCertificatesOfServices = true;
+    private String ciphers = null;
 
     @Data
     public static class TokenProperties {


### PR DESCRIPTION
- Set protocol for HTTPS clients
- Use apiml.security.ciphers as the configuration property that sets ciphers for all services
- Use server cipher ordering for all services (it used to be gateway only)