### PR TITLE
Client certificate is not used when it is not needed

### DIFF
--- a/apiml-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
@@ -73,6 +73,7 @@ public class HttpConfig {
     private String eurekaServerUrl;
 
     private CloseableHttpClient secureHttpClient;
+    private CloseableHttpClient secureHttpClientWithoutKeystore;
     private SSLContext secureSslContext;
     private HostnameVerifier secureHostnameVerifier;
     private EurekaJerseyClientBuilder eurekaJerseyClientBuilder;
@@ -95,6 +96,13 @@ public class HttpConfig {
             secureSslContext = factory.createSslContext();
             secureHostnameVerifier = factory.createHostnameVerifier();
             eurekaJerseyClientBuilder = factory.createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId);
+
+            HttpsConfig httpsConfigWithoutKeystore = HttpsConfig.builder().protocol(protocol).trustStore(trustStore)
+                    .trustStoreType(trustStoreType).trustStorePassword(trustStorePassword)
+                    .trustStoreRequired(trustStoreRequired)
+                    .verifySslCertificatesOfServices(verifySslCertificatesOfServices).build();
+            HttpsFactory factoryWithoutKeystore = new HttpsFactory(httpsConfigWithoutKeystore);
+            secureHttpClientWithoutKeystore = factoryWithoutKeystore.createSecureHttpClient();
 
             factory.setSystemSslProperties();
         }
@@ -132,6 +140,12 @@ public class HttpConfig {
     @Bean
     public RestTemplate restTemplate() {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(secureHttpClient);
+        return new RestTemplate(factory);
+    }
+
+    @Bean
+    public RestTemplate restTemplateWithoutKeystore() {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(secureHttpClientWithoutKeystore);
         return new RestTemplate(factory);
     }
 

--- a/apiml-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/com/ca/mfaas/product/web/HttpConfig.java
@@ -20,9 +20,11 @@ import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl.Eure
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
@@ -150,8 +152,15 @@ public class HttpConfig {
     }
 
     @Bean
+    @Primary
     public CloseableHttpClient secureHttpClient() {
         return secureHttpClient;
+    }
+
+    @Bean
+    @Qualifier("secureHttpClientWithoutKeystore")
+    public CloseableHttpClient secureHttpClientWithoutKeystore() {
+        return secureHttpClientWithoutKeystore;
     }
 
     @Bean

--- a/common-service-core/src/main/java/com/ca/mfaas/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/com/ca/mfaas/security/HttpsFactory.java
@@ -139,6 +139,9 @@ public class HttpsFactory {
             }
         } else {
             log.info("No key store is defined");
+            KeyStore emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            emptyKeystore.load(null, null);
+            sslContextBuilder.loadKeyMaterial(emptyKeystore, null);
         }
     }
 

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/config/GatewayConfig.java
@@ -10,31 +10,30 @@
 package com.ca.mfaas.gateway.config;
 
 import com.ca.mfaas.product.gateway.GatewayConfigProperties;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * This is the configuration class for gateway
- */
 @Configuration
 public class GatewayConfig {
 
-    /**
-     * Create gateway config Bean
-     *
-     * @param hostname gateway hostname
-     * @param port     gateway port
-     * @param scheme   gateway scheme
-     * @return
-     */
     @Bean
     public GatewayConfigProperties getGatewayConfigProperties(@Value("${apiml.gateway.hostname}") String hostname,
-                                                              @Value("${apiml.service.port}") String port,
-                                                              @Value("${apiml.service.scheme}") String scheme) {
-        return GatewayConfigProperties.builder()
-            .scheme(scheme)
-            .hostname(hostname + ":" + port)
-            .build();
+            @Value("${apiml.service.port}") String port, @Value("${apiml.service.scheme}") String scheme) {
+        return GatewayConfigProperties.builder().scheme(scheme).hostname(hostname + ":" + port).build();
+    }
+
+    @Bean
+    @Autowired
+    public SimpleHostRoutingFilter simpleHostRoutingFilter2(ProxyRequestHelper helper, ZuulProperties zuulProperties,
+            @Qualifier("secureHttpClientWithoutKeystore") CloseableHttpClient secureHttpClientWithoutKeystore) {
+        return new SimpleHostRoutingFilter(helper, zuulProperties, secureHttpClientWithoutKeystore);
     }
 }

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/ribbon/GatewayRibbonConfig.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/ribbon/GatewayRibbonConfig.java
@@ -12,6 +12,7 @@ package com.ca.mfaas.gateway.ribbon;
 import com.netflix.client.config.IClientConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpClient;
 import org.springframework.context.annotation.Bean;
@@ -23,9 +24,8 @@ public class GatewayRibbonConfig {
     @Bean
     @Autowired
     public RibbonLoadBalancingHttpClient ribbonLoadBalancingHttpClient(
-        CloseableHttpClient secureHttpClient,
-        IClientConfig config,
-        ServerIntrospector serverIntrospector) {
-        return new GatewayRibbonLoadBalancingHttpClient(secureHttpClient, config, serverIntrospector);
+            @Qualifier("secureHttpClientWithoutKeystore") CloseableHttpClient secureHttpClientWithoutKeystore,
+            IClientConfig config, ServerIntrospector serverIntrospector) {
+        return new GatewayRibbonLoadBalancingHttpClient(secureHttpClientWithoutKeystore, config, serverIntrospector);
     }
 }

--- a/gateway-service/src/main/java/com/ca/mfaas/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
+++ b/gateway-service/src/main/java/com/ca/mfaas/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
@@ -61,12 +61,12 @@ public class ZosmfAuthenticationProvider implements AuthenticationProvider {
                                        AuthenticationService authenticationService,
                                        DiscoveryClient discovery,
                                        ObjectMapper securityObjectMapper,
-                                       RestTemplate restTemplate) {
+                                       RestTemplate restTemplateWithoutKeystore) {
         this.authConfigurationProperties = authConfigurationProperties;
         this.discovery = discovery;
         this.authenticationService = authenticationService;
         this.securityObjectMapper = securityObjectMapper;
-        this.restTemplate = restTemplate;
+        this.restTemplate = restTemplateWithoutKeystore;
     }
 
     /**


### PR DESCRIPTION
The APIML client certificates are not used when the API gateway is sending requests to z/OSMF and routing other services.

It remains to be used for inter-APIML communication.

`HttpsFactory` needs to create an empty keystore because IBMJSSE2 behavior (different from Oracle Java):

> If no KeyStore parameter is passed to the IBMJSSE2 default IbmX509 KeyManagerFactory, the factory tries to find key material by consulting the system properties
> javax.net.ssl.keyStore
> javax.net.ssl.keyStorePassword
> javax.net.ssl.keyStoreType

Source: https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/jsse2Docs/x509keymanager.html
