### PR TITLE
Enablers some fixes

### DIFF
--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/Authentication.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/Authentication.java
@@ -11,9 +11,11 @@ package org.zowe.apiml.eurekaservice.client.config;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class Authentication {
     private String scheme;
     private String applid;

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -8,8 +8,6 @@ buildscript {
             } else {
                 springBootVersion = rootProject.ext.springBootVersion
             }
-        } else {
-            springBootVersion = rootProject.ext.springBootVersion
         }
     }
 
@@ -41,3 +39,5 @@ dependencies {
     annotationProcessor libraries.lombok
     testCompile libraries.gson
 }
+
+jar.baseName = "${jar.baseName}-${springBootVersion}"

--- a/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/config/EnableApiDiscoveryConfig.java
+++ b/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/config/EnableApiDiscoveryConfig.java
@@ -14,15 +14,16 @@ import org.zowe.apiml.eurekaservice.client.config.ApiMediationServiceConfig;
 import org.zowe.apiml.eurekaservice.client.impl.ApiMediationClientImpl;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
 
 
 @Configuration
 @ComponentScan(value = {"org.zowe.apiml.enable"})
+@EnableApimlLogger
 public class EnableApiDiscoveryConfig {
 
     @Bean
@@ -42,13 +43,5 @@ public class EnableApiDiscoveryConfig {
     @Bean
     public ApiMediationServiceConfig apiMediationServiceConfig() {
         return new ApiMediationServiceConfig();
-    }
-
-    @Value("${apiml.enabled:false}")
-    private boolean enabled;
-
-    @Bean
-    public Boolean apimlEnabled() {
-        return enabled;
     }
 }

--- a/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
+++ b/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
@@ -50,7 +50,6 @@ public class RegisterToApiLayer {
     @EventListener(ContextRefreshedEvent.class)
     public void onContextRefreshedEventEvent() {
         if (apimlEnabled) {
-
             if (apiMediationClient.getEurekaClient() != null) {
                 if (config != null) {
                     logger.log( "org.zowe.apiml.enabler.registration.renew"


### PR DESCRIPTION
I fixed some problems about enabler:
1. Authentication model needs default constructor. Because spring-boot-v1 based apps fill datas from configuration different than v2.
2. Enablers use ```@InjectApimlLogger``` mechanism. But for working with auto-injection 
 needs ```@EnableApimlLogger``` annotation as well. 
3. Added line, in case of building jar with spring-boot-v1 dependency.
```
jar.baseName = "${jar.baseName}-${springBootVersion}"
```

```
./gradlew onboarding-enabler-spring:build -Penabler=v1 
```

**Jar location**: build/libs/onboarding-enabler-spring-1.5.9.RELEASE-1.4.0-SNAPSHOT.jar