### PR TITLE
More stable builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,6 +282,30 @@ pipeline {
         always {
             junit allowEmptyResults: true, testResults: '**/test-results/**/*.xml'
             archiveArtifacts '.change_class'
+            publishHTML (target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'gateway-service/build/reports/tests/test',
+                reportFiles: 'index.html',
+                reportName: "Unit Tests Report - gateway-service"
+            ])
+            publishHTML (target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'discovery-service/build/reports/tests/test',
+                reportFiles: 'index.html',
+                reportName: "Unit Tests Report - discovery-service"
+            ])
+            publishHTML (target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'api-catalog-services/build/reports/tests/test',
+                reportFiles: 'index.html',
+                reportName: "Unit Tests Report - api-catalog-services"
+            ])
         }
 
         success {

--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,8 @@ subprojects {
     }
 
     tasks.withType(Test) {
-        maxParallelForks = Runtime.runtime.availableProcessors()
+        maxParallelForks = 1
     }
-
 }
 
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ nodejsVersion=8.11.1
 projectRoot=${project.projectDir}
 
 org.gradle.daemon=false
-org.gradle.parallel=true
+org.gradle.parallel=false


### PR DESCRIPTION
This PR contains the improvements that were discovered during working on PR-475.
We had several problems that were causing different tests to fail after different changes. These failures were not caused directly by the tests but the order of the tests.

What helped to resolve these problems that anyone can suffer from:
- Switching off parallel builds and tests
- Publishing Gradle unit tests reports to the Jenkins - they are quite friendly to use
- Making TomcatHttpsTest stabler by clearing the `javax.net.ssl` settings before the test, these can be set by other tests so the single-threaded tests and cleanup make sure that these tests will work well

Other tests that benefit from single-threaded execution are Zuul filter tests that use `RequestContext.getCurrentContext()` which can use the static `testContext`.

Many other tests (for example those that I have written or reviewed) were written without taking parallel execution into account and can be failing unpredictably.