### PR TITLE
Add support for VSCode development

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Follow the guidelines in [Local Configuration](docs/local-configuration.md) to s
 
 Also if you use IntelliJ IDEA, see [learn how to configure Run Dashboard](docs/idea-setup.md) to use these local configurations.
 
+If you use Visual Studio Code, see [how to configure it](docs/vscode-setup.md) to develop and debug local configurations.
+
 ## Adding services that does not support API Mediation Layer natively
 
 See [Adding Services to API Gateway without Code Changes](docs/static-apis.md).

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ allprojects {
     apply plugin: 'maven'
     apply plugin: 'com.github.hierynomus.license'
     apply plugin: 'org.owasp.dependencycheck'
+    apply plugin: 'eclipse'
 
     repositories mavenRepositories
 

--- a/docs/idea-setup.md
+++ b/docs/idea-setup.md
@@ -1,6 +1,6 @@
 # IntelliJ Idea setup
 
-If your editor of choice happens to be Idea and you wnat to use its 'Run Dashboard' follow these steps:
+If your editor of choice happens to be Idea and you want to use its 'Run Dashboard' follow these steps:
 
 First of all enable _Annotations processing_ if you haven't done so already (Just go to settings and search for 'annotation').
 

--- a/docs/vscode-setup.md
+++ b/docs/vscode-setup.md
@@ -1,0 +1,26 @@
+# Visual Studio Code setup
+
+If you want to use Visual Studio Code to develop and debug then follow these steps:
+
+1. Install the [Java Extension Pack](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack), [Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack) and [Lombok Annotations Support for VS Code](https://marketplace.visualstudio.com/items?itemName=GabrielBB.vscode-lombok) extensions.
+2. Run `gradlew eclipse` to generate the build information.
+1. Add the following definitions to the `launch.json` file in the workspace.
+    ```json
+    {
+        "type": "java",
+        "name": "Debug (Attach)-ApiCatalogApplication<api-catalog-services>",
+        "request": "attach",
+        "hostName": "localhost",
+        "port": 5014,
+        "projectName": "api-catalog-services"
+    },
+    {
+        "type": "java",
+        "name": "Debug (Attach)-GatewayApplication<gateway-service>",
+        "request": "attach",
+        "hostName": "localhost",
+        "port": 5010,
+        "projectName": "gateway-service"
+    }
+    ```
+Launch either of the services in debug mode and then attach the debugger by running the appropriate launch configuration.


### PR DESCRIPTION
Add configuration to the gradle file to generate the necessary build files to enable development in Visual Studio Code.