### PR TITLE
CORS headers provided by Southbound services are ignored

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -45,10 +46,7 @@ import org.zowe.apiml.security.common.content.BasicContentFilter;
 import org.zowe.apiml.security.common.content.CookieContentFilter;
 import org.zowe.apiml.security.common.login.LoginFilter;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Security configuration for Gateway
@@ -82,6 +80,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private final AuthProviderInitializer authProviderInitializer;
     @Qualifier("publicKeyCertificatesBase64")
     private final Set<String> publicKeyCertificatesBase64;
+    private final ZuulProperties zuulProperties;
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) {
@@ -168,6 +167,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         final CorsConfiguration config = new CorsConfiguration();
         List<String> pathsToEnable;
         if (corsEnabled) {
+            addCorsRelatedIgnoredHeaders();
+
             config.setAllowCredentials(true);
             config.addAllowedOrigin(CorsConfiguration.ALL);
             config.setAllowedHeaders(Collections.singletonList(CorsConfiguration.ALL));
@@ -178,6 +179,13 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         }
         pathsToEnable.forEach(path -> source.registerCorsConfiguration(path, config));
         return source;
+    }
+
+    private void addCorsRelatedIgnoredHeaders() {
+        zuulProperties.setIgnoredHeaders(new HashSet<>(
+            Arrays.asList(("Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin," +
+                "Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials").split(","))
+        ));
     }
 
     @Bean

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
@@ -69,6 +69,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${apiml.service.corsEnabled:false}")
     private boolean corsEnabled;
 
+    @Value("${apiml.service.ignoredHeadersWhenCorsEnabled}")
+    private String ignoredHeadersWhenCorsEnabled;
+
     private static final String EXTRACT_USER_PRINCIPAL_FROM_COMMON_NAME = "CN=(.*?)(?:,|$)";
 
     private final ObjectMapper securityObjectMapper;
@@ -183,8 +186,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private void addCorsRelatedIgnoredHeaders() {
         zuulProperties.setIgnoredHeaders(new HashSet<>(
-            Arrays.asList(("Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin," +
-                "Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials").split(","))
+            Arrays.asList((ignoredHeadersWhenCorsEnabled).split(","))
         ));
     }
 

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -31,6 +31,7 @@ apiml:
         scheme: https  # "https" or "http"
         preferIpAddress: false
         allowEncodedSlashes: false
