### PR TITLE
Upgrade to Gradle 6.2.2

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile(project(':security-service-client-spring'))
 
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     compile libraries.spring_boot_starter_web
     compile libraries.spring_boot_starter_actuator
@@ -61,7 +62,10 @@ dependencies {
 
     testCompile libraries.rest_assured
     testCompile libraries.spring_mock_mvc
+
     testCompile libraries.lombok
+    testAnnotationProcessor libraries.lombok
+
     testCompile libraries.spring_boot_starter_test
 }
 
@@ -90,10 +94,4 @@ bootRun {
              args project.args.split(',')
     }
     systemProperties = System.properties
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/api-catalog-ui/build.gradle
+++ b/api-catalog-ui/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.moowork.node" version "1.2.0"
+    id "com.moowork.node" version "1.3.1"
 }
 
 node {
@@ -50,7 +50,7 @@ task bundle(type: NpmTask) {
     inputs.dir('frontend/src').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir('frontend/public').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files('frontend/.env*').withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.file('frontend/eslintrc.json').withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file('frontend/.eslintrc').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.file('frontend/package.json').withPathSensitivity(PathSensitivity.RELATIVE)
 
     outputs.dir('frontend/build')

--- a/apiml-common/build.gradle
+++ b/apiml-common/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile project(':apiml-utility')
-    //compile project(':common-service-core')
 
     compile libraries.spring_boot_starter_web
     compile libraries.commons_validator
@@ -12,17 +11,14 @@ dependencies {
 
     compileOnly libraries.spring_boot_configuration_processor
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile libraries.javax_servlet_api
     testCompile libraries.spring_boot_starter_test
     testCompile libraries.powermock_api_mockito2
     testCompile libraries.power_mock_junit4
     testCompile libraries.power_mock_junit4_rule
-    testCompile libraries.lombok
-}
 
-test {
-    jacoco {
-        append = false
-    }
+    testCompile libraries.lombok
+    annotationProcessor libraries.lombok
 }

--- a/apiml-common/src/main/java/org/zowe/apiml/product/version/VersionService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/version/VersionService.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ResourceUtils;

--- a/apiml-security-common/build.gradle
+++ b/apiml-security-common/build.gradle
@@ -7,15 +7,13 @@ dependencies {
 
     compileOnly libraries.javax_servlet_api
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile libraries.junit
     testCompile libraries.mockito_core
     testCompile libraries.spring_mock_mvc
     testCompile libraries.spring_boot_starter_test
-}
 
-test {
-    jacoco {
-        append = false
-    }
+    testCompileOnly libraries.lombok
+    testAnnotationProcessor libraries.lombok
 }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/token/QueryResponse.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/token/QueryResponse.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.cache.EntryExpiration;
 
 import java.util.Date;

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/login/LoginFilterTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/login/LoginFilterTest.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.security.common.login;
 
+import org.springframework.http.HttpMethod;
 import org.zowe.apiml.security.common.error.AuthMethodNotSupportedException;
 import org.zowe.apiml.security.common.error.ErrorType;
 import org.zowe.apiml.security.common.error.ResourceAccessExceptionHandler;
@@ -35,7 +36,6 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 import javax.servlet.ServletException;
-import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 
 import static org.mockito.Mockito.*;
@@ -80,7 +80,7 @@ public class LoginFilterTest {
     @Test
     public void shouldCallAuthenticationManagerAuthenticateWithAuthHeader() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletRequest.addHeader(HttpHeaders.AUTHORIZATION, VALID_AUTH_HEADER);
         httpServletResponse = new MockHttpServletResponse();
 
@@ -94,7 +94,7 @@ public class LoginFilterTest {
     @Test
     public void shouldCallAuthenticationManagerAuthenticateWithJson() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletRequest.setContent(VALID_JSON.getBytes());
         httpServletResponse = new MockHttpServletResponse();
 
@@ -108,7 +108,7 @@ public class LoginFilterTest {
     @Test
     public void shouldFailWithJsonEmptyCredentials() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletRequest.setContent(EMPTY_JSON.getBytes());
         httpServletResponse = new MockHttpServletResponse();
 
@@ -121,7 +121,7 @@ public class LoginFilterTest {
     @Test
     public void shouldFailWithoutAuth() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletResponse = new MockHttpServletResponse();
 
         exception.expect(AuthenticationCredentialsNotFoundException.class);
@@ -133,7 +133,7 @@ public class LoginFilterTest {
     @Test
     public void shouldFailWithWrongHttpMethod() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.GET);
+        httpServletRequest.setMethod(HttpMethod.GET.name());
         httpServletResponse = new MockHttpServletResponse();
 
         exception.expect(AuthMethodNotSupportedException.class);
@@ -145,7 +145,7 @@ public class LoginFilterTest {
     @Test
     public void shouldFailWithIncorrectCredentialsFormat() throws ServletException {
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletRequest.addHeader(HttpHeaders.AUTHORIZATION, INVALID_AUTH_HEADER);
         httpServletResponse = new MockHttpServletResponse();
 
@@ -176,7 +176,7 @@ public class LoginFilterTest {
         when(authenticationManager.authenticate(authentication)).thenThrow(exception);
 
         httpServletRequest = new MockHttpServletRequest();
-        httpServletRequest.setMethod(HttpMethod.POST);
+        httpServletRequest.setMethod(HttpMethod.POST.name());
         httpServletRequest.addHeader(HttpHeaders.AUTHORIZATION, VALID_AUTH_HEADER);
         httpServletResponse = new MockHttpServletResponse();
 

--- a/apiml-utility/build.gradle
+++ b/apiml-utility/build.gradle
@@ -11,17 +11,14 @@ dependencies {
 
     compileOnly libraries.spring_boot_configuration_processor
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile libraries.javax_servlet_api
     testImplementation libraries.spring_boot_starter_test
     testCompile libraries.powermock_api_mockito2
     testCompile libraries.power_mock_junit4
     testCompile libraries.power_mock_junit4_rule
-    testCompile libraries.lombok
-}
 
-test {
-    jacoco {
-        append = false
-    }
+    testCompileOnly libraries.lombok
+    testAnnotationProcessor libraries.lombok
 }

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDependencyLogHider.java
@@ -13,7 +13,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Marker;
 
 import java.util.Arrays;

--- a/build.gradle
+++ b/build.gradle
@@ -29,19 +29,17 @@ buildscript {
 
     dependencies {
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5'
-        classpath 'com.palantir:jacoco-coverage:0.4.0'
         classpath 'net.researchgate:gradle-release:2.7.0'
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'
     }
 }
 
-apply plugin: 'com.palantir.jacoco-full-report'
+apply from: 'gradle/versions.gradle'
 apply from: 'gradle/license.gradle'
 apply from: 'gradle/publish.gradle'
 apply from: 'gradle/sonar.gradle'
 apply from: 'gradle/coverage.gradle'
-apply from: 'gradle/versions.gradle'
 apply from: 'gradle/code-quality.gradle'
 apply from: 'gradle/generate-pom.gradle'
 
@@ -121,27 +119,6 @@ task runIntegrationTests(dependsOn: ":integration-tests:runIntegrationTests") {
 task runAllIntegrationTests(dependsOn: ":integration-tests:runAllIntegrationTests") {
     description "Run all integration tests"
     group "Integration tests"
-}
-
-task jacocoSubProjects() {
-    subprojects.findAll { it.name in javaProjectsWithUnitTests }.each { dependsOn("${it.name}:jacocoTestReport") }
-}
-
-jacocoTestReport {
-    dependsOn test
-    reports {
-        xml.enabled true
-        html.enabled true
-    }
-}
-
-task mergeCoverage() {
-    dependsOn test, jacocoFullReport
-}
-
-task coverage() {
-    mergeCoverage.mustRunAfter jacocoSubProjects
-    dependsOn mergeCoverage, jacocoSubProjects, jacocoTestReport, ":api-catalog-ui:javaScriptCoverage"
 }
 
 task publishAllVersions {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     repositories mavenRepositories
 
     dependencies {
-        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5'
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7'
         classpath 'net.researchgate:gradle-release:2.7.0'
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'

--- a/common-service-core/build.gradle
+++ b/common-service-core/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     compile(libraries.eureka_client)
+    compile libraries.netflix_servo
+
     compile(libraries.http_client)
     compile(libraries.http_core)
     compile(libraries.jackson_annotations)
@@ -8,8 +10,16 @@ dependencies {
     compile(libraries.slf4j_api)
     compile(libraries.snakeyaml)
 
+    compile libraries.apache_commons_lang3
+    compile libraries.apache_commons_text
+
+    compile libraries.jsr305
+
     compileOnly(libraries.javax_servlet_api)
-    compileOnly(libraries.lombok)
+
+    compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
+
     compileOnly(libraries.spring_boot_starter_cache)
     compileOnly(libraries.eh_cache)
 
@@ -29,11 +39,6 @@ dependencies {
     testCompile(libraries.powermock_api_mockito2)
     testCompile(libraries.power_mock_junit4)
 
-    testCompileOnly(libraries.lombok)
-}
-
-test {
-    jacoco {
-        append = false
-    }
+    testCompileOnly libraries.lombok
+    testAnnotationProcessor libraries.lombok
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/CompositeKey.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/CompositeKey.java
@@ -9,8 +9,8 @@
  */
 package org.zowe.apiml.cache;
 
-import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
@@ -13,7 +13,7 @@ import org.zowe.apiml.message.api.ApiMessage;
 import org.zowe.apiml.message.api.ApiMessageView;
 import org.zowe.apiml.message.template.MessageTemplate;
 import org.zowe.apiml.util.ObjectUtil;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Collections;
 import java.util.IllegalFormatConversionException;
@@ -97,7 +97,7 @@ public final class Message {
      */
     public String getConvertedText() {
         String convertedText = validateMessageTextFormat(messageTemplate.getText(), messageParameters);
-        convertedText = StringEscapeUtils.escapeHtml(convertedText);
+        convertedText = StringEscapeUtils.escapeHtml4(convertedText);
         return convertedText;
     }
 

--- a/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
@@ -13,7 +13,7 @@ import org.zowe.apiml.util.ClassOrDefaultProxyUtils;
 import org.zowe.apiml.util.ObjectUtil;
 import lombok.AllArgsConstructor;
 import lombok.Value;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/common-service-core/src/main/java/org/zowe/apiml/util/ClassOrDefaultProxyUtils.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/ClassOrDefaultProxyUtils.java
@@ -11,7 +11,7 @@ package org.zowe.apiml.util;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.*;
 import java.util.HashMap;

--- a/common-service-core/src/main/java/org/zowe/apiml/util/CookieUtil.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/CookieUtil.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.util;
 
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A utility class for Cookies administration

--- a/common-service-core/src/main/java/org/zowe/apiml/util/ObjectUtil.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/ObjectUtil.java
@@ -11,7 +11,7 @@ package org.zowe.apiml.util;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.*;

--- a/common-service-core/src/main/java/org/zowe/apiml/util/UrlUtils.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/UrlUtils.java
@@ -11,7 +11,7 @@ package org.zowe.apiml.util;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.net.*;
 

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -51,16 +51,10 @@ dependencies {
 
     implementation libraries.gson
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testImplementation libraries.spring_boot_starter_test
 }
 
 
 bootJar.archiveName = "${bootJar.baseName}.jar"
-
-
-test {
-    jacoco {
-        append = false
-    }
-}

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -48,8 +48,14 @@ dependencies {
     compile libraries.jackson_dataformat_yaml
 
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
+
+    // https://mvnrepository.com/artifact/com.netflix.servo/servo-core
+    compile group: 'com.netflix.servo', name: 'servo-core', version: '0.12.28'
 
     testCompile libraries.lombok
+    testAnnotationProcessor libraries.lombok
+
     testCompile libraries.spring_boot_starter_test
     testCompile libraries.awaitility
 }
@@ -63,10 +69,4 @@ bootRun {
         args project.args.split(',')
     }
     systemProperties = System.properties
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -66,13 +66,19 @@ dependencies {
     compile libraries.jjwt
     compile libraries.eh_cache
 
+    compileOnly libraries.javax_inject
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
+
     implementation libraries.springFox
     testCompile libraries.spring_mock_mvc
     testCompile libraries.spring_boot_starter_test
     testRuntime libraries.http_client
     testCompile libraries.rest_assured
+
     testCompile libraries.lombok
+    testAnnotationProcessor libraries.lombok
+
     testCompile libraries.powermock_api_mockito2
     testCompile libraries.power_mock_junit4
     testCompile libraries.power_mock_junit4_rule
@@ -86,10 +92,4 @@ bootRun {
         args project.args.split(',')
     }
     systemProperties = System.properties
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'jacoco'
+
 ext.javaProjectsWithUnitTests = [
     'api-catalog-services',
     'common-service-core',
@@ -14,13 +16,14 @@ ext.javaProjectsWithUnitTests = [
     'apiml-security-common'
 ]
 
+ext.jacocoProjects = subprojects.findAll { it.name in javaProjectsWithUnitTests }
 
-configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
+configure(jacocoProjects) {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'jacoco'
     jacoco {
-        toolVersion = '0.8.2'
+        toolVersion = '0.8.4'
     }
 
     jacocoTestReport {
@@ -30,4 +33,40 @@ configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
             html.enabled true
         }
     }
+}
+
+task jacocoFullReport(type: JacocoReport) {
+    description = 'Generates an aggregate report from all subprojects'
+    dependsOn(jacocoProjects.jacocoTestReport)
+
+    getAdditionalSourceDirs().from(
+        files(jacocoProjects.sourceSets.main.allSource.srcDirs)
+    )
+
+    getSourceDirectories().from(
+        files(jacocoProjects.sourceSets.main.allSource.srcDirs)
+    )
+
+    getClassDirectories().from(
+        files(jacocoProjects.sourceSets.main.output)
+    )
+
+    getExecutionData().from(
+        files(jacocoProjects.jacocoTestReport.executionData)
+    )
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+    }
+
+    doFirst {
+        getExecutionData().from(
+            files(executionData.findAll { it.exists() })
+        )
+    }
+}
+
+task coverage() {
+    dependsOn jacocoFullReport, ":api-catalog-ui:javaScriptCoverage"
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -21,6 +21,7 @@ ext.publishTasksList = projectsToPublish.collect {
 configure(subprojects.findAll { it.name in projectsToPublish }) {
     apply plugin: "maven"
     apply plugin: 'maven-publish'
+    apply plugin: 'java'
 
     publishing {
         repositories.maven {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,12 +25,13 @@ ext {
     zsslVersion = '1.0.0'
     tomcatVersion = '9.0.13' //8.5.33
     commonsLang3Version = '3.7'
+    commonsTextVersion = '1.8'
     gradleGitPropertiesVersion = '1.5.1'
     jettyWebSocketClientVersion = '9.4.11.v20180605'
-    eurekaClientVersion = '1.8.6'
     junitVersion = '4.12'
     junitVintageVersion = '5.5.2'
     eurekaClientVersion = '1.9.13'
+    netflixServoVersion = '0.12.28'
     logbackVersion = '1.2.3'
     spring4Version = '4.3.7.RELEASE'
     awaitilityVersion = '3.0.0'
@@ -52,6 +53,8 @@ ext {
     ehCacheVersion = '2.10.6'
     bootstrapVersion = '4.3.1'
     jqueryVersion = '3.4.1'
+    jsr305Version = '3.0.1'
+    javaxInjectVersion = '1'
 
     libraries = [
         lombok                             : "org.projectlombok:lombok:${lombokVersion}",
@@ -119,9 +122,11 @@ ext {
         tomcat_coyote                      : "org.apache.tomcat:tomcat-coyote:${tomcatVersion}",
         tomcat_embed_core                  : "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
         apache_commons_lang3               : "org.apache.commons:commons-lang3:${commonsLang3Version}",
+        apache_commons_text                : "org.apache.commons:commons-text:${commonsTextVersion}",
         jetty_websocket_client             : "org.eclipse.jetty.websocket:websocket-client:${jettyWebSocketClientVersion}",
         jetty_util                         : "org.eclipse.jetty:jetty-util:${jettyWebSocketClientVersion}",
         eureka_client                      : "com.netflix.eureka:eureka-client:${eurekaClientVersion}",
+        netflix_servo                      : "com.netflix.servo:servo-core:${netflixServoVersion}",
 
         junit                              : "junit:junit:${junitVersion}",
         junitVintage                       : "org.junit.vintage:junit-vintage-engine:${junitVintageVersion}",
@@ -145,6 +150,8 @@ ext {
         jersey_media_json_jackson          : "org.glassfish.jersey.media:jersey-media-json-jackson:${jerseyVersion}",
         jersey_test_provider_jdk_http      : "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http:${jerseyVersion}",
         bootstrap                          : "org.webjars:bootstrap:${bootstrapVersion}",
-        jquery                             : "org.webjars:jquery:${jqueryVersion}"
+        jquery                             : "org.webjars:jquery:${jqueryVersion}",
+        jsr305                             : "com.google.code.findbugs:jsr305:${jsr305Version}",
+        javax_inject                       : "javax.inject:javax.inject:${javaxInjectVersion}"
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-enabler-spring-v1-sample-app/build.gradle
+++ b/integration-enabler-spring-v1-sample-app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     compile "io.springfox:springfox-spring-web:2.7.0"
 
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testCompile libraries.power_mock_junit4
     testCompile libraries.power_mock_junit4_rule
     testCompile libraries.lombok
+    testAnnotationProcessor libraries.lombok
     testCompile libraries.jsoup
     testCompile libraries.rest_assured
     testCompile(libraries.jackson_core)

--- a/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
@@ -18,7 +18,7 @@ import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 import org.springframework.boot.actuate.health.Status;

--- a/onboarding-enabler-java-sample-app/build.gradle
+++ b/onboarding-enabler-java-sample-app/build.gradle
@@ -22,7 +22,10 @@ dependencies {
 
     compileOnly libraries.javax_servlet_api
     compile libraries.jackson_dataformat_yaml
+
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
+
     compile libraries.jersey_server
     compile libraries.jersey_hk2
     compile libraries.jersey_container_servlet_core
@@ -51,10 +54,4 @@ tomcat {
     tomcatRun.truststoreFile = file("${project.rootDir}/keystore/localhost/localhost.truststore.p12")
     tomcatRun.keystorePass = "password"
     tomcatRun.truststorePass = "password"
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/onboarding-enabler-java/build.gradle
+++ b/onboarding-enabler-java/build.gradle
@@ -4,22 +4,21 @@ dependencies {
     implementation libraries.jackson_annotations
     implementation libraries.jackson_dataformat_yaml
     implementation libraries.eureka_client
-    implementation libraries.lombok
+
+    compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     compileOnly libraries.javax_servlet_api
+    compileOnly libraries.javax_inject
 
     testCompile libraries.junit
     testCompile libraries.mockito_core
     testCompile libraries.spring4Mvc
     testCompile libraries.spring4Test
-    testCompile libraries.logback_classic
+
     testCompile libraries.lombok
+    testAnnotationProcessor libraries.lombok
+
     testCompile libraries.javax_servlet_api
     testCompile libraries.hamcrest
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -30,23 +30,17 @@ dependencies {
     compile project(':onboarding-enabler-java')
     compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
 
-    compile libraries.lombok
+    compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
     testCompile libraries.mockito_core
 
     annotationProcessor libraries.spring_boot_configuration_processor
-    annotationProcessor libraries.lombok
     testCompile libraries.gson
 }
 
 jar {
     baseName = "enabler-springboot-${springBootVersion}"
     archiveName = "${baseName}.jar"
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }

--- a/security-service-client-spring/build.gradle
+++ b/security-service-client-spring/build.gradle
@@ -6,16 +6,13 @@ dependencies {
     compile libraries.apache_commons_lang3
 
     compileOnly libraries.javax_servlet_api
+
     compileOnly libraries.lombok
+    annotationProcessor libraries.lombok
+
 
     testCompile libraries.junit
     testCompile libraries.mockito_core
     testCompile libraries.spring_mock_mvc
     testCompile libraries.spring_boot_starter_test
-}
-
-test {
-    jacoco {
-        append = false
-    }
 }


### PR DESCRIPTION
Hey there, 
I upgraded Gradle from 4.9 to 6.2.2 and fixed depreciations. But there are still some problems that need to be fixed. They are mostly about dependencies and reason is:

After Gradle 5.0, the Java and Java Library plugins both honor the separation of compile and runtime scopes.

> Since Gradle 1.0, runtime-scoped dependencies have been included in the Java compilation classpath, which has some drawbacks:
> 
> The compilation classpath is much larger than it needs to be, slowing down compilation.
> 
> The compilation classpath includes runtime-scoped files that do not impact compilation, resulting in unnecessary re-compilation when those files change.

## Remained work:
- [x] 1.1  Nonnnull annotations.
- [x] 1.2

warning: unknown enum constant DataSourceType.GAUGE
warning: unknown enum constant DataSourceType.GAUGE
warning: unknown enum constant DataSourceType.GAUGE
warning: unknown enum constant DataSourceType.INFORMATIONAL
warning: unknown enum constant DataSourceType.INFORMATIONAL
warning: unknown enum constant DataSourceType.GAUGE
warning: unknown enum constant DataSourceType.GAUGE
warning: unknown enum constant DataSourceType.GAUGE

## Gradle scans:
Check Gradle 4.9
No deprications
https://scans.gradle.com/s/s64bhuipvapvk

### Upgrading from 4.9 and earlier to Gradle 4.10
https://gradle.com/s/7esjbcypgsnq4

### Upgrading from 4.10 and earlier to Gradle 5
https://scans.gradle.com/s/5j3vhruoimuie/deprecations?openUsages=WzIsMF0

### Upgrading from 5.0 and earlier to 5.1
https://scans.gradle.com/s/wefkjuuwwpmnw

### Upgrading from 5.1 and earlier to 5.2
https://gradle.com/s/gxfhgfekmxie4

### Upgrading from 5.2 and earlier to 5.3
https://scans.gradle.com/s/fqa3zjovrlmf4

### Upgrading from 5.3 and earlier to 5.4
https://gradle.com/s/c664i2ny56txy

### Upgrading from 5.4 and earlier to 5.5
https://scans.gradle.com/s/cyke3kuors6vi

### Upgrading from 5.5 and earlier to 5.6
https://scans.gradle.com/s/jghqtlmgsyxpw

### Upgrading from 5.6 and earlier to 6.2.2
https://scans.gradle.com/s/gbjkumnizyvrg/deprecations?openUsages=WzBd
Some features will gone in Gradle 7. So That deprecations will be fixed in different PR.