### PR TITLE
Increase cypress timeout

### DIFF
--- a/api-catalog-ui/frontend/cypress.json
+++ b/api-catalog-ui/frontend/cypress.json
@@ -7,6 +7,7 @@
         "password": "user"
     },
     "reporter": "junit",
+    "defaultCommandTimeout": 60000,
     "reporterOptions": {
         "mochaFile": "test-results/e2e/output-[hash].xml"
     }


### PR DESCRIPTION
Increase default timeout value used by Cypress E2E tests to fix the problem of failing tests when MF is slow.
Signed-off-by: at670475 <andrea.tabone@broadcom.com>