### PR TITLE
Remove flaky from the tests.

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.security.common.auth.Authentication;
 import org.zowe.apiml.security.common.auth.AuthenticationScheme;
+import org.zowe.apiml.util.categories.Flaky;
 import org.zowe.apiml.util.categories.NotForMainframeTest;
 import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.service.RequestVerifier;
@@ -188,6 +189,7 @@ public class AuthenticationOnDeploymentTest {
     }
 
     @Test
+    @Flaky
     @NotForMainframeTest
     void testServiceStatus() throws Exception {
 

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.security.common.auth.Authentication;
 import org.zowe.apiml.security.common.auth.AuthenticationScheme;
-import org.zowe.apiml.util.categories.Flaky;
 import org.zowe.apiml.util.categories.NotForMainframeTest;
 import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.service.RequestVerifier;
@@ -63,7 +62,6 @@ public class AuthenticationOnDeploymentTest {
     }
 
     @Test
-    @Flaky
     public void testMultipleAuthenticationSchemes() throws Exception {
         final String jwt = gatewayToken();
 
@@ -145,7 +143,6 @@ public class AuthenticationOnDeploymentTest {
     }
 
     @Test
-    @Flaky
     void testReregistration() throws Exception {
 
         try (
@@ -191,7 +188,6 @@ public class AuthenticationOnDeploymentTest {
     }
 
     @Test
-    @Flaky
     @NotForMainframeTest
     void testServiceStatus() throws Exception {
 


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

Return the tests to the standard CICD pipeline

Fixes # 692