### PR TITLE
Fix problem in error handling when no api-doc is available

### DIFF
--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
@@ -11,6 +11,7 @@ package org.zowe.apiml.apicatalog.services.cached;
 
 import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
 import org.zowe.apiml.apicatalog.services.status.APIDocRetrievalService;
+import org.zowe.apiml.apicatalog.services.status.model.ApiDocNotFoundException;
 import org.zowe.apiml.apicatalog.swagger.TransformApiDocService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,6 +20,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -38,7 +41,7 @@ public class CachedApiDocServiceTest {
     }
 
     @Test
-    public void testRetrievalOfApiDocWhenApiIsAvailable() {
+    public void givenValidApiDoc_whenRetrieving_thenReturnIt() {
         String serviceId = "Service";
         String version = "v1";
         String expectedApiDoc = "This is some api doc";
@@ -57,7 +60,7 @@ public class CachedApiDocServiceTest {
     }
 
     @Test
-    public void testUpdateOfApiDocForService() {
+    public void givenValidApiDoc_whenUpdating_thenRetrieve() {
         String serviceId = "Service";
         String version = "v1";
         String expectedApiDoc = "This is some api doc";
@@ -92,20 +95,13 @@ public class CachedApiDocServiceTest {
     }
 
     @Test
-    public void shouldReturnNullIfNotValidResponse() {
+    public void givenInvalidApiDoc_whenRetrieving_thenThrowException() {
         String serviceId = "Service";
         String version = "v1";
-        String expectedApiDoc = "This is some api doc";
 
-        ApiDocInfo apiDocInfo = new ApiDocInfo(null, null, null);
-
-        when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
-            .thenReturn(apiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
-            .thenReturn(expectedApiDoc);
-
-        String apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
-
-        Assert.assertNull(apiDoc);
+        Exception exception = assertThrows(ApiDocNotFoundException.class,
+            () -> cachedApiDocService.getApiDocForService(serviceId, version),
+        "Expected exception is not ApiDocNotFoundException");
+        assertEquals("No API Documentation was retrieved for the service Service.", exception.getMessage());
     }
 }


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

If the api doc was not retrieved for some reason and was null, a `200` HTTP status code was returned without any clear message. Instead now an API message is returned with `500` return code.
Fixes #571 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
