### PR TITLE
Publish Core services as libraries to depend upon.

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,10 +2,13 @@ ext.springBootEnabler = 'onboarding-enabler-spring'
 ext.javaEnabler = 'onboarding-enabler-java'
 
 ext.javaLibraries = [
+    'api-catalog-services',
     'common-service-core',
     'apiml-utility',
     'apiml-common',
     'apiml-security-common',
+    'discovery-service',
+    'gateway-service',
     'security-service-client-spring',
     'zaas-client'
 ]


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

Only the SDK related artifacts are published in the Zowe repository. As there could be extensions of the API Mediation Layer in future it is important to allow the extending parties access valid versions of the core services as well as the SDK

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
