### PR TITLE
Return protection by filtering for certificate other than issued by API ML

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -31,6 +31,7 @@ import org.zowe.apiml.security.SecurityUtils;
 import javax.annotation.PostConstruct;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import java.util.Set;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -84,6 +85,8 @@ public class HttpConfig {
     @InjectApimlLogger
     private ApimlLogger apimlLog = ApimlLogger.empty();
 
+    private Set<String> publicKeyCertificatesBase64;
+
     @PostConstruct
     public void init() {
         try {
@@ -112,6 +115,8 @@ public class HttpConfig {
             secureHttpClientWithoutKeystore = factoryWithoutKeystore.createSecureHttpClient();
 
             factory.setSystemSslProperties();
+
+            publicKeyCertificatesBase64 = SecurityUtils.loadCertificateChainBase64(httpsConfig);
         }
         catch (HttpsConfigError e) {
             System.exit(1); // NOSONAR
@@ -120,6 +125,12 @@ public class HttpConfig {
             apimlLog.log("org.zowe.apiml.common.unknownHttpsConfigError", e.getMessage());
             System.exit(1); // NOSONAR
         }
+    }
+
+    @Bean
+    @Qualifier("publicKeyCertificatesBase64")
+    public Set<String> publicKeyCertificatesBase64() {
+        return publicKeyCertificatesBase64;
     }
 
     @Bean

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilter.java
@@ -1,0 +1,79 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Set;
+
+/**
+ * This filter extends authentication via certificate. It removes all certificates signature from request which are not
+ * related to private key using to request signing.
+ *
+ * Be careful with usage as later on it means that the set of original certificates won't be available.
+ */
+@RequiredArgsConstructor
+public class ApimlX509AuthenticationFilter extends X509AuthenticationFilter {
+
+    private final Set<String> publicKeyCertificatesBase64;
+
+    /**
+     * Filter certificated by allowed - see publicKeyCertificatesBase64
+     * @param certs all certificated to filter
+     * @return filtered certificates (certs), contains only certificated used to sign in APIML
+     */
+    private X509Certificate[] filter(X509Certificate[] certs) {
+        return Arrays.stream(certs)
+            .filter(x -> publicKeyCertificatesBase64.contains(
+                Base64.getEncoder().encodeToString(x.getPublicKey().getEncoded())
+            ))
+            .toArray(X509Certificate[]::new);
+    }
+
+    /**
+     * Get certificates from request (if exists), filter them (to use only APIML certificate to request sign) and
+     * store again into request.
+     * @param request Request to filter certificates
+     */
+    private void filterCerts(ServletRequest request) {
+        X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        if (certs != null) {
+            certs = filter(certs);
+            request.setAttribute("javax.servlet.request.X509Certificate", certs);
+        }
+    }
+
+    /**
+     * ApimlX509AuthenticationFilter override methods {@link X509AuthenticationFilter#doFilter(ServletRequest, ServletResponse, FilterChain)}.
+     * This filter remove in attribute "javax.servlet.request.X509Certificate" all certificates which has no relations
+     * with private certificate using to request sign and then call original implementation (without "foreign"
+     * certificates)
+     * @param request request to process
+     * @param response response of call
+     * @param chain chain of filters to evaluate
+     **/
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException
+    {
+        filterCerts(request);
+        super.doFilter(request, response, chain);
+    }
+
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
@@ -22,7 +22,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.PublicKey;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Base64;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class ApimlX509AuthenticationFilterTest {
+class ApimlX509AuthenticationFilterTest {
 
     private ServletRequest request;
     private ServletResponse response;
@@ -45,7 +45,7 @@ public class ApimlX509AuthenticationFilterTest {
     }
 
     @Test
-    public void givenNoCertificates_thenDontUpdate_whenCallFilter() throws IOException, ServletException {
+    void givenNoCertificates_thenDontUpdate_whenCallFilter() throws IOException, ServletException {
         ApimlX509AuthenticationFilter filter = new ApimlX509AuthenticationFilter(Collections.emptySet());
 
         filter.doFilter(request, response, chain);
@@ -70,7 +70,7 @@ public class ApimlX509AuthenticationFilterTest {
     }
 
     @Test
-    public void giveCertificates_thenRemoveForeign_whenCallFilter() throws IOException, ServletException {
+    void giveCertificates_thenRemoveForeign_whenCallFilter() throws IOException, ServletException {
         ApimlX509AuthenticationFilter filter = new ApimlX509AuthenticationFilter(new HashSet<>(Arrays.asList(
             correctBase64("apimlCert1"),
             correctBase64("apimlCert2")

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlX509AuthenticationFilterTest.java
@@ -1,0 +1,102 @@
+package org.zowe.apiml.gateway.security.config;/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+
+import javax.security.auth.x500.X500Principal;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ApimlX509AuthenticationFilterTest {
+
+    private ServletRequest request;
+    private ServletResponse response;
+    private FilterChain chain;
+
+    @BeforeEach
+    public void setUp() {
+        request = new MockHttpServletRequest();
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+    }
+
+    @Test
+    public void givenNoCertificates_thenDontUpdate_whenCallFilter() throws IOException, ServletException {
+        ApimlX509AuthenticationFilter filter = new ApimlX509AuthenticationFilter(Collections.emptySet());
+
+        filter.doFilter(request, response, chain);
+
+        assertNull(request.getAttribute("javax.servlet.request.X509Certificate"));
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    private X509Certificate getCertificate(String base64) {
+        X509Certificate out = mock(X509Certificate.class);
+        PublicKey publicKey = mock(PublicKey.class);
+        doReturn(publicKey).when(out).getPublicKey();
+        doReturn(Base64.getDecoder().decode(base64)).when(publicKey).getEncoded();
+        doReturn(new X500Principal("CN=test")).when(out).getSubjectDN();
+        return out;
+    }
+
+    private String correctBase64(String i) {
+        return new String(
+            Base64.getEncoder().encode(i.getBytes())
+        );
+    }
+
+    @Test
+    public void giveCertificates_thenRemoveForeign_whenCallFilter() throws IOException, ServletException {
+        ApimlX509AuthenticationFilter filter = new ApimlX509AuthenticationFilter(new HashSet<>(Arrays.asList(
+            correctBase64("apimlCert1"),
+            correctBase64("apimlCert2")
+        )));
+        filter.setAuthenticationDetailsSource(mock(AuthenticationDetailsSource.class));
+        filter.setAuthenticationManager(mock(AuthenticationManager.class));
+
+        X509Certificate[] certificates = new X509Certificate[] {
+            getCertificate(correctBase64("foreignCert1")),
+            getCertificate(correctBase64("apimlCert1")),
+            getCertificate(correctBase64("foreignCert2")),
+            getCertificate(correctBase64("apimlCert2"))
+        };
+        //doReturn(certificates).when(request).getAttribute("javax.servlet.request.X509Certificate");
+        request.setAttribute("javax.servlet.request.X509Certificate", certificates);
+
+        filter.doFilter(request, response, chain);
+
+        X509Certificate[] filtered = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        assertNotNull(filtered);
+        assertEquals(2, filtered.length);
+        assertSame(certificates[1], filtered[0]);
+        assertSame(certificates[3], filtered[1]);
+
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
The problem the squad was trying to solve:

For certain endpoints the Gateway should accept only certificates issued by API Mediation Layer. The key reason  is that these endpoints leverage the Gateway certificate as an authentication method for the downstream service. This certificate has stronger privileges and as such the Gateway need to be more careful with who can use it.

This solution is risky as it removes the certificates from the chain from all subsequent processing. Despite this it seems to be the simplest solution to the problem. While exploring the topic, the API squad explored following possibilities without any results:

 1) As this is more linked to the authentication, move it to the CertificateAuthenticationProvider and distinguish authentication based on the provided certificates - This doesn't work as the CertificateAuthenticationProvider is never used

 2) Move the logic to decide whether the client which is signed by the Gateway client certificate should be used into the HttpClientChooser - This didn't work as the HttpClientChooser isn't used in these specific calls.

Fixes the issues create by previous PR related to the issue #634
The ticket endpoint is still excluded from this filtering. Any certificate valid based on the truststore used by the Gateway service will be authenticated.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>