### PR TITLE
Allow overwriting of the zosmf service Id

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
@@ -93,6 +93,7 @@ public class ConfigReader {
         String port = System.getProperty("zosmf.port", String.valueOf(zosmfConfiguration.getPort()));
         zosmfConfiguration.setPort(Integer.parseInt(port));
         zosmfConfiguration.setScheme(System.getProperty("zosmf.scheme", zosmfConfiguration.getScheme()));
+        zosmfConfiguration.setServiceId(System.getProperty("zosmf.serviceId", zosmfConfiguration.getServiceId()));
     }
 
     private static void setTlsConfigurationFromSystemProperties(EnvironmentConfiguration configuration) {

--- a/integration-tests/src/test/resources/environment-configuration.yml
+++ b/integration-tests/src/test/resources/environment-configuration.yml
@@ -29,3 +29,4 @@ zosmfServiceConfiguration:
     scheme: https
     host: river.zowe.org
     port: 10443
+    serviceId: zosmf


### PR DESCRIPTION
Add default zosm service id

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>