### PR TITLE
Add remaining react components for the refresh func

### DIFF
--- a/api-catalog-ui/frontend/README.md
+++ b/api-catalog-ui/frontend/README.md
@@ -79,7 +79,7 @@ You can see the coverage in the terminal window or go to the `coverage/lcov-repo
 
 For local development run `npm run start:dev`.
 
-Using this command you will have an instance of catalog UI running on <http://localhost:3000/> using mocked backend for info updates.
+Using this command you will have an instance of catalog UI running on <https://localhost:3000/> using mocked backend for info updates.
 
 To configure variouse environment specific variables for development see [this env file](./.env.development);
 
@@ -111,8 +111,11 @@ All commands related to cypress start with cy.
 As of now the available ones are:
 
 `cy:open` - opens the interactive window with no environment variables set
+
 `cy:e2e:ci` - runs all test inside the e2e folder testing the instance in the baseURL env variable while using credential passed as parameters (This command should be used in the pipeline)
+
 `cy:e2e:localhost` - runs all test inside the e2e folder testing the localhost instance
+
 `cy:e2e:mocked-backend` - runs all test inside the /integration/integration folder; integration tests should run locally against mocked backend
 
 

--- a/api-catalog-ui/frontend/cypress/integration/e2e/dashboard/dashboard.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/dashboard/dashboard.test.js
@@ -35,6 +35,12 @@ describe('>>> Dashboard test', () => {
         cy.get('input[data-testid="search-bar"]').should('exist');
         cy.contains('Available API services').should('exist');
 
+        cy.get('#refresh-api-button').should('exist').click();
+        cy.get('.Toastify').should('have.length.gte', 1);
+        cy.get('.Toastify > div> div')
+            .should('have.length', 1)
+            .should('contain', 'The refresh of static APIs was successful!');
+
         cy.get('input[data-testid="search-bar"]')
             .as('search')
             .type('API Mediation Layer API');

--- a/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.css
+++ b/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.css
@@ -35,7 +35,6 @@ a {
 }
 
 .no-tiles-container {
-    margin-top: 2rem;
     margin-left: 2rem;
     text-align: left;
     overflow: hidden;
@@ -120,4 +119,9 @@ a {
             padding-right: 1rem;
         }
     }
+}
+
+#refresh-api-button {
+    margin: -48px 100px;
+    float: right;
 }

--- a/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { Text } from 'mineral-ui';
+import { Text, Button, Dialog, DialogBody, DialogHeader, DialogTitle, DialogFooter, DialogActions } from 'mineral-ui';
 import React, { Component } from 'react';
 import SearchCriteria from '../Search/SearchCriteria';
 import Shield from '../ErrorBoundary/Shield/Shield';
@@ -8,6 +8,12 @@ import Spinner from '../Spinner/Spinner';
 import formatError from '../Error/ErrorFormatter';
 
 export default class Dashboard extends Component {
+
+    closeDialog = () => {
+        const { clearError } = this.props;
+        clearError();
+    };
+
     componentDidMount() {
         const { fetchTilesStart, clearService } = this.props;
         clearService();
@@ -25,17 +31,49 @@ export default class Dashboard extends Component {
         filterText(value);
     };
 
+    refreshStaticApis = () => {
+        const { refreshedStaticApi } = this.props;
+        refreshedStaticApi();
+    };
+
+    getCorrectRefreshMessage = error => {
+        let messageText;
+        if (error && !error.status && !error.messageNumber) {
+            messageText = error.toString();
+            messageText = "(ZWEAD702E) A problem occurred while parsing a static API definition file " + messageText;
+            return messageText;
+        }
+        const errorMessages = require("../../error-messages.json");
+        if (error &&
+            error.messageNumber !== undefined &&
+            error.messageNumber !== null &&
+            error.messageType !== undefined &&
+            error.messageType !== null) {
+            messageText = "Unexpected error, please try again later";
+            const filter = errorMessages.messages.filter(x => x.messageKey != null && x.messageKey === error.messageNumber);
+            if (filter.length !== 0) {
+                messageText = `(${error.messageNumber}) ${filter[0].messageText}`;
+            }
+        }
+        return messageText;
+    };
+
     render() {
-        const { tiles, history, searchCriteria, isLoading, fetchTilesError, fetchTilesStop } = this.props;
+        const { tiles, history, searchCriteria, isLoading, fetchTilesError, fetchTilesStop, refreshedStaticApisError } = this.props;
         const hasSearchCriteria = searchCriteria !== undefined && searchCriteria !== null && searchCriteria.length > 0;
+        const isTrue = true;
+        const isFalse = false;
         const hasTiles = !fetchTilesError && tiles && tiles.length > 0;
         let error = null;
+        let refreshError = this.getCorrectRefreshMessage(refreshedStaticApisError);
         if (fetchTilesError !== undefined && fetchTilesError !== null) {
             fetchTilesStop();
             error = formatError(fetchTilesError);
         }
+
         return (
             <div>
+                <Button id="refresh-api-button"size="medium" onClick={this.refreshStaticApis}>Refresh Static APIs</Button>
                 <Spinner isLoading={isLoading} />
                 {fetchTilesError && (
                     <div className="no-tiles-container">
@@ -45,6 +83,35 @@ export default class Dashboard extends Component {
                         {error}
                     </div>
                 )}
+                {((refreshedStaticApisError !== null &&
+                refreshedStaticApisError !== undefined &&
+                refreshedStaticApisError.status) || (refreshedStaticApisError && typeof refreshedStaticApisError === 'object'))
+                && (
+                        <Dialog
+                            variant="danger"
+                            appSelector="#App"
+                            closeOnClickOutside={isFalse}
+                            hideOverlay={isTrue}
+                            modeless={isFalse}
+                            isOpen={refreshedStaticApisError!==null}
+                        >
+                            <DialogHeader>
+                                <DialogTitle>Error</DialogTitle>
+                            </DialogHeader>
+                            <DialogBody>
+                                <Text>{refreshError}</Text>
+                            </DialogBody>
+                            <DialogFooter>
+                                <DialogActions>
+                                    <Button size="medium" variant="danger" onClick={this.closeDialog}>
+                                        Close
+                                    </Button>
+                                </DialogActions>
+                            </DialogFooter>
+                        </Dialog>
+                )
+                }
+
                 {!fetchTilesError && (
                     <div className="apis">
                         <div className="grid-container">

--- a/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/api-catalog-ui/frontend/src/components/Dashboard/Dashboard.jsx
@@ -44,11 +44,7 @@ export default class Dashboard extends Component {
             return messageText;
         }
         const errorMessages = require("../../error-messages.json");
-        if (error &&
-            error.messageNumber !== undefined &&
-            error.messageNumber !== null &&
-            error.messageType !== undefined &&
-            error.messageType !== null) {
+        if (error && error.messageNumber && error.messageType) {
             messageText = "Unexpected error, please try again later";
             const filter = errorMessages.messages.filter(x => x.messageKey != null && x.messageKey === error.messageNumber);
             if (filter.length !== 0) {

--- a/api-catalog-ui/frontend/src/components/Dashboard/DashboardContainer.jsx
+++ b/api-catalog-ui/frontend/src/components/Dashboard/DashboardContainer.jsx
@@ -8,7 +8,9 @@ import {
 } from '../../actions/catalog-tile-actions';
 import { clearService } from '../../actions/selected-service-actions';
 import { filterText, clear } from '../../actions/filter-actions';
+import { refreshedStaticApi } from "../../actions/refresh-static-apis-actions";
 import { createLoadingSelector, getVisibleTiles } from '../../selectors/selectors';
+import {clearError} from "../../actions/refresh-static-apis-actions";
 
 const loadingSelector = createLoadingSelector(['FETCH_TILES']);
 
@@ -17,6 +19,8 @@ const mapStateToProps = state => ({
     tiles: getVisibleTiles(state.tilesReducer.tiles, state.filtersReducer.text),
     fetchTilesError: state.tilesReducer.error,
     isLoading: loadingSelector(state),
+    refreshedStaticApisError: state.refreshStaticApisReducer.error,
+    refreshTimestamp: state.refreshStaticApisReducer.refreshTimestamp,
 });
 
 const mapDispatchToProps = {
@@ -27,6 +31,8 @@ const mapDispatchToProps = {
     fetchTilesStop,
     filterText,
     clear,
+    refreshedStaticApi,
+    clearError,
 };
 
 export default connect(


### PR DESCRIPTION
Implementation of the static APIs refresh functionality for the API Catalog UI #57

The user can now press a refresh button in the UI which will call the API Catalog service endpoint that will use the DS endpoint /discovery/api/v1/staticApi to refresh static APIs.

Error handling has been added. You will see a banner containing error message and related informations for the following errors:

ZWEAC706E - 503 Service Unavailable
ZWEAC707E - 500 internal error
ZWEAG708E Connection refused
ZWEAD702E Unable to process static API definition data.
In case of successful response, another "toast" popup will be displayed.

On local environment it takes few seconds (like 5 sec) to update and reflect in the UI the changes.
Signed-off-by: at670475 <andrea.tabone@broadcom.com>