### PR TITLE
missing parms for adding zosmf cert

### DIFF
--- a/zowe-install/src/main/resources/scripts/setup-apiml-certificates-template.sh
+++ b/zowe-install/src/main/resources/scripts/setup-apiml-certificates-template.sh
@@ -61,7 +61,7 @@ if [ "$RC" -ne "0" ]; then
 fi
 
 if [[ "**VERIFY_CERTIFICATES**" == "true" ]]; then
-  scripts/apiml_cm.sh --verbose --log $LOG_FILE --action trust-zosmf
+  scripts/apiml_cm.sh --verbose --log $LOG_FILE --action trust-zosmf --zosmf-keyring **ZOSMF_KEYRING** --zosmf-userid **ZOSMF_USER**
   RC=$?
 
   echo "apiml_cm.sh --action trust-zosmf returned: $RC" >> $LOG_FILE


### PR DESCRIPTION
added missing parameters `--zosmf-keyring **ZOSMF_KEYRING** --zosmf-userid **ZOSMF_USER**` when registering z/OSMF certs

see bugfix: https://app.slack.com/client/T1BAJVCTY/CC08782AG/thread/CC08782AG-1564487049.010900

Signed-off-by: Vitek Vlcek <vitezslavvit.vlcek@broadcom.com>