### PR TITLE
Use ZosmfServiceV2 only if the authentication endpoint exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ api-layer.tar.gz
 gateway-service/**/*.data
 gateway-service/**/*.index
 .ehcache-diskstore.lock
+gateway-service/jwt*.tmp

--- a/config/local/api-defs/zosmf-sample.yml_
+++ b/config/local/api-defs/zosmf-sample.yml_
@@ -14,7 +14,7 @@
 #   http --verify=keystore/local_ca/localca.cer GET https://localhost:10010/api/{zosmf-service-id}/zosmf/info 'X-CSRF-ZOSMF-HEADER;'
 #
 services:
-    - serviceId: zosmfserviceid                                   # unique lowercase ID of the service
+    - serviceId: zosmf                                            # unique lowercase ID of the service
       title: IBM z/OSMF                                           # Title of the z/OSMF service in the API catalog
       description: IBM z/OS Management Facility REST API service  # Description of the z/OSMF service in the API catalog
       catalogUiTileId: zosmf                                      # ID of the API Catalog UI tile for z/OSMF services

--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -8,12 +8,12 @@ apiml:
         discoveryServiceUrls: https://localhost:10011/eureka/
     security:
         auth:
-            provider: dummy
+            provider: zosmf
             zosmfServiceId: zosmf  # Replace me with the correct z/OSMF service id
             passTicket:
                 timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         ssl:
