### PR TITLE
Fix handling of zosmf sid

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
@@ -10,15 +10,15 @@
 package org.zowe.apiml.gateway.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
-import org.zowe.apiml.gateway.security.login.LoginProvider;
-import org.zowe.apiml.product.version.BuildInfo;
-import org.zowe.apiml.product.version.BuildInfoDetails;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.zowe.apiml.gateway.security.login.LoginProvider;
+import org.zowe.apiml.product.version.BuildInfo;
+import org.zowe.apiml.product.version.BuildInfoDetails;
+import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 
 import java.util.List;
 
@@ -146,7 +146,7 @@ public class GatewayHomepageController {
     private boolean authorizationServiceUp() {
         boolean authUp = true;
 
-        if (!authConfigurationProperties.getProvider().equalsIgnoreCase(LoginProvider.DUMMY.toString())) {
+        if (authConfigurationProperties.getProvider().equalsIgnoreCase(LoginProvider.ZOSMF.toString())) {
             authUp = !this.discoveryClient.getInstances(authConfigurationProperties.validatedZosmfServiceId()).isEmpty();
         }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/health/GatewayHealthIndicator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/health/GatewayHealthIndicator.java
@@ -9,9 +9,6 @@
  */
 package org.zowe.apiml.gateway.health;
 
-import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
-import org.zowe.apiml.gateway.security.login.LoginProvider;
-import org.zowe.apiml.product.constants.CoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -19,6 +16,9 @@ import org.springframework.boot.actuate.health.Status;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.stereotype.Component;
+import org.zowe.apiml.gateway.security.login.LoginProvider;
+import org.zowe.apiml.product.constants.CoreService;
+import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 
 import static org.springframework.boot.actuate.health.Status.DOWN;
 import static org.springframework.boot.actuate.health.Status.UP;
@@ -41,7 +41,7 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
         boolean discoveryUp = !this.discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId()).isEmpty();
 
         boolean authUp = true;
-        if (!authConfigurationProperties.getProvider().equalsIgnoreCase(LoginProvider.DUMMY.toString())) {
+        if (authConfigurationProperties.getProvider().equalsIgnoreCase(LoginProvider.ZOSMF.toString())) {
             try {
                 authUp = !this.discoveryClient.getInstances(authConfigurationProperties.validatedZosmfServiceId()).isEmpty();
             } catch (AuthenticationServiceException ex) {


### PR DESCRIPTION
as documented here: https://github.com/zowe/docs-site/pull/1371/files
`apiml.security.auth.zosmfServiceId=zosmf`
Gateway fails to start with AuthenticationServiceException.
This PR fixes so the check is performed only when started with ZOSMF auth provider