### PR TITLE
Replace the configuration values for ZOSMf by system properties

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
@@ -76,6 +76,7 @@ public class ConfigReader {
                     configuration.getDiscoveryServiceConfiguration().setPort(Integer.parseInt(System.getProperty("discovery.port", String.valueOf(configuration.getDiscoveryServiceConfiguration().getPort()))));
                     configuration.getDiscoveryServiceConfiguration().setInstances(Integer.parseInt(System.getProperty("discovery.instances", String.valueOf(configuration.getDiscoveryServiceConfiguration().getInstances()))));
 
+                    setZosmfConfigurationFromSystemProperties(configuration);
                     setTlsConfigurationFromSystemProperties(configuration);
 
                     instance = configuration;
@@ -84,6 +85,14 @@ public class ConfigReader {
         }
 
         return instance;
+    }
+
+    private static void setZosmfConfigurationFromSystemProperties(EnvironmentConfiguration configuration) {
+        ZosmfServiceConfiguration zosmfConfiguration = configuration.getZosmfServiceConfiguration();
+        zosmfConfiguration.setHost(System.getProperty("zosmf.host", zosmfConfiguration.getHost()));
+        String port = System.getProperty("zosmf.port", String.valueOf(zosmfConfiguration.getPort()));
+        zosmfConfiguration.setPort(Integer.parseInt(port));
+        zosmfConfiguration.setScheme(System.getProperty("zosmf.scheme", zosmfConfiguration.getScheme()));
     }
 
     private static void setTlsConfigurationFromSystemProperties(EnvironmentConfiguration configuration) {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
@@ -99,6 +99,7 @@ public class ConfigReader {
         TlsConfiguration tlsConfiguration = configuration.getTlsConfiguration();
         tlsConfiguration.setKeyAlias(System.getProperty("tlsConfiguration.keyAlias", tlsConfiguration.getKeyAlias()));
         tlsConfiguration.setKeyPassword(System.getProperty("tlsConfiguration.keyPassword", tlsConfiguration.getKeyPassword()));
+        tlsConfiguration.setKeyStore(System.getProperty("tlsConfiguration.keyStore", tlsConfiguration.getKeyStore()));
         tlsConfiguration.setKeyStoreType(System.getProperty("tlsConfiguration.keyStoreType", tlsConfiguration.getKeyStoreType()));
         tlsConfiguration.setKeyPassword(System.getProperty("tlsConfiguration.keyStorePassword", tlsConfiguration.getKeyStorePassword()));
         tlsConfiguration.setTrustStoreType(System.getProperty("tlsConfiguration.trustStoreType", tlsConfiguration.getTrustStoreType()));


### PR DESCRIPTION
if present.
The main reason is to allow running different tests locally against different zosmf instances.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>