### PR TITLE
Enable handling of the Proxy headers by default

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -81,7 +81,7 @@ server:
 
 zuul:
     sslHostnameValidationEnabled: false
-    addProxyHeaders: false
+    addProxyHeaders: true
     traceRequestBody: true
     ignoreSecurityHeaders: false
     includeDebugHeader: false

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/ForwardedProxyHeadersTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/ForwardedProxyHeadersTest.java
@@ -1,0 +1,60 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.acceptance;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zowe.apiml.acceptance.common.AcceptanceTest;
+import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
+
+import java.io.IOException;
+
+import static io.restassured.RestAssured.when;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@AcceptanceTest
+public class ForwardedProxyHeadersTest extends AcceptanceTestWithTwoServices {
+    @Test
+    void givenServiceWithOverwritenTimeoutAndAnotherWithout_whenOverwritingConfigurationForOneService_thenTheOtherServicesKeepDefault() throws IOException {
+        mockValid200HttpResponse();
+
+        // Tell the infrastructure to work with the request for serviceid
+        applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
+
+        when()
+            .get(basePath + serviceWithDefaultConfiguration.getPath())
+        .then()
+            .statusCode(is(SC_OK));
+
+        assertForwardedHeaders();
+    }
+
+    private void assertForwardedHeaders() throws IOException {
+        ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(mockClient, times(1)).execute(captor.capture());
+
+        HttpUriRequest toVerify = captor.getValue();
+
+        assertHeaderWithValue(toVerify, "X-Forwarded-Host", "localhost:" + port);
+        assertHeaderWithValue(toVerify, "X-Forwarded-Prefix", "/serviceid2");
+        assertHeaderWithValue(toVerify, "X-Forwarded-Port", String.valueOf(port));
+        assertHeaderWithValue(toVerify, "X-Forwarded-For", "127.0.0.1");
+    }
+
+    private void assertHeaderWithValue(HttpUriRequest request, String header, String value) {
+        assertThat(request.getHeaders(header).length, is(1));
+        assertThat(request.getFirstHeader(header).getValue(), is(value));
+    }
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithBasePath.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithBasePath.java
@@ -17,7 +17,7 @@ public class AcceptanceTestWithBasePath {
     protected String basePath;
 
     @LocalServerPort
-    private int port;
+    protected int port;
 
     @BeforeEach
     public void setBasePath() {

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -79,7 +79,7 @@ server:
 
 zuul:
     sslHostnameValidationEnabled: false
-    addProxyHeaders: false
+    addProxyHeaders: true
     traceRequestBody: true
     ignoreSecurityHeaders: false
     includeDebugHeader: false


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

Add Proxy related headers such as X-Forwarded-Host so the southbound services can use them to construct valid links. 

Fixes #669 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
