### PR TITLE
Return Passticket related pen tests to the CICD pipeline

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/penetration/JwtPenTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/penetration/JwtPenTest.java
@@ -14,7 +14,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -71,12 +70,12 @@ class JwtPenTest {
 
     private static final String BASE_PATH = "/api/v1/gateway";
     private static final String QUERY_ENDPOINT = "/auth/query";
-    private static final String STATICCLIENT_BASE_PATH = "/api/v1/staticclient";
+    private static final String PASSTICKETCLIENT_BASE_PATH = "/api/v1/dcpassticket";
     private static final String PASSTICKET_TEST_ENDPOINT = "/passticketTest";
     private static final String PASSTICKET_ENDPOINT = "/auth/ticket";
 
     private static final String QUERY_ENDPOINT_URL = String.format("%s://%s:%d%s%s", SCHEME, HOST, PORT, BASE_PATH, QUERY_ENDPOINT);
-    private static final String PASSTICKET_ENDPOINT_URL = String.format("%s://%s:%d%s%s", SCHEME, HOST, PORT, STATICCLIENT_BASE_PATH, PASSTICKET_TEST_ENDPOINT);
+    private static final String PASSTICKET_ENDPOINT_URL = String.format("%s://%s:%d%s%s", SCHEME, HOST, PORT, PASSTICKETCLIENT_BASE_PATH, PASSTICKET_TEST_ENDPOINT);
     private static final String GATEWAY_ENDPOINT_URL = String.format("%s://%s:%d%s%s", SCHEME, HOST, PORT, BASE_PATH, PASSTICKET_ENDPOINT);
 
     private static String validToken;
@@ -185,7 +184,7 @@ class JwtPenTest {
 
     @ParameterizedTest(name = "call passticket service with {0} to receive response code {2}")
     @MethodSource("getTokens")
-    @Disabled("The controller testing PassTickets doesn't support Bearer with JWT token")
+    @TestsNotMeantForZowe
     void givenJwt_thenCheckResponse_whenCallPassTicketService(String tokenType, String token, int status) {
         //@formatter:off
         given()


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

Enable Passticket related pen tests. Not meant for Zowe is because it depends on the functionality of the Discoverable Client which isn't part of Zowe. 

Related to 692