### PR TITLE
Implement API Path Pattern with serviceId as first element

### DIFF
--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
@@ -58,7 +58,7 @@ describe('>>> Detail page test', () => {
 
         cy.get('#root > div > div.content > div.detail-page > div.content-description-container > div > div:nth-child(2) > div > span > span > a')
             .should('have.attr', 'href')
-            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/ui/v1/apicatalog`);
+            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/apicatalog/ui/v1`);
 
         cy.get('pre.version').should('contain', '1.0.0');
 

--- a/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
@@ -84,8 +84,8 @@ public class TransformService {
         return String.format("%s://%s/%s/%s%s",
             gatewayConfigProperties.getScheme(),
             gatewayConfigProperties.getHostname(),
-            route.getGatewayUrl(),
             serviceId,
+            route.getGatewayUrl(),
             endPoint);
     }
 

--- a/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
@@ -60,8 +60,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            UI_PREFIX,
-            SERVICE_ID);
+            SERVICE_ID,
+            UI_PREFIX);
         assertEquals(expectedUrl, actualUrl);
     }
 
@@ -98,8 +98,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            WS_PREFIX,
-            SERVICE_ID);
+            SERVICE_ID,
+            WS_PREFIX);
         assertEquals(expectedUrl, actualUrl);
     }
 
@@ -119,8 +119,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            API_PREFIX,
-            SERVICE_ID);
+            SERVICE_ID,
+            API_PREFIX);
         assertEquals(expectedUrl, actualUrl);
     }
 
@@ -182,8 +182,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            WS_PREFIX,
             SERVICE_ID,
+            WS_PREFIX,
             "/");
         assertEquals(expectedUrl, actualUrl);
     }
@@ -203,8 +203,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            UI_PREFIX,
             SERVICE_ID,
+            UI_PREFIX,
             "/test");
         assertEquals(expectedUrl, actualUrl);
     }
