### PR TITLE
Add SAF keyring support to ZAAS client 

### DIFF
--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -39,7 +39,7 @@ gitProperties {
 
 dependencies {
     implementation project(':onboarding-enabler-spring')
-
+    implementation project(':zaas-client')
     implementation libraries.springFox
     implementation libraries.spring_boot_starter
     implementation libraries.spring_boot_starter_actuator

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
@@ -44,7 +44,6 @@ public class ZaasClientTestController {
         try {
             String jwt = zaasClient.login(loginRequest.getUsername(), loginRequest.getPassword());
             return ResponseEntity.ok().body(jwt);
-
         } catch (ZaasClientException e) {
             return ResponseEntity.status(e.getErrorCode().getReturnCode()).body(e.getErrorCode().getMessage());
         }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.zowe.apiml.client.configuration.ZaasClientConfig;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
@@ -34,8 +34,8 @@ public class ZaasClientTestController {
 
     private ZaasClient zaasClient;
 
-    public ZaasClientTestController(ZaasClientConfig zaasClientConfig) throws ZaasConfigurationException {
-        zaasClient = new ZaasClientHttps(zaasClientConfig.getConfigProperties());
+    public ZaasClientTestController(ConfigProperties getConfigProperties) throws ZaasConfigurationException {
+        zaasClient = new ZaasClientHttps(getConfigProperties);
     }
 
     @PostMapping

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
@@ -11,17 +11,16 @@ package org.zowe.apiml.client.api;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.zowe.apiml.zaasclient.config.ConfigProperties;
+import org.zowe.apiml.client.service.ZaasClientService;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
-import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
-import org.zowe.apiml.zaasclient.service.ZaasClient;
-import org.zowe.apiml.zaasclient.service.internal.ZaasClientHttps;
 
 @RestController
 @RequestMapping("/api/v1/zaasClient")
@@ -31,18 +30,17 @@ import org.zowe.apiml.zaasclient.service.internal.ZaasClientHttps;
     tags = {"Zaas client test call"})
 public class ZaasClientTestController {
 
+    private ZaasClientService zaasClientService;
 
-    private ZaasClient zaasClient;
-
-    public ZaasClientTestController(ConfigProperties getConfigProperties) throws ZaasConfigurationException {
-        zaasClient = new ZaasClientHttps(getConfigProperties);
+    public ZaasClientTestController(ZaasClientService zaasClientService) {
+        this.zaasClientService = zaasClientService;
     }
 
     @PostMapping
     @ApiOperation(value = "Forward login to gateway service via zaas client")
     public ResponseEntity<String> forwardLogin(@RequestBody LoginRequest loginRequest) {
         try {
-            String jwt = zaasClient.login(loginRequest.getUsername(), loginRequest.getPassword());
+            String jwt = zaasClientService.login(loginRequest.getUsername(), loginRequest.getPassword());
             return ResponseEntity.ok().body(jwt);
         } catch (ZaasClientException e) {
             return ResponseEntity.status(e.getErrorCode().getReturnCode()).body(e.getErrorCode().getMessage());
@@ -52,6 +50,8 @@ public class ZaasClientTestController {
 }
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 class LoginRequest {
     private String username;
     private String password;

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
@@ -1,0 +1,60 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.api;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.zowe.apiml.client.configuration.ZaasClientConfig;
+import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
+import org.zowe.apiml.zaasclient.service.ZaasClient;
+import org.zowe.apiml.zaasclient.service.internal.ZaasClientHttps;
+
+@RestController
+@RequestMapping("/api/v1/zaasClient")
+@Api(
+    value = "/api/v1/zaasClient",
+    consumes = "application/json",
+    tags = {"Zaas client test call"})
+public class ZaasClientTestController {
+
+
+    private ZaasClient zaasClient;
+
+    public ZaasClientTestController(ZaasClientConfig zaasClientConfig) throws ZaasConfigurationException {
+        zaasClient = new ZaasClientHttps(zaasClientConfig.getConfigProperties());
+    }
+
+    @PostMapping
+    @ApiOperation(value = "Forward login to gateway service via zaas client")
+    public ResponseEntity<String> forwardLogin(@RequestBody LoginRequest loginRequest) {
+        try {
+            String jwt = zaasClient.login(loginRequest.getUsername(), loginRequest.getPassword());
+            return ResponseEntity.ok().body(jwt);
+
+        } catch (ZaasClientException e) {
+            return ResponseEntity.status(e.getErrorCode().getReturnCode()).body(e.getErrorCode().getMessage());
+        }
+
+    }
+}
+
+@Data
+class LoginRequest {
+    private String username;
+    private String password;
+
+}

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/ZaasClientConfig.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/ZaasClientConfig.java
@@ -1,0 +1,63 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
+
+@Configuration
+public class ZaasClientConfig {
+
+    @Value("${apiml.service.hostname}")
+    private String host;
+
+    @Value("${apiml.service.customMetadata.apiml.gatewayPort}")
+    private String port;
+
+    @Value("${apiml.service.customMetadata.apiml.gatewayAuthEndpoint}")
+    private String baseUrl;
+
+    @Value("${apiml.service.ssl.keyStore}")
+    private String keyStorePath;
+
+    @Value("${apiml.service.ssl.keyStorePassword}")
+    private String keyStorePassword;
+
+    @Value("${apiml.service.ssl.keyStoreType}")
+    private String keyStoreType;
+
+    @Value("${apiml.service.ssl.trustStore}")
+    private String trustStorePath;
+
+    @Value("${apiml.service.ssl.trustStorePassword}")
+    private String trustStorePassword;
+
+    @Value("${apiml.service.ssl.trustStoreType}")
+    private String trustStoreType;
+
+
+
+    public ConfigProperties getConfigProperties() {
+
+        ConfigProperties configProperties = new ConfigProperties();
+        configProperties.setApimlHost(host);
+        configProperties.setApimlPort(port);
+        configProperties.setApimlBaseUrl(baseUrl);
+        configProperties.setKeyStorePath(keyStorePath);
+        configProperties.setKeyStorePassword(keyStorePassword);
+        configProperties.setKeyStoreType(keyStoreType);
+        configProperties.setTrustStorePath(trustStorePath);
+        configProperties.setTrustStorePassword(trustStorePassword);
+        configProperties.setTrustStoreType(trustStoreType);
+
+        return configProperties;
+    }
+}

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/ZaasClientConfig.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/ZaasClientConfig.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.client.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zowe.apiml.zaasclient.config.ConfigProperties;
 
@@ -44,7 +45,7 @@ public class ZaasClientConfig {
     private String trustStoreType;
 
 
-
+    @Bean
     public ConfigProperties getConfigProperties() {
 
         ConfigProperties configProperties = new ConfigProperties();

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/service/ZaasClientService.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/service/ZaasClientService.java
@@ -1,0 +1,31 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.service;
+
+import org.springframework.stereotype.Service;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
+import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
+import org.zowe.apiml.zaasclient.service.ZaasClient;
+import org.zowe.apiml.zaasclient.service.internal.ZaasClientHttps;
+
+@Service
+public class ZaasClientService {
+
+    private ZaasClient zaasClient;
+
+    public ZaasClientService(ConfigProperties getConfigProperties) throws ZaasConfigurationException {
+        zaasClient = new ZaasClientHttps(getConfigProperties);
+    }
+
+    public String login(String username, String password) throws ZaasClientException {
+        return zaasClient.login(username, password);
+    }
+}

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -10,7 +10,7 @@ logging:
         com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient: OFF
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
-        javax.net.ssl: DEBUG
+
 spring:
     application:
         name: ${apiml.service.serviceId}

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -76,6 +76,8 @@ apiml:
         customMetadata:
             apiml:
                 enableUrlEncodedCharacters: true
+                gatewayPort: 10010
+                gatewayAuthEndpoint: /api/v1/gateway/auth
 
 server:
     port: ${apiml.service.port}

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -10,7 +10,7 @@ logging:
         com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient: OFF
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
-
+        javax.net.ssl: DEBUG
 spring:
     application:
         name: ${apiml.service.serviceId}

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
@@ -1,0 +1,72 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zowe.apiml.client.configuration.ApplicationConfiguration;
+import org.zowe.apiml.client.configuration.SpringComponentsConfiguration;
+import org.zowe.apiml.client.service.ZaasClientService;
+import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
+import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = {ZaasClientTestController.class})
+@Import(value = {SpringComponentsConfiguration.class, ApplicationConfiguration.class, AnnotationConfigContextLoader.class})
+public class ZaasClientTestControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @MockBean
+    private ZaasClientService zaasClientService;
+
+    @Test
+    public void forwardLoginTest_successfulLogin() throws Exception {
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        when(zaasClientService.login("username", "password")).thenReturn("token");
+
+        this.mockMvc.perform(
+            post("/api/v1/zaasClient")
+                .content(mapper.writeValueAsString(loginRequest))
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andExpect(content().string("token"));
+    }
+
+    @Test
+    public void forwardLoginTest_invalidCredentials() throws Exception {
+        LoginRequest loginRequest = new LoginRequest("incorrectUser", "incorrectPass");
+        when(zaasClientService.login("incorrectUser", "incorrectPass"))
+            .thenThrow(new ZaasClientException(ZaasClientErrorCodes.INVALID_AUTHENTICATION));
+
+        this.mockMvc.perform(
+            post("/api/v1/zaasClient")
+                .content(mapper.writeValueAsString(loginRequest))
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andExpect(status().is(401))
+            .andExpect(content().string("Invalid username or password"));
+    }
+
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -1,0 +1,84 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.discoverableclient;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zowe.apiml.security.common.login.LoginRequest;
+import org.zowe.apiml.util.config.ConfigReader;
+import org.zowe.apiml.util.http.HttpRequestUtils;
+
+import java.net.URI;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+/**
+ * Purpose of this test is verify correct behavior of Zaas client
+ * as a part of application running on mainframe
+ */
+public class IntegratedZaasClientTest {
+
+    private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
+    private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
+    private final static String INVALID_USERNAME = "incorrectUser";
+    private final static String INVALID_PASSWORD = "incorrectPassword";
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    /**
+     * This method is testing a communication between discoverable client application
+     * using Zaas client and gateway service on mainframe. Main goal is to test correct
+     * configuration of SSL, specifically SAF keyring support.
+     */
+    @Test
+    public void loginWithValidCredentials() {
+        URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
+        LoginRequest loginRequest = new LoginRequest(USERNAME, PASSWORD);
+
+        given()
+            .contentType(JSON)
+            .body(loginRequest)
+            .when()
+            .post(uri)
+            .then()
+            .statusCode(is(SC_OK))
+            .body(not(isEmptyString()));
+    }
+
+    /**
+     * This method is testing a communication between discoverable client application
+     * using Zaas client and gateway service on mainframe. Main goal is to test correct
+     * configuration of SSL, specifically SAF keyring support.
+     */
+    @Test
+    public void invalidCredentials() {
+        URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
+        LoginRequest loginRequest = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
+
+        given()
+            .contentType(JSON)
+            .body(loginRequest)
+            .when()
+            .post(uri)
+            .then()
+            .statusCode(is(SC_UNAUTHORIZED))
+            .body(is("Invalid username or password"));
+    }
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.core.IsNot.not;
  * Purpose of this test is verify correct behavior of Zaas client
  * as a part of application running on mainframe
  */
-public class IntegratedZaasClientTest {
+class IntegratedZaasClientTest {
 
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
@@ -48,7 +48,7 @@ public class IntegratedZaasClientTest {
      * configuration of SSL, specifically SAF keyring support.
      */
     @Test
-    public void loginWithValidCredentials() {
+    void loginWithValidCredentials() {
         URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
         LoginRequest loginRequest = new LoginRequest(USERNAME, PASSWORD);
 
@@ -68,7 +68,7 @@ public class IntegratedZaasClientTest {
      * configuration of SSL, specifically SAF keyring support.
      */
     @Test
-    public void invalidCredentials() {
+    void invalidCredentials() {
         URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
         LoginRequest loginRequest = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
 

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/HttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/HttpsClientProvider.java
@@ -24,12 +24,15 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.*;
+import java.net.URL;
 import java.security.*;
 import java.security.cert.CertificateException;
 
 @AllArgsConstructor
 class HttpsClientProvider implements CloseableClientProvider {
     private final RequestConfig requestConfig;
+
+    public static final String SAFKEYRING = "safkeyring";
 
     private TrustManagerFactory tmf;
     private KeyManagerFactory kmf;
@@ -85,9 +88,7 @@ class HttpsClientProvider implements CloseableClientProvider {
         throws ZaasConfigurationException {
         try {
             tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            KeyStore trustStore = KeyStore.getInstance(trustStoreType);
-            File trustFile = new File(trustStorePath);
-            trustStore.load(new FileInputStream(trustFile), trustStorePassword.toCharArray());
+            KeyStore trustStore = getKeystore(trustStorePath, trustStoreType, trustStorePassword);
             tmf.init(trustStore);
         } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.WRONG_CRYPTO_CONFIGURATION, e);
@@ -99,15 +100,32 @@ class HttpsClientProvider implements CloseableClientProvider {
     private void initializeKeyStoreManagerFactory() throws ZaasConfigurationException {
         try {
             kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
-            File keyFile = new File(keyStorePath);
-            keyStore.load(new FileInputStream(keyFile), keyStorePassword.toCharArray());
+            KeyStore keyStore = getKeystore(keyStorePath, keyStoreType, keyStorePassword);
             kmf.init(keyStore, keyStorePassword.toCharArray());
         } catch (NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException | KeyStoreException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.WRONG_CRYPTO_CONFIGURATION, e);
         } catch (IOException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.IO_CONFIGURATION_ISSUE, e);
         }
+    }
+
+    private KeyStore getKeystore(String uri, String keyStoreType, String storePassword) throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        InputStream correctInStream = getCorrectInputStream(uri);
+        keyStore.load(correctInStream, storePassword.toCharArray());
+        return keyStore;
+    }
+
+    private InputStream getCorrectInputStream(String uri) throws IOException {
+        if (uri.startsWith(SAFKEYRING + ":////")) {
+            URL url = new URL(replaceFourSlashes(uri));
+            return url.openStream();
+        }
+        return new FileInputStream(new File(uri));
+    }
+
+    public static String replaceFourSlashes(String storeUri) {
+        return storeUri == null ? null : storeUri.replaceFirst("////", "//");
     }
 
     private SSLContext getSSLContext() throws ZaasConfigurationException {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/HttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/HttpsClientProvider.java
@@ -89,6 +89,7 @@ class HttpsClientProvider implements CloseableClientProvider {
         try {
             tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             KeyStore trustStore = getKeystore(trustStorePath, trustStoreType, trustStorePassword);
+
             tmf.init(trustStore);
         } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.WRONG_CRYPTO_CONFIGURATION, e);
@@ -130,7 +131,7 @@ class HttpsClientProvider implements CloseableClientProvider {
 
     private SSLContext getSSLContext() throws ZaasConfigurationException {
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(
                 kmf != null ? kmf.getKeyManagers() : null,
                 tmf.getTrustManagers(),

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
@@ -58,6 +58,7 @@ class TokenServiceHttpsJwt implements TokenService {
 
     private ClientWithResponse loginWithCredentials(String userId, String password) throws Exception {
         CloseableHttpClient client = httpsClientProvider.getHttpsClientWithTrustStore();
+        log.error(loginEndpoint);
         HttpPost httpPost = new HttpPost(loginEndpoint);
         ObjectMapper mapper = new ObjectMapper();
         String json = mapper.writeValueAsString(new Credentials(userId, password));
@@ -154,12 +155,14 @@ class TokenServiceHttpsJwt implements TokenService {
         ClientWithResponse clientWithResponse = new ClientWithResponse();
 
         try {
+
             clientWithResponse = request.request();
 
             return token.extract(clientWithResponse.getResponse());
         } catch (ZaasClientException e) {
             throw e;
         } catch (IOException e) {
+            log.error(e.getMessage(), e.fillInStackTrace());
             throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
         } catch (Exception e) {
             throw new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, e);

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
@@ -64,7 +64,7 @@ class TokenServiceHttpsJwt implements TokenService {
         String json = mapper.writeValueAsString(new Credentials(userId, password));
         StringEntity entity = new StringEntity(json);
         httpPost.setEntity(entity);
-
+        log.error("crd: " + json);
         httpPost.setHeader("Content-type", "application/json");
         return new ClientWithResponse(client, client.execute(httpPost));
     }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
@@ -130,6 +130,7 @@ class TokenServiceHttpsJwt implements TokenService {
     private String extractToken(CloseableHttpResponse response) throws ZaasClientException, IOException {
         String token = "";
         int httpResponseCode = response.getStatusLine().getStatusCode();
+        log.error("GWresponsecode: " + httpResponseCode);
         if (httpResponseCode == 204) {
             HeaderElement[] elements = response.getHeaders("Set-Cookie")[0].getElements();
             Optional<HeaderElement> apimlAuthCookie = Stream.of(elements)

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/TokenServiceHttpsJwt.java
@@ -58,13 +58,11 @@ class TokenServiceHttpsJwt implements TokenService {
 
     private ClientWithResponse loginWithCredentials(String userId, String password) throws Exception {
         CloseableHttpClient client = httpsClientProvider.getHttpsClientWithTrustStore();
-        log.error(loginEndpoint);
         HttpPost httpPost = new HttpPost(loginEndpoint);
         ObjectMapper mapper = new ObjectMapper();
         String json = mapper.writeValueAsString(new Credentials(userId, password));
         StringEntity entity = new StringEntity(json);
         httpPost.setEntity(entity);
-        log.error("crd: " + json);
         httpPost.setHeader("Content-type", "application/json");
         return new ClientWithResponse(client, client.execute(httpPost));
     }
@@ -130,7 +128,6 @@ class TokenServiceHttpsJwt implements TokenService {
     private String extractToken(CloseableHttpResponse response) throws ZaasClientException, IOException {
         String token = "";
         int httpResponseCode = response.getStatusLine().getStatusCode();
-        log.error("GWresponsecode: " + httpResponseCode);
         if (httpResponseCode == 204) {
             HeaderElement[] elements = response.getHeaders("Set-Cookie")[0].getElements();
             Optional<HeaderElement> apimlAuthCookie = Stream.of(elements)
@@ -163,7 +160,6 @@ class TokenServiceHttpsJwt implements TokenService {
         } catch (ZaasClientException e) {
             throw e;
         } catch (IOException e) {
-            log.error(e.getMessage(), e.fillInStackTrace());
             throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
         } catch (Exception e) {
             throw new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, e);

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
@@ -29,7 +29,7 @@ public class ZaasClientHttps implements ZaasClient {
             HttpsClientProvider provider = new HttpsClientProvider(configProperties);
             String baseUrl = String.format("https://%s:%s%s", configProperties.getApimlHost(), configProperties.getApimlPort(),
                 configProperties.getApimlBaseUrl());
-
+            log.error("gatewayUrl: "+baseUrl);
             tokens = new TokenServiceHttpsJwt(provider, baseUrl, configProperties.getApimlHost());
             passTickets = new PassTicketServiceHttps(provider, baseUrl);
         } catch (ZaasConfigurationException e) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
@@ -29,7 +29,7 @@ public class ZaasClientHttps implements ZaasClient {
             HttpsClientProvider provider = new HttpsClientProvider(configProperties);
             String baseUrl = String.format("https://%s:%s%s", configProperties.getApimlHost(), configProperties.getApimlPort(),
                 configProperties.getApimlBaseUrl());
-            log.error("gatewayUrl: "+baseUrl);
+            log.error("gatewayUrl: " + baseUrl);
             tokens = new TokenServiceHttpsJwt(provider, baseUrl, configProperties.getApimlHost());
             passTickets = new PassTicketServiceHttps(provider, baseUrl);
         } catch (ZaasConfigurationException e) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
@@ -29,7 +29,6 @@ public class ZaasClientHttps implements ZaasClient {
             HttpsClientProvider provider = new HttpsClientProvider(configProperties);
             String baseUrl = String.format("https://%s:%s%s", configProperties.getApimlHost(), configProperties.getApimlPort(),
                 configProperties.getApimlBaseUrl());
-            log.error("gatewayUrl: " + baseUrl);
             tokens = new TokenServiceHttpsJwt(provider, baseUrl, configProperties.getApimlHost());
             passTickets = new PassTicketServiceHttps(provider, baseUrl);
         } catch (ZaasConfigurationException e) {

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProviderTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProviderTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -152,5 +153,11 @@ public class CloseableClientProviderTest {
         });
 
         assertThat(zaasException.getErrorCode().getId(), is("ZWEAS502E"));
+    }
+
+    @Test
+    public void testReplaceFourSlashes() {
+        String newUrl = HttpsClientProvider.replaceFourSlashes("safkeyring:////userId/keyRing");
+        assertEquals("safkeyring://userId/keyRing", newUrl);
     }
 }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProviderTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProviderTest.java
@@ -156,7 +156,19 @@ public class CloseableClientProviderTest {
     }
 
     @Test
-    public void testReplaceFourSlashes() {
+    void givenInvalidTrustStoreType_whenTheClientIsConstructed_thenExceptionIsThrown() {
+        ConfigProperties config = new ConfigProperties();
+        config.setTrustStorePassword("password");
+        config.setTrustStorePath("src/test/resources/localhost.truststore.p12");
+        config.setTrustStoreType("invalidCryptoType");
+        ZaasConfigurationException zaasException = assertThrows(
+            ZaasConfigurationException.class, () -> new HttpsClientProvider(config)
+        );
+        assertThat(zaasException.getErrorCode().getId(), is("ZWEAS502E"));
+    }
+
+    @Test
+    void testReplaceFourSlashes() {
         String newUrl = HttpsClientProvider.replaceFourSlashes("safkeyring:////userId/keyRing");
         assertEquals("safkeyring://userId/keyRing", newUrl);
     }


### PR DESCRIPTION
Add ZAAS client do DC application, add REST endpoint to test keyring support on mainframe

Signed-off-by: achmelo <a.chmelo@gmail.com>