### PR TITLE
Improve Gateway logout endpoint error handling

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.gateway.security.config;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.security.common.error.AuthenticationTokenException;
@@ -52,7 +53,9 @@ public class JWTLogoutHandler implements LogoutHandler {
         } else {
             try {
                 authenticationService.invalidateJwtToken(token, true);
-            } catch (TokenFormatNotValidException e) {
+            } catch (TokenNotValidException e) {
+                failure.onAuthenticationFailure(request, response, new TokenFormatNotValidException(e.getMessage()));
+            } catch (AuthenticationException e) {
                 failure.onAuthenticationFailure(request, response, e);
             } catch (Exception e) {
                 failure.onAuthenticationFailure(request, response, new AuthenticationTokenException("Error while logging out token"));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.security.common.error.AuthenticationTokenException;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
 import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotProvidedException;
@@ -53,6 +54,8 @@ public class JWTLogoutHandler implements LogoutHandler {
                 authenticationService.invalidateJwtToken(token, true);
             } catch (TokenFormatNotValidException e) {
                 failure.onAuthenticationFailure(request, response, e);
+            } catch (Exception e) {
+                failure.onAuthenticationFailure(request, response, new AuthenticationTokenException("Error while logging out token"));
             }
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
+import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotProvidedException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 
@@ -50,7 +51,7 @@ public class JWTLogoutHandler implements LogoutHandler {
         } else {
             try {
                 authenticationService.invalidateJwtToken(token, true);
-            } catch (TokenNotValidException e) {
+            } catch (TokenFormatNotValidException e) {
                 failure.onAuthenticationFailure(request, response, e);
             }
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandler.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
-import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotProvidedException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -136,7 +136,7 @@ public class AuthenticationService {
                 zosmfService.invalidate(JWT, jwtToken);
                 break;
             default:
-                throw new TokenNotValidException("Unknown token type.");
+                throw new TokenFormatNotValidException("Unknown token type.");
         }
 
         return Boolean.TRUE;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -189,7 +189,7 @@ public class AuthenticationService {
         }
 
         log.debug(TOKEN_IS_NOT_VALID_DUE_TO, exception.getMessage());
-        return new TokenNotValidException("An internal error occurred while validating the token therefor the token is no longer valid.");
+        return new TokenNotValidException("An internal error occurred while validating the token therefore the token is no longer valid.");
     }
 
     private Claims validateAndParseLocalJwtToken(String jwtToken) {
@@ -207,12 +207,12 @@ public class AuthenticationService {
     /**
      * Method validate if jwtToken is valid or not. This method contains two types of verification:
      * - Zowe
-     *   - it checks validity of signature
-     *   - it checks if token is not expired
-     *   - it checks if token was not removed (see logout)
+     * - it checks validity of signature
+     * - it checks if token is not expired
+     * - it checks if token was not removed (see logout)
      * - z/OSMF
-     *   - it uses validation via REST directly in z/OSMF
-     *
+     * - it uses validation via REST directly in z/OSMF
+     * <p>
      * Method uses cache to speedup validation. In case of invalidating jwtToken in z/OSMF without Zowe, method
      * can return still true until cache will expired or be evicted.
      *

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.*;
 class JWTLogoutHandlerTest {
     private static final String TOKEN = "apimlToken";
 
-    private ExpectedException expectedException = ExpectedException.none();
+    private final ExpectedException expectedException = ExpectedException.none();
 
     private AuthenticationService authenticationService;
 
@@ -91,5 +91,14 @@ class JWTLogoutHandlerTest {
         expectedException.expectMessage("The response cannot be written during the logout exception handler: msg");
 
         handler.logout(request, response, authentication);
+    }
+
+    @Test
+    void givenLogoutRequest_whenUnknownError_thenHandleFailure() throws ServletException {
+        when(authenticationService.invalidateJwtToken(TOKEN, true)).thenThrow(new RuntimeException("msg"));
+
+        handler.logout(request, response, authentication);
+
+        verify(failedAuthenticationHandler, times(1)).onAuthenticationFailure(any(), any(), any());
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
 import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
+import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -67,9 +68,17 @@ class JWTLogoutHandlerTest {
     }
 
     @Test
-    void givenInvalidToken_exceptionIsThrown_thenItsCorrectlyHandled() throws ServletException {
+    void givenInvalidToken_formatExceptionIsThrown_thenItsCorrectlyHandled() throws ServletException {
         when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
         when(authenticationService.invalidateJwtToken(TOKEN, true)).thenThrow(new TokenFormatNotValidException("msg"));
+        handler.logout(request, response, authentication);
+        verify(failedAuthenticationHandler, times(1)).onAuthenticationFailure(any(), any(), any());
+    }
+
+    @Test
+    void givenInvalidToken_validityExceptionIsThrown_thenItsCorrectlyHandled() throws ServletException {
+        when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
+        when(authenticationService.invalidateJwtToken(TOKEN, true)).thenThrow(new TokenNotValidException("msg"));
         handler.logout(request, response, authentication);
         verify(failedAuthenticationHandler, times(1)).onAuthenticationFailure(any(), any(), any());
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/JWTLogoutHandlerTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 import org.springframework.security.core.Authentication;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
-import org.zowe.apiml.security.common.token.TokenNotValidException;
+import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -69,7 +69,7 @@ class JWTLogoutHandlerTest {
     @Test
     void givenInvalidToken_exceptionIsThrown_thenItsCorrectlyHandled() throws ServletException {
         when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
-        when(authenticationService.invalidateJwtToken(TOKEN, true)).thenThrow(new TokenNotValidException("msg"));
+        when(authenticationService.invalidateJwtToken(TOKEN, true)).thenThrow(new TokenFormatNotValidException("msg"));
         handler.logout(request, response, authentication);
         verify(failedAuthenticationHandler, times(1)).onAuthenticationFailure(any(), any(), any());
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -481,9 +481,9 @@ public class AuthenticationServiceTest {
 
     @Test
     void testHandleJwtParserException() {
-        class AuthenticationServiceExceptionHanlderTest extends AuthenticationService {
+        class AuthenticationServiceExceptionHandlerTest extends AuthenticationService {
 
-            AuthenticationServiceExceptionHanlderTest() {
+            AuthenticationServiceExceptionHandlerTest() {
                 super(null, null, null, null, null, null, null, null);
             }
 
@@ -494,7 +494,7 @@ public class AuthenticationServiceTest {
 
         }
 
-        AuthenticationServiceExceptionHanlderTest as = new AuthenticationServiceExceptionHanlderTest();
+        AuthenticationServiceExceptionHandlerTest as = new AuthenticationServiceExceptionHandlerTest();
         Exception exception;
 
         exception = as.handleJwtParserException(new ExpiredJwtException(mock(Header.class), mock(Claims.class), "msg"));
@@ -507,7 +507,7 @@ public class AuthenticationServiceTest {
 
         exception = as.handleJwtParserException(new RuntimeException("msg"));
         assertTrue(exception instanceof TokenNotValidException);
-        assertEquals("An internal error occurred while validating the token therefor the token is no longer valid.", exception.getMessage());
+        assertEquals("An internal error occurred while validating the token therefore the token is no longer valid.", exception.getMessage());
     }
 
     @Test

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -117,8 +117,6 @@ class IntegratedZaasClientTest {
 
     @Test
     void givenValidToken_whenCallingLogoutOldPathFormat_thenSuccess() {
-        String token = "validToken";
-
         String jwt = generateToken();
 
         given()
@@ -128,7 +126,6 @@ class IntegratedZaasClientTest {
             .post(ZAAS_CLIENT_URI_OLD_FORMAT + LOGOUT)
             .then()
             .statusCode(is(SC_NO_CONTENT));
-
     }
 
     @Test
@@ -142,12 +139,10 @@ class IntegratedZaasClientTest {
             .post(ZAAS_CLIENT_URI + LOGOUT)
             .then()
             .statusCode(is(SC_NO_CONTENT));
-
     }
 
     @Test
     void givenInvalidToken_whenCallingLogoutOldPathFormat_thenFail() {
-
         given()
             .contentType(JSON)
             .cookie(COOKIE_NAME, "invalidToken")
@@ -159,7 +154,6 @@ class IntegratedZaasClientTest {
 
     @Test
     void givenInvalidToken_whenCallingLogout_thenFail() {
-
         given()
             .contentType(JSON)
             .cookie(COOKIE_NAME, "invalidToken")
@@ -171,7 +165,6 @@ class IntegratedZaasClientTest {
 
     @Test
     void givenNoTokenInHeader_whenCallingLogoutOldPathFormat_thenFail() {
-
         given()
             .contentType(JSON)
             .when()
@@ -182,13 +175,33 @@ class IntegratedZaasClientTest {
 
     @Test
     void givenNoTokenInHeader_whenCallingLogout_thenFail() {
-
         given()
             .contentType(JSON)
             .when()
             .post(ZAAS_CLIENT_URI + LOGOUT)
             .then()
             .statusCode(is(SC_INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void givenValidToken_whenCallLogoutTwice_thenSecondLogoutUnauthorized() {
+        String jwt = generateToken();
+
+        given()
+            .contentType(JSON)
+            .cookie(COOKIE_NAME, jwt)
+            .when()
+            .post(ZAAS_CLIENT_URI + LOGOUT)
+            .then()
+            .statusCode(is(SC_NO_CONTENT));
+
+        given()
+            .contentType(JSON)
+            .cookie(COOKIE_NAME, jwt)
+            .when()
+            .post(ZAAS_CLIENT_URI + LOGOUT)
+            .then()
+            .statusCode(is(SC_UNAUTHORIZED));
     }
 
     private String generateToken() {

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/DummyLogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/DummyLogoutTest.java
@@ -15,11 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.zowe.apiml.gatewayservice.SecurityUtils;
 import org.zowe.apiml.util.categories.AuthenticationTest;
 
-import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
-import static org.hamcrest.core.Is.is;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
-import static org.zowe.apiml.gatewayservice.SecurityUtils.logoutOnGateway;
 
 @AuthenticationTest
 class DummyLogoutTest extends LogoutTest {
@@ -46,23 +44,21 @@ class DummyLogoutTest extends LogoutTest {
         assertIfLogged(jwt1, true);
         assertIfLogged(jwt2, true);
 
-        given()
-            .cookie(COOKIE_NAME, jwt1)
-            .when()
-            .post(SecurityUtils.getGateWayUrl(LOGOUT_ENDPOINT))
-            .then()
-            .statusCode(is(SC_NO_CONTENT));
+        assertLogout(jwt1, SC_NO_CONTENT);
 
         assertIfLogged(jwt1, false);
         assertIfLogged(jwt2, true);
 
-        logout(jwt1);
         logout(jwt2);
     }
 
-    @Override
-    protected void logout(String jwtToken) {
-        logoutOnGateway(jwtToken);
-    }
+    @Test
+    void givenValidToken_whenLogoutCalledTwice_thenSecondCallUnauthorized() {
+        String jwt = generateToken();
 
+        assertIfLogged(jwt, true);
+
+        assertLogout(jwt, SC_NO_CONTENT);
+        assertLogout(jwt, SC_UNAUTHORIZED);
+    }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/LogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/LogoutTest.java
@@ -11,12 +11,15 @@ package org.zowe.apiml.gatewayservice.authentication;
 
 import io.restassured.RestAssured;
 import org.apache.http.HttpHeaders;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.zowe.apiml.gatewayservice.SecurityUtils;
 import org.zowe.apiml.util.categories.AuthenticationTest;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
 @AuthenticationTest
@@ -43,9 +46,9 @@ abstract class LogoutTest {
 
         given()
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
-        .when()
+            .when()
             .get(SecurityUtils.getGateWayUrl(QUERY_ENDPOINT))
-        .then()
+            .then()
             .statusCode(status.value());
     }
 
@@ -69,6 +72,15 @@ abstract class LogoutTest {
 
     protected void logout(String jwtToken) {
         SecurityUtils.logoutOnGateway(jwtToken);
+    }
+
+    protected void assertLogout(String jwtToken, int expectedStatusCode) {
+        given()
+            .cookie(COOKIE_NAME, jwtToken)
+            .when()
+            .post(SecurityUtils.getGateWayUrl(LOGOUT_ENDPOINT))
+            .then()
+            .statusCode(is(expectedStatusCode));
     }
 
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/SafLogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/SafLogoutTest.java
@@ -16,11 +16,9 @@ import org.zowe.apiml.gatewayservice.SecurityUtils;
 import org.zowe.apiml.util.categories.AuthenticationTest;
 import org.zowe.apiml.util.categories.MainframeDependentTests;
 
-import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
-import static org.hamcrest.core.Is.is;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
-import static org.zowe.apiml.gatewayservice.SecurityUtils.logoutOnGateway;
 
 @AuthenticationTest
 @MainframeDependentTests
@@ -44,23 +42,21 @@ class SafLogoutTest extends LogoutTest {
         assertIfLogged(jwt1, true);
         assertIfLogged(jwt2, true);
 
-        given()
-            .cookie(COOKIE_NAME, jwt1)
-            .when()
-            .post(SecurityUtils.getGateWayUrl(LOGOUT_ENDPOINT))
-            .then()
-            .statusCode(is(SC_NO_CONTENT));
+        assertLogout(jwt1, SC_NO_CONTENT);
 
         assertIfLogged(jwt1, false);
         assertIfLogged(jwt2, true);
 
-        logout(jwt1);
         logout(jwt2);
     }
 
-    @Override
-    protected void logout(String jwtToken) {
-        logoutOnGateway(jwtToken);
-    }
+    @Test
+    void givenValidToken_whenLogoutCalledTwice_thenSecondCallUnauthorized() {
+        String jwt = generateToken();
 
+        assertIfLogged(jwt, true);
+
+        assertLogout(jwt, SC_NO_CONTENT);
+        assertLogout(jwt, SC_UNAUTHORIZED);
+    }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfAuthenticationLoginIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfAuthenticationLoginIntegrationTest.java
@@ -85,7 +85,6 @@ class ZosmfAuthenticationLoginIntegrationTest extends Login {
         assertThat(jwtToken1, is((jwtToken2)));
 
         logout(jwtToken1);
-        logout(jwtToken2);
     }
 
     @Test

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
@@ -36,22 +36,6 @@ class ZosmfLogoutTest extends LogoutTest {
     }
 
     @Test
-    void givenTwoValidTokens_whenLogoutCalledOnFirstOne_thenSecondStillValid() {
-        String jwt1 = generateToken();
-        String jwt2 = generateToken();
-
-        assertIfLogged(jwt1, true);
-        assertIfLogged(jwt2, true);
-
-        assertLogout(jwt1, SC_NO_CONTENT);
-
-        assertIfLogged(jwt1, false);
-        assertIfLogged(jwt2, true);
-
-        logout(jwt2);
-    }
-
-    @Test
     void givenValidToken_whenLogoutCalledTwice_thenSecondCallUnauthorized() {
         String jwt = generateToken();
 

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
@@ -23,7 +23,7 @@ import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig
 @AuthenticationTest
 @SuppressWarnings({"squid:S2187"})
 @MainframeDependentTests
-public class ZosmfLogoutTest extends LogoutTest {
+class ZosmfLogoutTest extends LogoutTest {
     private static AuthenticationProviders providers = new AuthenticationProviders(SecurityUtils.getGateWayUrl("/authentication"));
 
     // Change to dummy and run the same test as for the zOSMF

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/authentication/ZosmfLogoutTest.java
@@ -11,10 +11,13 @@ package org.zowe.apiml.gatewayservice.authentication;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.zowe.apiml.gatewayservice.SecurityUtils;
 import org.zowe.apiml.util.categories.AuthenticationTest;
 import org.zowe.apiml.util.categories.MainframeDependentTests;
 
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
 @AuthenticationTest
@@ -32,4 +35,29 @@ public class ZosmfLogoutTest extends LogoutTest {
         providers.switchProvider("zosmf");
     }
 
+    @Test
+    void givenTwoValidTokens_whenLogoutCalledOnFirstOne_thenSecondStillValid() {
+        String jwt1 = generateToken();
+        String jwt2 = generateToken();
+
+        assertIfLogged(jwt1, true);
+        assertIfLogged(jwt2, true);
+
+        assertLogout(jwt1, SC_NO_CONTENT);
+
+        assertIfLogged(jwt1, false);
+        assertIfLogged(jwt2, true);
+
+        logout(jwt2);
+    }
+
+    @Test
+    void givenValidToken_whenLogoutCalledTwice_thenSecondCallUnauthorized() {
+        String jwt = generateToken();
+
+        assertIfLogged(jwt, true);
+
+        assertLogout(jwt, SC_NO_CONTENT);
+        assertLogout(jwt, SC_UNAUTHORIZED);
+    }
 }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
@@ -127,7 +127,7 @@ class ZaasJwtService implements TokenService {
         else {
             String obtainedMessage = EntityUtils.toString(clientWithResponse.getResponse().getEntity());
             if (httpResponseCode == 401) {
-                throw new ZaasClientException(ZaasClientErrorCodes.INVALID_AUTHENTICATION, obtainedMessage);
+                throw new ZaasClientException(ZaasClientErrorCodes.EXPIRED_JWT_EXCEPTION, obtainedMessage);
             } else {
                 throw new ZaasClientException(ZaasClientErrorCodes.INVALID_JWT_TOKEN, obtainedMessage);
             }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpsTests.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpsTests.java
@@ -374,7 +374,7 @@ class ZaasClientImplHttpsTests {
         when(closeableHttpResponse.getStatusLine().getStatusCode()).thenReturn(401);
         ZaasClientException exception = assertThrows(ZaasClientException.class, () -> tokenService.logout("token"));
 
-        assertTrue(exception.getMessage().contains("'ZWEAS120E', message='Invalid username or password'"));
+        assertTrue(exception.getMessage().contains("'ZWEAS100E', message='Token is expired for URL'"));
     }
 
     @Test


### PR DESCRIPTION
# Description

This introduces the two following behaviours for the Gateway logout endpoint:

- When a previously invalidated token is attempted to be invalidated (logged out) again, the Gateway now returns a 401 with explanation, rather than a 204 response.

- When a token is valid but an unknown error happens during logout, the Gateway now returns a generic 500 internal server error.

Fixes #831 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
