### PR TITLE
Fix fulfill JWT in request on ZaasClient.logout

### DIFF
--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
@@ -26,6 +26,8 @@ import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
 
+import javax.servlet.http.Cookie;
+
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -76,7 +78,7 @@ public class ZaasClientTestControllerTest {
         String token = "token";
         this.mockMvc.perform(
             post("/api/v1/zaasClient/logout")
-                .header("Cookie", TOKEN_PREFIX + "=" + token)
+                .cookie(new Cookie(TOKEN_PREFIX, token))
                 .contentType(MediaType.APPLICATION_JSON_UTF8))
             .andExpect(status().is(204));
     }

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -133,8 +133,6 @@ class IntegratedZaasClientTest {
 
     @Test
     void givenValidToken_whenCallingLogout_thenSuccess() {
-        String token = "validToken";
-
         String jwt = generateToken();
 
         given()

--- a/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
@@ -229,8 +229,7 @@ class ZaasClientIntegrationTest {
     @Test
     void givenValidTokenBut_whenLogoutIsCalled_thenSuccess() throws ZaasClientException {
         String token = tokenService.login(USERNAME, PASSWORD);
-        assertDoesNotThrow(() ->
-            tokenService.logout("apimlAuthenticationToken=" + token));
+        assertDoesNotThrow(() -> tokenService.logout(token));
     }
 
     @Test

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
@@ -107,7 +107,7 @@ class ZaasJwtService implements TokenService {
         if (jwtToken.startsWith("Bearer")) {
             httpPost.addHeader(HttpHeaders.AUTHORIZATION,jwtToken);
         } else {
-            httpPost.addHeader(SM.COOKIE, jwtToken);
+            httpPost.addHeader(SM.COOKIE, TOKEN_PREFIX + "=" + jwtToken);
         }
         return getClientWithResponse(client, httpPost);
     }
@@ -179,15 +179,11 @@ class ZaasJwtService implements TokenService {
     private void doRequest(Operation request) throws ZaasClientException {
         ClientWithResponse clientWithResponse = new ClientWithResponse();
         try {
-
             clientWithResponse = request.request();
-        } catch (ZaasClientException e) {
-            throw e;
-        }
-        catch (IOException | ZaasConfigurationException e) {
+        } catch (IOException | ZaasConfigurationException e) {
             throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
         } finally {
-        finallyClose(clientWithResponse.getResponse());
+            finallyClose(clientWithResponse.getResponse());
         }
     }
 

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtServiceTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtServiceTest.java
@@ -1,0 +1,83 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zaasclient.service.internal;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.cookie.SM;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZaasJwtServiceTest {
+
+    private static final String JWT_TOKEN = "jwtTokenTest";
+    private static final String HEADER_AUTHORIZATION = "Bearer " + JWT_TOKEN;
+
+    private static final String COOKIE_NAME = "apimlAuthenticationToken";
+    private static final String BASE_URL = "/api/v1";
+
+    @Mock
+    private CloseableHttpClient closeableHttpClient;
+
+    @Mock
+    private CloseableClientProvider closeableClientProvider;
+
+    private ZaasJwtService zaasJwtService;
+
+    @Before
+    public void setUp() throws ZaasConfigurationException, IOException {
+        doReturn(closeableHttpClient).when(closeableClientProvider).getHttpClient();
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        doReturn(new BasicStatusLine(mock(ProtocolVersion.class), 204, null))
+            .when(response).getStatusLine();
+        doReturn(response).when(closeableHttpClient).execute(any());
+        zaasJwtService = new ZaasJwtService(closeableClientProvider, BASE_URL);
+    }
+
+    @Test
+    public void givenJwtToken_whenLogout_thenSetCookie() throws ZaasClientException, IOException {
+        zaasJwtService.logout(JWT_TOKEN);
+        verify(closeableHttpClient, times(1)).execute(
+            argThat(x ->
+                (x.getHeaders(SM.COOKIE) != null) &&
+                (x.getHeaders(SM.COOKIE).length == 1) &&
+                (COOKIE_NAME + "=" + JWT_TOKEN).equals(x.getHeaders(SM.COOKIE)[0].getValue())
+            )
+        );
+    }
+
+    @Test
+    public void givenAuthorizationHeaderWithJwtToken_whenLogout_thenAuthorizationHeader()
+        throws ZaasClientException, IOException
+    {
+        zaasJwtService.logout(HEADER_AUTHORIZATION);
+        verify(closeableHttpClient, times(1)).execute(
+            argThat(x ->
+                (x.getHeaders(HttpHeaders.AUTHORIZATION) != null) &&
+                (x.getHeaders(HttpHeaders.AUTHORIZATION).length == 1) &&
+                HEADER_AUTHORIZATION.equals(x.getHeaders(HttpHeaders.AUTHORIZATION)[0].getValue())
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
# Description

ZAAS client offers method logout to users. This method supports two types of JWT's "format": pure JWT, as an Authorization header value. In the case of pure JWT it set a value in the cookie, in case of authorization header set the header. Unfortunately, the setting of the cookie contains a bug and it is not working.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
