### PR TITLE
Don't check validity of certs when calling discovery/** apis when verify ssl certs false

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -122,6 +122,9 @@ public class HttpsWebSecurityConfig {
     @Order(3)
     public class FilterChainBasicAuthOrTokenOrCert extends AbstractWebSecurityConfigurer {
 
+        @Value("${apiml.security.ssl.verifySslCertificatesOfServices:true}")
+        private boolean verifySslCertificatesOfServices;
+
         @Override
         protected void configure(AuthenticationManagerBuilder auth) {
             auth.authenticationProvider(gatewayLoginProvider);
@@ -133,10 +136,11 @@ public class HttpsWebSecurityConfig {
             baseConfigure(http.antMatcher("/discovery/**"))
                 .addFilterBefore(basicFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(cookieFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
-                .httpBasic().realmName(DISCOVERY_REALM)
-                .and()
-                .authorizeRequests().anyRequest().authenticated()
-                .and().x509().userDetailsService(x509UserDetailsService());
+                .httpBasic().realmName(DISCOVERY_REALM);
+            if (verifySslCertificatesOfServices) {
+                http.authorizeRequests().anyRequest().authenticated().and()
+                .x509().userDetailsService(x509UserDetailsService());
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

# Description

Modify security config of discovery service so /discovery/** endpoint certificate checking is skipped unless verifySslCertificatesOfServices is set to true

Fixes https://github.com/zowe/api-layer/issues/737

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
