### PR TITLE
Mark the test as excluded from the Zowe testing.

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedApiMediationClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedApiMediationClientTest.java
@@ -13,6 +13,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.util.categories.SlowTests;
+import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import java.net.URI;
@@ -24,6 +25,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
+@TestsNotMeantForZowe
 class IntegratedApiMediationClientTest {
     private static final URI MEDIATION_CLIENT_URI = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/apiMediationClient");
 


### PR DESCRIPTION
The test needs Discoverable client which isn't part of the Zowe distribution.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>