### PR TITLE
thin jar fixes

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -100,7 +100,7 @@ jar {
     enabled = true
     archiveName = "${jar.baseName}-thin.jar"
 
-    def libClassPathEntries = configurations.compile.files.collect {
+    def libClassPathEntries = configurations.runtime.files.collect {
         "lib/" + it.getName()
     }
     doFirst {

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -58,3 +58,18 @@ dependencies {
 
 
 bootJar.archiveName = "${bootJar.baseName}.jar"
+
+jar {
+    enabled = true
+    archiveName = "${jar.baseName}-thin.jar"
+
+    def libClassPathEntries = configurations.runtime.files.collect {
+        "lib/" + it.getName()
+    }
+    doFirst {
+        manifest {
+            attributes "Class-Path": libClassPathEntries.join(" "),
+                "Main-Class": "org.zowe.apiml.client.DiscoverableClientSampleApplication"
+        }
+    }
+}

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -75,7 +75,7 @@ jar {
     enabled = true
     archiveName = "${jar.baseName}-thin.jar"
 
-    def libClassPathEntries = configurations.compile.files.collect {
+    def libClassPathEntries = configurations.runtime.files.collect {
         "lib/" + it.getName()
     }
     doFirst {

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -102,7 +102,7 @@ jar {
     enabled = true
     archiveName = "${jar.baseName}-thin.jar"
 
-    def libClassPathEntries = configurations.compile.files.collect {
+    def libClassPathEntries = configurations.runtime.files.collect {
         "lib/" + it.getName()
     }
     doFirst {


### PR DESCRIPTION
These changes are aside to our build and artifacts
enable thin jar for discoverable client
change classpath from compile to runtime to fix missing dependencies