@@ -225,8 +225,8 @@ public class TransformServiceTest {
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
-            UI_PREFIX,
             SERVICE_ID,
+            UI_PREFIX,
             path);
         assertEquals(expectedUrl, actualUrl);
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
@@ -48,23 +48,26 @@ public class RoutedServices {
         int maxSize = 0;
 
         for (Map.Entry<String, RoutedService> serviceEntry : routedService.entrySet()) {
-            if (!type.equals(ServiceType.ALL)
-                && !serviceEntry.getKey().toLowerCase().startsWith(type.name().toLowerCase())) {
-                continue;
-            }
-
-            RoutedService value = serviceEntry.getValue();
-            int size = value.getServiceUrl().length();
-            //Remove last slash for service url
-            String routeServiceUrl = UrlUtils.removeLastSlash(value.getServiceUrl().toLowerCase());
-            if (size > maxSize &&
-                serviceUrl.toLowerCase().startsWith(routeServiceUrl)) {
-                result = value;
-                maxSize = size;
+            if (isServiceTypeMatch(serviceEntry, type)) {
+                RoutedService value = serviceEntry.getValue();
+                int size = value.getServiceUrl().length();
+                //Remove last slash for service url
+                String routeServiceUrl = UrlUtils.removeLastSlash(value.getServiceUrl().toLowerCase());
+                if (size > maxSize &&
+                    serviceUrl.toLowerCase().startsWith(routeServiceUrl)) {
+                    result = value;
+                    maxSize = size;
+                }
             }
         }
 
         return result;
+    }
+
+    private boolean isServiceTypeMatch(Map.Entry<String, RoutedService> serviceEntry, ServiceType type) {
+        String serviceEntryKey = serviceEntry.getKey().toLowerCase();
+        String typeName = type.name().toLowerCase();
+        return type.equals(ServiceType.ALL) || serviceEntryKey.startsWith(typeName);
     }
 
     @Override

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/LocationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/LocationFilter.java
@@ -76,11 +76,11 @@ public class LocationFilter extends ZuulFilter implements RoutedServicesUser {
     }
 
     private RoutedService getService(RoutedServices routedServices, String proxy) {
-        // Try to find service by route using old API path format /{typeOfService}/{version}/{serviceId}
+        // Try to find service by route using old API path format /{typeOfService}/{version}/{serviceId} //NOSONAR
         String route = proxy.substring(0, proxy.lastIndexOf('/'));
         RoutedService service = routedServices.findServiceByGatewayUrl(route);
         if (service == null) {
-            // If not found, try by route using new API path format /{serviceId}/{typeOfService}/{version}
+            // If not found, try by route using new API path format /{serviceId}/{typeOfService}/{version} //NOSONAR
             route = proxy.substring(proxy.indexOf('/') + 1);
             service = routedServices.findServiceByGatewayUrl(route);
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
@@ -149,7 +149,7 @@ public class ApimlRouteLocator extends DiscoveryClientRouteLocator {
                 metadata -> eurekaMetadataParser.parseToListRoute(metadata).stream()
             )
             .forEach(routedService -> {
-                // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService}
+                // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService} //NOSONAR
                 keys.add("/" + routedService.getGatewayUrl() + "/" + mapRouteToService(serviceId) + "/**");
                 keys.add("/" + mapRouteToService(serviceId) + "/" + routedService.getGatewayUrl() + "/**");
                 routes.addRoutedService(routedService);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/ApimlRouteLocator.java
@@ -149,7 +149,9 @@ public class ApimlRouteLocator extends DiscoveryClientRouteLocator {
                 metadata -> eurekaMetadataParser.parseToListRoute(metadata).stream()
             )
             .forEach(routedService -> {
+                // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService}
                 keys.add("/" + routedService.getGatewayUrl() + "/" + mapRouteToService(serviceId) + "/**");
+                keys.add("/" + mapRouteToService(serviceId) + "/" + routedService.getGatewayUrl() + "/**");
                 routes.addRoutedService(routedService);
             });
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocator.java
@@ -70,7 +70,7 @@ public class NewApimlRouteLocator extends DiscoveryClientRouteLocator {
     }
 
     private Map<String, ZuulProperties.ZuulRoute> buildRoute(String serviceId, RoutedService routedService) {
-        // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService}
+        // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService} //NOSONAR
 
         LinkedHashMap<String, ZuulProperties.ZuulRoute> routesMap = new LinkedHashMap<>();
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocator.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientR
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.RoutedServices;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class NewApimlRouteLocator extends DiscoveryClientRouteLocator {
     private final DiscoveryClient discoveryClient;
     private final EurekaMetadataParser metadataParser = new EurekaMetadataParser();
 
-    private RoutedServicesNotifier routedServicesNotifier;
+    private final RoutedServicesNotifier routedServicesNotifier;
 
     public NewApimlRouteLocator(String servletPath, ZuulProperties properties, DiscoveryClient discoveryClient, RoutedServicesNotifier notifier) {
         super(servletPath, discoveryClient, properties, null, null);
@@ -69,12 +70,19 @@ public class NewApimlRouteLocator extends DiscoveryClientRouteLocator {
     }
 
     private Map<String, ZuulProperties.ZuulRoute> buildRoute(String serviceId, RoutedService routedService) {
+        // Currently support two API path formats. Old: /{typeOfService}/{version}/{serviceId}. New: /{serviceId}/{version}/{typeOfService}
+
         LinkedHashMap<String, ZuulProperties.ZuulRoute> routesMap = new LinkedHashMap<>();
 
-        String routeKey = "/" + routedService.getGatewayUrl() + "/" + serviceId + "/**";
-        ZuulProperties.ZuulRoute route = new ZuulProperties.ZuulRoute(routeKey, serviceId);
-        routesMap.put(routeKey, route);
-        log.debug("ServiceId: {}, RouteId: {}, Created Route: {}", serviceId, routedService.getSubServiceId(), route);
+        String routeKeyOldFormat = "/" + routedService.getGatewayUrl() + "/" + serviceId + "/**";
+        ZuulProperties.ZuulRoute routeOldFormat = new ZuulProperties.ZuulRoute(routeKeyOldFormat, serviceId);
+
+        String routeKeyNewFormat = "/" + serviceId + "/" + routedService.getGatewayUrl() + "/**";
+        ZuulProperties.ZuulRoute routeNewFormat = new ZuulProperties.ZuulRoute(routeKeyNewFormat, serviceId);
+
+        routesMap.put(routeKeyOldFormat, routeOldFormat);
+        routesMap.put(routeKeyNewFormat, routeNewFormat);
+        log.debug("ServiceId: {}, RouteId: {}, Created Routes: New Format: {} | Old Format: {}", serviceId, routedService.getSubServiceId(), routeNewFormat, routeOldFormat);
 
         return routesMap;
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PageRedirectionFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PageRedirectionFilterTest.java
@@ -97,7 +97,7 @@ class PageRedirectionFilterTest {
             .findFirst();
 
         verifyLocationUpdatedSameServer(locationHeader.map(Pair::second).orElse(null), location,
-            "/" + currentService.getGatewayUrl() + "/" + SERVICE_ID + relativePath);
+            "/" + SERVICE_ID + "/" + currentService.getGatewayUrl() + relativePath);
     }
 
 
@@ -166,7 +166,7 @@ class PageRedirectionFilterTest {
             .findFirst();
 
         this.verifyLocationUpdatedSameServer(locationHeader.map(Pair::second).orElse(null), location,
-            "/" + otherService.getGatewayUrl() + "/" + OTHER_SERVICE_ID + relativePath);
+            "/" + OTHER_SERVICE_ID + "/" + otherService.getGatewayUrl() + relativePath);
     }
 
 
@@ -234,7 +234,7 @@ class PageRedirectionFilterTest {
             .findFirst();
 
         verifyLocationUpdatedSameServer(locationHeader.map(Pair::second).orElse(null), location,
-            "/" + currentService.getGatewayUrl() + "/" + SERVICE_ID + relativePath);
+            "/" + SERVICE_ID + "/" + currentService.getGatewayUrl() + relativePath);
     }
 
 
@@ -280,7 +280,7 @@ class PageRedirectionFilterTest {
             .findFirst();
 
         verifyLocationUpdatedSameServer(locationHeader.map(Pair::second).orElse(null), location,
-            "/" + currentService.getGatewayUrl() + "/" + SERVICE_ID + relativePath);
+            "/" + SERVICE_ID + "/" + currentService.getGatewayUrl() + relativePath);
     }
 
     private String mockLocationSameServer(String relativeUrl) {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/LocationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/LocationFilterTest.java
@@ -31,7 +31,7 @@ class LocationFilterTest {
         RequestContext ctx = RequestContext.getCurrentContext();
         ctx.clear();
         ctx.set(REQUEST_URI_KEY, "/path");
-        ctx.set(PROXY_KEY, "api/v1/service");
+        ctx.set(PROXY_KEY, "service/api/v1");
         ctx.set(SERVICE_ID_KEY, "service");
         RoutedServices routedServices = new RoutedServices();
         routedServices.addRoutedService(
@@ -62,6 +62,14 @@ class LocationFilterTest {
     }
 
     @Test
+    void urlDefinedInMetadataIsModified_OldProxyFormat() {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(PROXY_KEY, "api/v1/service");
+        this.filter.run();
+        assertEquals("/service/v1/path", ctx.get(REQUEST_URI_KEY));
+    }
+
+    @Test
     void requestURIStartsWithoutSlash() {
         final RequestContext ctx = RequestContext.getCurrentContext();
         ctx.set(REQUEST_URI_KEY, "path");
@@ -72,6 +80,14 @@ class LocationFilterTest {
     @Test
     void proxyStartsWithSlash() {
         final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(PROXY_KEY, "/service/api/v2");
+        this.filter.run();
+        assertEquals("/service/v2/path", ctx.get(REQUEST_URI_KEY));
+    }
+
+    @Test
+    void proxyStartsWithSlash_OldProxyFormat() {
+        final RequestContext ctx = RequestContext.getCurrentContext();
         ctx.set(PROXY_KEY, "/api/v2/service");
         this.filter.run();
         assertEquals("/service/v2/path", ctx.get(REQUEST_URI_KEY));
@@ -79,6 +95,14 @@ class LocationFilterTest {
 
     @Test
     void proxyEndsWithSlash() {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        ctx.set(PROXY_KEY, "service/api/v2/");
+        this.filter.run();
+        assertEquals("/service/v2/path", ctx.get(REQUEST_URI_KEY));
+    }
+
+    @Test
+    void proxyEndsWithSlash_OldProxyFormat() {
         final RequestContext ctx = RequestContext.getCurrentContext();
         ctx.set(PROXY_KEY, "api/v2/service/");
         this.filter.run();

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocatorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/routing/NewApimlRouteLocatorTest.java
@@ -18,7 +18,12 @@ import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import java.util.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
@@ -40,9 +45,9 @@ class NewApimlRouteLocatorTest {
     }
 
     @Test
-    void givenOneServiceWithMultipleRoutes_whenLocateRoutes_thenTwoRoutesLocated() {
+    void givenOneServiceWithMultipleRoutes_whenLocateRoutes_thenTwoRoutesLocatedWithBothPathFormats() {
         //given
-        Map<String,String> metadata = new HashMap<>();
+        Map<String, String> metadata = new HashMap<>();
         metadata.put(ROUTES + ".api-v1." + ROUTES_GATEWAY_URL, "api/v1");
         metadata.put(ROUTES + ".api-v1." + ROUTES_SERVICE_URL, "/");
 
@@ -51,8 +56,15 @@ class NewApimlRouteLocatorTest {
         expectedRoute.setPath("/api/v1/service/**");
         expectedRoute.setServiceId("service");
 
-        LinkedHashMap<String, ZuulProperties.ZuulRoute> expectedRoutesMap = new LinkedHashMap();
+        LinkedHashMap<String, ZuulProperties.ZuulRoute> expectedRoutesMap = new LinkedHashMap<>();
         expectedRoutesMap.put("/api/v1/service/**", expectedRoute);
+
+        expectedRoute = new ZuulProperties.ZuulRoute();
+        expectedRoute.setId("service/api/v1");
+        expectedRoute.setPath("/service/api/v1/**");
+        expectedRoute.setServiceId("service");
+
+        expectedRoutesMap.put("/service/api/v1/**", expectedRoute);
 
         metadata.put(ROUTES + ".ws-v1." + ROUTES_GATEWAY_URL, "ws/v1");
         metadata.put(ROUTES + ".ws-v1." + ROUTES_SERVICE_URL, "/");
@@ -63,6 +75,13 @@ class NewApimlRouteLocatorTest {
         expectedRoute.setServiceId("service");
 
         expectedRoutesMap.put("/ws/v1/service/**", expectedRoute);
+
+        expectedRoute = new ZuulProperties.ZuulRoute();
+        expectedRoute.setId("service/ws/v1");
+        expectedRoute.setPath("/service/ws/v1/**");
+        expectedRoute.setServiceId("service");
+
+        expectedRoutesMap.put("/service/ws/v1/**", expectedRoute);
 
         when(eurekaDiscoveryClient.getServices()).thenReturn(Collections.singletonList("service"));
         when(eurekaDiscoveryClient.getInstances("service")).thenReturn(
@@ -78,6 +97,6 @@ class NewApimlRouteLocatorTest {
         //when
         Map<String, ZuulProperties.ZuulRoute> zuulRouteMap = underTest.locateRoutes();
         //then
-        verify(routedServicesNotifier,times(1)).notifyAndFlush();
+        verify(routedServicesNotifier, times(1)).notifyAndFlush();
     }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/DownloadApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/DownloadApiIntegrationTest.java
@@ -29,7 +29,7 @@ public class DownloadApiIntegrationTest {
 
     @Test
     @TestsNotMeantForZowe
-    public void shouldSendGetRequestAndDownloadCompressedImage() {
+    void shouldSendGetRequestAndDownloadCompressedImage() {
         RestAssured.registerParser("image/png", Parser.JSON);
         URI uri = HttpRequestUtils.getUriFromGateway("/discoverableclient/api/v1/get-file");
         given().
@@ -46,7 +46,7 @@ public class DownloadApiIntegrationTest {
 
     @Test
     @TestsNotMeantForZowe
-    public void shouldSendGetRequestAndDownloadCompressedImage_OldPathFormat() {
+    void shouldSendGetRequestAndDownloadCompressedImage_OldPathFormat() {
         RestAssured.registerParser("image/png", Parser.JSON);
         URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/get-file");
         given().

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/DownloadApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/DownloadApiIntegrationTest.java
@@ -31,6 +31,23 @@ public class DownloadApiIntegrationTest {
     @TestsNotMeantForZowe
     public void shouldSendGetRequestAndDownloadCompressedImage() {
         RestAssured.registerParser("image/png", Parser.JSON);
+        URI uri = HttpRequestUtils.getUriFromGateway("/discoverableclient/api/v1/get-file");
+        given().
+            contentType("application/octet-stream").
+            accept("image/png").
+            when().
+            get(uri).
+            then().
+            statusCode(200).
+            header("Content-Disposition", "attachment;filename=api-catalog.png").
+            header("Content-Encoding", "gzip").
+            contentType("image/png");
+    }
+
+    @Test
+    @TestsNotMeantForZowe
+    public void shouldSendGetRequestAndDownloadCompressedImage_OldPathFormat() {
+        RestAssured.registerParser("image/png", Parser.JSON);
         URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/get-file");
         given().
             contentType("application/octet-stream").

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
@@ -26,6 +26,18 @@ public class GreetingApiIntegrationTest {
     @TestsNotMeantForZowe
     public void shouldCallDiscoverableServiceApi() throws Exception {
         // When
+        final HttpResponse response = HttpRequestUtils.getResponse("/discoverableclient/api/v1/greeting", SC_OK);
+        final String jsonResponse = EntityUtils.toString(response.getEntity());
+        DocumentContext jsonContext = JsonPath.parse(jsonResponse);
+        String content = jsonContext.read("$.content");
+
+        // Then
+        assertThat(content, equalTo("Hello, world!"));
+    }
+    @Test
+    @TestsNotMeantForZowe
+    public void shouldCallDiscoverableServiceApi_OldPathFormat() throws Exception {
+        // When
         final HttpResponse response = HttpRequestUtils.getResponse("/api/v1/discoverableclient/greeting", SC_OK);
         final String jsonResponse = EntityUtils.toString(response.getEntity());
         DocumentContext jsonContext = JsonPath.parse(jsonResponse);

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertThat;
 public class GreetingApiIntegrationTest {
     @Test
     @TestsNotMeantForZowe
-    public void shouldCallDiscoverableServiceApi() throws Exception {
+    void shouldCallDiscoverableServiceApi() throws Exception {
         // When
         final HttpResponse response = HttpRequestUtils.getResponse("/discoverableclient/api/v1/greeting", SC_OK);
         final String jsonResponse = EntityUtils.toString(response.getEntity());
@@ -36,7 +36,7 @@ public class GreetingApiIntegrationTest {
     }
     @Test
     @TestsNotMeantForZowe
-    public void shouldCallDiscoverableServiceApi_OldPathFormat() throws Exception {
+    void shouldCallDiscoverableServiceApi_OldPathFormat() throws Exception {
         // When
         final HttpResponse response = HttpRequestUtils.getResponse("/api/v1/discoverableclient/greeting", SC_OK);
         final String jsonResponse = EntityUtils.toString(response.getEntity());

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedApiMediationClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedApiMediationClientTest.java
@@ -25,7 +25,8 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
 class IntegratedApiMediationClientTest {
-    private static final URI MEDIATION_CLIENT_URI = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/apiMediationClient");
+    private static final URI MEDIATION_CLIENT_URI = HttpRequestUtils.getUriFromGateway("/discoverableclient/api/v1/apiMediationClient");
+    private static final URI MEDIATION_CLIENT_URI_OLD_FORMAT = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/apiMediationClient");
 
     @BeforeAll
     static void beforeClass() {
@@ -34,37 +35,58 @@ class IntegratedApiMediationClientTest {
 
     @Test
     void shouldBeUnregisteredBeforeRegistration() {
-        requestIsRegistered(false);
+        requestIsRegistered(false, MEDIATION_CLIENT_URI);
     }
 
     @Test
     @SlowTests
     void shouldBeRegisteredAfterRegistration() {
-        requestToRegister();
-        requestIsRegistered(true);
+        requestToRegister(MEDIATION_CLIENT_URI);
+        requestIsRegistered(true, MEDIATION_CLIENT_URI);
 
-        requestToUnregister();
+        requestToUnregister(MEDIATION_CLIENT_URI);
     }
 
     @Test
     @SlowTests
     void shouldNotBeRegisteredAfterUnregistration() {
-        requestToRegister();
-        requestToUnregister();
+        requestToRegister(MEDIATION_CLIENT_URI);
+        requestToUnregister(MEDIATION_CLIENT_URI);
     }
 
-    private void requestIsRegistered(boolean expectedRegistrationState) {
+    @Test
+    void shouldBeUnregisteredBeforeRegistration_OldPathFormat() {
+        requestIsRegistered(false, MEDIATION_CLIENT_URI_OLD_FORMAT);
+    }
+
+    @Test
+    @SlowTests
+    void shouldBeRegisteredAfterRegistration_OldPathFormat() {
+        requestToRegister(MEDIATION_CLIENT_URI_OLD_FORMAT);
+        requestIsRegistered(true, MEDIATION_CLIENT_URI_OLD_FORMAT);
+
+        requestToUnregister(MEDIATION_CLIENT_URI_OLD_FORMAT);
+    }
+
+    @Test
+    @SlowTests
+    void shouldNotBeRegisteredAfterUnregistration_OldPathFormat() {
+        requestToRegister(MEDIATION_CLIENT_URI_OLD_FORMAT);
+        requestToUnregister(MEDIATION_CLIENT_URI_OLD_FORMAT);
+    }
+
+    private void requestIsRegistered(boolean expectedRegistrationState, URI uri) {
         // It can take some time for (un)registration to complete
         await().atMost(5, MINUTES).pollDelay(0, SECONDS).pollInterval(1, SECONDS)
-            .until(() -> registeredStateAsExpected(expectedRegistrationState));
+            .until(() -> registeredStateAsExpected(expectedRegistrationState, uri));
     }
 
-    private boolean registeredStateAsExpected(boolean expectedRegistrationState) {
+    private boolean registeredStateAsExpected(boolean expectedRegistrationState, URI uri) {
         try {
             given()
-            .when()
-                .get(MEDIATION_CLIENT_URI)
-            .then()
+                .when()
+                .get(uri)
+                .then()
                 .statusCode(is(SC_OK))
                 .body("isRegistered", is(expectedRegistrationState));
             return true;
@@ -73,19 +95,19 @@ class IntegratedApiMediationClientTest {
         }
     }
 
-    private void requestToRegister() {
+    private void requestToRegister(URI uri) {
         given()
-        .when()
-            .post(MEDIATION_CLIENT_URI)
-        .then()
+            .when()
+            .post(uri)
+            .then()
             .statusCode(is(SC_OK));
     }
 
-    private void requestToUnregister() {
+    private void requestToUnregister(URI uri) {
         given()
-        .when()
-            .delete(MEDIATION_CLIENT_URI)
-        .then()
+            .when()
+            .delete(uri)
+            .then()
             .statusCode(is(SC_OK));
     }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -33,11 +33,13 @@ import static org.hamcrest.core.IsNot.not;
  */
 @TestsNotMeantForZowe
 class IntegratedZaasClientTest {
-
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
     private final static String INVALID_USERNAME = "incorrectUser";
     private final static String INVALID_PASSWORD = "incorrectPassword";
+
+    private final static URI ZAAS_CLIENT_URI = HttpRequestUtils.getUriFromGateway("/discoverableclient/api/v1/zaasClient");
+    private final static URI ZAAS_CLIENT_URI_OLD_FORMAT = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
 
     @BeforeEach
     public void setUp() {
@@ -51,14 +53,13 @@ class IntegratedZaasClientTest {
      */
     @Test
     void loginWithValidCredentials() {
-        URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
         LoginRequest loginRequest = new LoginRequest(USERNAME, PASSWORD);
 
         given()
             .contentType(JSON)
             .body(loginRequest)
             .when()
-            .post(uri)
+            .post(ZAAS_CLIENT_URI)
             .then()
             .statusCode(is(SC_OK))
             .body(not(isEmptyString()));
@@ -71,14 +72,41 @@ class IntegratedZaasClientTest {
      */
     @Test
     void invalidCredentials() {
-        URI uri = HttpRequestUtils.getUriFromGateway("/api/v1/discoverableclient/zaasClient");
         LoginRequest loginRequest = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
 
         given()
             .contentType(JSON)
             .body(loginRequest)
             .when()
-            .post(uri)
+            .post(ZAAS_CLIENT_URI)
+            .then()
+            .statusCode(is(SC_UNAUTHORIZED))
+            .body(is("Invalid username or password"));
+    }
+
+    @Test
+    void loginWithValidCredentials_OldPathFormat() {
+        LoginRequest loginRequest = new LoginRequest(USERNAME, PASSWORD);
+
+        given()
+            .contentType(JSON)
+            .body(loginRequest)
+            .when()
+            .post(ZAAS_CLIENT_URI_OLD_FORMAT)
+            .then()
+            .statusCode(is(SC_OK))
+            .body(not(isEmptyString()));
+    }
+
+    @Test
+    void invalidCredentials_OldPathFormat() {
+        LoginRequest loginRequest = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
+
+        given()
+            .contentType(JSON)
+            .body(loginRequest)
+            .when()
+            .post(ZAAS_CLIENT_URI_OLD_FORMAT)
             .then()
             .statusCode(is(SC_UNAUTHORIZED))
             .body(is("Invalid username or password"));

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/MultipartPutIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/MultipartPutIntegrationTest.java
@@ -24,7 +24,8 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 class MultipartPutIntegrationTest {
-    private static final String MULTIPART_PATH = "/api/v1/discoverableclient/multipart";
+    private static final String MULTIPART_PATH = "/discoverableclient/api/v1/multipart";
+    private static final String MULTIPART_PATH_OLD_FORMAT = "/api/v1/discoverableclient/multipart";
     private final String configFileName = "example.txt";
     private final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
 
@@ -63,6 +64,37 @@ class MultipartPutIntegrationTest {
             body("fileName", equalTo("example.txt")).
             body("fileType", equalTo("application/octet-stream")).
         when().
+            post(uri);
+    }
+    @Test
+    @TestsNotMeantForZowe
+    void shouldDoPutRequestAndMatchReturnBody_OldPathFormat() {
+        RestAssured.registerParser("text/plain", Parser.JSON);
+        URI uri = HttpRequestUtils.getUriFromGateway(MULTIPART_PATH_OLD_FORMAT);
+        given().
+            contentType("multipart/form-data").
+            multiPart(new File(classLoader.getResource(configFileName).getFile())).
+            expect().
+            statusCode(200).
+            body("fileName", equalTo("example.txt")).
+            body("fileType", equalTo("application/octet-stream")).
+            when().
+            put(uri);
+    }
+
+    @Test
+    @TestsNotMeantForZowe
+    void shouldDoPostRequestAndMatchReturnBody_OldPathFormat() {
+        RestAssured.registerParser("text/plain", Parser.JSON);
+        URI uri = HttpRequestUtils.getUriFromGateway(MULTIPART_PATH_OLD_FORMAT);
+        given().
+            contentType("multipart/form-data").
+            multiPart(new File(classLoader.getResource(configFileName).getFile())).
+            expect().
+            statusCode(200).
+            body("fileName", equalTo("example.txt")).
+            body("fileType", equalTo("application/octet-stream")).
+            when().
             post(uri);
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/RequestInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/RequestInfoIntegrationTest.java
@@ -42,7 +42,7 @@ public class RequestInfoIntegrationTest {
     }
 
     private static String getGatewayUrl() {
-        return HttpRequestUtils.getUriFromGateway("/api/v1/dcbypass/request").toString();
+        return HttpRequestUtils.getUriFromGateway("/dcbypass/api/v1/request").toString();
     }
 
     public static Stream<Arguments> getInputs() {

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/UiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/UiIntegrationTest.java
@@ -25,7 +25,7 @@ class UiIntegrationTest {
     @TestsNotMeantForZowe
     void shouldCallDiscoverableUiWithSlashAtPathEnd() throws Exception {
         // Given
-        HttpGet request = HttpRequestUtils.getRequest("/ui/v1/discoverableclient/");
+        HttpGet request = HttpRequestUtils.getRequest("/discoverableclient/ui/v1/");
 
         // When
         final HttpResponse response = HttpClientUtils.client().execute(request);
@@ -38,7 +38,7 @@ class UiIntegrationTest {
     @TestsNotMeantForZowe
     void shouldRedirectToDiscoverableUiWithoutSlashAtPathEnd() throws Exception {
         // Given
-        HttpGet request = HttpRequestUtils.getRequest("/ui/v1/discoverableclient");
+        HttpGet request = HttpRequestUtils.getRequest("/discoverableclient/ui/v1");
 
         // When
         final HttpResponse response = HttpClientUtils.client(true).execute(request);
@@ -47,4 +47,29 @@ class UiIntegrationTest {
         assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_MOVED_TEMPORARILY));
     }
 
+    @Test
+    @TestsNotMeantForZowe
+    void shouldCallDiscoverableUiWithSlashAtPathEnd_OldPathFormat() throws Exception {
+        // Given
+        HttpGet request = HttpRequestUtils.getRequest("/ui/v1/discoverableclient/");
+
+        // When
+        final HttpResponse response = HttpClientUtils.client().execute(request);
+
+        // Then
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
+    }
+
+    @Test
+    @TestsNotMeantForZowe
+    void shouldRedirectToDiscoverableUiWithoutSlashAtPathEnd_OldPathFormat() throws Exception {
+        // Given
+        HttpGet request = HttpRequestUtils.getRequest("/ui/v1/discoverableclient");
+
+        // When
+        final HttpResponse response = HttpClientUtils.client(true).execute(request);
+
+        // Then
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_MOVED_TEMPORARILY));
+    }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PageRedirectionTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PageRedirectionTest.java
@@ -60,11 +60,78 @@ class PageRedirectionTest {
     }
 
     /**
-     * Test api instance of staticclient
+     * Test api instance of staticclient in new path format of /{serviceId}/{typeOfService}/{version}
      */
     @Test
     @TestsNotMeantForZowe
     void apiRouteOfDiscoverableClient() {
+        String apiRelativeUrl = "/api/v1";
+        String location = String.format("%s://%s:%d%s%s%s", dcScheme, dcHost, dcPort, BASE_URL, apiRelativeUrl, "/greeting");
+        String transformedLocation = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, API_PREFIX, "/greeting");
+
+        RedirectLocation redirectLocation = new RedirectLocation(location);
+
+        given()
+            .contentType(JSON)
+            .body(redirectLocation)
+            .when()
+            .post(requestUrl)
+            .then()
+            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
+            .header(LOCATION, transformedLocation);
+    }
+
+    /**
+     * Test ws instance of staticclient in new path format of /{serviceId}/{typeOfService}/{version}
+     */
+    @Test
+    @TestsNotMeantForZowe
+    void wsRouteOfDiscoverableClient() {
+        String wsRelativeUrl = "/ws";
+        String location = String.format("%s://%s:%d%s%s", dcScheme, dcHost, dcPort, BASE_URL, wsRelativeUrl);
+        String wsPrefix = "/ws/v1";
+        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, wsPrefix);
+
+        RedirectLocation redirectLocation = new RedirectLocation(location);
+
+        given()
+            .contentType(JSON)
+            .body(redirectLocation)
+            .when()
+            .post(requestUrl)
+            .then()
+            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
+            .header(LOCATION, transformedLocation);
+    }
+
+    /**
+     * Test ui instance of staticclient in new path format of /{serviceId}/{typeOfService}/{version}
+     */
+    @Test
+    @TestsNotMeantForZowe
+    void uiRouteOfDiscoverableClient() {
+        String location = String.format("%s://%s:%d%s", dcScheme, dcHost, dcPort, BASE_URL);
+        String uiPrefix = "/ui/v1";
+        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, uiPrefix);
+
+        RedirectLocation redirectLocation = new RedirectLocation(location);
+
+        given()
+            .contentType(JSON)
+            .body(redirectLocation)
+            .when()
+            .post(requestUrl)
+            .then()
+            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
+            .header(LOCATION, transformedLocation);
+    }
+
+    /**
+     * Test api instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
+     */
+    @Test
+    @TestsNotMeantForZowe
+    void apiRouteOfDiscoverableClient_OldPathFormat() {
         String apiRelativeUrl = "/api/v1";
         String location = String.format("%s://%s:%d%s%s%s", dcScheme, dcHost, dcPort, BASE_URL, apiRelativeUrl, "/greeting");
         String transformedLocation = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, API_PREFIX, "/" + SERVICE_ID, "/greeting");
@@ -82,11 +149,11 @@ class PageRedirectionTest {
     }
 
     /**
-     * Test ws instance of staticclient
+     * Test ws instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
      */
     @Test
     @TestsNotMeantForZowe
-    void wsRouteOfDiscoverableClient() {
+    void wsRouteOfDiscoverableClient_OldPathFormat() {
         String wsRelativeUrl = "/ws";
         String location = String.format("%s://%s:%d%s%s", dcScheme, dcHost, dcPort, BASE_URL, wsRelativeUrl);
         String wsPrefix = "/ws/v1";
@@ -105,11 +172,11 @@ class PageRedirectionTest {
     }
 
     /**
-     * Test ui instance of staticclient
+     * Test ui instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
      */
     @Test
     @TestsNotMeantForZowe
-    void uiRouteOfDiscoverableClient() {
+    void uiRouteOfDiscoverableClient_OldPathFormat() {
         String location = String.format("%s://%s:%d%s", dcScheme, dcHost, dcPort, BASE_URL);
         String uiPrefix = "/ui/v1";
         String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, uiPrefix, "/" + SERVICE_ID);
@@ -179,7 +246,7 @@ class PageRedirectionTest {
     }
 
 
-    class RedirectLocation {
+    static class RedirectLocation {
 
         private String location;
 

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PageRedirectionTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PageRedirectionTest.java
@@ -44,7 +44,7 @@ class PageRedirectionTest {
     private final String EUREKA_APP = "/eureka/apps";
     private final String SERVICE_ID = "staticclient";
     private final String BASE_URL = "/discoverableclient";
-    private final String API_PREFIX = "/api/v1";
+    private final String API_POSTFIX = "/api/v1";
 
     private String gatewayScheme;
     private String gatewayHost;
@@ -67,7 +67,7 @@ class PageRedirectionTest {
     void apiRouteOfDiscoverableClient() {
         String apiRelativeUrl = "/api/v1";
         String location = String.format("%s://%s:%d%s%s%s", dcScheme, dcHost, dcPort, BASE_URL, apiRelativeUrl, "/greeting");
-        String transformedLocation = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, API_PREFIX, "/greeting");
+        String transformedLocation = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, API_POSTFIX, "/greeting");
 
         RedirectLocation redirectLocation = new RedirectLocation(location);
 
@@ -89,8 +89,8 @@ class PageRedirectionTest {
     void wsRouteOfDiscoverableClient() {
         String wsRelativeUrl = "/ws";
         String location = String.format("%s://%s:%d%s%s", dcScheme, dcHost, dcPort, BASE_URL, wsRelativeUrl);
-        String wsPrefix = "/ws/v1";
-        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, wsPrefix);
+        String wsPostfix = "/ws/v1";
+        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, wsPostfix);
 
         RedirectLocation redirectLocation = new RedirectLocation(location);
 
@@ -111,75 +111,8 @@ class PageRedirectionTest {
     @TestsNotMeantForZowe
     void uiRouteOfDiscoverableClient() {
         String location = String.format("%s://%s:%d%s", dcScheme, dcHost, dcPort, BASE_URL);
-        String uiPrefix = "/ui/v1";
-        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, uiPrefix);
-
-        RedirectLocation redirectLocation = new RedirectLocation(location);
-
-        given()
-            .contentType(JSON)
-            .body(redirectLocation)
-            .when()
-            .post(requestUrl)
-            .then()
-            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
-            .header(LOCATION, transformedLocation);
-    }
-
-    /**
-     * Test api instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
-     */
-    @Test
-    @TestsNotMeantForZowe
-    void apiRouteOfDiscoverableClient_OldPathFormat() {
-        String apiRelativeUrl = "/api/v1";
-        String location = String.format("%s://%s:%d%s%s%s", dcScheme, dcHost, dcPort, BASE_URL, apiRelativeUrl, "/greeting");
-        String transformedLocation = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, API_PREFIX, "/" + SERVICE_ID, "/greeting");
-
-        RedirectLocation redirectLocation = new RedirectLocation(location);
-
-        given()
-            .contentType(JSON)
-            .body(redirectLocation)
-            .when()
-            .post(requestUrl)
-            .then()
-            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
-            .header(LOCATION, transformedLocation);
-    }
-
-    /**
-     * Test ws instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
-     */
-    @Test
-    @TestsNotMeantForZowe
-    void wsRouteOfDiscoverableClient_OldPathFormat() {
-        String wsRelativeUrl = "/ws";
-        String location = String.format("%s://%s:%d%s%s", dcScheme, dcHost, dcPort, BASE_URL, wsRelativeUrl);
-        String wsPrefix = "/ws/v1";
-        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, wsPrefix, "/" + SERVICE_ID);
-
-        RedirectLocation redirectLocation = new RedirectLocation(location);
-
-        given()
-            .contentType(JSON)
-            .body(redirectLocation)
-            .when()
-            .post(requestUrl)
-            .then()
-            .statusCode(is(HttpStatus.TEMPORARY_REDIRECT.value()))
-            .header(LOCATION, transformedLocation);
-    }
-
-    /**
-     * Test ui instance of staticclient in old path format of /{typeOfService}/{version}/{serviceId}
-     */
-    @Test
-    @TestsNotMeantForZowe
-    void uiRouteOfDiscoverableClient_OldPathFormat() {
-        String location = String.format("%s://%s:%d%s", dcScheme, dcHost, dcPort, BASE_URL);
-        String uiPrefix = "/ui/v1";
-        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, uiPrefix, "/" + SERVICE_ID);
+        String uiPostfix = "/ui/v1";
+        String transformedLocation = String.format("%s://%s:%d%s%s", gatewayScheme, gatewayHost, gatewayPort, "/" + SERVICE_ID, uiPostfix);
 
         RedirectLocation redirectLocation = new RedirectLocation(location);
 
@@ -205,7 +138,7 @@ class PageRedirectionTest {
         RestAssured.port = gatewayPort;
         RestAssured.useRelaxedHTTPSValidation();
 
-        requestUrl = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, API_PREFIX, "/" + SERVICE_ID, "/redirect");
+        requestUrl = String.format("%s://%s:%d%s%s%s", gatewayScheme, gatewayHost, gatewayPort, API_POSTFIX, "/" + SERVICE_ID, "/redirect");
     }
 
     /**


### PR DESCRIPTION
# Description

Allows for paths with the pattern `https://gateway.zowe.org/{serviceId}/{typeOfService}/{version}/{pathOnTheService}`, in addition to the old pattern `https://gateway.zowe.org/{typeOfService/{version}/{serviceId}`.

Fixes #688 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
