### PR TITLE
set ribbon retry parameter per service

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/metadata/service/RibbonMetadataProcessor.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/metadata/service/RibbonMetadataProcessor.java
@@ -34,30 +34,26 @@ public class RibbonMetadataProcessor extends MetadataProcessor {
         String serviceId = instanceInfo.getVIPAddress();
         Map<String, String> metadata = instanceInfo.getMetadata();
         if (metadata != null) {
-            setConnectTimeout(serviceId, metadata);
-            setReadTimeout(serviceId, metadata);
-            setConnectionManagerTimeout(serviceId, metadata);
+            setIfExistsAndIsNumeric(serviceId + ".ribbon.ConnectTimeout",
+                metadata.get("apiml.connectTimeout"));
+            setIfExistsAndIsNumeric(serviceId + ".ribbon.ReadTimeout",
+                metadata.get("apiml.readTimeout"));
+            setIfExistsAndIsNumeric(serviceId + ".ribbon.ConnectionManagerTimeout",
+                metadata.get("apiml.connectionManagerTimeout"));
+            setIfExists(serviceId + ".ribbon.OkToRetryOnAllOperations",
+                metadata.get("apiml.okToRetryOnAllOperations"));
         }
     }
 
-    public void setConnectTimeout(String serviceId, Map<String, String> metadata) {
-        String connectTimeout = metadata.get("apiml.connectTimeout");
-        if (!Strings.isEmpty(connectTimeout) && StringUtils.isNumeric(connectTimeout)) {
-            System.setProperty(serviceId + ".ribbon.ConnectTimeout", connectTimeout);
+    void setIfExistsAndIsNumeric(String key, String value) {
+        if (!Strings.isEmpty(value) && StringUtils.isNumeric(value)) {
+            System.setProperty(key, value);
         }
     }
 
-    public void setReadTimeout(String serviceId, Map<String, String> metadata) {
-        String readTimeout = metadata.get("apiml.readTimeout");
-        if (!Strings.isEmpty(readTimeout) && StringUtils.isNumeric(readTimeout)) {
-            System.setProperty(serviceId + ".ribbon.ReadTimeout", readTimeout);
-        }
-    }
-
-    public void setConnectionManagerTimeout(String serviceId, Map<String, String> metadata) {
-        String connectionManagerTimeout = metadata.get("apiml.connectionManagerTimeout");
-        if (!Strings.isEmpty(connectionManagerTimeout) && StringUtils.isNumeric(connectionManagerTimeout)) {
-            System.setProperty(serviceId + ".ribbon.ConnectionManagerTimeout", connectionManagerTimeout);
+    void setIfExists(String key, String value) {
+        if (!Strings.isEmpty(value)) {
+            System.setProperty(key, value);
         }
     }
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -99,8 +99,9 @@ ribbon:
     ReadTimeout: ${apiml.gateway.timeoutMillis}
     ConnectionManagerTimeout: ${apiml.gateway.timeoutMillis}
     MaxAutoRetries: 0
+    retryableStatusCodes: 503, 404
     MaxAutoRetriesNextServer: 5
-    OkToRetryOnAllOperations: true
+    OkToRetryOnAllOperations: false
     GZipPayload: false # this stops Gateway from deflating gzip responses from services
 
 http:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -99,7 +99,7 @@ ribbon:
     ReadTimeout: ${apiml.gateway.timeoutMillis}
     ConnectionManagerTimeout: ${apiml.gateway.timeoutMillis}
     MaxAutoRetries: 0
-    retryableStatusCodes: 503, 404
+    retryableStatusCodes: 503
     MaxAutoRetriesNextServer: 5
     OkToRetryOnAllOperations: false
     GZipPayload: false # this stops Gateway from deflating gzip responses from services

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.acceptance;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.springframework.test.annotation.DirtiesContext;
 import org.zowe.apiml.acceptance.common.AcceptanceTest;
 import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
 
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @AcceptanceTest
+@DirtiesContext
 public class RetryPerServiceTest extends AcceptanceTestWithTwoServices {
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.acceptance;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.zowe.apiml.acceptance.common.AcceptanceTest;
+import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
+
+import static io.restassured.RestAssured.when;
+import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@AcceptanceTest
+public class RetryPerServiceTest extends AcceptanceTestWithTwoServices {
+
+    @Test
+    void givenRetryOnAllOperationsIsDisabled_whenGetReturnsUnavailable_thenRetry() throws Exception {
+        applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
+        mockUnavailableHttpResponseWithEntity(503);
+        when().get(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_SERVICE_UNAVAILABLE));
+        verify(mockClient, times(6)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+
+    @Test
+    void givenRetryOnAllOperationsIsDisabled_whenRequestReturnsUnauthorized_thenDontRetry() throws Exception {
+        applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
+        mockUnavailableHttpResponseWithEntity(401);
+        when().get(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_UNAUTHORIZED));
+        verify(mockClient, times(1)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+        when().post(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_UNAUTHORIZED));
+        verify(mockClient, times(2)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+        when().put(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_UNAUTHORIZED));
+        verify(mockClient, times(3)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+        when().delete(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_UNAUTHORIZED));
+        verify(mockClient, times(4)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+        when().patch(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_UNAUTHORIZED));
+        verify(mockClient, times(5)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+
+    @Test
+    void givenRetryOnAllOperationsIsDisabled_whenPostReturnsUnavailable_thenDontRetry() throws Exception {
+        applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
+        mockUnavailableHttpResponseWithEntity(503);
+        when().post(basePath + serviceWithDefaultConfiguration.getPath()).then().statusCode(is(SC_SERVICE_UNAVAILABLE));
+        verify(mockClient, times(1)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+
+    @Test
+    void givenRetryOnAllOperationsIsEnabled_whenPostReturnsUnavailable_thenRetry() throws Exception {
+        applicationRegistry.setCurrentApplication(serviceWithCustomConfiguration.getId());
+        mockUnavailableHttpResponseWithEntity(503);
+        discoveryClient.createRefreshCacheEvent();
+        when().post(basePath + serviceWithCustomConfiguration.getPath()).then().statusCode(is(SC_SERVICE_UNAVAILABLE));
+        verify(mockClient, times(6)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/RetryPerServiceTest.java
@@ -12,7 +12,6 @@ package org.zowe.apiml.acceptance;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.springframework.test.annotation.DirtiesContext;
 import org.zowe.apiml.acceptance.common.AcceptanceTest;
 import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
 
@@ -24,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @AcceptanceTest
-@DirtiesContext
 public class RetryPerServiceTest extends AcceptanceTestWithTwoServices {
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
@@ -134,7 +134,7 @@ public class ApplicationRegistry {
         }
         metadata.put("apiml.corsEnabled",String.valueOf(corsEnabled));
         metadata.put("apiml.routes.gateway-url","/");
-
+        metadata.put("apiml.okToRetryOnAllOperations","true");
         return metadata;
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
@@ -34,12 +34,13 @@ public class ApplicationRegistry {
 
     private List<Services> servicesToAdd = new ArrayList<>();
 
-    public ApplicationRegistry() {}
+    public ApplicationRegistry() {
+    }
 
     /**
      * Add new route to a service.
      *
-     * @param service Details of the service to be registered in the Gateway
+     * @param service    Details of the service to be registered in the Gateway
      * @param addTimeout Whether the custom metadata should be provided for given service.
      */
     public void addApplication(Service service, boolean addTimeout, boolean corsEnabled) {
@@ -81,6 +82,7 @@ public class ApplicationRegistry {
 
     /**
      * Sets which application should be returned for all the callers looking up the service.
+     *
      * @param currentApplication Id of the application.
      */
     public void setCurrentApplication(String currentApplication) {
@@ -108,7 +110,7 @@ public class ApplicationRegistry {
 
         if (!servicesToAdd.isEmpty()) {
             for (RoutedServicesUser routedServicesUser : routedServicesUsers) {
-                for (Services services: servicesToAdd) {
+                for (Services services : servicesToAdd) {
                     routedServicesUser.addRoutedServices(services.id, services.routedServices);
                 }
             }
@@ -125,16 +127,16 @@ public class ApplicationRegistry {
             .build();
     }
 
-    private Map<String, String> createMetadata(boolean addTimeout,boolean corsEnabled) {
+    private Map<String, String> createMetadata(boolean addRibbonConfig, boolean corsEnabled) {
         Map<String, String> metadata = new HashMap<>();
-        if (addTimeout) {
+        if (addRibbonConfig) {
             metadata.put("apiml.connectTimeout", "5000");
             metadata.put("apiml.readTimeout", "5000");
             metadata.put("apiml.connectionManagerTimeout", "5000");
+            metadata.put("apiml.okToRetryOnAllOperations", "true");
         }
-        metadata.put("apiml.corsEnabled",String.valueOf(corsEnabled));
-        metadata.put("apiml.routes.gateway-url","/");
-        metadata.put("apiml.okToRetryOnAllOperations","true");
+        metadata.put("apiml.corsEnabled", String.valueOf(corsEnabled));
+        metadata.put("apiml.routes.gateway-url", "/");
         return metadata;
     }
 

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -98,7 +98,7 @@ ribbon:
     ConnectionManagerTimeout: ${apiml.gateway.timeoutMillis}
     MaxAutoRetries: 0
     MaxAutoRetriesNextServer: 5
-    retryableStatusCodes: 404, 503
+    retryableStatusCodes: 503
     OkToRetryOnAllOperations: false
     GZipPayload: false # this stops Gateway from deflating gzip responses from services
 

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -98,7 +98,8 @@ ribbon:
     ConnectionManagerTimeout: ${apiml.gateway.timeoutMillis}
     MaxAutoRetries: 0
     MaxAutoRetriesNextServer: 5
-    OkToRetryOnAllOperations: true
+    retryableStatusCodes: 404, 503
+    OkToRetryOnAllOperations: false
     GZipPayload: false # this stops Gateway from deflating gzip responses from services
 
 http:


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

Default retry policy is set to allow retry only for status codes 503, 404 and method get. Combinations of status codes 503, 404 and other methods can be enabled per service.
#701 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
