### PR TITLE
Fix Veracode CWE ID 316

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
@@ -17,16 +17,22 @@ import lombok.Value;
 @Value
 @ToString(exclude = { "trustStorePassword", "keyStorePassword", "keyPassword" })
 public class HttpsConfig {
-    @Builder.Default private String protocol = "TLSv1.2";
-    @Builder.Default private String trustStore = null;
-    @Builder.Default private char[] trustStorePassword = null;
-    @Builder.Default private String trustStoreType = "PKCS12";
-    @Builder.Default private boolean trustStoreRequired = false;
-    @Builder.Default private String keyAlias = null;
-    @Builder.Default private String keyStore = null;
-    @Builder.Default private char[] keyStorePassword = null;
-    @Builder.Default private char[] keyPassword = null;
-    @Builder.Default private String keyStoreType = "PKCS12";
-    @Builder.Default private boolean clientAuth = false;
-    @Builder.Default private boolean verifySslCertificatesOfServices = true;
+
+    @Builder.Default
+    private String protocol = "TLSv1.2";
+    private String trustStore;
+    private char[] trustStorePassword;
+    @Builder.Default
+    private String trustStoreType = "PKCS12";
+    private boolean trustStoreRequired;
+    private String keyAlias;
+    private String keyStore;
+    private char[] keyStorePassword;
+    private char[] keyPassword;
+    @Builder.Default
+    private String keyStoreType = "PKCS12";
+    private boolean clientAuth;
+    @Builder.Default
+    private boolean verifySslCertificatesOfServices = true;
+
 }


### PR DESCRIPTION
# Description

This PR continues in fixing of problem CWE ID 361 (http://cwe.mitre.org/data/definitions/316.html) particularly fixed in PR-741.

Lombok Builder generates code when a field with a password is annotated @Builder.Default which Veracode marks as vulnerable. The solution is just don't use annotation @Builder.Default if default value is the same as default value in JVM.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
