### PR TITLE
Fix OAS3 parser when no tags are present

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -170,6 +170,6 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
     }
 
     private boolean isHidden(List<Tag> tags) {
-        return tags.stream().anyMatch(tag -> tag.getName().equals(HIDDEN_TAG));
+        return tags != null && tags.stream().anyMatch(tag -> tag.getName().equals(HIDDEN_TAG));
     }
 }


### PR DESCRIPTION
**HOTFIX only**

**Related problem:**
#571 

**Fixes:**
The catalog does not display OAS3 document when no tags are present. Nullpointer exception occurs instead.

**Does not fix:**
Error handling. The Catalog should not return 200 when something fails.