### PR TITLE
Call ZSS with valid JWT token

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationMapper.java
@@ -12,5 +12,12 @@ import java.security.cert.X509Certificate;
 
 public interface X509AuthenticationMapper {
 
+    /**
+     * Get the information about the certificate and return mainframe user id if there is one associated with the provided
+     * certificate.
+     *
+     * @param certificate Certificate to map.
+     * @return Either valid user id or null.
+     */
     String mapCertificateToMainframeUserId(X509Certificate certificate);
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationProvider.java
@@ -12,16 +12,11 @@ package org.zowe.apiml.gateway.security.login.x509;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.zowe.apiml.gateway.security.login.Providers;
-import org.zowe.apiml.gateway.security.login.zosmf.ZosmfAuthenticationProvider;
-import org.zowe.apiml.gateway.security.service.AuthenticationService;
-import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
-import org.zowe.apiml.passticket.PassTicketService;
+import org.zowe.apiml.gateway.security.service.TokenCreationService;
 import org.zowe.apiml.security.common.error.AuthenticationTokenException;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
 import org.zowe.apiml.security.common.token.X509AuthenticationToken;
 
 import java.security.cert.X509Certificate;
@@ -30,19 +25,13 @@ import java.security.cert.X509Certificate;
 @RequiredArgsConstructor
 public class X509AuthenticationProvider implements AuthenticationProvider {
 
-    @Value("${apiml.security.zosmf.applid:IZUDFLT}")
-    private String zosmfApplId;
     @Value("${apiml.security.x509.enabled:false}")
     boolean isClientCertEnabled;
     @Value("${apiml.security.x509.useZss:false}")
     boolean useZss;
 
     private final X509AuthenticationMapper x509AuthenticationMapper;
-    private final AuthenticationService authenticationService;
-
-    private final PassTicketService passTicketService;
-    private final ZosmfAuthenticationProvider zosmfAuthenticationProvider;
-    private final Providers providers;
+    private final TokenCreationService tokenCreationService;
 
     /**
      * Performs Authentication of Client certificate
@@ -54,7 +43,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
      * If SAF or DUMMY auth providers are selected, they defer the decision to the mapping component.
      * For list of mapping components, see implementations of {@link X509AuthenticationMapper}
      *
-     * @param {@link Authentication}
+     * @param authentication {@link Authentication}
      * @return {@link Authentication}
      */
     @Override
@@ -67,24 +56,10 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
             if (username == null) {
                 return null;
             }
-            boolean isZosmfUsedAndAvailable = false;
-            try {
-                isZosmfUsedAndAvailable = providers.isZosfmUsed() && providers.isZosmfAvailable();
-            } catch (AuthenticationServiceException ex) {
-                // Intentionally do nothing. The issue is logged deeper.
-            }
-            if (isZosmfUsedAndAvailable) {
-                try {
-                    String passTicket = passTicketService.generate(username, zosmfApplId);
-                    return zosmfAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(username, passTicket));
-                } catch (IRRPassTicketGenerationException e) {
-                    throw new AuthenticationTokenException("Problem with generating PassTicket");
-                }
-            } else {
-                final String domain = "security-domain";
-                final String jwtToken = authenticationService.createJwtToken(username, domain, null);
-                return authenticationService.createTokenAuthentication(username, jwtToken);
-            }
+            String jwtToken = tokenCreationService.createJwtTokenWithoutCredentials(username);
+            Authentication tokenAuthentication = new TokenAuthentication(username, jwtToken);
+            tokenAuthentication.setAuthenticated(true);
+            return tokenAuthentication;
         } else {
             // This should never happen because of supports method which should fail.
             throw new AuthenticationTokenException("Wrong authentication token. " + authentication.getClass());
@@ -98,6 +73,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
 
     private String getUserid(Authentication authentication) {
         X509Certificate[] certs = (X509Certificate[]) authentication.getCredentials();
+
         return x509AuthenticationMapper.mapCertificateToMainframeUserId(certs[0]);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509ExternalMapper.java
@@ -71,7 +71,7 @@ public class X509ExternalMapper extends X509AbstractMapper {
                 HttpEntity httpEntity = new ByteArrayEntity(certificate.getEncoded());
                 httpPost.setEntity(httpEntity);
 
-                httpPost.setHeader(new BasicHeader("Cookie", jwtToken));
+                httpPost.setHeader(new BasicHeader("Cookie", "apimlAuthenticationToken=" + jwtToken));
 
                 HttpResponse httpResponse = httpClientProxy.execute(httpPost);
                 String response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/x509/X509ExternalMapper.java
@@ -17,11 +17,13 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.gateway.security.login.x509.model.CertMapperResponse;
+import org.zowe.apiml.gateway.security.service.TokenCreationService;
 
 import java.io.IOException;
 import java.net.URI;
@@ -43,15 +45,18 @@ import java.security.cert.X509Certificate;
 public class X509ExternalMapper extends X509AbstractMapper {
 
     private final CloseableHttpClient httpClientProxy;
+    private final TokenCreationService tokenCreationService;
 
     @Value("${apiml.security.x509.externalMapperUrl}")
     private String externalMapperUrl;
+    @Value("${apiml.security.x509.externalMapperUser}")
+    private String externalMapperUser;
 
     /**
-     * Maps certificate to the mainframe user id
+     * Maps certificate to the mainframe user id.
      *
-     * @param certificate
-     * @return the user
+     * @param certificate Certificate to get mapping for.
+     * @return the user id or null if there is either no mapping or problem with certificate
      * @throws URISyntaxException           if the certificate mapping URL is wrong
      * @throws CertificateEncodingException when it cannot get encoded data from certificate
      * @throws IOException                  if not able to send certificate to the mapper
@@ -60,9 +65,14 @@ public class X509ExternalMapper extends X509AbstractMapper {
     public String mapCertificateToMainframeUserId(X509Certificate certificate) {
         if (isClientAuthCertificate(certificate)) {
             try {
+                String jwtToken = tokenCreationService.createJwtTokenWithoutCredentials(externalMapperUser);
+
                 HttpPost httpPost = new HttpPost(new URI(externalMapperUrl));
                 HttpEntity httpEntity = new ByteArrayEntity(certificate.getEncoded());
                 httpPost.setEntity(httpEntity);
+
+                httpPost.setHeader(new BasicHeader("Cookie", jwtToken));
+
                 HttpResponse httpResponse = httpClientProxy.execute(httpPost);
                 String response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
                 if (response == null || response.isEmpty()) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/TokenCreationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/TokenCreationService.java
@@ -1,0 +1,64 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.zowe.apiml.gateway.security.login.Providers;
+import org.zowe.apiml.gateway.security.login.zosmf.ZosmfAuthenticationProvider;
+import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
+import org.zowe.apiml.passticket.PassTicketService;
+import org.zowe.apiml.security.common.error.AuthenticationTokenException;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
+
+@RequiredArgsConstructor
+@Service
+public class TokenCreationService {
+    private final Providers providers;
+    private final ZosmfAuthenticationProvider zosmfAuthenticationProvider;
+    private final PassTicketService passTicketService;
+    private final AuthenticationService authenticationService;
+
+    @Value("${apiml.security.zosmf.applid:IZUDFLT}")
+    protected String zosmfApplId;
+
+    /**
+     * Creates valid JWT token without using any credentials. The token will be valid for zOSMF as well as for southbound
+     * services
+     *
+     * @param user Username to create the JWT token for.
+     * @return Valid JWT token or null
+     */
+    public String createJwtTokenWithoutCredentials(String user) {
+        boolean isZosmfUsedAndAvailable = false;
+        try {
+            isZosmfUsedAndAvailable = providers.isZosfmUsed() && providers.isZosmfAvailable();
+        } catch (AuthenticationServiceException ex) {
+            // Intentionally do nothing. The issue is logged deeper.
+        }
+
+        if (isZosmfUsedAndAvailable) {
+            try {
+                String passTicket = passTicketService.generate(user, zosmfApplId);
+                return ((TokenAuthentication) zosmfAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(user, passTicket)))
+                    .getCredentials();
+            } catch (IRRPassTicketGenerationException e) {
+                throw new AuthenticationTokenException("Problem with generating PassTicket");
+            }
+        } else {
+            final String domain = "security-domain";
+            final String jwtTokenString = authenticationService.createJwtToken(user, domain, null);
+            return authenticationService.createTokenAuthentication(user, jwtTokenString).getCredentials();
+        }
+    }
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/x509/X509AuthenticationProviderTest.java
@@ -11,16 +11,9 @@ package org.zowe.apiml.gateway.security.login.x509;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
-import org.zowe.apiml.gateway.security.login.Providers;
-import org.zowe.apiml.gateway.security.login.zosmf.ZosmfAuthenticationProvider;
-import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.gateway.security.service.TokenCreationService;
 import org.zowe.apiml.gateway.utils.X509Utils;
-import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
-import org.zowe.apiml.passticket.PassTicketService;
-import org.zowe.apiml.security.common.error.AuthenticationTokenException;
-import org.zowe.apiml.security.common.token.TokenAuthentication;
 import org.zowe.apiml.security.common.token.X509AuthenticationToken;
 
 import java.security.cert.X509Certificate;
@@ -28,20 +21,16 @@ import java.security.cert.X509Certificate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class X509AuthenticationProviderTest {
 
     private X509AuthenticationMapper x509AuthenticationMapper;
-    private AuthenticationService authenticationService;
+    private TokenCreationService tokenCreationService;
     private X509AuthenticationProvider x509AuthenticationProvider;
-
-    private PassTicketService passTicketService;
-    private ZosmfAuthenticationProvider zosmfAuthenticationProvider;
-    private Providers providers;
 
     private X509Certificate[] x509Certificate = new X509Certificate[]{
         X509Utils.getCertificate(X509Utils.correctBase64("zowe"), "CN=user"),
@@ -50,40 +39,9 @@ class X509AuthenticationProviderTest {
     @BeforeEach
     void setUp() {
         x509AuthenticationMapper = mock(X509AuthenticationMapper.class);
-        authenticationService = mock(AuthenticationService.class);
-        passTicketService = mock(PassTicketService.class);
-        zosmfAuthenticationProvider = mock(ZosmfAuthenticationProvider.class);
-        providers = mock(Providers.class);
-        when(authenticationService.createJwtToken("user", "security-domain", null)).thenReturn("jwt");
-        when(authenticationService.createTokenAuthentication("user", "jwt")).thenReturn(new TokenAuthentication("user", "jwt"));
-        x509AuthenticationProvider = new X509AuthenticationProvider(x509AuthenticationMapper
-            , authenticationService, passTicketService, zosmfAuthenticationProvider, providers);
+        tokenCreationService = mock(TokenCreationService.class);
+        x509AuthenticationProvider = new X509AuthenticationProvider(x509AuthenticationMapper, tokenCreationService);
         x509AuthenticationProvider.isClientCertEnabled = true;
-    }
-
-    @Test
-    void givenZosmfIsntPresent_whenProvidedCertificate_shouldReturnToken() {
-        when(providers.isZosmfAvailable()).thenReturn(false);
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn("user");
-        TokenAuthentication token = (TokenAuthentication) x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate));
-        assertEquals("jwt", token.getCredentials());
-    }
-
-    @Test
-    void givenZosmfIsntPresentBecauseOfError_whenProvidedCertificate_shouldReturnToken() {
-        when(providers.isZosmfAvailable()).thenThrow(new AuthenticationServiceException("zOSMF id invalid"));
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn("user");
-        TokenAuthentication token = (TokenAuthentication) x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate));
-        assertEquals("jwt", token.getCredentials());
-    }
-
-    @Test
-    void givenZosmfIsntPresent_whenWrongTokenProvided_ThrowException() {
-        when(providers.isZosmfAvailable()).thenReturn(false);
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn("user");
-        TokenAuthentication token = new TokenAuthentication("user", "user");
-        AuthenticationTokenException exception = assertThrows(AuthenticationTokenException.class, () -> x509AuthenticationProvider.authenticate(token));
-        assertEquals("Wrong authentication token. " + TokenAuthentication.class, exception.getMessage());
     }
 
     @Test
@@ -92,52 +50,28 @@ class X509AuthenticationProviderTest {
     }
 
     @Test
-    void givenZosmfIsntPresent_givenZosmfIsntPresent_whenCommonNameIsNotCorrect_returnNull() {
-        when(providers.isZosmfAvailable()).thenReturn(false);
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn("wrong username");
-        assertNull(x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate)));
-    }
-
-    @Test
     void givenX509AuthIsDisabled_whenRequested_thenNullIsReturned() {
         x509AuthenticationProvider.isClientCertEnabled = false;
         assertNull(x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate)));
     }
 
