### PR TITLE
fix PassTicket scheme when call without JWT

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -48,6 +48,10 @@ public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
         final long before = System.currentTimeMillis();
         final QueryResponse token = tokenSupplier.get();
 
+        if (token == null) {
+            return AuthenticationCommand.EMPTY;
+        }
+
         final String applId = authentication.getApplid();
         final String userId = token.getUserId();
         String passTicket;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -108,4 +108,11 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
         assertTrue(ac.isRequiredValidJwt());
     }
 
+    @Test
+    public void whenCallWithutJwt_thenDoNothing() {
+        Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
+        AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, () -> null);
+        assertSame(ac, AuthenticationCommand.EMPTY);
+    }
+
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -109,7 +109,7 @@ public class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTes
     }
 
     @Test
-    public void whenCallWithutJwt_thenDoNothing() {
+    public void whenCallWithoutJwt_thenDoNothing() {
         Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
         AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, () -> null);
         assertSame(ac, AuthenticationCommand.EMPTY);


### PR DESCRIPTION
In case of call service using PassTicket authentication scheme without JWT, call should be send, but without credentials.

It is used for example in case of calling endpoints like /application/healts. Not all endpoints have to required credentials.