### PR TITLE
AuthenticationOnDeploymentTest and ServiceHaMode requires the Gateway…

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/EurekaInstancesIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/EurekaInstancesIntegrationTest.java
@@ -151,7 +151,7 @@ public class EurekaInstancesIntegrationTest {
     }
 
     @Test
-    @Flaky
+    @TestsNotMeantForZowe @Flaky
     public void testApplicationInfoEndpoints_whenProvidedToken() throws Exception {
         RestAssured.useRelaxedHTTPSValidation();
         String jwtToken = SecurityUtils.gatewayToken(username, password);

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.zowe.apiml.security.common.auth.Authentication;
 import org.zowe.apiml.security.common.auth.AuthenticationScheme;
 import org.zowe.apiml.util.categories.Flaky;
+import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.service.RequestVerifier;
 import org.zowe.apiml.util.service.VirtualService;
 
@@ -36,7 +37,7 @@ import static org.zowe.apiml.gatewayservice.SecurityUtils.*;
  * - credentials.user = user
  * - credentials.password = user
  */
-
+@TestsNotMeantForZowe
 public class AuthenticationOnDeploymentTest {
 
     private static final int TIMEOUT = 10;

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/ServiceHaMode.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/ServiceHaMode.java
@@ -15,6 +15,7 @@ import io.restassured.response.Response;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.service.VirtualService;
 
 import java.util.List;
@@ -36,6 +37,7 @@ import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig
  * and responses are inspected. Implementation returns a debug header that describes the retries.
  * The test repeats calls until it sees that request has been retried from mentioned header.
  */
+@TestsNotMeantForZowe
 public class ServiceHaMode {
     private static final int TIMEOUT = 30;
 


### PR DESCRIPTION
… to have access to the server where they are run. As such they wont work in local verification of the integration for Zowe

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>