### PR TITLE
Add warning logging for poorly formed URL config parameters

### DIFF
--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
@@ -29,8 +29,8 @@ public class EurekaInstanceConfigValidator {
     private static final String UNSET_VALUE_STRING = "{apiml.";
     private static final char[] UNSET_VALUE_CHAR_ARRAY = UNSET_VALUE_STRING.toCharArray();
 
-    private List<String> missingSslParameters = new ArrayList<>();
-    private List<String> missingRoutesParameters = new ArrayList<>();
+    private final List<String> missingSslParameters = new ArrayList<>();
+    private final List<String> missingRoutesParameters = new ArrayList<>();
 
     /**
      * Validation method that validates mandatory and non-mandatory parameters
@@ -60,10 +60,10 @@ public class EurekaInstanceConfigValidator {
         }
         routes.forEach(route -> {
             if (isInvalid(route.getGatewayUrl())) {
-                createListOfMissingRoutesParameters("gatewayUrl", missingRoutesParameters);
+                addParameterToProblemsList("gatewayUrl", missingRoutesParameters);
             }
             if (isInvalid(route.getServiceUrl())) {
-                createListOfMissingRoutesParameters("serviceUrl", missingRoutesParameters);
+                addParameterToProblemsList("serviceUrl", missingRoutesParameters);
             }
             if (!missingRoutesParameters.isEmpty()) {
                 throw new MetadataValidationException(String.format("Routes parameters  ** %s ** are missing or were not replaced by the system properties.", String.join(", ", missingRoutesParameters)));
@@ -76,40 +76,40 @@ public class EurekaInstanceConfigValidator {
             throw new MetadataValidationException("SSL configuration was not provided. Try add apiml.service.ssl section.");
         }
         if (isInvalid(ssl.getProtocol())) {
-            createListOfMissingSslParameters("protocol", missingSslParameters);
+            addParameterToProblemsList("protocol", missingSslParameters);
         }
         if (isInvalid(ssl.getTrustStore())) {
-            createListOfMissingSslParameters("trustStore", missingSslParameters);
+            addParameterToProblemsList("trustStore", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyStore())) {
-            createListOfMissingSslParameters("keyStore", missingSslParameters);
+            addParameterToProblemsList("keyStore", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyAlias())) {
-            createListOfMissingSslParameters("keyAlias", missingSslParameters);
+            addParameterToProblemsList("keyAlias", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyStoreType())) {
-            createListOfMissingSslParameters("keyStoreType", missingSslParameters);
+            addParameterToProblemsList("keyStoreType", missingSslParameters);
         }
         if (isInvalid(ssl.getTrustStoreType())) {
-            createListOfMissingSslParameters("trustStoreType", missingSslParameters);
+            addParameterToProblemsList("trustStoreType", missingSslParameters);
         }
         if (isInvalid(ssl.getTrustStorePassword())) {
             if (isInvalid(ssl.getTrustStoreType()) ||
                 (!isInvalid(ssl.getTrustStoreType()) && !ssl.getTrustStoreType().equals("JCERACFKS"))) {
-                createListOfMissingSslParameters("trustStorePassword", missingSslParameters);
+                addParameterToProblemsList("trustStorePassword", missingSslParameters);
             }
         }
         if (isInvalid(ssl.getKeyStorePassword())) {
             if (isInvalid(ssl.getKeyStoreType()) ||
                 (!isInvalid(ssl.getKeyStoreType()) && !ssl.getKeyStoreType().equals("JCERACFKS"))) {
-                createListOfMissingSslParameters("keyStorePassword", missingSslParameters);
+                addParameterToProblemsList("keyStorePassword", missingSslParameters);
             }
         }
         if (isInvalid(ssl.getKeyPassword())) {
-            createListOfMissingSslParameters("keyPassword", missingSslParameters);
+            addParameterToProblemsList("keyPassword", missingSslParameters);
         }
         if (ssl.getEnabled() == null) {
-            createListOfMissingSslParameters("enabled", missingSslParameters);
+            addParameterToProblemsList("enabled", missingSslParameters);
         }
         if (!missingSslParameters.isEmpty()) {
             throw new MetadataValidationException(String.format("SSL parameters ** %s ** are missing or were not replaced by the system properties.", String.join(", ", missingSslParameters)));
@@ -124,12 +124,7 @@ public class EurekaInstanceConfigValidator {
         return value == null || value.length == 0 || Chars.indexOf(value, UNSET_VALUE_CHAR_ARRAY) >= 0;
     }
 
-    private void createListOfMissingSslParameters(String parameter, List parameters) {
-        parameters.add(parameter);
+    private void addParameterToProblemsList(String parameter, List<String> problemParameters){
+        problemParameters.add(parameter);
     }
-
-    private void createListOfMissingRoutesParameters(String parameter, List parameters) {
-        parameters.add(parameter);
-    }
-
 }

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class EurekaInstanceConfigValidatorTest {
 
-    private EurekaInstanceConfigValidator validator = new EurekaInstanceConfigValidator();
-    private ApiMediationServiceConfigReader configReader = new ApiMediationServiceConfigReader();
+    private final EurekaInstanceConfigValidator validator = new EurekaInstanceConfigValidator();
+    private final ApiMediationServiceConfigReader configReader = new ApiMediationServiceConfigReader();
 
     @Test
     void givenServiceConfiguration_whenConfigurationIsValid_thenValidate() throws ServiceDefinitionException {
@@ -104,7 +104,7 @@ class EurekaInstanceConfigValidatorTest {
         ApiMediationServiceConfig testConfig = configReader.loadConfiguration("empty-catalog-service-configuration.yml");
         validator.validate(testConfig);
 
-        assertEquals(null, testConfig.getCatalog());
+        assertNull(testConfig.getCatalog());
     }
 
     @Test
@@ -112,7 +112,7 @@ class EurekaInstanceConfigValidatorTest {
         ApiMediationServiceConfig testConfig = configReader.loadConfiguration("empty-apiinfo-service-configuration.yml");
         validator.validate(testConfig);
 
-        assertEquals(null, testConfig.getApiInfo());
+        assertNull(testConfig.getApiInfo());
     }
 
     @Test


### PR DESCRIPTION
# Description

Malformed URLs are apt to occur when the `baseUrl` or `contextPath` parameters end with a trailing `/`, and/or when `homePageRelativeUrl`, `statusPageRelativeUrl`, `healthCheckRelativeUrl`, and `contextPath` parameters don't begin with a `/`. This PR adds warnings that are logged when the `/` are not in appropriate places.

Tests were not added as there is no precedent in api-layer for using log messages as acceptance conditions, and there are no other acceptance conditions than log status.

Fixes #744 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
