### PR TITLE
fix PR artifact publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,7 +156,7 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh '''
-                    sudo sed -i '/version=/ s/-SNAPSHOT/-'"$BRANCH_NAME"'-SNAPSHOT/' ./gradle.properties
+                    sed -i '/version=/ s/-SNAPSHOT/-'"$BRANCH_NAME"'-SNAPSHOT/' ./gradle.properties
                     ./gradlew publishAllVersions -Pzowe.deploy.username=$USERNAME -Pzowe.deploy.password=$PASSWORD  -Partifactory_user=$USERNAME -Partifactory_password=$PASSWORD -PpullRequest=$env.BRANCH_NAME
                     '''
                 }


### PR DESCRIPTION
publish enabled on second run of jenkins, proof of publish here:

https://zowe.jfrog.io/zowe/libs-snapshot-local/org/zowe/apiml/sdk/zowe-install/1.12.0-PR-658-SNAPSHOT/