### PR TITLE
Fix evicting of expired authentication tokens

### DIFF
--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     compile libraries.spring_boot_starter_websocket
     compile libraries.spring_boot_starter_thymeleaf
     compile libraries.spring_boot_starter_cache
+    compile libraries.spring_boot_starter_aop
     compile libraries.spring_security_web
     compile libraries.spring_security_config
     compile libraries.swagger3_core

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway;
 
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.zowe.apiml.gateway.ribbon.GatewayRibbonConfig;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
 import org.zowe.apiml.product.service.ServiceStartupEventHandler;
@@ -43,6 +44,7 @@ import javax.annotation.Nonnull;
 @RibbonClients(defaultConfiguration = GatewayRibbonConfig.class)
 @EnableEurekaClient
 @EnableWebSocket
+@EnableAspectJAutoProxy
 public class GatewayApplication implements ApplicationListener<ApplicationReadyEvent> {
 
     public static void main(String[] args) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/RetryIfExpired.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/RetryIfExpired.java
@@ -1,0 +1,23 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to enable aspect {@link RetryIfExpiredAspect}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RetryIfExpired {
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/RetryIfExpiredAspect.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/RetryIfExpiredAspect.java
@@ -1,0 +1,61 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.cache;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.zowe.apiml.cache.EntryExpiration;
+
+/**
+ * This aspect check returned value of a method. It has to return type {@link org.zowe.apiml.cache.EntryExpiration} .
+ * If value is expired the method is call again. Method should be annotated by
+ * {@see org.zowe.apiml.gateway.cache.RetryIfExpired}.
+ *
+ * It is helpful in case of caching of entries, which have detection of expiration. With Spring Cache is no easy way to
+ * return value from cache and checking expiration in one step. If entry is expired, it could be evicted, but this value
+ * is also returned. It can be solved by splitting method (first to evict and second to caching), or with this
+ * aspect, like:
+ *
+ *  @RetryIfExpired
+ *  @CacheEvict(value = <cache name>, condition = "#result != null && #result.isExpired()")
+ *  @Cacheable(value = <cache name>)
+ *  public <? extends EntryExpiration> someMethod(...) { ... }
+ *
+ * If cache contains expired entry matching to cache key, Cacheable and CacheEvict together remove entry from cache and
+ * return it. This aspect then check expiration and call this method once time (in case of expired entry). It will make
+ * new fetching of value and caching.
+ */
+@Aspect
+@Component
+public class RetryIfExpiredAspect implements Ordered {
+
+    @Override
+    public int getOrder() {
+        return LOWEST_PRECEDENCE - 1;
+    }
+
+    @Around("@annotation(org.zowe.apiml.gateway.cache.RetryIfExpired)")
+    public Object process(ProceedingJoinPoint pjp) throws Throwable {
+        Object returnValue = pjp.proceed(pjp.getArgs());
+
+        if (returnValue == null) return returnValue;
+        if (!(returnValue instanceof EntryExpiration)) {
+            throw new IllegalArgumentException("Unsupported type : " + returnValue.getClass());
+        }
+
+        EntryExpiration entryExpiration = (EntryExpiration) returnValue;
+        if (!entryExpiration.isExpired()) return entryExpiration;
+        return pjp.proceed(pjp.getArgs());
+    }
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
+import org.zowe.apiml.gateway.cache.RetryIfExpired;
 import org.zowe.apiml.gateway.config.CacheConfig;
 import org.zowe.apiml.gateway.security.service.schema.AbstractAuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
@@ -101,7 +102,12 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
     }
 
     @Override
-    @CacheEvict(value = CACHE_BY_SERVICE_ID, condition = "#result != null && #result.isExpired()")
+    @RetryIfExpired
+    @CacheEvict(
+        value = CACHE_BY_SERVICE_ID,
+        condition = "#result != null && #result.isExpired()",
+        keyGenerator = CacheConfig.COMPOSITE_KEY_GENERATOR
+    )
     @Cacheable(value = CACHE_BY_SERVICE_ID, keyGenerator = CacheConfig.COMPOSITE_KEY_GENERATOR)
     public AuthenticationCommand getAuthenticationCommand(String serviceId, String jwtToken) {
         final Application application = discoveryClient.getApplication(serviceId);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/cache/RetryIfExpiredAspectTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/cache/RetryIfExpiredAspectTest.java
@@ -1,0 +1,86 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.zowe.apiml.cache.EntryExpiration;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class RetryIfExpiredAspectTest {
+
+    public Object call(Object first, Object second) throws Throwable {
+        Object[] args = new Object[0];
+        ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+
+        doReturn(args).when(proceedingJoinPoint).getArgs();
+        doAnswer(new Answer<Object>() {
+
+            int counter;
+
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                switch (counter++) {
+                    case 0: return first;
+                    case 1: return second;
+                    default:
+                        fail("Unexpected call");
+                        return null;
+                }
+            }
+
+        }).when(proceedingJoinPoint).proceed(args);
+
+        return new RetryIfExpiredAspect().process(proceedingJoinPoint);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNonEntryExpirationValue_whenCallService_thenThrowException() throws Throwable {
+        call(new Object(), null);
+    }
+
+    @Test
+    public void givenNull_whenCallService_thenReturnNull() throws Throwable {
+        assertNull(call(null, null));
+    }
+
+    @Test
+    public void givenNonExpired_whenCallService_thenReturnFirst() throws Throwable {
+        TestObject first = new TestObject(false);
+        assertSame(first, call(first, null));
+    }
+
+    @Test
+    public void givenExpired_whenCallService_thenReturnSecond() throws Throwable {
+        TestObject first = new TestObject(true);
+        TestObject second = new TestObject(false);
+        assertSame(second, call(first, second));
+    }
+
+    @Test
+    public void givenRetryIfExpiredAspect_whenGetOrder_thenNotLowestPrecedence() {
+        assertTrue(new RetryIfExpiredAspect().getOrder() < Integer.MAX_VALUE);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private class TestObject implements EntryExpiration {
+
+        private boolean expired;
+
+    }
+
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
@@ -14,6 +14,9 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.shared.Application;
 import com.netflix.loadbalancer.reactive.ExecutionListener;
 import com.netflix.zuul.context.RequestContext;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,16 +24,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
 import org.springframework.aop.framework.Advised;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.zowe.apiml.gateway.cache.RetryIfExpiredAspect;
 import org.zowe.apiml.gateway.config.CacheConfig;
 import org.zowe.apiml.gateway.security.service.schema.*;
 import org.zowe.apiml.gateway.utils.CurrentRequestContextTest;
@@ -58,8 +61,10 @@ import static org.zowe.apiml.gateway.security.service.ServiceAuthenticationServi
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     ServiceAuthenticationServiceImplTest.Context.class,
-    CacheConfig.class
+    CacheConfig.class,
+    RetryIfExpiredAspect.class
 })
+@EnableAspectJAutoProxy
 public class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
 
     @Autowired
@@ -218,12 +223,9 @@ public class ServiceAuthenticationServiceImplTest extends CurrentRequestContextT
 
         //AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
         AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) {
-                ((Supplier<?>) invocation.getArgument(1)).get();
-                return ok;
-            }
+        doAnswer(invocation -> {
+            ((Supplier<?>) invocation.getArgument(1)).get();
+            return ok;
         }).when(scheme).createCommand(any(), any());
         when(authenticationSchemeFactory.getSchema(any())).thenReturn(scheme);
 
@@ -281,7 +283,7 @@ public class ServiceAuthenticationServiceImplTest extends CurrentRequestContextT
             .thenReturn(ac1);
 
         assertSame(ac1, serviceAuthenticationService.getAuthenticationCommand("s1", "jwt"));
-        verify(discoveryClient, times(1)).getApplication("s1");
+        verify(discoveryClient, times(2)).getApplication("s1");
 
         serviceAuthenticationService.evictCacheAllService();
         Mockito.reset(aas1);
@@ -289,9 +291,9 @@ public class ServiceAuthenticationServiceImplTest extends CurrentRequestContextT
         when(aas1.createCommand(eq(new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1")), any()))
             .thenReturn(ac2);
         assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", "jwt"));
-        verify(discoveryClient, times(2)).getApplication("s1");
+        verify(discoveryClient, times(3)).getApplication("s1");
         assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", "jwt"));
-        verify(discoveryClient, times(2)).getApplication("s1");
+        verify(discoveryClient, times(3)).getApplication("s1");
     }
 
     @Test
@@ -464,20 +466,46 @@ public class ServiceAuthenticationServiceImplTest extends CurrentRequestContextT
         verify(ac, times(1)).apply(any());
     }
 
+    @Test
+    public void givenServiceIdAndJwt_whenExpiringCommand_thenReturnNewOne() {
+        AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
+        Application application = createApplication(
+            createInstanceInfo("instanceId", AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid")
+        );
+        doReturn(application).when(discoveryClient).getApplication("serviceId");
+        doReturn(scheme).when(authenticationSchemeFactory).getSchema(any());
+        AuthenticationCommandTest cmd = new AuthenticationCommandTest(false);
+        doReturn(cmd).when(scheme).createCommand(any(), any());
+
+        // first time, create and put into cache
+        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", "jwt"));
+        verify(scheme, times(1)).createCommand(any(), any());
+
+        // second time, get from cache
+        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", "jwt"));
+        verify(scheme, times(1)).createCommand(any(), any());
+
+        // command expired, take new one
+        cmd.setExpired(true);
+        AuthenticationCommand cmd2 = new AuthenticationCommandTest(false);
+        reset(scheme);
+        doReturn(cmd2).when(scheme).createCommand(any(), any());
+        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", "jwt"));
+        verify(scheme, times(1)).createCommand(any(), any());
+
+        // second command is cached now
+        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", "jwt"));
+        verify(scheme, times(1)).createCommand(any(), any());
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
     public class AuthenticationCommandTest extends AuthenticationCommand {
 
         private static final long serialVersionUID = 8527412076986152763L;
 
         private boolean expired;
-
-        public AuthenticationCommandTest(boolean expired) {
-            this.expired = expired;
-        }
-
-        @Override
-        public boolean isExpired() {
-            return expired;
-        }
 
         @Override
         public void apply(InstanceInfo instanceInfo) {


### PR DESCRIPTION
CacheEvict and Cacheable in ServiceAuthenticationServiceImpl used different key generator. For this reason expired entry cannot be evicted (different class of key).

During fixing was detected another problem, if entry is expired, it is evicted, but method return previous object from cache. It should return new value. It is fixed in this PR too.

Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>