### PR TITLE
Created api-def for zosmf now allows encoded url characters by default

### DIFF
--- a/zowe-install/src/main/resources/component-scripts/configure.sh
+++ b/zowe-install/src/main/resources/component-scripts/configure.sh
@@ -34,6 +34,9 @@ services:
         - apiId: com.ibm.zosmf
           gatewayUrl: api/v1
           documentationUrl: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.izua700/IZUHPINFO_RESTServices.htm
+      customMetadata:
+          apiml:
+              enableUrlEncodedCharacters: true
 catalogUiTiles:
     zosmf:
         title: z/OSMF services


### PR DESCRIPTION
Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

# Description

Default configuration of zosmf api definition now allows encoded special characters so requests made to access datasets from UI components that do url encoding can succeed.

Fixes https://github.com/zowe/api-layer/issues/716

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
