### PR TITLE
Add system property for spring profiles

### DIFF
--- a/zowe-install/src/main/resources/component-scripts/start.sh
+++ b/zowe-install/src/main/resources/component-scripts/start.sh
@@ -26,8 +26,12 @@
 # - ZOWE_MANIFEST - The full path to Zowe's manifest.json file
 
 # API Mediation Layer Debug Mode
-# To activate `debug` mode, set LOG_LEVEL=debug (in lowercase)
 LOG_LEVEL=
+
+if [ "$APIML_DEBUG_MODE_ENABLED" ]
+then
+  LOG_LEVEL="debug"
+fi
 
 stop_jobs()
 {
@@ -80,7 +84,6 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${DISCOVERY_CODE} java -Xms32m -Xmx256m -Xquickstart 
     -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
     -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -Dspring.profiles.include=${SPRING_PROFILE} \
     -jar ${ROOT_DIR}"/components/api-mediation/discovery-service.jar" &
 discovery_pid=$?
 
@@ -110,7 +113,6 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${CATALOG_CODE} java -Xms16m -Xmx512m -Xquickstart \
     -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
     -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -Dspring.profiles.include=${SPRING_PROFILE} \
     -jar ${ROOT_DIR}"/components/api-mediation/api-catalog-services.jar" &
 catalog_pid=$?
 
@@ -148,7 +150,6 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${GATEWAY_CODE} java -Xms32m -Xmx256m -Xquickstart \
     -Dapiml.security.x509.externalMapperUser=ZWESVUSR \
     -Dapiml.security.zosmf.applid=${APIML_SECURITY_ZOSMF_APPLID} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -Dspring.profiles.include=${SPRING_PROFILE} \
     -cp ${ROOT_DIR}"/components/api-mediation/gateway-service.jar":/usr/include/java_classes/IRRRacf.jar \
     org.springframework.boot.loader.PropertiesLauncher &
 gateway_pid=$?

--- a/zowe-install/src/main/resources/component-scripts/start.sh
+++ b/zowe-install/src/main/resources/component-scripts/start.sh
@@ -80,6 +80,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${DISCOVERY_CODE} java -Xms32m -Xmx256m -Xquickstart 
     -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
     -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -Dspring.profiles.include=${SPRING_PROFILE} \
     -jar ${ROOT_DIR}"/components/api-mediation/discovery-service.jar" &
 discovery_pid=$?
 
@@ -109,6 +110,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${CATALOG_CODE} java -Xms16m -Xmx512m -Xquickstart \
     -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
     -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -Dspring.profiles.include=${SPRING_PROFILE} \
     -jar ${ROOT_DIR}"/components/api-mediation/api-catalog-services.jar" &
 catalog_pid=$?
 
@@ -146,6 +148,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${GATEWAY_CODE} java -Xms32m -Xmx256m -Xquickstart \
     -Dapiml.security.x509.externalMapperUser=ZWESVUSR \
     -Dapiml.security.zosmf.applid=${APIML_SECURITY_ZOSMF_APPLID} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -Dspring.profiles.include=${SPRING_PROFILE} \
     -cp ${ROOT_DIR}"/components/api-mediation/gateway-service.jar":/usr/include/java_classes/IRRRacf.jar \
     org.springframework.boot.loader.PropertiesLauncher &
 gateway_pid=$?


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

Add mapping of the system property `spring.profiles.include` from the `instance.env` to the start.sh script

Fixes #901 
Depends on https://github.com/zowe/zowe-install-packaging/pull/1774 (zowe-install-pkg)
Depends on https://github.com/zowe/docs-site/pull/1481 (Zowe docs)
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