-            verifySslCertificatesOfServices: true
+            verifySslCertificatesOfServices: false
         zosmf:
             useJwtToken: true # if true and z/OSMF returns JWT token use it, otherwise create Zowe JWT token with LTPA token from z/OSMF, default is true
     banner: console

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ZosmfService.java
@@ -51,13 +51,15 @@ public interface ZosmfService {
     void invalidate(ZosmfService.TokenType type, String token);
 
     /**
-     * Method is to decide which version of z/OSMF are supported by implementation. If bean is not real implementation
-     * but delegates it has to return false (see {@link org.zowe.apiml.gateway.security.service.zosmf.ZosmfServiceFacade}).
+     * Method is to decide which version of z/OSMF are supported by implementation.
+     * If bean is not real implementation but delegates it has to return false (see
+     * {@link org.zowe.apiml.gateway.security.service.zosmf.ZosmfServiceFacade}).
      *
      * @param version version of z/OSMF
-     * @return if bean provides implementation for specific version of z/OSMF
+     * @return if bean provides implementation for specific version and
+     *         configuration of z/OSMF
      */
-    boolean matchesVersion(int version);
+    boolean isSupported(int version);
 
     /**
      * Enumeration of supported security tokens

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceFacade.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceFacade.java
@@ -145,7 +145,7 @@ public class ZosmfServiceFacade extends AbstractZosmfService implements ServiceC
         final ZosmfInfo zosmfInfo = meProxy.getZosmfInfo(zosmfServiceId);
         final int version = getVersion(zosmfInfo);
         for (final ZosmfService zosmfService : implementations) {
-            if (zosmfService.matchesVersion(version)) return new ImplementationWrapper(zosmfInfo, zosmfService);
+            if (zosmfService.isSupported(version)) return new ImplementationWrapper(zosmfInfo, zosmfService);
         }
 
         meProxy.evictCaches();
@@ -179,9 +179,8 @@ public class ZosmfServiceFacade extends AbstractZosmfService implements ServiceC
     public void invalidate(TokenType type, String token) {
         getImplementation().getZosmfService().invalidate(type, token);
     }
-
     @Override
-    public boolean matchesVersion(int version) {
+    public boolean isSupported(int version) {
         return false;
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV1.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV1.java
@@ -1,3 +1,4 @@
+
 /*
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at
@@ -12,6 +13,7 @@ package org.zowe.apiml.gateway.security.service.zosmf;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -30,6 +32,7 @@ import org.zowe.apiml.security.common.token.TokenNotValidException;
  * Bean could be served via {@link ZosmfServiceFacade}
  */
 @Service
+@Order(2)
 public class ZosmfServiceV1 extends AbstractZosmfService {
 
     public ZosmfServiceV1(
@@ -89,12 +92,12 @@ public class ZosmfServiceV1 extends AbstractZosmfService {
 
     @Override
     public void invalidate(TokenType type, String token) {
-        // not supported by z/OSMF
+        // not supported by this version of z/OSMF
     }
 
     @Override
-    public boolean matchesVersion(int version) {
-        return version <= 25;
+    public boolean isSupported(int version) {
+        return true;
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV2.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV2.java
@@ -16,30 +16,32 @@ import org.zowe.apiml.gateway.security.service.ZosmfService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * This implementation is used for version z/OSMF which support authentication endpoint. This endpoint allows to
- * generate new token, verify using token and also deactivation of token. Token could be LTPA or JWT (depends on
- * z/OSMF's configuration)
+ * This implementation is used for version z/OSMF which can support authentication
+ * endpoint depends on z/OSMF's configuration).
+ * This endpoint allows to generate new token, verify using token and
+ * also deactivation of token. Token could be LTPA or JWT.
  *
  * Bean could be served via {@link ZosmfServiceFacade}
  */
 @Service
+@Order(1)
 public class ZosmfServiceV2 extends AbstractZosmfService {
 
-    public ZosmfServiceV2(
-        AuthConfigurationProperties authConfigurationProperties,
-        DiscoveryClient discovery,
-        @Qualifier("restTemplateWithoutKeystore") RestTemplate restTemplateWithoutKeystore,
-        ObjectMapper securityObjectMapper
-    ) {
+    public ZosmfServiceV2(AuthConfigurationProperties authConfigurationProperties, DiscoveryClient discovery,
+            @Qualifier("restTemplateWithoutKeystore") RestTemplate restTemplateWithoutKeystore,
+            ObjectMapper securityObjectMapper) {
         super(authConfigurationProperties, discovery, restTemplateWithoutKeystore, securityObjectMapper);
     }
 
@@ -52,15 +54,29 @@ public class ZosmfServiceV2 extends AbstractZosmfService {
         headers.add(ZOSMF_CSRF_HEADER, "");
 
         try {
-            final ResponseEntity<String> response = restTemplateWithoutKeystore.exchange(
-                url,
-                HttpMethod.POST,
-                new HttpEntity<>(null, headers),
-                String.class);
+            final ResponseEntity<String> response = restTemplateWithoutKeystore.exchange(url, HttpMethod.POST,
+                    new HttpEntity<>(null, headers), String.class);
             return getAuthenticationResponse(response);
         } catch (RuntimeException re) {
             throw handleExceptionOnCall(url, re);
         }
+    }
+
+    private boolean authenticationEndpointExists() {
+        String url = getURI(getZosmfServiceId()) + ZOSMF_AUTHENTICATE_END_POINT;
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(ZOSMF_CSRF_HEADER, "");
+
+        try {
+            restTemplateWithoutKeystore.exchange(url, HttpMethod.POST, new HttpEntity<>(null, headers), String.class);
+        } catch (HttpClientErrorException hce) {
+            if (hce.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
+                return true;
+            }
+        } catch (RuntimeException re) {
+        }
+        return false;
     }
 
     @Override
@@ -72,13 +88,11 @@ public class ZosmfServiceV2 extends AbstractZosmfService {
         headers.add(HttpHeaders.COOKIE, type.getCookieName() + "=" + token);
 
         try {
-            ResponseEntity<String> re = restTemplateWithoutKeystore.exchange(
-                url ,
-                HttpMethod.POST,
-                new HttpEntity<>(null, headers),
-                String.class);
+            ResponseEntity<String> re = restTemplateWithoutKeystore.exchange(url, HttpMethod.POST,
+                    new HttpEntity<>(null, headers), String.class);
 
-            if (re.getStatusCode().is2xxSuccessful()) return;
+            if (re.getStatusCode().is2xxSuccessful())
+                return;
             if (re.getStatusCodeValue() == 401) {
                 throw new TokenNotValidException("Token is not valid.");
             }
@@ -98,13 +112,11 @@ public class ZosmfServiceV2 extends AbstractZosmfService {
         headers.add(HttpHeaders.COOKIE, type.getCookieName() + "=" + token);
 
         try {
-            ResponseEntity<String> re = restTemplateWithoutKeystore.exchange(
-                url,
-                HttpMethod.DELETE,
-                new HttpEntity<>(null, headers),
-                String.class);
+            ResponseEntity<String> re = restTemplateWithoutKeystore.exchange(url, HttpMethod.DELETE,
+                    new HttpEntity<>(null, headers), String.class);
 
-            if (re.getStatusCode().is2xxSuccessful()) return;
+            if (re.getStatusCode().is2xxSuccessful())
+                return;
             apimlLog.log("org.zowe.apiml.security.serviceUnavailable", url, re.getStatusCodeValue());
             throw new ServiceNotAccessibleException("Could not get an access to z/OSMF service.");
         } catch (RuntimeException re) {
@@ -112,9 +124,10 @@ public class ZosmfServiceV2 extends AbstractZosmfService {
         }
     }
 
+
     @Override
-    public boolean matchesVersion(int version) {
-        return version >= 26;
+    public boolean isSupported(int version) {
+        return (version >= 26) && authenticationEndpointExists();
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV2.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV2.java
@@ -12,6 +12,9 @@ package org.zowe.apiml.gateway.security.service.zosmf;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.zowe.apiml.gateway.security.service.ZosmfService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
@@ -37,6 +40,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Service
 @Order(1)
+@Slf4j
 public class ZosmfServiceV2 extends AbstractZosmfService {
 
     public ZosmfServiceV2(AuthConfigurationProperties authConfigurationProperties, DiscoveryClient discovery,
@@ -74,7 +78,12 @@ public class ZosmfServiceV2 extends AbstractZosmfService {
             if (hce.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
                 return true;
             }
+            else if (hce.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                return false;
+            }
+            log.warn("The check of z/OSMF JWT authentication endpoint has failed with exception", hce);
         } catch (RuntimeException re) {
+            log.warn("The check of z/OSMF JWT authentication endpoint has failed with exception", re);
         }
         return false;
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -208,7 +208,7 @@ public class AuthenticationServiceTest {
         assertEquals(DOMAIN, parsedToken.getDomain());
         assertEquals(USER, parsedToken.getUserId());
         assertEquals(parsedToken.getCreation().toString().substring(0, 16), dateNow);
-        Date toBeExpired = DateUtils.addDays(parsedToken.getCreation(), 1);
+        Date toBeExpired = DateUtils.addHours(parsedToken.getCreation(), 24);
         assertEquals(parsedToken.getExpiration(), toBeExpired);
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceFacadeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceFacadeTest.java
@@ -209,9 +209,9 @@ public class ZosmfServiceFacadeTest {
     }
 
     @Test
-    public void testMatchesVersion() {
-        assertFalse(zosmfService.matchesVersion(1));
-        assertFalse(zosmfService.matchesVersion(25));
+    public void testIsSupported() {
+        assertFalse(zosmfService.isSupported(1));
+        assertFalse(zosmfService.isSupported(25));
     }
 
     @Test
@@ -304,7 +304,7 @@ public class ZosmfServiceFacadeTest {
         }
 
         @Override
-        public boolean matchesVersion(int version) {
+        public boolean isSupported(int version) {
             return this.version == version;
         }
 
@@ -331,7 +331,7 @@ public class ZosmfServiceFacadeTest {
         }
 
         @Override
-        public boolean matchesVersion(int version) {
+        public boolean isSupported(int version) {
             return this.version == version;
         }
 
@@ -345,7 +345,7 @@ public class ZosmfServiceFacadeTest {
 
         public ZosmfService getService(int version) {
             for (final ZosmfService zosmfService : implementations) {
-                if (zosmfService.matchesVersion(version)) return zosmfService;
+                if (zosmfService.isSupported(version)) return zosmfService;
             }
             return null;
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV1Test.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceV1Test.java
@@ -201,11 +201,11 @@ public class ZosmfServiceV1Test {
     }
 
     @Test
-    public void testMatchesVersion() {
-        assertTrue(zosmfService.matchesVersion(Integer.MIN_VALUE));
-        assertTrue(zosmfService.matchesVersion(25));
-        assertFalse(zosmfService.matchesVersion(26));
-        assertFalse(zosmfService.matchesVersion(Integer.MAX_VALUE));
+    public void testIsSupported() {
+        assertTrue(zosmfService.isSupported(Integer.MIN_VALUE));
+        assertTrue(zosmfService.isSupported(25));
+        assertTrue(zosmfService.isSupported(26));
+        assertTrue(zosmfService.isSupported(Integer.MAX_VALUE));
     }
 
 }


### PR DESCRIPTION
The z/OSMF provides `/zosmf/services/authenticate` only if the JWT support is activated even on the latest version.

The code is changed to use ZosmfServiceV2 only when the endpoint is available.

Reported by @jackjia-ibm: https://openmainframeproject.slack.com/archives/CC5UUL005/p1585348336019100

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>