### PR TITLE
Updating coverage settings to match the current state

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     patch:
       default:
-        target: 60
+        target: 80
     project:
       default:
-        target: 55
+        target: 70


### PR DESCRIPTION
Hello,

this updates the Codecov settings to prevent SonarQube quality gate from failing when the new code coverage is lower than 80%.

The project coverage has been increased to current coverage. The coverage has improved from 55% to 70%. Thank you and keep up the good work!

![image](https://user-images.githubusercontent.com/7644758/64799296-cb04ce80-d584-11e9-8eb1-c79202b73c03.png)