### PR TITLE
Switch to React.lazy for code splitting and use async components

### DIFF
--- a/api-catalog-ui/frontend/package.json
+++ b/api-catalog-ui/frontend/package.json
@@ -86,7 +86,7 @@
         "prettier": "1.14.2",
         "react-testing-library": "5.3.0",
         "rimraf": "3.0.2",
-        "source-map-explorer": "1.6.0",
+        "source-map-explorer": "2.3.1",
         "start-server-and-test": "1.10.8"
     },
     "jest": {

--- a/api-catalog-ui/frontend/pnpm-lock.yaml
+++ b/api-catalog-ui/frontend/pnpm-lock.yaml
@@ -56,7 +56,7 @@ devDependencies:
   nodemon: 1.18.6
   prettier: 1.14.2
   react-testing-library: 5.3.0_react-dom@16.6.3
-  source-map-explorer: 1.6.0
+  source-map-explorer: 2.3.1
   start-server-and-test: 1.10.8
 lockfileVersion: 5.1
 packages:
@@ -1600,7 +1600,6 @@ packages:
     resolution:
       integrity: sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==
   /@types/color-name/1.1.1:
-    dev: false
     resolution:
       integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
   /@types/eslint-visitor-keys/1.0.0:
@@ -2060,7 +2059,6 @@ packages:
     resolution:
       integrity: sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
   /ansi-regex/5.0.0:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2081,7 +2079,6 @@ packages:
     dependencies:
       '@types/color-name': 1.1.1
       color-convert: 2.0.1
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2746,7 +2743,7 @@ packages:
   /browserslist/4.8.6:
     dependencies:
       caniuse-lite: 1.0.30001032
-      electron-to-chromium: 1.3.369
+      electron-to-chromium: 1.3.370
       node-releases: 1.1.50
     dev: false
     hasBin: true
@@ -2755,7 +2752,7 @@ packages:
   /browserslist/4.9.1:
     dependencies:
       caniuse-lite: 1.0.30001032
-      electron-to-chromium: 1.3.369
+      electron-to-chromium: 1.3.370
       node-releases: 1.1.50
     dev: false
     hasBin: true
@@ -3009,7 +3006,6 @@ packages:
     dependencies:
       ansi-styles: 4.2.1
       supports-color: 7.1.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3187,6 +3183,14 @@ packages:
       wrap-ansi: 5.1.0
     resolution:
       integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  /cliui/6.0.0:
+    dependencies:
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+      wrap-ansi: 6.2.0
+    dev: true
+    resolution:
+      integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   /clone-deep/0.2.4:
     dependencies:
       for-own: 0.1.5
@@ -3246,7 +3250,6 @@ packages:
   /color-convert/2.0.1:
     dependencies:
       color-name: 1.1.4
-    dev: false
     engines:
       node: '>=7.0.0'
     resolution:
@@ -3255,7 +3258,6 @@ packages:
     resolution:
       integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
   /color-name/1.1.4:
-    dev: false
     resolution:
       integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
   /color-string/1.5.3:
@@ -4174,12 +4176,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
-  /docopt/0.6.2:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=
   /doctrine/1.5.0:
     dependencies:
       esutils: 2.0.3
@@ -4337,10 +4333,17 @@ packages:
   /ee-first/1.1.1:
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.369:
+  /ejs/3.0.1:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    requiresBuild: true
+    resolution:
+      integrity: sha512-cuIMtJwxvzumSAkqaaoGY/L6Fc/t6YvoP9/VIaK0V/CyqKLEQ8sqODmYfy/cjXEdZ9+OOL8TecbJu+1RsofGDw==
+  /electron-to-chromium/1.3.370:
     dev: false
     resolution:
-      integrity: sha512-6laJEDffEppIKT01TbyQtNhbdvF8ZfJWuK4L53sQCSiUHv0wSsJOFPvV0E63PZEQUzGcS2ZRSJlM5F4Ol9ffHg==
+      integrity: sha512-399cXDE9C7qoVF2CUgCA/MLflfvxbo1F0kB/pkB94426freL/JgZ0HNaloomsOfnE+VC/qgTFZqzmivSdaNfPQ==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -4371,7 +4374,6 @@ packages:
     resolution:
       integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
   /emoji-regex/8.0.0:
-    dev: false
     resolution:
       integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
   /emojis-list/2.1.0:
@@ -5529,7 +5531,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -5967,7 +5968,6 @@ packages:
     dependencies:
       duplexer: 0.1.1
       pify: 4.0.1
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -6012,7 +6012,6 @@ packages:
     resolution:
       integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
   /has-flag/4.0.0:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -6659,7 +6658,6 @@ packages:
     resolution:
       integrity: sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
   /is-docker/2.0.0:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -6707,7 +6705,6 @@ packages:
     resolution:
       integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
   /is-fullwidth-code-point/3.0.0:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -6914,7 +6911,6 @@ packages:
     resolution:
       integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
   /is-wsl/2.1.1:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -7865,7 +7861,6 @@ packages:
   /locate-path/5.0.0:
     dependencies:
       p-locate: 4.1.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -8983,7 +8978,6 @@ packages:
     dependencies:
       is-docker: 2.0.0
       is-wsl: 2.1.1
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -8991,6 +8985,7 @@ packages:
   /opn/5.5.0:
     dependencies:
       is-wsl: 1.1.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -9112,7 +9107,6 @@ packages:
   /p-locate/4.1.0:
     dependencies:
       p-limit: 2.2.2
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -9285,7 +9279,6 @@ packages:
     resolution:
       integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
   /path-exists/4.0.0:
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -11960,20 +11953,24 @@ packages:
     dev: false
     resolution:
       integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
-  /source-map-explorer/1.6.0:
+  /source-map-explorer/2.3.1:
     dependencies:
       btoa: 1.2.1
+      chalk: 3.0.0
       convert-source-map: 1.7.0
-      docopt: 0.6.2
+      ejs: 3.0.1
+      escape-html: 1.0.3
       glob: 7.1.6
-      opn: 5.5.0
-      source-map: 0.5.7
-      temp: 0.8.4
-      underscore: 1.9.2
+      gzip-size: 5.1.1
+      lodash: 4.17.15
+      open: 7.0.2
+      source-map: 0.7.3
+      temp: 0.9.1
+      yargs: 15.1.0
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-Om4L02wExk1tWZ2KJqW7A/gadFoU6/6vuPUOiYyeMCtkQqhexTod6Pi6aCQ6HiIEd7ZSbiOOPgIrG6bn/72foQ==
+      integrity: sha512-l3WQUCwaqia5x7EBnNp4GYwhXnROMz3NqKM2QMwQ3ADgjekp+enP+PHkjjbjoVX6WJ2G5mbvM6TjeE/q7fnIFw==
   /source-map-resolve/0.5.3:
     dependencies:
       atob: 2.1.2
@@ -12003,7 +12000,6 @@ packages:
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
   /source-map/0.7.3:
-    dev: false
     engines:
       node: '>= 8'
     resolution:
@@ -12249,7 +12245,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -12324,7 +12319,6 @@ packages:
   /strip-ansi/6.0.0:
     dependencies:
       ansi-regex: 5.0.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -12427,7 +12421,6 @@ packages:
   /supports-color/7.1.0:
     dependencies:
       has-flag: 4.0.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -12559,14 +12552,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-  /temp/0.8.4:
+  /temp/0.9.1:
     dependencies:
       rimraf: 2.6.3
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==
+      integrity: sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==
   /term-size/1.2.0:
     dependencies:
       execa: 0.7.0
@@ -12880,10 +12873,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
-  /underscore/1.9.2:
-    dev: true
-    resolution:
-      integrity: sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==
   /unicode-canonical-property-names-ecmascript/1.0.4:
     dev: false
     engines:
@@ -13565,6 +13554,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  /wrap-ansi/6.2.0:
+    dependencies:
+      ansi-styles: 4.2.1
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   /wrappy/1.0.2:
     resolution:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
@@ -13672,6 +13671,13 @@ packages:
       decamelize: 1.2.0
     resolution:
       integrity: sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  /yargs-parser/16.1.0:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
   /yargs/12.0.5:
     dependencies:
       cliui: 4.1.0
@@ -13702,6 +13708,24 @@ packages:
       yargs-parser: 13.1.1
     resolution:
       integrity: sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
+  /yargs/15.1.0:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.0
+      which-module: 2.0.0
+      y18n: 4.0.0
+      yargs-parser: 16.1.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
   /yauzl/2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
@@ -13774,7 +13798,7 @@ specifiers:
   redux-thunk: 2.3.0
   rimraf: 3.0.2
   rxjs: 6.3.3
-  source-map-explorer: 1.6.0
+  source-map-explorer: 2.3.1
   start-server-and-test: 1.10.8
   swagger-ui: 3.25.0
   uuid: 3.3.2

--- a/api-catalog-ui/frontend/pnpm-lock.yaml
+++ b/api-catalog-ui/frontend/pnpm-lock.yaml
@@ -67,7 +67,7 @@ packages:
       integrity: sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
   /@babel/compat-data/7.8.6:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       invariant: 2.2.4
       semver: 5.7.1
     dev: false
@@ -76,18 +76,18 @@ packages:
   /@babel/core/7.8.4:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.8.6
+      '@babel/generator': 7.8.7
       '@babel/helpers': 7.8.4
-      '@babel/parser': 7.8.6
+      '@babel/parser': 7.8.7
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
       json5: 2.1.1
-      lodash: 4.17.15
-      resolve: 1.15.1
+      lodash: 4.17.14
+      resolve: 1.15.0
       semver: 5.7.1
       source-map: 0.5.7
     dev: false
@@ -95,15 +95,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==
-  /@babel/core/7.8.6:
+  /@babel/core/7.8.7:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.8.6
+      '@babel/generator': 7.8.7
       '@babel/helpers': 7.8.4
-      '@babel/parser': 7.8.6
+      '@babel/parser': 7.8.7
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
@@ -115,48 +115,48 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==
-  /@babel/generator/7.8.6:
+      integrity: sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==
+  /@babel/generator/7.8.7:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       jsesc: 2.5.2
       lodash: 4.17.14
       source-map: 0.5.7
     resolution:
-      integrity: sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==
+      integrity: sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==
   /@babel/helper-annotate-as-pure/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.8.3:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.8.3
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==
   /@babel/helper-builder-react-jsx/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       esutils: 2.0.3
     dev: false
     resolution:
       integrity: sha512-JT8mfnpTkKNCboTqZsQTdGo3l3Ik3l7QIt9hh0O9DYiwVel37VoJpILKM4YFbP2euF32nkQSb+F9cUk9b7DDXQ==
-  /@babel/helper-call-delegate/7.8.3:
+  /@babel/helper-call-delegate/7.8.7:
     dependencies:
       '@babel/helper-hoist-variables': 7.8.3
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
-      integrity: sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==
-  /@babel/helper-compilation-targets/7.8.6_@babel+core@7.8.4:
+      integrity: sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==
+  /@babel/helper-compilation-targets/7.8.7_@babel+core@7.8.4:
     dependencies:
       '@babel/compat-data': 7.8.6
       '@babel/core': 7.8.4
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       invariant: 2.2.4
       levenary: 1.1.1
       semver: 5.7.1
@@ -164,20 +164,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==
-  /@babel/helper-compilation-targets/7.8.6_@babel+core@7.8.6:
-    dependencies:
-      '@babel/compat-data': 7.8.6
-      '@babel/core': 7.8.6
-      browserslist: 4.9.0
-      invariant: 2.2.4
-      levenary: 1.1.1
-      semver: 5.7.1
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==
+      integrity: sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==
   /@babel/helper-create-class-features-plugin/7.8.6_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -203,29 +190,18 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==
-  /@babel/helper-create-regexp-features-plugin/7.8.6_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-annotate-as-pure': 7.8.3
-      '@babel/helper-regex': 7.8.3
-      regexpu-core: 4.6.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==
   /@babel/helper-define-map/7.8.3:
     dependencies:
       '@babel/helper-function-name': 7.8.3
-      '@babel/types': 7.8.6
-      lodash: 4.17.15
+      '@babel/types': 7.8.7
+      lodash: 4.17.14
     dev: false
     resolution:
       integrity: sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==
   /@babel/helper-explode-assignable-expression/7.8.3:
     dependencies:
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==
@@ -233,29 +209,29 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.8.3
       '@babel/template': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
   /@babel/helper-get-function-arity/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
   /@babel/helper-hoist-variables/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==
   /@babel/helper-member-expression-to-functions/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
   /@babel/helper-module-imports/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -266,14 +242,14 @@ packages:
       '@babel/helper-simple-access': 7.8.3
       '@babel/helper-split-export-declaration': 7.8.3
       '@babel/template': 7.8.6
-      '@babel/types': 7.8.6
-      lodash: 4.17.15
+      '@babel/types': 7.8.7
+      lodash: 4.17.14
     dev: false
     resolution:
       integrity: sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==
   /@babel/helper-optimise-call-expression/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
@@ -282,7 +258,7 @@ packages:
       integrity: sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
   /@babel/helper-regex/7.8.3:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.14
     dev: false
     resolution:
       integrity: sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==
@@ -292,7 +268,7 @@ packages:
       '@babel/helper-wrap-function': 7.8.3
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==
@@ -301,20 +277,20 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.8.3
       '@babel/helper-optimise-call-expression': 7.8.3
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
   /@babel/helper-simple-access/7.8.3:
     dependencies:
       '@babel/template': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
   /@babel/helper-split-export-declaration/7.8.3:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   /@babel/helper-wrap-function/7.8.3:
@@ -322,7 +298,7 @@ packages:
       '@babel/helper-function-name': 7.8.3
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     resolution:
       integrity: sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==
@@ -330,7 +306,7 @@ packages:
     dependencies:
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
   /@babel/highlight/7.8.3:
@@ -340,29 +316,18 @@ packages:
       js-tokens: 4.0.0
     resolution:
       integrity: sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
-  /@babel/parser/7.8.6:
+  /@babel/parser/7.8.7:
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==
+      integrity: sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==
   /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==
-  /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-remap-async-to-generator': 7.8.3
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -399,16 +364,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
-  /@babel/plugin-proposal-dynamic-import/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
   /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -419,31 +374,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==
-  /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==
   /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -469,16 +404,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==
-  /@babel/plugin-proposal-object-rest-spread/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==
   /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -489,31 +414,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
-  /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
   /@babel/plugin-proposal-optional-chaining/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
-  /@babel/plugin-proposal-optional-chaining/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -531,30 +436,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==
-  /@babel/plugin-proposal-unicode-property-regex/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-create-regexp-features-plugin': 7.8.6_@babel+core@7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    engines:
-      node: '>=4'
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -579,15 +463,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   /@babel/plugin-syntax-flow/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -606,15 +481,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   /@babel/plugin-syntax-jsx/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -624,27 +490,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
-  /@babel/plugin-syntax-jsx/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -669,9 +517,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.6:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.7:
     dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.7
       '@babel/helper-plugin-utils': 7.8.3
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -680,15 +528,6 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -704,27 +543,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==
-  /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -749,29 +570,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==
-  /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==
   /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-imports': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-remap-async-to-generator': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==
-  /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
@@ -789,30 +590,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==
-  /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==
   /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
-  /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      lodash: 4.17.15
+      lodash: 4.17.14
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -821,22 +603,6 @@ packages:
   /@babel/plugin-transform-classes/7.8.6_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-annotate-as-pure': 7.8.3
-      '@babel/helper-define-map': 7.8.3
-      '@babel/helper-function-name': 7.8.3
-      '@babel/helper-optimise-call-expression': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-replace-supers': 7.8.6
-      '@babel/helper-split-export-declaration': 7.8.3
-      globals: 11.12.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==
-  /@babel/plugin-transform-classes/7.8.6_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-define-map': 7.8.3
       '@babel/helper-function-name': 7.8.3
@@ -859,27 +625,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==
-  /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==
   /@babel/plugin-transform-destructuring/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==
-  /@babel/plugin-transform-destructuring/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -896,16 +644,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
-  /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-create-regexp-features-plugin': 7.8.6_@babel+core@7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
   /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -915,28 +653,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==
-  /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==
   /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==
-  /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
@@ -963,28 +682,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==
-  /@babel/plugin-transform-for-of/7.8.6_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==
   /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-function-name': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==
-  /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
@@ -1001,27 +701,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==
-  /@babel/plugin-transform-literals/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==
   /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==
-  /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -1039,32 +721,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==
-  /@babel/plugin-transform-modules-amd/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-module-transforms': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      babel-plugin-dynamic-import-node: 2.3.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==
   /@babel/plugin-transform-modules-commonjs/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-transforms': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-simple-access': 7.8.3
-      babel-plugin-dynamic-import-node: 2.3.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==
-  /@babel/plugin-transform-modules-commonjs/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-module-transforms': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-simple-access': 7.8.3
@@ -1086,31 +745,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==
-  /@babel/plugin-transform-modules-systemjs/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-hoist-variables': 7.8.3
-      '@babel/helper-module-transforms': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      babel-plugin-dynamic-import-node: 2.3.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==
   /@babel/plugin-transform-modules-umd/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-transforms': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==
-  /@babel/plugin-transform-modules-umd/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-module-transforms': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
@@ -1127,27 +764,9 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-create-regexp-features-plugin': 7.8.6_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==
   /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
-  /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -1164,38 +783,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==
-  /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-replace-supers': 7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==
-  /@babel/plugin-transform-parameters/7.8.4_@babel+core@7.8.4:
+  /@babel/plugin-transform-parameters/7.8.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-call-delegate': 7.8.3
+      '@babel/helper-call-delegate': 7.8.7
       '@babel/helper-get-function-arity': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
-  /@babel/plugin-transform-parameters/7.8.4_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-call-delegate': 7.8.3
-      '@babel/helper-get-function-arity': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
+      integrity: sha512-brYWaEPTRimOctz2NDA3jnBbDi7SVN2T4wYuu0aqSzxC3nozFZngGaw29CJ9ZPweB7k+iFmZuoG3IVPIcXmD2g==
   /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1205,18 +803,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==
-  /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.6:
+  /@babel/plugin-transform-react-constant-elements/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==
-  /@babel/plugin-transform-react-constant-elements/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.4
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
@@ -1233,15 +822,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==
-  /@babel/plugin-transform-react-display-name/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==
   /@babel/plugin-transform-react-jsx-self/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1252,31 +832,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-01OT7s5oa0XTLf2I8XGsL8+KqV9lx3EZV+jxn/L2LQ97CGKila2YMroTkCEIE0HV/FF7CMSRsIAybopdN9NTdg==
-  /@babel/plugin-transform-react-jsx-self/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-01OT7s5oa0XTLf2I8XGsL8+KqV9lx3EZV+jxn/L2LQ97CGKila2YMroTkCEIE0HV/FF7CMSRsIAybopdN9NTdg==
   /@babel/plugin-transform-react-jsx-source/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-PLMgdMGuVDtRS/SzjNEQYUT8f4z1xb2BAT54vM1X5efkVuYBf5WyGUMbpmARcfq3NaglIwz08UVQK4HHHbC6ag==
-  /@babel/plugin-transform-react-jsx-source/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1293,47 +853,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==
-  /@babel/plugin-transform-react-jsx/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-builder-react-jsx': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==
-  /@babel/plugin-transform-regenerator/7.8.3_@babel+core@7.8.4:
+  /@babel/plugin-transform-regenerator/7.8.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      regenerator-transform: 0.14.1
+      regenerator-transform: 0.14.2
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==
-  /@babel/plugin-transform-regenerator/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      regenerator-transform: 0.14.1
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==
+      integrity: sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==
   /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==
-  /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
     dev: false
     peerDependencies:
@@ -1361,15 +892,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==
-  /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==
   /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1379,28 +901,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==
-  /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==
   /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-regex': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==
-  /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-regex': 7.8.3
     dev: false
@@ -1418,16 +921,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==
-  /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-annotate-as-pure': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==
   /@babel/plugin-transform-typeof-symbol/7.8.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1437,16 +930,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
-  /@babel/plugin-transform-typeof-symbol/7.8.4_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
-  /@babel/plugin-transform-typescript/7.8.3_@babel+core@7.8.4:
+  /@babel/plugin-transform-typescript/7.8.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-class-features-plugin': 7.8.6_@babel+core@7.8.4
@@ -1456,7 +940,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Ebj230AxcrKGZPKIp4g4TdQLrqX95TobLUWKd/CwG7X1XHUH1ZpkpFvXuXqWbtGRWb7uuEWNlrl681wsOArAdQ==
+      integrity: sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==
   /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1467,21 +951,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==
-  /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-create-regexp-features-plugin': 7.8.6_@babel+core@7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==
   /@babel/preset-env/7.8.4_@babel+core@7.8.4:
     dependencies:
       '@babel/compat-data': 7.8.6
       '@babel/core': 7.8.4
-      '@babel/helper-compilation-targets': 7.8.6_@babel+core@7.8.4
+      '@babel/helper-compilation-targets': 7.8.7_@babel+core@7.8.4
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.4
@@ -1521,9 +995,9 @@ packages:
       '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.4
-      '@babel/plugin-transform-parameters': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-transform-parameters': 7.8.7_@babel+core@7.8.4
       '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.4
-      '@babel/plugin-transform-regenerator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-regenerator': 7.8.7_@babel+core@7.8.4
       '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.4
@@ -1531,8 +1005,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-typeof-symbol': 7.8.4_@babel+core@7.8.4
       '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.4
-      '@babel/types': 7.8.6
-      browserslist: 4.9.0
+      '@babel/types': 7.8.7
+      browserslist: 4.9.1
       core-js-compat: 3.6.4
       invariant: 2.2.4
       levenary: 1.1.1
@@ -1542,62 +1016,62 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==
-  /@babel/preset-env/7.8.6_@babel+core@7.8.6:
+  /@babel/preset-env/7.8.7_@babel+core@7.8.4:
     dependencies:
       '@babel/compat-data': 7.8.6
-      '@babel/core': 7.8.6
-      '@babel/helper-compilation-targets': 7.8.6_@babel+core@7.8.6
+      '@babel/core': 7.8.4
+      '@babel/helper-compilation-targets': 7.8.7_@babel+core@7.8.4
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-object-rest-spread': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-proposal-unicode-property-regex': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.6
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-classes': 7.8.6_@babel+core@7.8.6
-      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-destructuring': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-for-of': 7.8.6_@babel+core@7.8.6
-      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-modules-amd': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-modules-commonjs': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-modules-systemjs': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-modules-umd': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-parameters': 7.8.4_@babel+core@7.8.6
-      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-regenerator': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-typeof-symbol': 7.8.4_@babel+core@7.8.6
-      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.6
-      '@babel/types': 7.8.6
-      browserslist: 4.9.0
+      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-object-rest-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-classes': 7.8.6_@babel+core@7.8.4
+      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-destructuring': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-for-of': 7.8.6_@babel+core@7.8.4
+      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-amd': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-commonjs': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-systemjs': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-umd': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-parameters': 7.8.7_@babel+core@7.8.4
+      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-regenerator': 7.8.7_@babel+core@7.8.4
+      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-typeof-symbol': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/types': 7.8.7
+      browserslist: 4.9.1
       core-js-compat: 3.6.4
       invariant: 2.2.4
       levenary: 1.1.1
@@ -1606,7 +1080,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-M5u8llV9DIVXBFB/ArIpqJuvXpO+ymxcJ6e8ZAmzeK3sQeBNOD1y+rHvHCGG4TlEmsNpIrdecsHGHT8ZCoOSJg==
+      integrity: sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==
   /@babel/preset-react/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -1620,68 +1094,61 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==
-  /@babel/preset-react/7.8.3_@babel+core@7.8.6:
-    dependencies:
-      '@babel/core': 7.8.6
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-transform-react-display-name': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-react-jsx': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-react-jsx-self': 7.8.3_@babel+core@7.8.6
-      '@babel/plugin-transform-react-jsx-source': 7.8.3_@babel+core@7.8.6
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==
   /@babel/preset-typescript/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-transform-typescript': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-typescript': 7.8.7_@babel+core@7.8.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-qee5LgPGui9zQ0jR1TeU5/fP9L+ovoArklEqY12ek8P/wV5ZeM/VYSQYwICeoT6FfpJTekG9Ilay5PhwsOpMHA==
-  /@babel/runtime-corejs2/7.8.4:
+  /@babel/runtime-corejs2/7.8.7:
     dependencies:
       core-js: 2.6.11
-      regenerator-runtime: 0.13.3
+      regenerator-runtime: 0.13.4
     dev: false
     resolution:
-      integrity: sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==
+      integrity: sha512-R8zbPiv25S0pGfMqAr55dRRxWB8vUeo3wicI4g9PFVBKmsy/9wmQUV1AaYW/kxRHUhx42TTh6F0+QO+4pwfYWg==
   /@babel/runtime/7.8.4:
     dependencies:
       regenerator-runtime: 0.13.3
+    dev: false
     resolution:
       integrity: sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  /@babel/runtime/7.8.7:
+    dependencies:
+      regenerator-runtime: 0.13.4
+    resolution:
+      integrity: sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
   /@babel/template/7.8.6:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/parser': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/parser': 7.8.7
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
   /@babel/traverse/7.8.6:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.8.6
+      '@babel/generator': 7.8.7
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-split-export-declaration': 7.8.3
-      '@babel/parser': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/parser': 7.8.7
+      '@babel/types': 7.8.7
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.14
     resolution:
       integrity: sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==
-  /@babel/types/7.8.6:
+  /@babel/types/7.8.7:
     dependencies:
       esutils: 2.0.3
       lodash: 4.17.14
       to-fast-properties: 2.0.0
     resolution:
-      integrity: sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==
+      integrity: sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
   /@braintree/sanitize-url/3.1.0:
     dev: false
     resolution:
@@ -1930,7 +1397,7 @@ packages:
       integrity: sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
   /@jest/transform/24.9.0:
     dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.7
       '@jest/types': 24.9.0
       babel-plugin-istanbul: 5.2.0
       chalk: 2.4.2
@@ -2065,7 +1532,7 @@ packages:
       integrity: sha512-qNuGF1QON1626UCaZamWt5yedpgOytvLj5BQZe2j1k1B8DUG4OyugZyfEwBeXozCUwhLEpsrgPrE+eCu4fY17w==
   /@svgr/hast-util-to-babel-ast/4.3.2:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     dev: false
     engines:
       node: '>=8'
@@ -2073,10 +1540,10 @@ packages:
       integrity: sha512-JioXclZGhFIDL3ddn4Kiq8qEqYM2PyDKV0aYno8+IXTLuYt6TOgHUbUAAFvqtb0Xn37NwP0BTHglejFoYr8RZg==
   /@svgr/plugin-jsx/4.3.3:
     dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.7
       '@svgr/babel-preset': 4.3.3
       '@svgr/hast-util-to-babel-ast': 4.3.2
-      svg-parser: 2.0.3
+      svg-parser: 2.0.4
     dev: false
     engines:
       node: '>=8'
@@ -2094,10 +1561,10 @@ packages:
       integrity: sha512-PrMtEDUWjX3Ea65JsVCwTIXuSqa3CG9px+DluF1/eo9mlDrgrtFE7NE/DjdhjJgSM9wenlVBzkzneSIUgfUI/w==
   /@svgr/webpack/4.3.3:
     dependencies:
-      '@babel/core': 7.8.6
-      '@babel/plugin-transform-react-constant-elements': 7.8.3_@babel+core@7.8.6
-      '@babel/preset-env': 7.8.6_@babel+core@7.8.6
-      '@babel/preset-react': 7.8.3_@babel+core@7.8.6
+      '@babel/core': 7.8.4
+      '@babel/plugin-transform-react-constant-elements': 7.8.3_@babel+core@7.8.4
+      '@babel/preset-env': 7.8.7_@babel+core@7.8.4
+      '@babel/preset-react': 7.8.3_@babel+core@7.8.4
       '@svgr/core': 4.3.3
       '@svgr/plugin-jsx': 4.3.3
       '@svgr/plugin-svgo': 4.3.1
@@ -2109,8 +1576,8 @@ packages:
       integrity: sha512-bjnWolZ6KVsHhgyCoYRFmbd26p8XVbulCzSG53BDQqAr+JOAderYK7CuYrB3bDjHJuF6LJ7Wrr42+goLRV9qIg==
   /@types/babel__core/7.1.6:
     dependencies:
-      '@babel/parser': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/parser': 7.8.7
+      '@babel/types': 7.8.7
       '@types/babel__generator': 7.6.1
       '@types/babel__template': 7.0.2
       '@types/babel__traverse': 7.0.9
@@ -2118,20 +1585,24 @@ packages:
       integrity: sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==
   /@types/babel__generator/7.6.1:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/parser': 7.8.7
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
   /@types/babel__traverse/7.0.9:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
     resolution:
       integrity: sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==
+  /@types/color-name/1.1.1:
+    dev: false
+    resolution:
+      integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
   /@types/eslint-visitor-keys/1.0.0:
     dev: false
     resolution:
@@ -2144,7 +1615,7 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 13.7.6
+      '@types/node': 13.7.7
     dev: false
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -2170,9 +1641,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
-  /@types/node/13.7.6:
+  /@types/node/13.7.7:
     resolution:
-      integrity: sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA==
+      integrity: sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
   /@types/parse-json/4.0.0:
     dev: false
     resolution:
@@ -2203,10 +1674,10 @@ packages:
       '@types/yargs-parser': 15.0.0
     resolution:
       integrity: sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
-  /@typescript-eslint/eslint-plugin/2.21.0_5d52a47f0409d8125a5f3a0453d25801:
+  /@typescript-eslint/eslint-plugin/2.22.0_c71b9097996349ed327b811b2e237f3b:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.21.0_eslint@6.8.0
-      '@typescript-eslint/parser': 2.21.0_eslint@6.8.0
+      '@typescript-eslint/experimental-utils': 2.22.0_eslint@6.8.0
+      '@typescript-eslint/parser': 2.22.0_eslint@6.8.0
       eslint: 6.8.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
@@ -2218,16 +1689,15 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^2.0.0
       eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-b5jjjDMxzcjh/Sbjuo7WyhrQmVJg0WipTHQgXh5Xwx10uYm6nPWqN1WGOsaNq4HR3Zh4wUx4IRQdDkCHwyewyw==
-  /@typescript-eslint/experimental-utils/2.21.0_eslint@6.8.0:
+      integrity: sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==
+  /@typescript-eslint/experimental-utils/2.22.0_eslint@6.8.0:
     dependencies:
       '@types/json-schema': 7.0.4
-      '@typescript-eslint/typescript-estree': 2.21.0
+      '@typescript-eslint/typescript-estree': 2.22.0
       eslint: 6.8.0
       eslint-scope: 5.0.0
     dev: false
@@ -2236,12 +1706,12 @@ packages:
     peerDependencies:
       eslint: '*'
     resolution:
-      integrity: sha512-olKw9JP/XUkav4lq0I7S1mhGgONJF9rHNhKFn9wJlpfRVjNo3PPjSvybxEldvCXnvD+WAshSzqH5cEjPp9CsBA==
-  /@typescript-eslint/parser/2.21.0_eslint@6.8.0:
+      integrity: sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==
+  /@typescript-eslint/parser/2.22.0_eslint@6.8.0:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.21.0_eslint@6.8.0
-      '@typescript-eslint/typescript-estree': 2.21.0
+      '@typescript-eslint/experimental-utils': 2.22.0_eslint@6.8.0
+      '@typescript-eslint/typescript-estree': 2.22.0
       eslint: 6.8.0
       eslint-visitor-keys: 1.1.0
     dev: false
@@ -2249,13 +1719,12 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-VrmbdrrrvvI6cPPOG7uOgGUFXNYTiSbnRq8ZMyuGa4+qmXJXVLEEz78hKuqupvkpwJQNk1Ucz1TenrRP90gmBg==
-  /@typescript-eslint/typescript-estree/2.21.0:
+      integrity: sha512-FaZKC1X+nvD7qMPqKFUYHz3H0TAioSVFGvG29f796Nc5tBluoqfHgLbSFKsh7mKjRoeTm8J9WX2Wo9EyZWjG7w==
+  /@typescript-eslint/typescript-estree/2.22.0:
     dependencies:
       debug: 4.1.1
       eslint-visitor-keys: 1.1.0
@@ -2267,13 +1736,11 @@ packages:
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-NC/nogZNb9IK2MEFQqyDBAciOT8Lp8O3KgAfvHx2Skx6WBo+KmDqlU3R9KxHONaijfTIKtojRe3SZQyMjr3wBw==
+      integrity: sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==
   /@webassemblyjs/ast/1.8.5:
     dependencies:
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -2430,9 +1897,9 @@ packages:
       acorn-walk: 6.2.0
     resolution:
       integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
-  /acorn-jsx/5.2.0_acorn@7.1.0:
+  /acorn-jsx/5.2.0_acorn@7.1.1:
     dependencies:
-      acorn: 7.1.0
+      acorn: 7.1.1
     dev: false
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
@@ -2455,13 +1922,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
-  /acorn/7.1.0:
+  /acorn/7.1.1:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+      integrity: sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
   /address/1.1.2:
     dev: false
     engines:
@@ -2562,14 +2029,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
-  /ansi-escapes/4.3.0:
+  /ansi-escapes/4.3.1:
     dependencies:
-      type-fest: 0.8.1
+      type-fest: 0.11.0
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==
+      integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   /ansi-html/0.0.7:
     dev: false
     engines:
@@ -2610,6 +2077,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  /ansi-styles/4.2.1:
+    dependencies:
+      '@types/color-name': 1.1.1
+      color-convert: 2.0.1
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   /anymatch/2.0.0:
     dependencies:
       micromatch: 3.1.10
@@ -2781,13 +2257,13 @@ packages:
       integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
   /async/2.6.1:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.14
     dev: true
     resolution:
       integrity: sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
   /async/2.6.3:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.14
     dev: false
     resolution:
       integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -2808,8 +2284,8 @@ packages:
       integrity: sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=
   /autoprefixer/9.7.4:
     dependencies:
-      browserslist: 4.9.0
-      caniuse-lite: 1.0.30001030
+      browserslist: 4.9.1
+      caniuse-lite: 1.0.30001032
       chalk: 2.4.2
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -2842,12 +2318,12 @@ packages:
   /babel-eslint/10.0.3_eslint@6.8.0:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/parser': 7.8.6
+      '@babel/parser': 7.8.7
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       eslint: 6.8.0
       eslint-visitor-keys: 1.1.0
-      resolve: 1.15.1
+      resolve: 1.15.0
     dev: false
     engines:
       node: '>=6'
@@ -2880,14 +2356,14 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
-  /babel-jest/24.9.0_@babel+core@7.8.6:
+  /babel-jest/24.9.0_@babel+core@7.8.7:
     dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.7
       '@jest/transform': 24.9.0
       '@jest/types': 24.9.0
       '@types/babel__core': 7.1.6
       babel-plugin-istanbul: 5.2.0
-      babel-preset-jest: 24.9.0_@babel+core@7.8.6
+      babel-preset-jest: 24.9.0_@babel+core@7.8.7
       chalk: 2.4.2
       slash: 2.0.0
     engines:
@@ -2954,7 +2430,7 @@ packages:
       integrity: sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   /babel-plugin-macros/2.8.0:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       cosmiconfig: 6.0.0
       resolve: 1.15.1
     dev: false
@@ -2999,10 +2475,10 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
-  /babel-preset-jest/24.9.0_@babel+core@7.8.6:
+  /babel-preset-jest/24.9.0_@babel+core@7.8.7:
     dependencies:
-      '@babel/core': 7.8.6
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.6
+      '@babel/core': 7.8.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.7
       babel-plugin-jest-hoist: 24.9.0
     engines:
       node: '>= 6'
@@ -3206,9 +2682,9 @@ packages:
     dev: false
     resolution:
       integrity: sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
-  /browser-process-hrtime/0.1.3:
+  /browser-process-hrtime/1.0.0:
     resolution:
-      integrity: sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
+      integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
   /browser-resolve/1.11.3:
     dependencies:
       resolve: 1.1.7
@@ -3269,22 +2745,22 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/4.8.6:
     dependencies:
-      caniuse-lite: 1.0.30001030
-      electron-to-chromium: 1.3.363
+      caniuse-lite: 1.0.30001032
+      electron-to-chromium: 1.3.369
       node-releases: 1.1.50
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
-  /browserslist/4.9.0:
+  /browserslist/4.9.1:
     dependencies:
-      caniuse-lite: 1.0.30001030
-      electron-to-chromium: 1.3.363
+      caniuse-lite: 1.0.30001032
+      electron-to-chromium: 1.3.369
       node-releases: 1.1.50
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-seffIXhwgB84+OCeT/aMjpZnsAsYDiMSC+CEs3UkF8iU64BZGYcu+TZYs/IBpo4nRi0vJywUJWYdbTsOhFTweg==
+      integrity: sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==
   /bser/2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -3472,17 +2948,17 @@ packages:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
   /caniuse-api/3.0.0:
     dependencies:
-      browserslist: 4.9.0
-      caniuse-lite: 1.0.30001030
+      browserslist: 4.9.1
+      caniuse-lite: 1.0.30001032
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
     resolution:
       integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  /caniuse-lite/1.0.30001030:
+  /caniuse-lite/1.0.30001032:
     dev: false
     resolution:
-      integrity: sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw==
+      integrity: sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -3529,6 +3005,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  /chalk/3.0.0:
+    dependencies:
+      ansi-styles: 4.2.1
+      supports-color: 7.1.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
   /change-emitter/0.1.6:
     dev: false
     resolution:
@@ -3758,6 +3243,14 @@ packages:
       color-name: 1.1.3
     resolution:
       integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  /color-convert/2.0.1:
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+    engines:
+      node: '>=7.0.0'
+    resolution:
+      integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   /color-name/1.1.3:
     resolution:
       integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
@@ -3977,7 +3470,7 @@ packages:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
   /core-js-compat/3.6.4:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       semver: 7.0.0
     dev: false
     resolution:
@@ -4718,7 +4211,7 @@ packages:
       integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   /dom-helpers/3.4.0:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
     dev: false
     resolution:
       integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
@@ -4737,7 +4230,7 @@ packages:
       integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   /dom-testing-library/3.19.4:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       '@sheerun/mutationobserver-shim': 0.3.2
       pretty-format: 24.9.0
       wait-for-expect: 1.3.0
@@ -4844,10 +4337,10 @@ packages:
   /ee-first/1.1.1:
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.363:
+  /electron-to-chromium/1.3.369:
     dev: false
     resolution:
-      integrity: sha512-4w19wPBkeunBjOA53lNFT36IdOD3Tk1OoIDtTX+VToJUUDX42QfuhtsNKXv25wmSnoBOExM3kTbj7/WDNBwHuQ==
+      integrity: sha512-6laJEDffEppIKT01TbyQtNhbdvF8ZfJWuK4L53sQCSiUHv0wSsJOFPvV0E63PZEQUzGcS2ZRSJlM5F4Ol9ffHg==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -5159,10 +4652,10 @@ packages:
       eslint: '>=3.14.1'
     resolution:
       integrity: sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==
-  /eslint-config-react-app/5.2.0_d62effe7bc20bdda71c3f1e51cf446b4:
+  /eslint-config-react-app/5.2.0_f63f168c8803da2808853788fe3bef7d:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.21.0_5d52a47f0409d8125a5f3a0453d25801
-      '@typescript-eslint/parser': 2.21.0_eslint@6.8.0
+      '@typescript-eslint/eslint-plugin': 2.22.0_c71b9097996349ed327b811b2e237f3b
+      '@typescript-eslint/parser': 2.22.0_eslint@6.8.0
       babel-eslint: 10.0.3_eslint@6.8.0
       confusing-browser-globals: 1.0.9
       eslint: 6.8.0
@@ -5268,7 +4761,7 @@ packages:
       minimatch: 3.0.4
       object.values: 1.1.1
       read-pkg-up: 2.0.0
-      resolve: 1.15.1
+      resolve: 1.15.0
     dev: false
     engines:
       node: '>=4'
@@ -5295,7 +4788,7 @@ packages:
       integrity: sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==
   /eslint-plugin-jsx-a11y/6.2.3_eslint@6.8.0:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       aria-query: 3.0.0
       array-includes: 3.1.1
       ast-types-flow: 0.0.7
@@ -5358,7 +4851,7 @@ packages:
       object.fromentries: 2.0.2
       object.values: 1.1.1
       prop-types: 15.7.2
-      resolve: 1.15.1
+      resolve: 1.15.0
     dev: false
     engines:
       node: '>=4'
@@ -5413,7 +4906,7 @@ packages:
       eslint-scope: 5.0.0
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.1.0
-      espree: 6.1.2
+      espree: 6.2.0
       esquery: 1.1.0
       esutils: 2.0.3
       file-entry-cache: 5.0.1
@@ -5423,12 +4916,12 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.2.1
       imurmurhash: 0.1.4
-      inquirer: 7.0.4
+      inquirer: 7.0.6
       is-glob: 4.0.1
       js-yaml: 3.13.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
-      lodash: 4.17.15
+      lodash: 4.17.14
       minimatch: 3.0.4
       mkdirp: 0.5.1
       natural-compare: 1.4.0
@@ -5447,16 +4940,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
-  /espree/6.1.2:
+  /espree/6.2.0:
     dependencies:
-      acorn: 7.1.0
-      acorn-jsx: 5.2.0_acorn@7.1.0
+      acorn: 7.1.1
+      acorn-jsx: 5.2.0_acorn@7.1.1
       eslint-visitor-keys: 1.1.0
     dev: false
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
+      integrity: sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==
   /esprima/4.0.1:
     engines:
       node: '>=4'
@@ -6620,9 +6113,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  /hosted-git-info/2.8.7:
+  /hosted-git-info/2.8.8:
     resolution:
-      integrity: sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg==
+      integrity: sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
   /hpack.js/2.1.6:
     dependencies:
       inherits: 2.0.4
@@ -6670,7 +6163,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.3
       relateurl: 0.2.7
-      terser: 4.6.4
+      terser: 4.6.6
     dev: false
     engines:
       node: '>=6'
@@ -6749,7 +6242,7 @@ packages:
     dependencies:
       http-proxy: 1.18.0
       is-glob: 4.0.1
-      lodash: 4.17.15
+      lodash: 4.17.14
       micromatch: 3.1.10
     dev: false
     engines:
@@ -6952,7 +6445,7 @@ packages:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
   /inquirer/7.0.4:
     dependencies:
-      ansi-escapes: 4.3.0
+      ansi-escapes: 4.3.1
       chalk: 2.4.2
       cli-cursor: 3.1.0
       cli-width: 2.2.0
@@ -6970,6 +6463,26 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
+  /inquirer/7.0.6:
+    dependencies:
+      ansi-escapes: 4.3.1
+      chalk: 3.0.0
+      cli-cursor: 3.1.0
+      cli-width: 2.2.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.15
+      mute-stream: 0.0.8
+      run-async: 2.4.0
+      rxjs: 6.5.4
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+      through: 2.3.8
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==
   /install/0.12.2:
     dev: false
     engines:
@@ -7455,11 +6968,11 @@ packages:
       integrity: sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.8.6
-      '@babel/parser': 7.8.6
+      '@babel/generator': 7.8.7
+      '@babel/parser': 7.8.7
       '@babel/template': 7.8.6
       '@babel/traverse': 7.8.6
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     engines:
@@ -7524,10 +7037,10 @@ packages:
       integrity: sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
   /jest-config/24.9.0:
     dependencies:
-      '@babel/core': 7.8.6
+      '@babel/core': 7.8.7
       '@jest/test-sequencer': 24.9.0
       '@jest/types': 24.9.0
-      babel-jest: 24.9.0_@babel+core@7.8.6
+      babel-jest: 24.9.0_@babel+core@7.8.7
       chalk: 2.4.2
       glob: 7.1.6
       jest-environment-jsdom: 24.9.0
@@ -7853,7 +7366,7 @@ packages:
       integrity: sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
   /jest-snapshot/24.9.0:
     dependencies:
-      '@babel/types': 7.8.6
+      '@babel/types': 7.8.7
       '@jest/types': 24.9.0
       chalk: 2.4.2
       expect: 24.9.0
@@ -7902,7 +7415,7 @@ packages:
       integrity: sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
   /jest-watch-typeahead/0.4.2:
     dependencies:
-      ansi-escapes: 4.3.0
+      ansi-escapes: 4.3.1
       chalk: 2.4.2
       jest-regex-util: 24.9.0
       jest-watcher: 24.9.0
@@ -7994,7 +7507,7 @@ packages:
       sax: 1.2.4
       symbol-tree: 3.2.4
       tough-cookie: 2.5.0
-      w3c-hr-time: 1.0.1
+      w3c-hr-time: 1.0.2
       webidl-conversions: 4.0.2
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
@@ -8023,7 +7536,7 @@ packages:
       saxes: 3.1.11
       symbol-tree: 3.2.4
       tough-cookie: 2.5.0
-      w3c-hr-time: 1.0.1
+      w3c-hr-time: 1.0.2
       w3c-xmlserializer: 1.1.2
       webidl-conversions: 4.0.2
       whatwg-encoding: 1.0.5
@@ -8158,7 +7671,7 @@ packages:
       integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
   /last-call-webpack-plugin/3.0.0:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.14
       webpack-sources: 1.4.3
     dev: false
     resolution:
@@ -9123,7 +8636,7 @@ packages:
       integrity: sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   /normalize-package-data/2.5.0:
     dependencies:
-      hosted-git-info: 2.8.7
+      hosted-git-info: 2.8.8
       resolve: 1.15.1
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
@@ -9724,7 +9237,7 @@ packages:
       integrity: sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
   /parse5/3.0.3:
     dependencies:
-      '@types/node': 13.7.6
+      '@types/node': 13.7.7
     resolution:
       integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   /parse5/4.0.0:
@@ -9974,9 +9487,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==
-  /postcss-browser-comments/3.0.0_browserslist@4.9.0:
+  /postcss-browser-comments/3.0.0_browserslist@4.9.1:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       postcss: 7.0.27
     dev: false
     engines:
@@ -10042,7 +9555,7 @@ packages:
       integrity: sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==
   /postcss-colormin/4.0.3:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       color: 3.1.2
       has: 1.0.3
       postcss: 7.0.27
@@ -10257,7 +9770,7 @@ packages:
       integrity: sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==
   /postcss-merge-rules/4.0.3:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.27
@@ -10291,7 +9804,7 @@ packages:
   /postcss-minify-params/4.0.2:
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.27
       postcss-value-parser: 3.3.1
@@ -10417,7 +9930,7 @@ packages:
       integrity: sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==
   /postcss-normalize-unicode/4.0.1:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       postcss: 7.0.27
       postcss-value-parser: 3.3.1
     dev: false
@@ -10448,9 +9961,9 @@ packages:
   /postcss-normalize/8.0.1:
     dependencies:
       '@csstools/normalize.css': 10.1.0
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       postcss: 7.0.27
-      postcss-browser-comments: 3.0.0_browserslist@4.9.0
+      postcss-browser-comments: 3.0.0_browserslist@4.9.1
       sanitize.css: 10.0.0
     dev: false
     engines:
@@ -10493,8 +10006,8 @@ packages:
   /postcss-preset-env/6.7.0:
     dependencies:
       autoprefixer: 9.7.4
-      browserslist: 4.9.0
-      caniuse-lite: 1.0.30001030
+      browserslist: 4.9.1
+      caniuse-lite: 1.0.30001032
       css-blank-pseudo: 0.1.4
       css-has-pseudo: 0.10.0
       css-prefers-color-scheme: 3.1.1
@@ -10545,7 +10058,7 @@ packages:
       integrity: sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==
   /postcss-reduce-initial/4.0.3:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       caniuse-api: 3.0.0
       has: 1.0.3
       postcss: 7.0.27
@@ -10759,12 +10272,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==
-  /promise/8.0.3:
+  /promise/8.1.0:
     dependencies:
       asap: 2.0.6
     dev: false
     resolution:
-      integrity: sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==
+      integrity: sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
   /prompts/2.3.1:
     dependencies:
       kleur: 3.0.3
@@ -11009,7 +10522,7 @@ packages:
     dependencies:
       core-js: 3.6.4
       object-assign: 4.1.1
-      promise: 8.0.3
+      promise: 8.1.0
       raf: 3.4.1
       regenerator-runtime: 0.13.3
       whatwg-fetch: 3.0.0
@@ -11202,7 +10715,7 @@ packages:
       integrity: sha512-tjL0Bmpkj75Td0k+lXlF8Fc8a9GuXFv/3ahUOCXExWs/jhsKiQeTffdH0j5byejCGCRL4tvGFYlrwBF1X/Aujg==
   /react-redux/5.1.1_react@16.6.3+redux@4.0.1:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       loose-envify: 1.4.0
@@ -11270,8 +10783,8 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@svgr/webpack': 4.3.3
-      '@typescript-eslint/eslint-plugin': 2.21.0_5d52a47f0409d8125a5f3a0453d25801
-      '@typescript-eslint/parser': 2.21.0_eslint@6.8.0
+      '@typescript-eslint/eslint-plugin': 2.22.0_c71b9097996349ed327b811b2e237f3b
+      '@typescript-eslint/parser': 2.22.0_eslint@6.8.0
       babel-eslint: 10.0.3_eslint@6.8.0
       babel-jest: 24.9.0_@babel+core@7.8.4
       babel-loader: 8.0.6_@babel+core@7.8.4+webpack@4.41.5
@@ -11283,7 +10796,7 @@ packages:
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
       eslint: 6.8.0
-      eslint-config-react-app: 5.2.0_d62effe7bc20bdda71c3f1e51cf446b4
+      eslint-config-react-app: 5.2.0_f63f168c8803da2808853788fe3bef7d
       eslint-loader: 3.0.3_eslint@6.8.0+webpack@4.41.5
       eslint-plugin-flowtype: 4.6.0_eslint@6.8.0
       eslint-plugin-import: 2.20.0_eslint@6.8.0
@@ -11623,14 +11136,19 @@ packages:
     resolution:
       integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
   /regenerator-runtime/0.13.3:
+    dev: false
     resolution:
       integrity: sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-  /regenerator-transform/0.14.1:
+  /regenerator-runtime/0.13.4:
+    resolution:
+      integrity: sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
+  /regenerator-transform/0.14.2:
     dependencies:
+      '@babel/runtime': 7.8.7
       private: 0.1.8
     dev: false
     resolution:
-      integrity: sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
+      integrity: sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==
   /regex-not/1.0.2:
     dependencies:
       extend-shallow: 3.0.2
@@ -12859,7 +12377,7 @@ packages:
       integrity: sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==
   /stylehacks/4.0.3:
     dependencies:
-      browserslist: 4.9.0
+      browserslist: 4.9.1
       postcss: 7.0.27
       postcss-selector-parser: 3.1.2
     dev: false
@@ -12914,10 +12432,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
-  /svg-parser/2.0.3:
+  /svg-parser/2.0.4:
     dev: false
     resolution:
-      integrity: sha512-fnCWiifNhK8i2Z7b9R5tbNahpxrRdAaQbnoxKlT2KrSCj9Kq/yBSgulCRgBJRhy1dPnSY5slg5ehPUnzpEcHlg==
+      integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
   /svgo/1.3.2:
     dependencies:
       chalk: 2.4.2
@@ -12941,7 +12459,7 @@ packages:
       integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==
   /swagger-client/3.10.0:
     dependencies:
-      '@babel/runtime-corejs2': 7.8.4
+      '@babel/runtime-corejs2': 7.8.7
       '@kyleshockey/object-assign-deep': 0.4.2
       btoa: 1.1.2
       buffer: 5.4.3
@@ -12964,7 +12482,7 @@ packages:
       integrity: sha512-XUvqO/jeF+P5gYklN+ThEFq1++XnXV9RTdOpS65B5Y0dHnamxO8v0wG8geVEwIIqKjCYbKQ2Vd67DZMZMeaNvg==
   /swagger-ui/3.25.0:
     dependencies:
-      '@babel/runtime-corejs2': 7.8.4
+      '@babel/runtime-corejs2': 7.8.7
       '@braintree/sanitize-url': 3.1.0
       '@kyleshockey/object-assign-deep': 0.4.2
       '@kyleshockey/xml': 1.0.2
@@ -13027,7 +12545,7 @@ packages:
   /table/5.4.6:
     dependencies:
       ajv: 6.12.0
-      lodash: 4.17.15
+      lodash: 4.17.14
       slice-ansi: 2.1.0
       string-width: 3.1.0
     dev: false
@@ -13065,7 +12583,7 @@ packages:
       schema-utils: 1.0.0
       serialize-javascript: 2.1.2
       source-map: 0.6.1
-      terser: 4.6.4
+      terser: 4.6.6
       webpack: 4.41.5_webpack@4.41.5
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
@@ -13085,7 +12603,7 @@ packages:
       schema-utils: 2.6.4
       serialize-javascript: 2.1.2
       source-map: 0.6.1
-      terser: 4.6.4
+      terser: 4.6.6
       webpack: 4.41.5_webpack@4.41.5
       webpack-sources: 1.4.3
     dev: false
@@ -13095,7 +12613,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-Nv96Nws2R2nrFOpbzF6IxRDpIkkIfmhvOws+IqMvYdFLO7o6wAILWFKONFgaYy8+T4LVz77DQW0f7wOeDEAjrg==
-  /terser/4.6.4:
+  /terser/4.6.6:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -13105,7 +12623,7 @@ packages:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==
+      integrity: sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
   /test-exclude/5.2.3:
     dependencies:
       glob: 7.1.6
@@ -13284,8 +12802,6 @@ packages:
     dev: false
     engines:
       node: '>=6'
-    peerDependencies:
-      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -13323,6 +12839,12 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  /type-fest/0.11.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
   /type-fest/0.8.1:
     dev: false
     engines:
@@ -13622,11 +13144,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-  /w3c-hr-time/1.0.1:
+  /w3c-hr-time/1.0.2:
     dependencies:
-      browser-process-hrtime: 0.1.3
+      browser-process-hrtime: 1.0.0
     resolution:
-      integrity: sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
+      integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   /w3c-xmlserializer/1.1.2:
     dependencies:
       domexception: 1.0.1
@@ -13744,7 +13266,6 @@ packages:
     hasBin: true
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
-      webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
         optional: true
@@ -13762,7 +13283,7 @@ packages:
   /webpack-manifest-plugin/2.2.0_webpack@4.41.5:
     dependencies:
       fs-extra: 7.0.1
-      lodash: 4.17.15
+      lodash: 4.17.14
       object.entries: 1.1.1
       tapable: 1.1.3
       webpack: 4.41.5_webpack@4.41.5
@@ -13903,7 +13424,7 @@ packages:
       integrity: sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==
   /workbox-build/4.3.1:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       '@hapi/joi': 15.1.1
       common-tags: 1.8.0
       fs-extra: 4.0.3
@@ -13998,7 +13519,7 @@ packages:
       integrity: sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==
   /workbox-webpack-plugin/4.3.1_webpack@4.41.5:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
       json-stable-stringify: 1.0.1
       webpack: 4.41.5_webpack@4.41.5
       workbox-build: 4.3.1
@@ -14133,7 +13654,7 @@ packages:
       integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
   /yaml/1.7.2:
     dependencies:
-      '@babel/runtime': 7.8.4
+      '@babel/runtime': 7.8.7
     dev: false
     engines:
       node: '>= 6'

--- a/api-catalog-ui/frontend/src/components/App/App.jsx
+++ b/api-catalog-ui/frontend/src/components/App/App.jsx
@@ -9,10 +9,8 @@ import '../../assets/css/APIMReactToastify.css';
 import PageNotFound from '../PageNotFound/PageNotFound';
 import HeaderContainer from '../Header/HeaderContainer';
 import Spinner from '../Spinner/Spinner';
-import DetailPageContainer from '../DetailPage/DetailPageContainer';
-import DashboardContainer from '../Dashboard/DashboardContainer';
-import LoginContainer from '../Login/LoginContainer';
 import Footer from '../Footer/Footer';
+import { AsyncDashboardContainer, AsyncDetailPageContainer, AsyncLoginContainer } from "./AsyncModules";
 
 class App extends Component {
     render() {
@@ -33,14 +31,14 @@ class App extends Component {
                                         <Route
                                             path="/login"
                                             exact
-                                            render={(props, state) => <LoginContainer {...props} {...state} />}
+                                            render={(props, state) => <AsyncLoginContainer {...props} {...state} />}
                                         />
                                         <Route
                                             exact
                                             path="/dashboard"
                                             render={(props, state) => (
                                                 <BigShield>
-                                                    <DashboardContainer {...props} {...state} />
+                                                    <AsyncDashboardContainer {...props} {...state} />
                                                 </BigShield>
                                             )}
                                         />
@@ -48,7 +46,7 @@ class App extends Component {
                                             path="/tile/:tileID"
                                             render={(props, state) => (
                                                 <BigShield history={history}>
-                                                    <DetailPageContainer {...props} {...state} />
+                                                    <AsyncDetailPageContainer {...props} {...state} />
                                                 </BigShield>
                                             )}
                                         />

--- a/api-catalog-ui/frontend/src/components/App/AsyncModules.jsx
+++ b/api-catalog-ui/frontend/src/components/App/AsyncModules.jsx
@@ -1,21 +1,14 @@
 import Loadable from 'react-loadable';
+import React, { lazy } from 'react';
 
 export const AsyncAppContainer = Loadable({
     loader: () => import('../App/AppContainer'),
     loading: () => null,
 });
 
-export const AsyncLoginContainer = Loadable({
-    loader: () => import('../Login/LoginContainer'),
-    loading: () => null,
-});
+export const AsyncLoginContainer = lazy(() => import('../Login/LoginContainer'));
 
-export const AsyncDashboardContainer = Loadable({
-    loader: () => import('../Dashboard/DashboardContainer'),
-    loading: () => null,
-});
+export const AsyncDashboardContainer = lazy(()  => import('../Dashboard/DashboardContainer'));
 
-export const AsyncDetailPageContainer = Loadable({
-    loader: () => import('../DetailPage/DetailPageContainer'),
-    loading: () => null,
-});
+export const AsyncDetailPageContainer = lazy(() => import('../DetailPage/DetailPageContainer'));
+


### PR DESCRIPTION
To implement code splitting in react, our UI was using `react-loadable`, but since React 16+, this feature is natively implemented and it's more flexible. Code splitting allows better performance for the UI, since it loads components only on demand, and not at the beginning.

`AsyncLoginContainer`, `AsyncDashboardContainer` and `AsyncDetailPageContainer` are now using the native `React.lazy` rather than `react-loadable` for code splitting feature. They were also never used even if defined, only `AsyncAppContainer` was used. Switching it to `React.lazy` is causing some problem so it still uses `react-loadable.`

Signed-off-by: at670475 <andrea.tabone@broadcom.com>