### PR TITLE
Consistent path pattern in API Catalog

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGenerator.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGenerator.java
@@ -36,8 +36,8 @@ public class SubstituteSwaggerGenerator {
                                                       String gatewayScheme, String gatewayHost) {
         String title = service.getMetadata().get(SERVICE_TITLE);
         String description = service.getMetadata().get(SERVICE_DESCRIPTION);
-        String basePath = (api.getGatewayUrl().startsWith("/") ? "" : "/") + api.getGatewayUrl()
-            + (api.getGatewayUrl().endsWith("/") ? "" : "/") + service.getAppName().toLowerCase();
+        String basePath = (api.getGatewayUrl().startsWith("/") ? "" : "/") + service.getAppName().toLowerCase()
+            + (api.getGatewayUrl().endsWith("/") ? "" : "/") + api.getGatewayUrl();
 
         Template t = ve.getTemplate("substitute_swagger.json");
         VelocityContext context = new VelocityContext();

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocService.java
@@ -9,14 +9,14 @@
  */
 package org.zowe.apiml.apicatalog.swagger.api;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
 import org.zowe.apiml.config.ApiInfo;
 import org.zowe.apiml.product.gateway.GatewayClient;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.ServiceType;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -86,7 +86,7 @@ public abstract class AbstractApiDocService<T, N> {
             return Pair.of(endPoint, endPoint);
         } else {
             String updatedShortEndPoint = getShortEndPoint(route.getServiceUrl(), endPoint);
-            String updatedLongEndPoint = OpenApiUtil.SEPARATOR + route.getGatewayUrl() + OpenApiUtil.SEPARATOR + serviceId + updatedShortEndPoint;
+            String updatedLongEndPoint = OpenApiUtil.SEPARATOR + serviceId + OpenApiUtil.SEPARATOR + route.getGatewayUrl() + updatedShortEndPoint;
 
             return Pair.of(updatedShortEndPoint, updatedLongEndPoint);
         }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
@@ -9,10 +9,6 @@
  */
 package org.zowe.apiml.apicatalog.swagger.api;
 
-import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
-import org.zowe.apiml.apicatalog.swagger.ApiDocTransformationException;
-import org.zowe.apiml.product.gateway.GatewayClient;
-import org.zowe.apiml.product.gateway.GatewayConfigProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.models.ExternalDocs;
 import io.swagger.models.Path;
@@ -20,10 +16,15 @@ import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
 import io.swagger.util.Json;
 import lombok.extern.slf4j.Slf4j;
+import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
+import org.zowe.apiml.apicatalog.swagger.ApiDocTransformationException;
+import org.zowe.apiml.product.gateway.GatewayClient;
+import org.zowe.apiml.product.gateway.GatewayConfigProperties;
 
 import javax.validation.UnexpectedTypeException;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
 
 @Slf4j
 public class ApiDocV2Service extends AbstractApiDocService<Swagger, Path> {
@@ -94,7 +95,7 @@ public class ApiDocV2Service extends AbstractApiDocService<Swagger, Path> {
 
         Map<String, Path> updatedPaths;
         if (apiDocPath.getPrefixes().size() == 1) {
-            swagger.setBasePath(OpenApiUtil.SEPARATOR + apiDocPath.getPrefixes().iterator().next() + OpenApiUtil.SEPARATOR + serviceId);
+            swagger.setBasePath(OpenApiUtil.getBasePath(serviceId, apiDocPath));
             updatedPaths = apiDocPath.getShortPaths();
         } else {
             swagger.setBasePath("");

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -108,10 +108,10 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
 
         Map<String, PathItem> updatedPaths;
         if (apiDocPath.getPrefixes().size() == 1) {
-            updateServerUrl(openAPI, server, apiDocPath.getPrefixes().iterator().next() + OpenApiUtil.SEPARATOR + serviceId);
+            updateServerUrl(openAPI, server, OpenApiUtil.getBasePath(serviceId, apiDocPath));
             updatedPaths = apiDocPath.getShortPaths();
         } else {
-            updateServerUrl(openAPI, server, "");
+            updateServerUrl(openAPI, server, "/");
             updatedPaths = apiDocPath.getLongPaths();
         }
 
@@ -142,7 +142,7 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
             URI uri = new URI(serverUrl);
             basePath = uri.getPath();
         } catch (Exception e) {
-            log.debug("serverUrl is not parsable");
+            log.debug("serverUrl is not parse-able");
         }
         return basePath;
     }
@@ -169,7 +169,7 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
 
     private void updateServerUrl(OpenAPI openAPI, Server server, String basePath) {
         if (server != null) {
-            server.setUrl(basePath);
+            server.setUrl(basePath.startsWith("/") ? basePath.substring(1) : basePath); // server expects no / at start of url
             openAPI.setServers(Collections.singletonList(server));
         } else {
             openAPI.addServersItem(new Server().url(basePath));

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/OpenApiUtil.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/OpenApiUtil.java
@@ -9,9 +9,9 @@
  */
 package org.zowe.apiml.apicatalog.swagger.api;
 
+import lombok.experimental.UtilityClass;
 import org.zowe.apiml.product.constants.CoreService;
 import org.zowe.apiml.product.gateway.GatewayConfigProperties;
-import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class OpenApiUtil {
@@ -23,8 +23,9 @@ public class OpenApiUtil {
     public static final String SEPARATOR = "/";
 
     public static String getOpenApiLink(String serviceId, GatewayConfigProperties gatewayConfigProperties) {
-        String link = gatewayConfigProperties.getScheme() + "://" + gatewayConfigProperties.getHostname() + CATALOG_VERSION + SEPARATOR + CoreService.API_CATALOG.getServiceId() +
-            CATALOG_APIDOC_ENDPOINT + SEPARATOR + serviceId + HARDCODED_VERSION;
-        return  "\n\n" + SWAGGER_LOCATION_LINK + "(" + link + ")";
+        String link = gatewayConfigProperties.getScheme() + "://" + gatewayConfigProperties.getHostname()
+            + SEPARATOR + CoreService.API_CATALOG.getServiceId() + CATALOG_VERSION
+            + CATALOG_APIDOC_ENDPOINT + SEPARATOR + serviceId + HARDCODED_VERSION;
+        return "\n\n" + SWAGGER_LOCATION_LINK + "(" + link + ")";
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/OpenApiUtil.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/OpenApiUtil.java
@@ -28,4 +28,8 @@ public class OpenApiUtil {
             + CATALOG_APIDOC_ENDPOINT + SEPARATOR + serviceId + HARDCODED_VERSION;
         return "\n\n" + SWAGGER_LOCATION_LINK + "(" + link + ")";
     }
+
+    public static String getBasePath(String serviceId, ApiDocPath<?> apiDocPath) {
+        return SEPARATOR + serviceId + SEPARATOR + apiDocPath.getPrefixes().iterator().next();
+    }
 }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/LocalApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/LocalApiDocServiceTest.java
@@ -186,7 +186,7 @@ public class LocalApiDocServiceTest {
             "      , \"version\": \"1.0.0\"\n" +
             "    },\n" +
             "    \"host\": \"gateway:10000\",\n" +
-            "    \"basePath\": \"/api/v1/service\",\n" +
+            "    \"basePath\": \"/service/api/v1\",\n" +
             "    \"schemes\": [\"http\"],\n" +
             "    \"tags\": [\n" +
             "        {\n" +

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGeneratorTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGeneratorTest.java
@@ -23,23 +23,43 @@ import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
 import static org.junit.Assert.assertTrue;
 
 public class SubstituteSwaggerGeneratorTest {
+    private static final String GATEWAY_SCHEME = "https";
+    private static final String GATEWAY_HOST = "localhost:8080";
+    private static final String DOC_URL = "https://doc.ca.com/api";
+    private static final String HOST_NAME = "localhost";
+    private static final String APP_NAME = "serviceId";
+
+    private final SubstituteSwaggerGenerator swaggerGenerator = new SubstituteSwaggerGenerator();
 
     @Test
     public void testParseApiInfo() {
-        String gatewayScheme = "https";
-        String gatewayHost = "localhost:8080";
-
         Map<String, String> metadata = new HashMap<>();
         metadata.put(API_INFO + ".1." + API_INFO_GATEWAY_URL, "api/v1");
-        metadata.put(API_INFO + ".1." + API_INFO_DOCUMENTATION_URL, "https://doc.ca.com/api");
+        metadata.put(API_INFO + ".1." + API_INFO_DOCUMENTATION_URL, DOC_URL);
 
         List<ApiInfo> info = new EurekaMetadataParser().parseApiInfo(metadata);
 
-        InstanceInfo service = InstanceInfo.Builder.newBuilder().setAppName("serviceId").setHostName("localhost")
+        InstanceInfo service = InstanceInfo.Builder.newBuilder().setAppName(APP_NAME).setHostName(HOST_NAME)
             .setSecurePort(8080).enablePort(PortType.SECURE, true).setMetadata(metadata).build();
 
-        String result = new SubstituteSwaggerGenerator().generateSubstituteSwaggerForService(service,
-            info.get(0), gatewayScheme, gatewayHost);
-        assertTrue(result.contains("https://doc.ca.com/api"));
+        String result = swaggerGenerator.generateSubstituteSwaggerForService(service,
+            info.get(0), GATEWAY_SCHEME, GATEWAY_HOST);
+        assertTrue(result.contains(DOC_URL));
+    }
+
+    @Test
+    public void testParseApiInfoWithGatewayUrlSlashes() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(API_INFO + ".1." + API_INFO_GATEWAY_URL, "/api/v1/");
+        metadata.put(API_INFO + ".1." + API_INFO_DOCUMENTATION_URL, DOC_URL);
+
+        List<ApiInfo> info = new EurekaMetadataParser().parseApiInfo(metadata);
+
+        InstanceInfo service = InstanceInfo.Builder.newBuilder().setAppName(APP_NAME).setHostName(HOST_NAME)
+            .setSecurePort(8080).enablePort(PortType.SECURE, true).setMetadata(metadata).build();
+
+        String result = swaggerGenerator.generateSubstituteSwaggerForService(service,
+            info.get(0), GATEWAY_SCHEME, GATEWAY_HOST);
+        assertTrue(result.contains(DOC_URL));
     }
 }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
@@ -65,7 +65,7 @@ public class AbstractApiDocServiceTest {
     public void shouldGetEndpointPairs() {
         RoutedService routedService = new RoutedService("api_v1", "api/v1", "/apicatalog/api/v1");
         Pair endpointPairs = abstractApiDocService.getEndPointPairs("/apicatalog", "apicatalog", routedService);
-        ImmutablePair expectedPairs = new ImmutablePair("/apicatalog", "/api/v1/apicatalog/apicatalog");
+        ImmutablePair expectedPairs = new ImmutablePair("/apicatalog", "/apicatalog/api/v1/apicatalog");
         assertEquals(expectedPairs, endpointPairs);
     }
 
@@ -95,7 +95,7 @@ public class AbstractApiDocServiceTest {
 
         abstractApiDocService.preparePath(openAPI.getPaths(), apiDocPath, apiDocInfo, "/api/v1/api-doc", "/", "apicatalog");
 
-        assertThat(apiDocPath.getLongPaths(), hasKey("/api/v1/apicatalog/api-doc/"));
+        assertThat(apiDocPath.getLongPaths(), hasKey("/apicatalog/api/v1/api-doc/"));
         assertThat(apiDocPath.getShortPaths(), hasKey("/api-doc/"));
         assertTrue(apiDocPath.getPrefixes().contains("api/v1"));
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
@@ -105,9 +105,9 @@ public class ApiDocV2ServiceTest {
             gatewayClient.getGatewayConfigProperties().getScheme() +
             "://" +
             gatewayClient.getGatewayConfigProperties().getHostname() +
-            CATALOG_VERSION +
             SEPARATOR +
             CoreService.API_CATALOG.getServiceId() +
+            CATALOG_VERSION +
             CATALOG_APIDOC_ENDPOINT +
             SEPARATOR +
             SERVICE_ID +
@@ -222,9 +222,9 @@ public class ApiDocV2ServiceTest {
             gatewayClient.getGatewayConfigProperties().getScheme() +
             "://" +
             gatewayClient.getGatewayConfigProperties().getHostname() +
-            CATALOG_VERSION +
             SEPARATOR +
             CoreService.API_CATALOG.getServiceId() +
+            CATALOG_VERSION +
             CATALOG_APIDOC_ENDPOINT +
             SEPARATOR +
             SERVICE_ID +

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
@@ -10,13 +10,6 @@
 
 package org.zowe.apiml.apicatalog.swagger.api;
 
-import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
-import org.zowe.apiml.config.ApiInfo;
-import org.zowe.apiml.product.constants.CoreService;
-import org.zowe.apiml.product.gateway.GatewayClient;
-import org.zowe.apiml.product.gateway.GatewayConfigProperties;
-import org.zowe.apiml.product.routing.RoutedService;
-import org.zowe.apiml.product.routing.RoutedServices;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.models.*;
@@ -27,6 +20,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
+import org.zowe.apiml.config.ApiInfo;
+import org.zowe.apiml.product.constants.CoreService;
+import org.zowe.apiml.product.gateway.GatewayClient;
+import org.zowe.apiml.product.gateway.GatewayConfigProperties;
+import org.zowe.apiml.product.routing.RoutedService;
+import org.zowe.apiml.product.routing.RoutedServices;
 
 import javax.validation.UnexpectedTypeException;
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class ApiDocV2ServiceTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void givenSwaggerJsonNotAsExpectedFormat_whenConvertToSwagger_thenThrowIOException () throws IOException {
+    public void givenSwaggerJsonNotAsExpectedFormat_whenConvertToSwagger_thenThrowIOException() throws IOException {
         String apiDocContent = "Failed content";
 
         ApiDocInfo apiDocInfo = new ApiDocInfo(null, apiDocContent, null);
@@ -118,7 +118,7 @@ public class ApiDocV2ServiceTest {
         assertEquals(gatewayConfigProperties.getHostname(), actualSwagger.getHost());
         assertEquals(EXTERNAL_DOCUMENTATION, actualSwagger.getExternalDocs().getDescription());
         assertEquals(apiDocInfo.getApiInfo().getDocumentationUrl(), actualSwagger.getExternalDocs().getUrl());
-        assertEquals("/api/v1/" + SERVICE_ID, actualSwagger.getBasePath());
+        assertEquals("/" + SERVICE_ID + "/api/v1", actualSwagger.getBasePath());
 
         assertThat(actualSwagger.getSchemes(), hasItem(Scheme.forValue(gatewayConfigProperties.getScheme())));
         assertThat(actualSwagger.getPaths(), is(dummySwaggerObject.getPaths()));
@@ -142,7 +142,7 @@ public class ApiDocV2ServiceTest {
         Swagger actualSwagger = convertJsonToSwagger(actualContent);
         assertNotNull(actualSwagger);
 
-        assertEquals("/api/v1/" + SERVICE_ID, actualSwagger.getBasePath());
+        assertEquals("/" + SERVICE_ID + "/api/v1", actualSwagger.getBasePath());
         assertThat(actualSwagger.getPaths(), is(dummySwaggerObject.getPaths()));
     }
 
@@ -238,8 +238,8 @@ public class ApiDocV2ServiceTest {
         assertEquals("", actualSwagger.getBasePath());
 
         assertThat(actualSwagger.getSchemes(), hasItem(Scheme.forValue(gatewayConfigProperties.getScheme())));
-        assertThat(actualSwagger.getPaths(), IsMapContaining.hasKey("/" + routedService.getGatewayUrl() + "/" + SERVICE_ID));
-        assertThat(actualSwagger.getPaths(), IsMapContaining.hasKey("/" + routedService3.getGatewayUrl() + "/" + SERVICE_ID));
+        assertThat(actualSwagger.getPaths(), IsMapContaining.hasKey("/" + SERVICE_ID + "/" + routedService.getGatewayUrl()));
+        assertThat(actualSwagger.getPaths(), IsMapContaining.hasKey("/" + SERVICE_ID + "/" + routedService3.getGatewayUrl()));
     }
 
     @Test
@@ -261,7 +261,7 @@ public class ApiDocV2ServiceTest {
         Swagger actualSwagger = convertJsonToSwagger(actualContent);
         assertNotNull(actualSwagger);
 
-        assertEquals("/api/v1/" + SERVICE_ID, actualSwagger.getBasePath());
+        assertEquals("/" + SERVICE_ID + "/api/v1", actualSwagger.getBasePath());
 
         dummySwaggerObject.getPaths().forEach((k, v) ->
             assertThat(actualSwagger.getPaths(), IsMapContaining.hasKey(dummySwaggerObject.getBasePath() + k))

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -90,9 +90,9 @@ public class ApiDocV3ServiceTest {
             gatewayClient.getGatewayConfigProperties().getScheme() +
             "://" +
             gatewayClient.getGatewayConfigProperties().getHostname() +
-            CATALOG_VERSION +
             SEPARATOR +
             CoreService.API_CATALOG.getServiceId() +
+            CATALOG_VERSION +
             CATALOG_APIDOC_ENDPOINT +
             SEPARATOR +
             SERVICE_ID +

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -99,7 +99,7 @@ public class ApiDocV3ServiceTest {
             HARDCODED_VERSION +
             ")";
 
-        assertEquals("https://localhost:10010/api/v1/serviceId", actualSwagger.getServers().get(0).getUrl());
+        assertEquals("https://localhost:10010/serviceId/api/v1", actualSwagger.getServers().get(0).getUrl());
         assertThat(actualSwagger.getPaths(), is(dummyOpenApiObject.getPaths()));
 
         assertEquals(expectedDescription, actualSwagger.getInfo().getDescription());

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
@@ -90,7 +90,7 @@ describe('>>> Detail page test', () => {
 
         cy.get('#swaggerContainer > div > div:nth-child(2) > div.scheme-container > section > div:nth-child(1) > div > label > select > option')
             .should('exist')
-            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/api/v1/gateway`);
+            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/gateway/api/v1`);
 
         cy.get('.tabs-container')
             .should('exist')

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
@@ -40,7 +40,7 @@ public class GatewayHomepageController {
     @Autowired
     public GatewayHomepageController(DiscoveryClient discoveryClient,
                                      Providers providers) {
-       this(discoveryClient, providers, new BuildInfo());
+        this(discoveryClient, providers, new BuildInfo());
     }
 
     public GatewayHomepageController(DiscoveryClient discoveryClient,
@@ -139,7 +139,7 @@ public class GatewayHomepageController {
     private String getCatalogLink(ServiceInstance catalogInstance) {
         String gatewayUrl = catalogInstance.getMetadata().get(String.format("%s.ui_v1.%s", ROUTES, ROUTES_GATEWAY_URL));
         String serviceUrl = catalogInstance.getMetadata().get(String.format("%s.ui_v1.%s", ROUTES, ROUTES_SERVICE_URL));
-        return gatewayUrl + serviceUrl;
+        return serviceUrl + "/" + gatewayUrl;
     }
 
     private boolean authorizationServiceUp() {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/controllers/GatewayHomepageControllerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/controllers/GatewayHomepageControllerTest.java
@@ -156,7 +156,7 @@ class GatewayHomepageControllerTest {
         assertThat(preparedModelView, hasEntry("catalogIconName", "success"));
         assertThat(preparedModelView, hasEntry("catalogStatusText", "The API Catalog is running"));
         assertThat(preparedModelView, hasEntry("linkEnabled", true));
-        assertThat(preparedModelView, hasEntry("catalogLink", "ui/v1/apicatalog"));
+        assertThat(preparedModelView, hasEntry("catalogLink", "/apicatalog/ui/v1"));
     }
 
     private void discoveryReturnValidZosmfAuthorizationInstance() {

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -37,13 +37,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
 public class ApiCatalogEndpointIntegrationTest {
-    private static final String GET_ALL_CONTAINERS_ENDPOINT = "/api/v1/apicatalog/containers";
-    private static final String INVALID_CONTAINER_ENDPOINT = "/api/v1/apicatalog/containerz";
-    private static final String INVALID_STATUS_UPDATES_ENDPOINT = "/api/v1/apicatalog/statuz/updatez";
-    private static final String GET_API_CATALOG_API_DOC_ENDPOINT = "/api/v1/apicatalog/apidoc/apicatalog/v1";
-    private static final String GET_DISCOVERABLE_CLIENT_API_DOC_ENDPOINT = "/api/v1/apicatalog/apidoc/discoverableclient/v1";
-    private static final String INVALID_API_CATALOG_API_DOC_ENDPOINT = "/api/v1/apicatalog/apidoc/apicatalog/v2";
-    private static final String REFRESH_STATIC_APIS_ENDPOINT = "/api/v1/apicatalog/static-api/refresh";
+    private static final String GET_ALL_CONTAINERS_ENDPOINT = "/apicatalog/api/v1/containers";
+    private static final String INVALID_CONTAINER_ENDPOINT = "/apicatalog/api/v1/containerz";
+    private static final String INVALID_STATUS_UPDATES_ENDPOINT = "/apicatalog/api/v1/statuz/updatez";
+    private static final String GET_API_CATALOG_API_DOC_ENDPOINT = "/apicatalog/api/v1/apidoc/apicatalog/v1";
+    private static final String GET_DISCOVERABLE_CLIENT_API_DOC_ENDPOINT = "/apicatalog/api/v1/apidoc/discoverableclient/v1";
+    private static final String INVALID_API_CATALOG_API_DOC_ENDPOINT = "/apicatalog/api/v1/apidoc/apicatalog/v2";
+    private static final String REFRESH_STATIC_APIS_ENDPOINT = "/apicatalog/api/v1/static-api/refresh";
 
     private String baseHost;
 
@@ -93,7 +93,7 @@ public class ApiCatalogEndpointIntegrationTest {
         assertFalse(apiCatalogSwagger, paths.isEmpty());
         assertFalse(apiCatalogSwagger, definitions.isEmpty());
         assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "/api/v1/apicatalog", swaggerBasePath);
+        assertEquals(apiCatalogSwagger, "/apicatalog/api/v1", swaggerBasePath);
         assertNull(apiCatalogSwagger, paths.get("/status/updates"));
         assertNotNull(apiCatalogSwagger, paths.get("/containers/{id}"));
         assertNotNull(apiCatalogSwagger, paths.get("/containers"));
@@ -128,7 +128,7 @@ public class ApiCatalogEndpointIntegrationTest {
         // Then
         assertTrue(apiCatalogSwagger, swaggerInfo.get("description").toString().contains("API"));
         assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "/api/v1/discoverableclient", swaggerBasePath);
+        assertEquals(apiCatalogSwagger, "/discoverableclient/api/v1", swaggerBasePath);
         assertEquals(apiCatalogSwagger, "External documentation", externalDoc.get("description"));
 
         assertFalse(apiCatalogSwagger, paths.isEmpty());
@@ -170,7 +170,7 @@ public class ApiCatalogEndpointIntegrationTest {
         final String jsonResponse = EntityUtils.toString(response.getEntity());
         String swaggerBasePath = JsonPath.parse(jsonResponse).read("$.basePath");
 
-        assertEquals("/api/v1/apicatalog", swaggerBasePath);
+        assertEquals("/apicatalog/api/v1", swaggerBasePath);
     }
 
     @Test


### PR DESCRIPTION
# Description

Sets all base paths used in the API catalog to be of the format `/{serviceId}/{type}/{version}` rather than the old format of `/{type}/{version}/{serviceId}`.

Fixes #853 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
