### PR TITLE
handle exception on notification gateways by discovery to have safe registration process

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListener.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListener.java
@@ -28,7 +28,7 @@ public class EurekaInstanceCanceledListener {
      */
     @EventListener
     public void listen(EurekaInstanceCanceledEvent event) {
-        gatewayNotifier.serviceUpdated(EurekaUtils.getServiceIdFromInstanceId(event.getServerId()));
+        gatewayNotifier.serviceUpdated(EurekaUtils.getServiceIdFromInstanceId(event.getServerId()), null);
     }
 
 }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListener.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListener.java
@@ -43,7 +43,7 @@ public class EurekaInstanceRegisteredListener {
         metadataTranslationService.translateMetadata(metadata);
         metadataDefaultsService.updateMetadata(serviceId, metadata);
         // ie. new instance can have different authentication (than other one), this is reason to evict caches on gateway
-        gatewayNotifier.serviceUpdated(serviceId);
+        gatewayNotifier.serviceUpdated(serviceId, instanceInfo.getInstanceId());
     }
 
 }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/GatewayNotifier.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/GatewayNotifier.java
@@ -57,7 +57,7 @@ public class GatewayNotifier {
         final List<InstanceInfo> gatewayInstances = application.getInstances();
 
         for (final InstanceInfo instanceInfo : gatewayInstances) {
-            // dont notify service itself, it is not required
+            // don't notify service itself, it is not required
             if (StringUtils.equalsIgnoreCase(instanceId, instanceInfo.getInstanceId())) continue;
 
             final StringBuilder url = new StringBuilder();
@@ -67,7 +67,7 @@ public class GatewayNotifier {
             try {
                 restTemplate.delete(url.toString());
             } catch (Exception e) {
-                log.debug("Cannot notify gateway {} about {}", url.toString(), instanceId, e);
+                log.debug("Cannot notify the Gateway {} about {}", url.toString(), instanceId, e);
                 logger.log("org.zowe.apiml.discovery.registration.gateway.notify", url.toString(), instanceId);
             }
         }

--- a/discovery-service/src/main/resources/discovery-log-messages.yml
+++ b/discovery-service/src/main/resources/discovery-log-messages.yml
@@ -8,6 +8,16 @@ messages:
 
     # HTTP,Protocol messages
     # 400-499
+    - key: org.zowe.apiml.discovery.registration.gateway.notify
+      number: ZWEAD400
+      type: ERROR
+      text: "Cannot notify gateway on '%s' about new instance '%s'"
+      reason: "The discovery service tried to notify a gateway about instance updates, but REST call failed. It is used for update caches on gateway's side. Gateway might be down or a network problem happened."
+      action: "If gateway was restarted this message is expected, it doesn't require any other action, otherwise check
+      - if gateway is at the specified address.
+      - if URL is well-formed.
+      - if gateway is accessible from discovery's location.
+      Instance 'null' means any change (there is not specified instance)"
 
     # TLS,Certificate messages
     # 500-599

--- a/discovery-service/src/main/resources/discovery-log-messages.yml
+++ b/discovery-service/src/main/resources/discovery-log-messages.yml
@@ -11,13 +11,9 @@ messages:
     - key: org.zowe.apiml.discovery.registration.gateway.notify
       number: ZWEAD400
       type: ERROR
-      text: "Cannot notify gateway on '%s' about new instance '%s'"
-      reason: "The discovery service tried to notify a gateway about instance updates, but REST call failed. It is used for update caches on gateway's side. Gateway might be down or a network problem happened."
-      action: "If gateway was restarted this message is expected, it doesn't require any other action, otherwise check
-      - if gateway is at the specified address.
-      - if URL is well-formed.
-      - if gateway is accessible from discovery's location.
-      Instance 'null' means any change (there is not specified instance)"
+      text: "Cannot notify Gateway on '%s' about new instance '%s'"
+      reason: "The Discovery Service tried to notify the Gateway about instance update, but the REST call failed. The purpose of this call is to update the Gateway caches. The Gateway might be down or a network problem occured."
+      action: "Ensure there are no network issues and the Gateway was not restarted. If the problem reoccurs, contact Broadcom support. "
 
     # TLS,Certificate messages
     # 500-599

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListenerTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListenerTest.java
@@ -28,9 +28,9 @@ public class EurekaInstanceCanceledListenerTest {
         EurekaInstanceCanceledListener listener = new EurekaInstanceCanceledListener(notifier);
 
         listener.listen(createEvent("host:service:instance"));
-        verify(notifier, times(1)).serviceUpdated("service");
+        verify(notifier, times(1)).serviceUpdated("service", null);
         listener.listen(createEvent("unknown format"));
-        verify(notifier, times(1)).serviceUpdated(null);
+        verify(notifier, times(1)).serviceUpdated(null, null);
     }
 
 }

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListenerTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListenerTest.java
@@ -63,9 +63,9 @@ public class EurekaInstanceRegisteredListenerTest {
         EurekaInstanceRegisteredListener listener = new EurekaInstanceRegisteredListener(Mockito.mock(MetadataTranslationService.class), Mockito.mock(MetadataDefaultsService.class), notifier);
 
         listener.listen(createEvent("host:service:instance"));
-        verify(notifier, times(1)).serviceUpdated("service");
+        verify(notifier, times(1)).serviceUpdated("service", "host:service:instance");
         listener.listen(createEvent("unknown format"));
-        verify(notifier, times(1)).serviceUpdated(null);
+        verify(notifier, times(1)).serviceUpdated(null, "unknown format");
     }
 
 }


### PR DESCRIPTION
When service is registration into discovery service, discovery service notify about change all gateways. They can evict caches and speed up registry update.

This PR fix this process:
- do not notify gateway itself about its registration
- if any gateway is not available, dont distribute exception from REST (it can break whole process)
- instanceof trackstack write only message into log