+        ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials
 
     gateway:
         # The `apiml.gateway` node contains gateway-service only configuration

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/CorsPerServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/CorsPerServiceTest.java
@@ -60,9 +60,9 @@ class CorsPerServiceTest extends AcceptanceTestWithTwoServices {
             .header(new Header("Origin", "https://foo.bar.org"))
             .header(new Header("Access-Control-Request-Method", "POST"))
             .header(new Header("Access-Control-Request-Headers", "origin, x-requested-with"))
-            .when()
+        .when()
             .options(basePath + serviceWithDefaultConfiguration.getPath())
-            .then()
+        .then()
             .statusCode(is(SC_FORBIDDEN))
             .header("Access-Control-Allow-Origin", is(nullValue()));
 
@@ -81,9 +81,9 @@ class CorsPerServiceTest extends AcceptanceTestWithTwoServices {
             .header(new Header("Origin", "https://foo.bar.org"))
             .header(new Header("Access-Control-Request-Method", "POST"))
             .header(new Header("Access-Control-Request-Headers", "origin, x-requested-with"))
-            .when()
+        .when()
             .get(basePath + serviceWithDefaultConfiguration.getPath())
-            .then()
+        .then()
             .statusCode(is(SC_FORBIDDEN))
             .header("Access-Control-Allow-Origin", is(nullValue()));
 
@@ -103,9 +103,9 @@ class CorsPerServiceTest extends AcceptanceTestWithTwoServices {
             .header(new Header("Origin", "https://foo.bar.org"))
             .header(new Header("Access-Control-Request-Method", "POST"))
             .header(new Header("Access-Control-Request-Headers", "origin, x-requested-with"))
-            .when()
+        .when()
             .options(basePath + serviceWithCustomConfiguration.getPath())
-            .then()
+        .then()
             .statusCode(is(SC_OK))
             .header("Access-Control-Allow-Origin", is("https://foo.bar.org"))
             .header("Access-Control-Allow-Methods", is("GET,HEAD,POST,DELETE,PUT,OPTIONS"))
@@ -117,9 +117,9 @@ class CorsPerServiceTest extends AcceptanceTestWithTwoServices {
         // Actual request
         given()
             .header(new Header("Origin", "https://foo.bar.org"))
-            .when()
+        .when()
             .post(basePath + serviceWithCustomConfiguration.getPath())
-            .then()
+        .then()
             .statusCode(is(SC_OK))
             .header("Access-Control-Allow-Origin", is("https://foo.bar.org"));
 
@@ -139,9 +139,67 @@ class CorsPerServiceTest extends AcceptanceTestWithTwoServices {
         // Preflight request
         given()
             .header(new Header("Origin", "https://foo.bar.org"))
-            .when()
+        .when()
             .get(basePath + serviceWithCustomConfiguration.getPath())
-            .then()
+        .then()
+            .statusCode(is(SC_OK))
+            .header("Access-Control-Allow-Origin", is("https://foo.bar.org"));
+
+        // The actual request is passed to the southbound service
+        verify(mockClient, times(1)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+
+    @Test
+    // There is request to the southbound server for the request
+    // The CORS header is properly set.
+    void givenCorsIsAllowedForSpecificService_whenSimpleRequestArrives_thenCorsHeadersAreSetAndOnlyTheOnesByGateway() throws Exception {
+        // There is request to the southbound server and the CORS headers are properly set on the response
+        mockValid200HttpResponseWithAddedCors();
+        applicationRegistry.setCurrentApplication(serviceWithCustomConfiguration.getId());
+        discoveryClient.createRefreshCacheEvent();
+
+        // Preflight request
+        given()
+            .header(new Header("Origin", "https://foo.bar.org"))
+        .when()
+            .get(basePath + serviceWithCustomConfiguration.getPath())
+        .then()
+            .statusCode(is(SC_OK))
+            .header("Access-Control-Allow-Origin", is("https://foo.bar.org"));
+
+        // The actual request is passed to the southbound service
+        verify(mockClient, times(1)).execute(ArgumentMatchers.any(HttpUriRequest.class));
+    }
+
+    @Test
+        // There is no request to the southbound server for preflight
+        // There is request to the southbound server for the second request
+    void givenCorsIsAllowedForSpecificService_whenTheServiceIsSet_thenCorsHeadersAreSetAndOnlyTheOnesByGateway() throws Exception {
+        mockValid200HttpResponseWithAddedCors();
+        applicationRegistry.setCurrentApplication(serviceWithCustomConfiguration.getId());
+        discoveryClient.createRefreshCacheEvent();
+        // Preflight request
+        given()
+            .header(new Header("Origin", "https://foo.bar.org"))
+            .header(new Header("Access-Control-Request-Method", "POST"))
+            .header(new Header("Access-Control-Request-Headers", "origin, x-requested-with"))
+        .when()
+            .options(basePath + serviceWithCustomConfiguration.getPath())
+        .then()
+            .statusCode(is(SC_OK))
+            .header("Access-Control-Allow-Origin", is("https://foo.bar.org"))
+            .header("Access-Control-Allow-Methods", is("GET,HEAD,POST,DELETE,PUT,OPTIONS"))
+            .header("Access-Control-Allow-Headers", is("origin, x-requested-with"));
+
+        // The preflight request isn't passed to the southbound service
+        verify(mockClient, never()).execute(ArgumentMatchers.any(HttpUriRequest.class));
+
+        // Actual request
+        given()
+            .header(new Header("Origin", "https://foo.bar.org"))
+        .when()
+            .post(basePath + serviceWithCustomConfiguration.getPath())
+        .then()
             .statusCode(is(SC_OK))
             .header("Access-Control-Allow-Origin", is("https://foo.bar.org"));
 

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithTwoServices.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithTwoServices.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
@@ -54,6 +55,15 @@ public class AcceptanceTestWithTwoServices extends AcceptanceTestWithBasePath {
 
     protected void mockValid200HttpResponse() throws IOException {
         mockValid200HttpResponseWithHeaders(new Header[]{});
+    }
+
+    protected void mockValid200HttpResponseWithAddedCors() throws IOException {
+        mockValid200HttpResponseWithHeaders(new Header[]{
+            new BasicHeader("Access-Control-Allow-Origin","test"),
+            new BasicHeader("Access-Control-Allow-Methods","RANDOM"),
+            new BasicHeader("Access-Control-Allow-Headers","origin,x-test"),
+            new BasicHeader("Access-Control-Allow-Credentials","true"),
+        });
     }
 
     protected void mockValid200HttpResponseWithHeaders(org.apache.http.Header[] headers) throws IOException {

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -16,6 +16,7 @@ apiml:
         preferIpAddress: false
         allowEncodedSlashes: false
         discoveryServiceUrls: https://localhost:10011/eureka/
+        ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials
     gateway:
         # The `apiml.gateway` node contains gateway-service only configuration
         hostname: ${apiml.service.hostname}  # The hostname for other services to access the gateway. For example Catalog uses


### PR DESCRIPTION
# Description

zOSMF has custom handling of CORS. To make sure the CORS handling is properly delegated
to the API ML filter the CORS related headers from the response of the southbound service.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

Fixes # (issue)

#384 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