-    @Test
-    void givenZosmfIsPresent_whenValidCertificateAndPassTicketGenerate_returnZosmfJwtToken() throws IRRPassTicketGenerationException {
-        String validUsername = "validUsername";
-        String validZosmfApplId = "IZUDFLT";
-
-        when(providers.isZosmfAvailable()).thenReturn(true);
-        when(providers.isZosfmUsed()).thenReturn(true);
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn(validUsername);
-        when(passTicketService.generate(validUsername, validZosmfApplId)).thenReturn("validPassticket");
-        Authentication authentication = new TokenAuthentication(validUsername, "validJwtToken");
-        authentication.setAuthenticated(true);
-        when(zosmfAuthenticationProvider.authenticate(any())).thenReturn(authentication);
-
-        Authentication result = x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate));
-        assertThat(result.isAuthenticated(), is(true));
-    }
-
-    @Test
-    void givenZosmfIPresent_whenPassTicketGeneratesException_thenThrowAuthenticationException() throws IRRPassTicketGenerationException {
-        String validUsername = "validUsername";
-
-        when(providers.isZosmfAvailable()).thenReturn(true);
-        when(providers.isZosfmUsed()).thenReturn(true);
-        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn(validUsername);
-        when(passTicketService.generate(validUsername, null)).thenThrow(new IRRPassTicketGenerationException(8, 8, 8));
-
-        X509AuthenticationToken token = new X509AuthenticationToken(x509Certificate);
-        assertThrows(AuthenticationTokenException.class, () -> x509AuthenticationProvider.authenticate(token));
-    }
 
     @Test
     void givenCertificateIsntMappedToUser_whenAuthenticationIsRequired_thenNullIsReturned() {
         when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn(null);
         Authentication result = x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate));
         assertThat(result, is(nullValue()));
