### PR TITLE
Normalize the build-info and git properties files from the bundle cache.

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -6,6 +6,13 @@ buildscript {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        ignore("**/*git.properties*")
+        ignore("**/*build-info.properties*")
+    }
+}
+
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'com.gorylenko.gradle-git-properties'

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -6,6 +6,13 @@ buildscript {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        ignore("**/*git.properties*")
+        ignore("**/*build-info.properties*")
+    }
+}
+
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.gorylenko.gradle-git-properties'
 

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -6,6 +6,13 @@ buildscript {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        ignore("**/*git.properties*")
+        ignore("**/*build-info.properties*")
+    }
+}
+
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'com.gorylenko.gradle-git-properties'

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -6,6 +6,13 @@ buildscript {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        ignore("**/*git.properties*")
+        ignore("**/*build-info.properties*")
+    }
+}
+
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'com.gorylenko.gradle-git-properties'


### PR DESCRIPTION
This way it is possible to specify the build cache and run locally
with `--build-cache` for the usage of build cache.

It is also possible to add the following to `gradle.properties` and it will apply to all builds
`org.gradle.cache=true`.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>