### PR TITLE
adjust logbackformat to latest agreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ Following tools are required to build and develop API Mediation Layer:
 
 ## Quick start
 
-Bootstrap gradle to get wrapper:
-
-    UNIX
-    ./bootstrap_gradlew.sh
-
-    Windows
-    bootstrap_gradlew.bat
-
 Build all modules:
 
     ./gradlew build

--- a/gateway-common/src/main/resources/logback.xml
+++ b/gateway-common/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(&lt;${logbackService:-${logbackServiceName}}:%thread:${PID:- }&gt;){magenta} %X{userid:-} %clr(%-5level) %clr(\(%file:%line\)){cyan} %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS,UTC} %clr(&lt;${logbackService:-${logbackServiceName}}:%thread:${PID:- }&gt;){magenta} %X{userid:-} %clr(%-5level) %clr(\(%logger{15},%file:%line\)){cyan} %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/keystore/README.md
+++ b/keystore/README.md
@@ -165,12 +165,14 @@ If you have the sample service described in the User Guide at [this link](https:
 
 Import [keystore/local_ca/localca.cer](/keystore/local_ca/localca.cer) to your root certificate store and trust it. 
 
-For **Windows**, you can run the following command:
+For **Windows**, you can run the following command as administrator:
 
     certutil -enterprise -f -v -AddStore "Root" keystore/local_ca/localca.cer 
     
 You have to open the terminal as administrator. This will install the certificate to the Trusted Root Certification Authorities. 
 
+*Note:* you can use `npm run register-certificates-win` to run above command, however it requires `sudo` to be installed. If you don't have `sudo` available install [chocolatey](https://chocolatey.org/docs/installation#install-downloaded-nuget-package-from-powershell), then run `chocolatey install sudo`.
+    
 If you're using **MacOS**, you can run the following command: 
 
     $ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain keystore/local_ca/localca.cer 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
         "discoverable-client-1": "java -jar discoverable-client/build/libs/discoverable-client.jar --spring.config.additional-location=file:./config/local-multi/discoverable-client.yml",
         "test": "./gradlew runAllIntegrationTests",
         "test-scripts": "mocha scripts",
-        "test-scripts-ci": "TEST_DIR=./scripts/test-results jenkins-mocha --no-coverage scripts"
+        "test-scripts-ci": "TEST_DIR=./scripts/test-results jenkins-mocha --no-coverage scripts",
+		
+		"//": ["for windows: to install sudo, run chocolatey.exe install sudo"],
+		"register-certificates-win": "echo \"for windows: to install sudo, run chocolatey.exe install sudo\" & sudo . cmd /C \"certutil -enterprise -delstore Root \"Zowe Development Instances Certificate Authority\"  &  certutil -enterprise -f -v -AddStore Root \"keystore/local_ca/localca.cer\" || pause\""
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
         "test-scripts": "mocha scripts",
         "test-scripts-ci": "TEST_DIR=./scripts/test-results jenkins-mocha --no-coverage scripts",
 		
-		"//": ["for windows: to install sudo, run chocolatey.exe install sudo"],
-		"register-certificates-win": "echo \"for windows: to install sudo, run chocolatey.exe install sudo\" & sudo . cmd /C \"certutil -enterprise -delstore Root \"Zowe Development Instances Certificate Authority\"  &  certutil -enterprise -f -v -AddStore Root \"keystore/local_ca/localca.cer\" || pause\""
+        "//": "echo \"for windows: to install sudo, run chocolatey.exe install sudo\"",
+        "register-certificates-win": "echo \"for windows: to install sudo, run chocolatey.exe install sudo\" & sudo . cmd /C \"certutil -enterprise -delstore Root \"Zowe Development Instances Certificate Authority\"  &  certutil -enterprise -f -v -AddStore Root \"keystore/local_ca/localca.cer\" || pause\""
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Signed-off-by: Vitek Vlcek <vitezslavvit.vlcek@ca.com>

* Adjusted logback format for API-ML based on proposal https://github.com/zowe/zlc/issues/90#issuecomment-505948963
* add new `npm run register-certificates-win` that imports `keystore/local_ca/localca.cer` into windows keystore. This depends on `sudo` installed by `chocolatey.exe install sudo` 