### PR TITLE
Hotfixes for the 1.12 release

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.apicatalog.staticapi;
 
-import com.netflix.appinfo.InstanceInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +18,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.zowe.apiml.apicatalog.instance.InstanceRetrievalService;
-import org.zowe.apiml.apicatalog.services.status.model.ServiceNotFoundException;
-import org.zowe.apiml.product.constants.CoreService;
-import org.zowe.apiml.product.instance.InstanceInitializationException;
-import org.zowe.apiml.util.EurekaUtils;
+import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
 
 import java.util.Base64;
 
@@ -31,7 +26,7 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class StaticAPIService {
 
-    private static final String REFRESH_ENDPOINT = "/discovery/api/v1/staticApi";
+    private static final String REFRESH_ENDPOINT = "discovery/api/v1/staticApi";
 
     @Value("${apiml.discovery.userid:eureka}")
     private String eurekaUserid;
@@ -42,7 +37,7 @@ public class StaticAPIService {
     @Qualifier("restTemplateWithKeystore")
     private final RestTemplate restTemplate;
 
-    private final InstanceRetrievalService instanceRetrievalService;
+    private final DiscoveryConfigProperties discoveryConfigProperties;
 
     public StaticAPIResponse refresh() {
         String discoveryServiceUrl = getDiscoveryServiceUrl();
@@ -64,15 +59,6 @@ public class StaticAPIService {
     }
 
     private String getDiscoveryServiceUrl() {
-        try {
-            InstanceInfo discoveryInstance = instanceRetrievalService.getInstanceInfo(CoreService.DISCOVERY.getServiceId());
-            if (discoveryInstance == null) {
-                throw new ServiceNotFoundException("Discovery service could not be found");
-            }
-
-            return EurekaUtils.getUrl(discoveryInstance) + REFRESH_ENDPOINT;
-        }  catch (InstanceInitializationException ie) {
-            throw new ServiceNotFoundException("Discovery service instance could not be initialized");
-        }
+        return discoveryConfigProperties.getLocations().replace("/eureka", "") + REFRESH_ENDPOINT;
     }
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -39,7 +39,7 @@ apiml:
                                              # and is all run from single host.
                                              # In Brightside, this holds the DVIPA address and is overridden in PARMLIB to work
                                              # properly.
-        timeoutMillis: 30000  # Timeout for connection to the services
+        timeoutMillis: 600000  # Timeout for connection to the services
     security:
         ssl:
             ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384


### PR DESCRIPTION
Static refresh works with the preferIpAdress: true
Gateway allows long timeouts needed for example by /mvs/datasets