### PR TITLE
Rip/gh743/passticket in cookie

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/util/CookieUtil.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/CookieUtil.java
@@ -18,6 +18,8 @@ import org.apache.commons.lang3.StringUtils;
 @UtilityClass
 public final class CookieUtil {
 
+    public static final String COOKIE_HEADER = "cookie";
+
     /**
      * It replace or add cookie into header string value (see header with name "Cookie").
      *
@@ -73,7 +75,7 @@ public final class CookieUtil {
         }
 
         if (!changed) return cookieHeader;
-        return sb.toString();
+        return (sb.length() > 0) ? sb.toString() : null;
     }
 
 }

--- a/common-service-core/src/test/java/org/zowe/apiml/util/CookieUtilTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/util/CookieUtilTest.java
@@ -33,9 +33,9 @@ public class CookieUtilTest {
     public void removeCookie() {
         String c = "a=1;b=2";
         assertSame(c, CookieUtil.removeCookie(c, "c"));
-        assertEquals("", CookieUtil.removeCookie("a=b", "a"));
+        assertNull(CookieUtil.removeCookie("a=b", "a"));
         assertEquals("a=1;c=3", CookieUtil.removeCookie("a=1;b=2;c=3", "b"));
-        assertEquals("", CookieUtil.removeCookie("a=1;a=2;a=3", "a"));
+        assertNull(CookieUtil.removeCookie("a=1;a=2;a=3", "a"));
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.zowe.apiml.gateway.cache.RetryIfExpired;
 import org.zowe.apiml.gateway.config.CacheConfig;
+import org.zowe.apiml.gateway.ribbon.RequestContextUtils;
 import org.zowe.apiml.gateway.security.service.schema.AbstractAuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationSchemeFactory;
@@ -123,6 +124,9 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
             if (found == null) {
                 // this is the first record
                 found = auth;
+
+                RequestContext.getCurrentContext().set(AUTHENTICATION_COMMAND_KEY, new ServiceAuthenticationServiceImpl.UniversalAuthenticationCommand());
+                RequestContextUtils.setInstanceInfo((instance));
             } else if (!found.equals(auth)) {
                 // if next record is different, authentication cannot be determined before load balancer
                 return loadBalancerCommand;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -126,7 +126,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
                 found = auth;
 
                 RequestContext.getCurrentContext().set(AUTHENTICATION_COMMAND_KEY, new ServiceAuthenticationServiceImpl.UniversalAuthenticationCommand());
-                RequestContextUtils.setInstanceInfo((instance));
+                RequestContextUtils.setInstanceInfo(instance);
             } else if (!found.equals(auth)) {
                 // if next record is different, authentication cannot be determined before load balancer
                 return loadBalancerCommand;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -31,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.function.Supplier;
 
+import static org.zowe.apiml.util.CookieUtil.COOKIE_HEADER;
+
 /**
  * This bean support PassTicket. Bean is responsible for getting PassTicket from
  * SAF and generating new authentication header in request.
@@ -90,8 +92,6 @@ public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
     public static class PassTicketCommand extends AuthenticationCommand {
 
         private static final long serialVersionUID = 3941300386857998443L;
-
-        private static final String COOKIE_HEADER = "cookie";
 
         private final String authorizationValue;
         private final String cookieName;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -30,6 +30,8 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static org.zowe.apiml.util.CookieUtil.COOKIE_HEADER;
+
 /**
  * This bean provide LTPA token into request. It get LTPA from JWT token (value is set on logon) and distribute it as
  * cookie.
@@ -59,8 +61,6 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
     public class ZosmfCommand extends AuthenticationCommand {
 
         private static final long serialVersionUID = 2284037230674275720L;
-
-        public static final String COOKIE_HEADER = "cookie";
 
         private final Long expireAt;
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.zowe.apiml.gateway.security.service.schema.ZosmfScheme.ZosmfCommand.COOKIE_HEADER;
+import static org.zowe.apiml.util.CookieUtil.COOKIE_HEADER;
 
 @ExtendWith(MockitoExtension.class)
 class ZosmfSchemeTest extends CleanCurrentRequestContextTest {


### PR DESCRIPTION
# Description

Changed GW ServiceAuthenticationServiceImpl  to set RequestContext with necessary properties to create appropriate Passticket authentication  command on which applyTorequest is called when HttpRequest is ready to be send to southvbound service.

Unit test is provided to verify behavior of creating the command.

Fixes #743

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
