### PR TITLE
fix JwtValidatorFilter to support expired tokens to services

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRoutingConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRoutingConfig.java
@@ -44,8 +44,8 @@ public class ApimlRoutingConfig {
     }
 
     @Bean
-    public JwtValidatorFilter jwtValidatorFilter(AuthenticationService authenticationService) {
-        return new JwtValidatorFilter(authenticationService);
+    public JwtValidatorFilter jwtValidatorFilter(AuthenticationService authenticationService, AuthConfigurationProperties authConfigurationProperties) {
+        return new JwtValidatorFilter(authenticationService, authConfigurationProperties);
     }
 
     @Bean


### PR DESCRIPTION
resolves #583

When filter treats expired JWT token, token is removed and request send to service to allow interaction with service. PR also fix response of calls with invalid token (modified JWT)