### PR TITLE
Configuration validator enhancement

### DIFF
--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
@@ -17,6 +17,7 @@ import org.zowe.apiml.eurekaservice.client.config.Route;
 import org.zowe.apiml.eurekaservice.client.config.Ssl;
 import org.zowe.apiml.exception.MetadataValidationException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -27,6 +28,9 @@ public class EurekaInstanceConfigValidator {
 
     private static final String UNSET_VALUE_STRING = "{apiml.";
     private static final char[] UNSET_VALUE_CHAR_ARRAY = UNSET_VALUE_STRING.toCharArray();
+
+    private List<String> missingSslParameters = new ArrayList<>();
+    private List<String> missingRoutesParameters = new ArrayList<>();
 
     /**
      * Validation method that validates mandatory and non-mandatory parameters
@@ -55,8 +59,14 @@ public class EurekaInstanceConfigValidator {
             throw new MetadataValidationException("Routes configuration was not provided. Try to add apiml.service.routes section.");
         }
         routes.forEach(route -> {
-            if (isInvalid(route.getGatewayUrl()) || isInvalid(route.getServiceUrl())) {
-                throw new MetadataValidationException("Routes parameters are missing or were not replaced by the system properties.");
+            if (isInvalid(route.getGatewayUrl())) {
+                createListOfMissingRoutesParameters("gatewayUrl", missingRoutesParameters);
+            }
+            if (isInvalid(route.getServiceUrl())) {
+                createListOfMissingRoutesParameters("serviceUrl", missingRoutesParameters);
+            }
+            if (!missingRoutesParameters.isEmpty()) {
+                throw new MetadataValidationException(String.format("Routes parameters  ** %s ** are missing or were not replaced by the system properties.", String.join(", ", missingRoutesParameters)));
             }
         });
     }
@@ -65,17 +75,44 @@ public class EurekaInstanceConfigValidator {
         if (ssl == null) {
             throw new MetadataValidationException("SSL configuration was not provided. Try add apiml.service.ssl section.");
         }
-        if (isInvalid(ssl.getProtocol()) ||
-            isInvalid(ssl.getTrustStore()) ||
-            isInvalid(ssl.getKeyStore()) ||
-            isInvalid(ssl.getKeyAlias()) ||
-            isInvalid(ssl.getKeyStoreType()) ||
-            isInvalid(ssl.getTrustStoreType()) ||
-            (isInvalid(ssl.getTrustStorePassword()) && !ssl.getTrustStoreType().equals("JCERACFKS")) ||
-            (isInvalid(ssl.getKeyStorePassword()) && !ssl.getKeyStoreType().equals("JCERACFKS")) ||
-            isInvalid(ssl.getKeyPassword()) ||
-            ssl.getEnabled() == null) {
-            throw new MetadataValidationException("SSL parameters are missing or were not replaced by the system properties.");
+        if (isInvalid(ssl.getProtocol())) {
+            createListOfMissingSslParameters("protocol", missingSslParameters);
+        }
+        if (isInvalid(ssl.getTrustStore())) {
+            createListOfMissingSslParameters("trustStore", missingSslParameters);
+        }
+        if (isInvalid(ssl.getKeyStore())) {
+            createListOfMissingSslParameters("keyStore", missingSslParameters);
+        }
+        if (isInvalid(ssl.getKeyAlias())) {
+            createListOfMissingSslParameters("keyAlias", missingSslParameters);
+        }
+        if (isInvalid(ssl.getKeyStoreType())) {
+            createListOfMissingSslParameters("keyStoreType", missingSslParameters);
+        }
+        if (isInvalid(ssl.getTrustStoreType())) {
+            createListOfMissingSslParameters("trustStoreType", missingSslParameters);
+        }
+        if (isInvalid(ssl.getTrustStorePassword())) {
+            if (isInvalid(ssl.getTrustStoreType()) ||
+                (!isInvalid(ssl.getTrustStoreType()) && !ssl.getTrustStoreType().equals("JCERACFKS"))) {
+                createListOfMissingSslParameters("trustStorePassword", missingSslParameters);
+            }
+        }
+        if (isInvalid(ssl.getKeyStorePassword())) {
+            if (isInvalid(ssl.getKeyStoreType()) ||
+                (!isInvalid(ssl.getKeyStoreType()) && !ssl.getKeyStoreType().equals("JCERACFKS"))) {
+                createListOfMissingSslParameters("keyStorePassword", missingSslParameters);
+            }
+        }
+        if (isInvalid(ssl.getKeyPassword())) {
+            createListOfMissingSslParameters("keyPassword", missingSslParameters);
+        }
+        if (ssl.getEnabled() == null) {
+            createListOfMissingSslParameters("enabled", missingSslParameters);
+        }
+        if (!missingSslParameters.isEmpty()) {
+            throw new MetadataValidationException(String.format("SSL parameters ** %s ** are missing or were not replaced by the system properties.", String.join(", ", missingSslParameters)));
         }
     }
 
@@ -85,6 +122,14 @@ public class EurekaInstanceConfigValidator {
 
     private boolean isInvalid(char[] value) {
         return value == null || value.length == 0 || Chars.indexOf(value, UNSET_VALUE_CHAR_ARRAY) >= 0;
+    }
+
+    private void createListOfMissingSslParameters(String parameter, List parameters) {
+        parameters.add(parameter);
+    }
+
+    private void createListOfMissingRoutesParameters(String parameter, List parameters) {
+        parameters.add(parameter);
     }
 
 }

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
@@ -66,13 +66,13 @@ public class EurekaInstanceConfigValidator {
             throw new MetadataValidationException("SSL configuration was not provided. Try add apiml.service.ssl section.");
         }
         if (isInvalid(ssl.getProtocol()) ||
-            isInvalid(ssl.getTrustStorePassword()) ||
             isInvalid(ssl.getTrustStore()) ||
-            isInvalid(ssl.getKeyStorePassword()) ||
             isInvalid(ssl.getKeyStore()) ||
             isInvalid(ssl.getKeyAlias()) ||
             isInvalid(ssl.getKeyStoreType()) ||
             isInvalid(ssl.getTrustStoreType()) ||
+            (isInvalid(ssl.getTrustStorePassword()) && !ssl.getTrustStoreType().equals("JCERACFKS")) ||
+            (isInvalid(ssl.getKeyStorePassword()) && !ssl.getKeyStoreType().equals("JCERACFKS")) ||
             isInvalid(ssl.getKeyPassword()) ||
             ssl.getEnabled() == null) {
             throw new MetadataValidationException("SSL parameters are missing or were not replaced by the system properties.");

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
@@ -73,7 +73,7 @@ class EurekaInstanceConfigValidatorTest {
         Exception exception = assertThrows(MetadataValidationException.class,
             () -> validator.validate(testConfig),
             "Expected exception is not MetadataValidationException");
-        assertEquals("SSL parameters are missing or were not replaced by the system properties.", exception.getMessage());
+        assertEquals("SSL parameters ** keyStore ** are missing or were not replaced by the system properties.", exception.getMessage());
     }
 
     @Test
@@ -91,12 +91,12 @@ class EurekaInstanceConfigValidatorTest {
     }
 
     @Test
-    void givenConfigurationWrongSsl_whenValidate_thenThrowException() throws Exception {
+    void givenConfigurationWrongRoutes_whenValidate_thenThrowException() throws Exception {
         ApiMediationServiceConfig testConfig = configReader.loadConfiguration("wrong-routes-service-configuration.yml");
         Exception exception = assertThrows(MetadataValidationException.class,
             () -> validator.validate(testConfig),
             "Expected exception is not MetadataValidationException");
-        assertEquals("Routes parameters are missing or were not replaced by the system properties.", exception.getMessage());
+        assertEquals("Routes parameters  ** gatewayUrl, serviceUrl ** are missing or were not replaced by the system properties.", exception.getMessage());
     }
 
     @Test
@@ -113,5 +113,20 @@ class EurekaInstanceConfigValidatorTest {
         validator.validate(testConfig);
 
         assertEquals(null, testConfig.getApiInfo());
+    }
+
+    @Test
+    void givenConfigurationWithMissingSslParams_whenValidate_thenThrowException() throws Exception {
+        ApiMediationServiceConfig testConfig = configReader.loadConfiguration("missing-ssl-configuration.yml");
+        Exception exception = assertThrows(MetadataValidationException.class,
+            () -> validator.validate(testConfig),
+            "Expected exception is not MetadataValidationException");
+        assertEquals("SSL parameters ** protocol, trustStore, keyStore, keyAlias, keyStoreType, trustStoreType, trustStorePassword, keyStorePassword, keyPassword, enabled ** are missing or were not replaced by the system properties.", exception.getMessage());
+    }
+
+    @Test
+    void givenConfigurationWithKeyring_whenOtherConfigurationIsValid_thenValidate() throws Exception {
+        ApiMediationServiceConfig testConfig = configReader.loadConfiguration("keyring-ssl-configuration.yml");
+        assertDoesNotThrow(() -> validator.validate(testConfig));
     }
 }

--- a/onboarding-enabler-java/src/test/resources/keyring-ssl-configuration.yml
+++ b/onboarding-enabler-java/src/test/resources/keyring-ssl-configuration.yml
@@ -1,0 +1,54 @@
+serviceId: service
+title: HelloWorld Spring REST API
+description: POC for exposing a Spring REST API
+baseUrl: http://localhost:10021/hellospring
+serviceIpAddress: 127.0.0.1
+
+homePageRelativeUrl: /
+statusPageRelativeUrl: /application/info
+healthCheckRelativeUrl: /application/health
+
+discoveryServiceUrls:
+    - http://eureka:password@localhost:10011/eureka
+    - http://eureka:password@localhost:10011/eureka1
+
+routes:
+    - gatewayUrl: api/v1
+      serviceUrl: /hellospring/api/v1
+    - gatewayUrl: api/v1/api-doc
+      serviceUrl: /hellospring/api-doc
+
+apiInfo:
+    - apiId: org.zowe.hellospring
+      gatewayUrl: api/v1
+      swaggerUrl: http://localhost:10021/hellospring/api-doc
+
+catalog:
+    tile:
+        id: helloworld-spring
+        title: HelloWorld Spring REST API
+        description: Proof of Concept application to demonstrate exposing a REST API in the MFaaS ecosystem
+        version: 1.0.0
+
+ssl:
+    enabled: true
+    protocol: TLSv1.2
+    keyAlias: localhost
+    keyPassword: password
+    keyStore: keystore/localhost/localhost.keystore.p12
+    keyStoreType: JCERACFKS
+    trustStore: keystore/localhost/localhost.truststore.p12
+    trustStoreType: JCERACFKS
+
+customMetadata:
+    key: value
+    customService.key1: value1
+    customService.key2: value2
+    customService:
+        key3: value3
+        key4: value4
+        evenmorelevels:
+            key5:
+                key6:
+                    key7: value7
+

--- a/onboarding-enabler-java/src/test/resources/missing-ssl-configuration.yml
+++ b/onboarding-enabler-java/src/test/resources/missing-ssl-configuration.yml
@@ -1,0 +1,56 @@
+serviceId: service
+title: HelloWorld Spring REST API
+description: POC for exposing a Spring REST API
+baseUrl: http://localhost:10021/hellospring
+serviceIpAddress: 127.0.0.1
+
+homePageRelativeUrl: /
+statusPageRelativeUrl: /application/info
+healthCheckRelativeUrl: /application/health
+
+discoveryServiceUrls:
+    - http://eureka:password@localhost:10011/eureka
+    - http://eureka:password@localhost:10011/eureka1
+
+routes:
+    - gatewayUrl: api/v1
+      serviceUrl: /hellospring/api/v1
+    - gatewayUrl: api/v1/api-doc
+      serviceUrl: /hellospring/api-doc
+
+apiInfo:
+    - apiId: org.zowe.hellospring
+      gatewayUrl: api/v1
+      swaggerUrl: http://localhost:10021/hellospring/api-doc
+
+catalog:
+    tile:
+        id: helloworld-spring
+        title: HelloWorld Spring REST API
+        description: Proof of Concept application to demonstrate exposing a REST API in the MFaaS ecosystem
+        version: 1.0.0
+
+ssl:
+    enabled:
+    protocol: ${apiml.protocol}
+    keyAlias:
+    keyPassword:
+    keyStore:
+    keyStorePassword:
+    keyStoreType:
+    trustStore:
+    trustStorePassword:
+    trustStoreType:
+
+customMetadata:
+    key: value
+    customService.key1: value1
+    customService.key2: value2
+    customService:
+        key3: value3
+        key4: value4
+        evenmorelevels:
+            key5:
+                key6:
+                    key7: value7
+


### PR DESCRIPTION
# Description

Enhancement of the spring enabler validator to list the ssl and routing props missing in the configuration. This PR also fix problem with validation of trustStorePassword and keyStorePassword, avoiding requirement for them in case of keyrings.

Fixes #745 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
