### PR TITLE
Remove Codecov dependency

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,1 +1,0 @@
-docs/architecture/decisions

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    patch:
-      default:
-        target: 80
-    project:
-      default:
-        target: 70

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,14 +175,6 @@ pipeline {
                 ])
             }
         }
-
-        stage ('Codecov') {
-            steps {
-                withCredentials([usernamePassword(credentialsId: 'Codecov', usernameVariable: 'CODECOV_USERNAME', passwordVariable: 'CODECOV_TOKEN')]) {
-                    sh 'curl -s https://codecov.io/bash | bash -s'
-                }
-            }
-        }
     }
 
     post {


### PR DESCRIPTION
# Description

The Codecov isn't used anymore to check coverage of the code for the API Layer, as such it is possible to remove the dependency. 