### PR TITLE
If service has no instances don't return null routes

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
@@ -79,7 +79,7 @@ public class ApimlRouteLocator extends DiscoveryClientRouteLocator {
                 List<ServiceInstance> serviceInstances = this.discovery.getInstances(serviceId);
                 if (serviceInstances == null || serviceInstances.isEmpty()) {
                     apimlLog.log("org.zowe.apiml.gateway.instanceNotFound", serviceId);
-                    break;
+                    continue;
                 }
 
                 RoutedServices routedServices = new RoutedServices();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
@@ -79,7 +79,7 @@ public class ApimlRouteLocator extends DiscoveryClientRouteLocator {
                 List<ServiceInstance> serviceInstances = this.discovery.getInstances(serviceId);
                 if (serviceInstances == null || serviceInstances.isEmpty()) {
                     apimlLog.log("org.zowe.apiml.gateway.instanceNotFound", serviceId);
-                    return null;
+                    break;
                 }
 
                 RoutedServices routedServices = new RoutedServices();


### PR DESCRIPTION
Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

# Description

Fixes #735 
Rather than returning null when a service has no instances, break and allow other services to to still have their routes surfaced. This means one badly configured service does not bring down the api gateway landing page.

The fix feels a bit like I'm treating the symptom rather than the cause, though I'm not sure where in the discovery service the instance creation of an invalid service is failing. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
