### PR TITLE
Cleanup Gateway dependency logs

### DIFF
--- a/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
@@ -24,13 +24,15 @@ public class ApimlDependencyLogHider extends TurboFilter {
 
     private static final List<String> IGNORED_MESSAGE_KEYWORDS = Arrays.asList(
         "Tomcat initialized",
+        "Tomcat started on port(s)",
         "lease doesn't exist", "Not Found (Renew)",
         "route 53",
         "eureka.server.peer-node-read-timeout-ms",
         "Found more than one MBeanServer instance",
         "dirty timestamp", "Using the existing instanceInfo instead of the new instanceInfo as the registrant",
         "Network level connection to peer",
-        "Tomcat started on port(s)");
+
+        "No routes found from RouteLocator");
 
     private boolean isFilterActive;
 

--- a/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
@@ -35,7 +35,9 @@ public class ApimlDependencyLogHider extends TurboFilter {
         "No routes found from RouteLocator",
         "Exception Processing ErrorPage",
         "Error while sending response to client",
-        "Request execution error");
+        "Request execution error",
+        "The Hystrix timeout",
+        "Error during filtering");
 
     private boolean isFilterActive;
 

--- a/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
@@ -23,16 +23,18 @@ import java.util.List;
 public class ApimlDependencyLogHider extends TurboFilter {
 
     private static final List<String> IGNORED_MESSAGE_KEYWORDS = Arrays.asList(
-        "Tomcat initialized",
-        "Tomcat started on port(s)",
+        "Tomcat initialized", "Tomcat started on port(s)",
         "lease doesn't exist", "Not Found (Renew)",
         "route 53",
+        "dirty timestamp", "Using the existing instanceInfo instead of the new instanceInfo as the registrant",
         "eureka.server.peer-node-read-timeout-ms",
         "Found more than one MBeanServer instance",
-        "dirty timestamp", "Using the existing instanceInfo instead of the new instanceInfo as the registrant",
         "Network level connection to peer",
+        "DS: Registry: expired lease for",
 
-        "No routes found from RouteLocator");
+        "No routes found from RouteLocator",
+        "Exception Processing ErrorPage",
+        "Error while sending response to client");
 
     private boolean isFilterActive;
 

--- a/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/logging/ApimlDependencyLogHider.java
@@ -34,7 +34,8 @@ public class ApimlDependencyLogHider extends TurboFilter {
 
         "No routes found from RouteLocator",
         "Exception Processing ErrorPage",
-        "Error while sending response to client");
+        "Error while sending response to client",
+        "Request execution error");
 
     private boolean isFilterActive;
 

