### PR TITLE
Use uppercase parameters for PassTicket service

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
@@ -56,11 +56,11 @@ public class PassTicketService {
 
         private static int id = 0;
 
-        public static final String ZOWE_DUMMY_USERID = "user";
-        public static final String ZOWE_DUMMY_PASS_TICKET_PREFIX = "ZoweDummyPassTicket";
+        public static final String ZOWE_DUMMY_USERID = "USER";
+        public static final String ZOWE_DUMMY_PASS_TICKET_PREFIX = "ZOWEDUMMYPASSTICKET";
 
-        public static final String DUMMY_USER = "user";
-        public static final String UNKNOWN_USER = "unknownUser";
+        public static final String DUMMY_USER = "USER";
+        public static final String UNKNOWN_USER = "UNKNOWNUSER";
         public static final String UNKNOWN_APPLID = "XBADAPPL";
 
         private final Map<UserApp, Set<String>> userAppToPasstickets = new HashMap<>();

--- a/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
@@ -13,6 +13,7 @@ import org.zowe.apiml.util.ClassOrDefaultProxyUtils;
 import org.zowe.apiml.util.ObjectUtil;
 import lombok.AllArgsConstructor;
 import lombok.Value;
+
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
@@ -39,11 +40,11 @@ public class PassTicketService {
     }
 
     public void evaluate(String userId, String applId, String passTicket) throws IRRPassTicketEvaluationException {
-        irrPassTicket.evaluate(userId, applId, passTicket);
+        irrPassTicket.evaluate(userId.toUpperCase(), applId.toUpperCase(), passTicket.toUpperCase());
     }
 
     public String generate(String userId, String applId) throws IRRPassTicketGenerationException {
-        return irrPassTicket.generate(userId, applId);
+        return irrPassTicket.generate(userId.toUpperCase(), applId.toUpperCase());
     }
 
     public boolean isUsingSafImplementation() {

--- a/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/passticket/PassTicketService.java
@@ -57,10 +57,10 @@ public class PassTicketService {
         private static int id = 0;
 
         public static final String ZOWE_DUMMY_USERID = "USER";
-        public static final String ZOWE_DUMMY_PASS_TICKET_PREFIX = "ZOWEDUMMYPASSTICKET";
+        public static final String ZOWE_DUMMY_PASS_TICKET_PREFIX = "ZOWE_DUMMY_PASS_TICKET";
 
         public static final String DUMMY_USER = "USER";
-        public static final String UNKNOWN_USER = "UNKNOWNUSER";
+        public static final String UNKNOWN_USER = "UNKNOWN_USER";
         public static final String UNKNOWN_APPLID = "XBADAPPL";
 
         private final Map<UserApp, Set<String>> userAppToPasstickets = new HashMap<>();

--- a/common-service-core/src/test/java/org/zowe/apiml/passticket/PassTicketServiceTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/passticket/PassTicketServiceTest.java
@@ -57,11 +57,11 @@ public class PassTicketServiceTest {
 
         evaluated = null;
         passTicketService.evaluate("userId", "applId", "passTicket");
-        assertEquals("userId-applId-passTicket", evaluated);
+        assertEquals("USERID-APPLID-PASSTICKET", evaluated);
         passTicketService.evaluate("1", "2", "3");
         assertEquals("1-2-3", evaluated);
 
-        assertEquals("userId-applId", passTicketService.generate("userId", "applId"));
+        assertEquals("USERID-APPLID", passTicketService.generate("userId", "applId"));
         assertEquals("1-2", passTicketService.generate("1", "2"));
     }
 

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/PassTicketTestControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/PassTicketTestControllerTest.java
@@ -43,7 +43,7 @@ public class PassTicketTestControllerTest {
     private PassTicketTestController passTicketTestController;
 
     private static final String ZOWE_PASSTICKET_AUTH_HEADER = "Basic "
-            + Base64.getEncoder().encodeToString(("user:ZoweDummyPassTicket").getBytes());
+            + Base64.getEncoder().encodeToString(("user:ZOWE_DUMMY_PASS_TICKET").getBytes());
 
     private static final String BAD_PASSTICKET_AUTH_HEADER = "Basic "
             + Base64.getEncoder().encodeToString(("user:bad").getBytes());

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -30,6 +30,7 @@ import static org.zowe.apiml.passticket.PassTicketService.DefaultPassTicketImpl.
 import static org.junit.Assert.assertEquals;
 
 public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
+    private static final String USERNAME = "USERNAME";
     private final AuthConfigurationProperties authConfigurationProperties = new AuthConfigurationProperties();
     private HttpBasicPassTicketScheme httpBasicPassTicketScheme;
 
@@ -42,8 +43,8 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
     @Test
     public void testCreateCommand() throws Exception {
         Calendar calendar = Calendar.getInstance();
-        Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
-        QueryResponse queryResponse = new QueryResponse("domain", "username", calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
+        Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "APPLID");
+        QueryResponse queryResponse = new QueryResponse("domain", USERNAME, calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
 
         AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, queryResponse);
         assertNotNull(ac);
@@ -54,23 +55,23 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
         RequestContext.testSetCurrentContext(requestContext);
         ac.apply(null);
 
-        assertEquals("Basic dXNlcm5hbWU6Wm93ZUR1bW15UGFzc1RpY2tldF9hcHBsaWRfdXNlcm5hbWVfMA==",
+        assertEquals("Basic VVNFUk5BTUU6Wk9XRURVTU1ZUEFTU1RJQ0tFVF9BUFBMSURfVVNFUk5BTUVfMA==",  // USERNAME:ZOWEDUMMYPASSTICKET_APPLID_USERNAME_0
             requestContext.getZuulRequestHeaders().get("authorization"));
 
         // JWT token expired one minute ago (command expired also if JWT token expired)
         calendar.add(Calendar.MINUTE, -1);
-        queryResponse = new QueryResponse("domain", "username", calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
+        queryResponse = new QueryResponse("domain", USERNAME, calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
         ac = httpBasicPassTicketScheme.createCommand(authentication, queryResponse);
         assertTrue(ac.isExpired());
 
         // JWT token will expire in one minute (command expired also if JWT token expired)
         calendar.add(Calendar.MINUTE, 2);
-        queryResponse = new QueryResponse("domain", "username", calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
+        queryResponse = new QueryResponse("domain", USERNAME, calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
         ac = httpBasicPassTicketScheme.createCommand(authentication, queryResponse);
         assertFalse(ac.isExpired());
 
         calendar.add(Calendar.MINUTE, 100);
-        queryResponse = new QueryResponse("domain", "username", calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
+        queryResponse = new QueryResponse("domain", USERNAME, calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
         ac = httpBasicPassTicketScheme.createCommand(authentication, queryResponse);
 
         calendar = Calendar.getInstance();
@@ -86,7 +87,7 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
 
     @Test
     public void getExceptionWhenUserIdNotValid() {
-        String applId = "applId";
+        String applId = "APPLID";
 
         Calendar calendar = Calendar.getInstance();
         Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, applId);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -55,7 +55,7 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
         RequestContext.testSetCurrentContext(requestContext);
         ac.apply(null);
 
-        assertEquals("Basic VVNFUk5BTUU6Wk9XRURVTU1ZUEFTU1RJQ0tFVF9BUFBMSURfVVNFUk5BTUVfMA==",  // USERNAME:ZOWEDUMMYPASSTICKET_APPLID_USERNAME_0
+        assertEquals("Basic VVNFUk5BTUU6Wk9XRV9EVU1NWV9QQVNTX1RJQ0tFVF9BUFBMSURfVVNFUk5BTUVfMA==",  // USERNAME:ZOWE_DUMMY_PASS_TICKET_APPLID_USERNAME_0
             requestContext.getZuulRequestHeaders().get("authorization"));
 
         // JWT token expired one minute ago (command expired also if JWT token expired)

--- a/passticket/test-programs/PtGen.java
+++ b/passticket/test-programs/PtGen.java
@@ -3,6 +3,7 @@ import java.io.PrintWriter;
 
 import com.ibm.eserver.zos.racf.IRRPassTicket;
 import com.ibm.eserver.zos.racf.IRRPassTicketGenerationException;
+import com.ibm.os390.security.PlatformThread;
 
 public class PtGen {
     public static void main(String args[]) {
@@ -11,6 +12,7 @@ public class PtGen {
         String applid = args[1];
 
         try {
+            System.out.println("activeUserid=" + PlatformThread.getUserName());
             passTicketService = new IRRPassTicket();
             System.out.println("userid=" + userid + " applid=" + applid);
             String passTicket = passTicketService.generate(userid, applid);


### PR DESCRIPTION
Prevent issues when PassTicket generated for lower case user ID is not valid in mainframe services.

Signed-off-by: Petr Plavjanik <plavjanik@gmail.com>