### PR TITLE
Improve performance of query endpoint and ZAAS client

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -295,7 +295,7 @@ public class AuthenticationService {
      * @throws TokenNotValidException if the token is not valid
      */
     public TokenAuthentication validateJwtToken(TokenAuthentication token) {
-        return validateJwtToken(Optional.ofNullable(token).map(TokenAuthentication::getCredentials).orElse(null));
+        return meAsProxy.validateJwtToken(Optional.ofNullable(token).map(TokenAuthentication::getCredentials).orElse(null));
     }
 
     /**

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/CloseableClientProvider.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.zaasclient.service.internal;
 
-import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 
@@ -21,14 +20,6 @@ interface CloseableClientProvider {
      * @throws ZaasConfigurationException Wrapper for errors in the crypto methods and IO based on the configuration.
      */
     CloseableHttpClient getHttpsClientWithTrustStore() throws ZaasConfigurationException;
-
-    /**
-     * Return Closeable Client with properly set up SSL using Trust store. The client also contain Cookie Store.
-     *
-     * @return Valid closeable client to be used.
-     * @throws ZaasConfigurationException Wrapper for errors in the crypto methods and IO based on the configuration.
-     */
-    CloseableHttpClient getHttpsClientWithTrustStore(BasicCookieStore cookieStore) throws ZaasConfigurationException;
 
     /**
      * Return Closeable Client with properly set up SSL using Trust store and properly set up private keys for

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceHttps.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceHttps.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 @Slf4j
 class PassTicketServiceHttps implements PassTicketService {
-    private static final String COOKIE_PREFIX = "apimlAuthenticationToken";
+    private static final String TOKEN_PREFIX = "apimlAuthenticationToken";
 
     private HttpsClientProvider httpsClientProvider;
     private final String ticketUrl;
@@ -50,7 +50,7 @@ class PassTicketServiceHttps implements PassTicketService {
             HttpPost httpPost = new HttpPost(ticketUrl);
             httpPost.setEntity(new StringEntity(mapper.writeValueAsString(zaasClientTicketRequest)));
             httpPost.setHeader("Content-type", "application/json");
-            httpPost.setHeader("Cookie", COOKIE_PREFIX + "=" + jwtToken);
+            httpPost.setHeader("Cookie", TOKEN_PREFIX + "=" + jwtToken);
 
             response = closeableHttpsClient.execute(httpPost);
             return extractPassTicket(response);
@@ -59,7 +59,7 @@ class PassTicketServiceHttps implements PassTicketService {
         } catch (Exception e) {
             throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
         } finally {
-            finallyClose(closeableHttpsClient, response);
+            finallyClose(response);
         }
     }
 
@@ -84,13 +84,10 @@ class PassTicketServiceHttps implements PassTicketService {
         }
     }
 
-    private void finallyClose(CloseableHttpClient client, CloseableHttpResponse response) {
+    private void finallyClose(CloseableHttpResponse response) {
         try {
             if (response != null) {
                 response.close();
-            }
-            if (client != null) {
-                client.close();
             }
         } catch (IOException e) {
             log.warn("It wasn't possible to close the resources. " + e.getMessage());

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttps.java
@@ -29,7 +29,7 @@ public class ZaasClientHttps implements ZaasClient {
             HttpsClientProvider provider = new HttpsClientProvider(configProperties);
             String baseUrl = String.format("https://%s:%s%s", configProperties.getApimlHost(), configProperties.getApimlPort(),
                 configProperties.getApimlBaseUrl());
-            tokens = new TokenServiceHttpsJwt(provider, baseUrl, configProperties.getApimlHost());
+            tokens = new TokenServiceHttpsJwt(provider, baseUrl);
             passTickets = new PassTicketServiceHttps(provider, baseUrl);
         } catch (ZaasConfigurationException e) {
             log.error(e.getErrorCode().toString());
@@ -82,6 +82,7 @@ public class ZaasClientHttps implements ZaasClient {
     }
 
     @Override
+    @SuppressWarnings("squid:S2147")
     public String passTicket(String jwtToken, String applicationId) throws ZaasClientException, ZaasConfigurationException {
         if (Objects.isNull(applicationId) || applicationId.isEmpty()) {
             throw new ZaasClientException(ZaasClientErrorCodes.APPLICATION_NAME_NOT_FOUND);

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttpsTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientHttpsTest.java
@@ -17,7 +17,6 @@ import org.apache.http.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,7 +93,7 @@ class ZaasClientHttpsTest {
         expiredToken = getToken(now, expirationForExpiredToken, jwtSecretKey);
         invalidToken = token + "DUMMY TEXT";
 
-        when(httpsClientProvider.getHttpsClientWithTrustStore(any(BasicCookieStore.class))).thenReturn(closeableHttpClient);
+        when(httpsClientProvider.getHttpsClientWithTrustStore()).thenReturn(closeableHttpClient);
         when(closeableHttpClient.execute(any(HttpGet.class))).thenReturn(closeableHttpResponse);
         when(closeableHttpClient.execute(any(HttpPost.class))).thenReturn(closeableHttpResponse);
         when(closeableHttpResponse.getEntity()).thenReturn(httpsEntity);
@@ -102,7 +101,7 @@ class ZaasClientHttpsTest {
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
 
         String baseUrl = "/api/v1/gateway/auth";
-        tokenService = new TokenServiceHttpsJwt(httpsClientProvider, baseUrl, "localhost");
+        tokenService = new TokenServiceHttpsJwt(httpsClientProvider, baseUrl);
         passTicketService = new PassTicketServiceHttps(httpsClientProvider, baseUrl);
     }
 


### PR DESCRIPTION
# Description

Improve performance of query endpoint and ZAAS client

The ZAAS client had query performance measured on SDK sample including ZAAS client around 700ms. With heavy load, we measured a performance degradation up to 10x (7s per request)

After the fix, with heavy load, the requests take around 300ms and do not scale with load

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
