### PR TITLE
fix for issue API Catalog cannot be loaded under zLux #312

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
                 stage('Build and unit test with coverage') {
                     steps {
                         timeout(time: 20, unit: 'MINUTES') {
-                            sh './gradlew build coverage'
+                            sh './gradlew build coverage -Dhttp.socketTimeout=90000 -Dhttp.connectionTimeout=90000'
                         }
                     }
                 }

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/security/SecurityConfiguration.java
@@ -103,9 +103,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .exceptionHandling().authenticationEntryPoint(unAuthorizedHandler)
 
             .and()
-            .headers().httpStrictTransportSecurity().disable()
-
-            .and()
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 

--- a/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/com/ca/mfaas/apicatalog/security/SecurityConfiguration.java
@@ -99,7 +99,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http
 
             .csrf().disable()
-            .headers().disable()
+            .headers()
+            .httpStrictTransportSecurity().disable()
+            .frameOptions().disable()
+            .and()
             .exceptionHandling().authenticationEntryPoint(unAuthorizedHandler)
 
             .and()

--- a/apiml-auth/lib/apimlAuth.js
+++ b/apiml-auth/lib/apimlAuth.js
@@ -98,7 +98,7 @@ ApimlAuthenticator.prototype = {
       const options = {
         hostname: this.apimlConf.hostname,
         port: this.apimlConf.gatewayPort,
-        path: '/api/v1/gateway/auth/login',
+        path: '/api/v1/apicatalog/auth/login',
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -110,7 +110,7 @@ ApimlAuthenticator.prototype = {
       const req = https.request(options, (res) => {
         res.on('data', (d) => {
           let apimlCookie;
-          if (res.statusCode == 204) {
+          if (res.statusCode == 200) {
             if (typeof res.headers['set-cookie'] === 'object') {
               for (const cookie of res.headers['set-cookie']) {
                 const content = cookie.split(';')[0];

--- a/apiml-auth/lib/apimlAuth.js
+++ b/apiml-auth/lib/apimlAuth.js
@@ -110,7 +110,7 @@ ApimlAuthenticator.prototype = {
       const req = https.request(options, (res) => {
         res.on('data', (d) => {
           let apimlCookie;
-          if (res.statusCode == 200) {
+          if (res.statusCode == 204) {
             if (typeof res.headers['set-cookie'] === 'object') {
               for (const cookie of res.headers['set-cookie']) {
                 const content = cookie.split(';')[0];

--- a/apiml-auth/lib/tokenInjector.js
+++ b/apiml-auth/lib/tokenInjector.js
@@ -3,7 +3,7 @@ const express = require('express');
 module.exports = pluginContext => {
   const r = express.Router();
   r.get('/**', (req, res) => {
-    const apimlSession = req.session['org.zowe.zlux.auth.apiml'];
+    const apimlSession = req.session.authPlugins['org.zowe.zlux.auth.apiml'];
     if (apimlSession === undefined) {
       res.status(401).send("Missing APIML authentication token in zLUX session");
     }

--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/config/EurekaSecurityConfiguration.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/config/EurekaSecurityConfiguration.java
@@ -56,7 +56,7 @@ public class EurekaSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
             http.csrf().disable()
-            .headers().disable()
+            .headers().httpStrictTransportSecurity().disable().and()
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 

--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/config/EurekaSecurityConfiguration.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/config/EurekaSecurityConfiguration.java
@@ -55,9 +55,10 @@ public class EurekaSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();
-        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        http.headers().httpStrictTransportSecurity().disable();
+            http.csrf().disable()
+            .headers().disable()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         if (Arrays.asList(environment.getActiveProfiles()).contains("https")) {
             if (verifySslCertificatesOfServices) {

--- a/discovery-service/src/main/java/com/ca/mfaas/discovery/config/HttpsEurekaSecurityConfiguration.java
+++ b/discovery-service/src/main/java/com/ca/mfaas/discovery/config/HttpsEurekaSecurityConfiguration.java
@@ -30,7 +30,7 @@ public class HttpsEurekaSecurityConfiguration extends WebSecurityConfigurerAdapt
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        http.headers().disable();
+        http.headers().httpStrictTransportSecurity().disable();
         http.antMatcher("/**")
             .authorizeRequests()
             .anyRequest()

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/security/config/SecurityConfiguration.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/security/config/SecurityConfiguration.java
@@ -79,11 +79,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http
             .csrf().disable()
             .headers().disable()
-            .exceptionHandling()
-            .authenticationEntryPoint(unAuthorizedHandler)
+            .exceptionHandling().authenticationEntryPoint(unAuthorizedHandler)
 
-            .and()
-            .headers().httpStrictTransportSecurity().disable()
             .and()
             .httpBasic()
 

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/security/config/SecurityConfiguration.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/security/config/SecurityConfiguration.java
@@ -78,7 +78,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .csrf().disable()
-            .headers().disable()
+            .headers()
+            .httpStrictTransportSecurity().disable()
+            .frameOptions().disable()
+            .and()
             .exceptionHandling().authenticationEntryPoint(unAuthorizedHandler)
 
             .and()

--- a/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogHttpHeadersIntegrationTest.java
+++ b/integration-tests/src/test/java/com/ca/mfaas/apicatalog/ApiCatalogHttpHeadersIntegrationTest.java
@@ -7,94 +7,38 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package com.ca.mfaas.gatewayservice;
+package com.ca.mfaas.apicatalog;
 
+import com.ca.mfaas.gatewayservice.SecurityUtils;
 import com.ca.mfaas.utils.config.ConfigReader;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.*;
+
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class GatewaySecurityTest {
+public class ApiCatalogHttpHeadersIntegrationTest {
+
+    private static final String GET_ALL_CONTAINERS_ENDPOINT = "/ui/v1/apicatalog/#";
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String SCHEME = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getScheme();
     private final static String HOST = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getHost();
     private final static int PORT = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getPort();
-    private static final String PROTECTED_ENDPOINT = "/application/routes";
     private final static String COOKIE = "apimlAuthenticationToken";
 
     @Before
     public void setUp() {
         RestAssured.useRelaxedHTTPSValidation();
-    }
-
-    //@formatter:off
-    @Test
-    public void accessProtectedEndpointWithoutCredentials() {
-        given()
-        .when()
-            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
-        .then()
-            .statusCode(is(SC_UNAUTHORIZED));
-    }
-
-    @Test
-    public void loginToGatewayAndAccessProtectedEndpointWithBasicAuthentication() {
-        given()
-            .auth().preemptive().basic(USERNAME, PASSWORD)
-        .when()
-            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
-        .then()
-            .statusCode(is(SC_OK));
-    }
-
-    @Test
-    public void loginToGatewayAndAccessProtectedEndpointWithCookie() {
-        String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
-
-        given()
-            .cookie(COOKIE, token)
-        .when()
-            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
-        .then()
-            .statusCode(is(SC_OK));
-    }
-
-    @Test
-    public void accessProtectedEndpointWithInvalidToken() {
-        String invalidToken = "badToken";
-
-        given()
-            .cookie(COOKIE, invalidToken)
-        .when()
-            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
-        .then()
-            .statusCode(is(SC_UNAUTHORIZED));
-    }
-
-
-    @Test
-    public void accessProtectedEndpointWithInvalidCredentials() {
-        String invalidPassword = "badPassword";
-
-        given()
-            .auth().preemptive().basic(USERNAME, invalidPassword)
-        .when()
-            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
-        .then()
-            .statusCode(is(SC_UNAUTHORIZED));
     }
 
     @Test
@@ -114,7 +58,7 @@ public class GatewaySecurityTest {
         forbiddenHeaders.add("Strict-Transport-Security");
 
         Response response =  RestAssured.given().cookie(COOKIE, token)
-                            .get(String.format("%s://%s:%d", SCHEME, HOST, PORT));
+            .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, GET_ALL_CONTAINERS_ENDPOINT));
         Map<String,String> responseHeaders = new HashMap<>();
         response.getHeaders().forEach(h -> responseHeaders.put(h.getName(),h.getValue()));
 


### PR DESCRIPTION
fix for issue API Catalog cannot be loaded under zLux #312
our configuration of spring security http headers was faulty

Another change to the apiml-auth plugin for zlux to expect HTTP RC 204 from login instead of 200