### PR TITLE
Integration test for logout has sence only on mainframe, not on localhost

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/LogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/LogoutTest.java
@@ -13,7 +13,9 @@ import io.restassured.RestAssured;
 import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.springframework.http.HttpStatus;
+import org.zowe.apiml.util.categories.MainframeDependentTests;
 import org.zowe.apiml.util.service.DiscoveryUtils;
 
 import static io.restassured.RestAssured.given;
@@ -21,6 +23,7 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.hamcrest.core.Is.is;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
+@Category(MainframeDependentTests.class)
 public class LogoutTest {
 
     private final static String BASE_PATH = "/api/v1/gateway";


### PR DESCRIPTION
Integration test LogoutTest is testing integration of REST API to z/OSMF. For this reason it is not possible to test it on localhost without dependecies and it is mark to run just on mainframe

Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>