+    }
+
+
+    @Test
+    void givenZosmfIsPresent_whenValidCertificateAndPassTicketGenerate_returnZosmfJwtToken() {
+        String validUsername = "validUsername";
+
+        when(x509AuthenticationMapper.mapCertificateToMainframeUserId(x509Certificate[0])).thenReturn(validUsername);
+        when(tokenCreationService.createJwtTokenWithoutCredentials(validUsername)).thenReturn("validJwtToken");
+
+        Authentication result = x509AuthenticationProvider.authenticate(new X509AuthenticationToken(x509Certificate));
+        assertThat(result.isAuthenticated(), is(true));
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/TokenCreationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/TokenCreationServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.zowe.apiml.gateway.security.login.Providers;
+import org.zowe.apiml.gateway.security.login.zosmf.ZosmfAuthenticationProvider;
+import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
+import org.zowe.apiml.passticket.PassTicketService;
+import org.zowe.apiml.security.common.error.AuthenticationTokenException;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TokenCreationServiceTest {
+    private TokenCreationService underTest;
+
+    private PassTicketService passTicketService;
+    private ZosmfAuthenticationProvider zosmfAuthenticationProvider;
+    private Providers providers;
+    private AuthenticationService authenticationService;
+
+    private final String VALID_USER_ID = "validUserId";
+    private final String VALID_ZOSMF_TOKEN = "validZosmfToken";
+    private final String VALID_APIML_TOKEN = "validApimlToken";
+    private final String VALID_ZOSMF_APPLID = "IZUDFLT";
+
+    @BeforeEach
+    void setUp() {
+        passTicketService = mock(PassTicketService.class);
+        zosmfAuthenticationProvider = mock(ZosmfAuthenticationProvider.class);
+        providers = mock(Providers.class);
+        authenticationService = mock(AuthenticationService.class);
+
+        underTest = new TokenCreationService(providers, zosmfAuthenticationProvider, passTicketService, authenticationService);
+        underTest.zosmfApplId = "IZUDFLT";
+    }
+
+    @Test
+    void givenZosmfIsUnavailable_whenTokenIsRequested_thenTokenCreatedByApiMlIsReturned() {
+        when(providers.isZosmfAvailable()).thenReturn(false);
+        when(authenticationService.createJwtToken(eq(VALID_USER_ID), any(), any())).thenReturn(VALID_APIML_TOKEN);
+        when(authenticationService.createTokenAuthentication(VALID_USER_ID, VALID_APIML_TOKEN)).thenReturn(new TokenAuthentication(VALID_USER_ID, VALID_APIML_TOKEN));
+
+        String jwtToken = underTest.createJwtTokenWithoutCredentials(VALID_USER_ID);
+        assertThat(jwtToken, is(VALID_APIML_TOKEN));
+    }
+
+    @Test
+    void givenZosmfIsntPresentBecauseOfError_whenTokenIsRequested_shouldReturnTokenCreatedByApiMl() {
+        when(providers.isZosmfAvailable()).thenThrow(new AuthenticationServiceException("zOSMF id invalid"));
+        when(authenticationService.createJwtToken(eq(VALID_USER_ID), any(), any())).thenReturn(VALID_APIML_TOKEN);
+        when(authenticationService.createTokenAuthentication(VALID_USER_ID, VALID_APIML_TOKEN)).thenReturn(new TokenAuthentication(VALID_USER_ID, VALID_APIML_TOKEN));
+
+        String jwtToken = underTest.createJwtTokenWithoutCredentials(VALID_USER_ID);
+        assertThat(jwtToken, is(VALID_APIML_TOKEN));
+    }
+
+    @Test
+    void givenZosmfIsAvailable_whenTokenIsRequested_thenTokenCreatedByZosmfIsReturned() throws IRRPassTicketGenerationException {
+        when(providers.isZosmfAvailable()).thenReturn(true);
+        when(providers.isZosfmUsed()).thenReturn(true);
+        when(passTicketService.generate(VALID_USER_ID, VALID_ZOSMF_APPLID)).thenReturn("validPassticket");
+        when(zosmfAuthenticationProvider.authenticate(any())).thenReturn(new TokenAuthentication(VALID_USER_ID, VALID_ZOSMF_TOKEN));
+
+        String jwtToken = underTest.createJwtTokenWithoutCredentials(VALID_USER_ID);
+        assertThat(jwtToken, is(VALID_ZOSMF_TOKEN));
+    }
+
+    @Test
+    void givenZosmfIsAvailableButPassticketGenerationFails_whenTokenIsRequested_thenExceptionIsThrown() throws IRRPassTicketGenerationException {
+        when(providers.isZosmfAvailable()).thenReturn(true);
+        when(providers.isZosfmUsed()).thenReturn(true);
+        when(passTicketService.generate(VALID_USER_ID, VALID_ZOSMF_APPLID)).thenThrow(new IRRPassTicketGenerationException(4, 4, 4));
+
+        assertThrows(AuthenticationTokenException.class,
+            () -> underTest.createJwtTokenWithoutCredentials(VALID_USER_ID)
+        );
+    }
+}

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -31,6 +31,7 @@ apiml:
             verifySslCertificatesOfServices: true
         x509:
             externalMapperUrl: http://localhost:8542/certificate/x509/map
+            externalMapperUser: validUserForMap
         auth:
             provider: dummy
             zosmfServiceId: zosmf  # Replace me with the correct z/OSMF service id


### PR DESCRIPTION
Add JWT token to the call to the ZSS
Extract the JWT token creation without credentials to the separate class.

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

ZSS API providing the mapping functionality for certificate is secured by JWT token in the same way as Single Sign On. 

Linked to #827 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