--- a/apiml-common/src/test/java/com/ca/mfaas/product/logging/ApimlDependencyLogHiderTest.java
+++ b/apiml-common/src/test/java/com/ca/mfaas/product/logging/ApimlDependencyLogHiderTest.java
@@ -55,7 +55,7 @@ public class ApimlDependencyLogHiderTest {
 
 
     @Test
-    public void testDecide_whenLoggerLevelWhenIgnoredMessagesArePresent() {
+    public void testDecide_whenIgnoredMessagesArePresent() {
         logger.setLevel(Level.INFO);
 
         Map<String, Boolean> logMessages = new HashMap<>();
@@ -71,4 +71,19 @@ public class ApimlDependencyLogHiderTest {
             assertEquals("Log levels are not same", expectedFilterReply, actualFilterReply);
         });
     }
+
+    @Test
+    public void testDecide_whenIgnoredMessagesArePresentWithException() {
+        logger.setLevel(Level.ERROR);
+
+        String format = "Error during filtering";
+        RuntimeException filterException = new RuntimeException("Token is not valid");
+
+        FilterReply actualFilterReply = apimlDependencyLogHider.decide(null, logger, null,
+            format, null, filterException);
+
+        FilterReply expectedFilterReply =  FilterReply.DENY;
+        assertEquals("Log levels are not same", expectedFilterReply, actualFilterReply);
+    }
+
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -197,7 +197,7 @@ logging:
         ROOT: INFO
         com.ca.mfaas: DEBUG
         org.springframework: INFO
-        org.apache.catalina: INFO
+        org.apache: INFO
         com.netflix: INFO
         org.hibernate: INFO
         org.springframework.web.servlet.PageNotFound: WARN

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -3,7 +3,6 @@ logging:
         ROOT: INFO
         com.ca.mfaas: INFO
         org.springframework: WARN
-        org.apache.catalina: WARN
         com.netflix: WARN
         com.netflix.discovery: ERROR
         com.netflix.config: ERROR
@@ -12,12 +11,14 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.springframework.cloud.netflix.zuul.filters.route.support.AbstractRibbonCommand: ERROR
         org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter: ERROR
-        org.apache.tomcat.websocket: WARN
         org.springframework.web.socket: WARN
         com.ca.mfaas.gateway.ws: INFO
         com.ca.mfaas.gateway.error: INFO
         org.eclipse.jetty: WARN
         org.springframework.web.servlet.PageNotFound: ERROR
+
+        # New Config
+        org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
 
 apiml:
     # The `apiml` node contains API Mediation Layer specific configuration

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -9,8 +9,6 @@ logging:
         com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient: OFF
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
-        org.springframework.cloud.netflix.zuul.filters.route.support.AbstractRibbonCommand: ERROR
-        org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter: ERROR
         org.springframework.web.socket: WARN
         com.ca.mfaas.gateway.ws: INFO
         com.ca.mfaas.gateway.error: INFO


### PR DESCRIPTION
## Suppressed Messages
### P1:
```shell
2019-10-21 11:42:39.479 <MAS2AGW1:main:67439433> MASSERV INFO  (o.a.c.h.Http11NioProtocol) Initializing ProtocolHandler ["https-jsse
-nio-0.0.0.0-10010"]
2019-10-21 11:42:50.715 <MAS2AGW1:main:67439433> MASSERV INFO  (o.a.c.h.Http11NioProtocol) Starting ProtocolHandler ["https-jsse-nio
-0.0.0.0-10010"]
2019-10-21 11:42:52.086 <MAS2AGW1:main:67439433> MASSERV INFO  (o.a.t.u.n.NioSelectorPool) Using a shared selector for servlet write
/read
```

## P2
STITUATION: From MF, when app runs
```shell
2019-10-21 11:42:53.556 <MAS2AGW1:https-jsse-nio-0.0.0.0-10010-exec-9:67439433> MASSERV WARN  (o.s.c.n.z.w.ZuulHandlerMapping) No ro
utes found from RouteLocator
```
## P3
```shell
2019-10-22 10:20:21.034 <MAS2AGW1:https-jsse-nio-0.0.0.0-10010-exec-4:17107440> MASSERV ERROR (o.a.c.c.C.[.[localhost]) Exception Pr
 ocessing ErrorPage[errorCode=500, location=/internal_error]
 org.apache.catalina.connector.ClientAbortException: java.io.IOException: EDC5140I Broken pipe.
     at org.apache.catalina.connector.OutputBuffer.doFlush(OutputBuffer.java:321)
     at org.apache.catalina.connector.OutputBuffer.flush(OutputBuffer.java:284)
     at org.apache.catalina.connector.CoyoteOutputStream.flush(CoyoteOutputStream.java:118)
     at com.fasterxml.jackson.core.json.UTF8JsonGenerator.flush(UTF8JsonGenerator.java:1100)
     at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:915)
```
## P4
```shell
2019-10-22 09:15:15.785 <ZWEAGW1:https-jsse-nio-0.0.0.0-40004-exec-2:17107386> IZUSVR WARN  (o.s.c.n.z.f.p.SendResponseFilter,SendResponseFilter.java:184) Error while sending response to client: java.io.IOException: EDC5140I Broken pipe.
NOTE: We can reproduce it in browser by refreshing gateway homepage too fast (by just continuously pressing Refresh), so data transfer from mainframe will be interrupted and “Error while sending response to client: java.io.IOException: EDC5140I Broken pipe.” occurs.  That is why this error is easy to see during Performance tests.
```
## P5
```shell
2019-10-29 17:03:06.353 <MAS2BGW2:DiscoveryClient-CacheRefreshExecutor-5:17171824> MASSERV ERROR (c.n.d.s.t.d.RedirectingEurekaHttpC
 lient) Request execution error
 javax.ws.rs.WebApplicationException: null
     at com.netflix.discovery.provider.DiscoveryJerseyProvider.readFrom(DiscoveryJerseyProvider.java:110)
     at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:634)
     at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:586)
     at com.netflix.discovery.shared.transport.jersey.AbstractJerseyEurekaHttpClient.getApplicationsInternal(AbstractJerseyEurekaHttpCli
 ent.java:198)
     at com.netflix.discovery.shared.transport.jersey.AbstractJerseyEurekaHttpClient.getDelta(AbstractJerseyEurekaHttpClient.java:170)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator$7.execute(EurekaHttpClientDecorator.java:152)
     at com.netflix.discovery.shared.transport.decorator.MetricsCollectingEurekaHttpClient.execute(MetricsCollectingEurekaHttpClient.jav
 a:73)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.getDelta(EurekaHttpClientDecorator.java:149)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator$7.execute(EurekaHttpClientDecorator.java:152)
     at com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient.execute(RedirectingEurekaHttpClient.java:89)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.getDelta(EurekaHttpClientDecorator.java:149)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator$7.execute(EurekaHttpClientDecorator.java:152)
     at com.netflix.discovery.shared.transport.decorator.RetryableEurekaHttpClient.execute(RetryableEurekaHttpClient.java:120)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.getDelta(EurekaHttpClientDecorator.java:149)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator$7.execute(EurekaHttpClientDecorator.java:152)
     at com.netflix.discovery.shared.transport.decorator.SessionedEurekaHttpClient.execute(SessionedEurekaHttpClient.java:77)
     at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.getDelta(EurekaHttpClientDecorator.java:149)
     at com.netflix.discovery.DiscoveryClient.getAndUpdateDelta(DiscoveryClient.java:1085)
     at com.netflix.discovery.DiscoveryClient.fetchRegistry(DiscoveryClient.java:967)
     at com.netflix.discovery.DiscoveryClient.refreshRegistry(DiscoveryClient.java:1473)
     at com.netflix.discovery.DiscoveryClient$CacheRefreshThread.run(DiscoveryClient.java:1440)
     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:522)
     at java.util.concurrent.FutureTask.run(FutureTask.java:277)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
     at java.lang.Thread.run(Thread.java:812)
```
## P6
```shell
2019-10-30 15:08:48.725 <ZWEAGW1:https-jsse-nio-127.0.0.1-10010-exec-7:66876> abdil01 WARN  (o.s.c.n.z.f.r.s.AbstractRibbonCommand) The Hystrix timeout of 30000ms for the command apicatalog is set lower than the combination of the Ribbon read and connect timeout, 120000ms.
```
## P7
```shell
2019-10-31 08:35:26.543 <MAS2BGW1:https-jsse-nio-0.0.0.0-10210-exec-10:84215789> MASSERV WARN  (o.s.c.n.z.f.p.SendErrorFilter) Error
  during filtering
 com.netflix.zuul.exception.ZuulException: Filter threw Exception
     at com.netflix.zuul.FilterProcessor.processZuulFilter(FilterProcessor.java:227)
     at com.netflix.zuul.FilterProcessor.runFilters(FilterProcessor.java:157)
     at com.netflix.zuul.FilterProcessor.preRoute(FilterProcessor.java:133)
     at com.netflix.zuul.ZuulRunner.preRoute(ZuulRunner.java:105)
     at com.netflix.zuul.http.ZuulServlet.preRoute(ZuulServlet.java:125)
     at com.netflix.zuul.http.ZuulServlet.service(ZuulServlet.java:74)
     at org.springframework.web.servlet.mvc.ServletWrappingController.handleRequestInternal(ServletWrappingController.java:165)
     at org.springframework.cloud.netflix.zuul.web.ZuulController.handleRequest(ZuulController.java:44)
     at org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter.handle(SimpleControllerHandlerAdapter.java:52)
     at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:991)
     at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:925)
     at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:974)
     at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:866)
     at javax.servlet.http.HttpServlet.service(HttpServlet.java:635)
     at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:851)
     at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.springframework.boot.actuate.web.trace.servlet.HttpTraceFilter.doFilterInternal(HttpTraceFilter.java:90)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:320)
     at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.invoke(FilterSecurityInterceptor.java:127)
     at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.doFilter(FilterSecurityInterceptor.java:91)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:119)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:137)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:111)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFi
 lter.java:170)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:101)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:101)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessing
 Filter.java:200)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessing
 Filter.java:200)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:116)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:66)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrat
 ionFilter.java:56)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
     at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334)
     at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:215)
     at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:178)
     at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:357)
     at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:270)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.filterAndRecordMetrics(WebMvcMetricsFilter.java:155)
     at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.filterAndRecordMetrics(WebMvcMetricsFilter.java:123)
     at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:108)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:200)
     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
     at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
     at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
     at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
     at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
     at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
     at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
     at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
     at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:800)
     at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
     at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:806)
     at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1498)
     at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
     at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
     at java.lang.Thread.run(Thread.java:812)
 Caused by: com.ca.apiml.security.common.token.TokenNotValidException: Token is not valid
     at com.ca.mfaas.gateway.security.service.AuthenticationService.getLtpaTokenFromJwtToken(AuthenticationService.java:165)
     at com.ca.mfaas.gateway.filters.pre.ZosmfFilter.lambda$run$0(ZosmfFilter.java:62)
     at com.ca.mfaas.gateway.filters.pre.ZosmfFilter$$Lambda$722.00000000877FF1B0.accept(Unknown Source)
     at java.util.Optional.ifPresent(Optional.java:170)
     at com.ca.mfaas.gateway.filters.pre.ZosmfFilter.run(ZosmfFilter.java:61)
     at com.netflix.zuul.ZuulFilter.runFilter(ZuulFilter.java:117)
     at com.netflix.zuul.FilterProcessor.processZuulFilter(FilterProcessor.java:193)
     ... 88 common frames omitted
```