### PR TITLE
Carsoncook/gh862/componentize start

### DIFF
--- a/zowe-install/src/main/resources/component-scripts/setup.sh
+++ b/zowe-install/src/main/resources/component-scripts/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+# API Mediation Layer Debug Mode
+export LOG_LEVEL=
+
+if [[ ! -z ${APIML_DEBUG_MODE_ENABLED} && ${APIML_DEBUG_MODE_ENABLED} == true ]]
+then
+  export LOG_LEVEL="debug"
+fi
+
+stop_jobs()
+{
+  kill -15 "$DISCOVERY_PID" "$CATALOG_PID" "$GATEWAY_PID" "$CACHE_PID"
+}
+
+trap 'stop_jobs' INT
+
+# If set append $ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES to $STATIC_DEF_CONFIG_DIR
+export APIML_STATIC_DEF=${STATIC_DEF_CONFIG_DIR}
+if [[ ! -z "$ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES" ]]
+then
+  export APIML_STATIC_DEF="${APIML_STATIC_DEF};${ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES}"
+fi
+
+LIBPATH="$LIBPATH":"/lib"
+LIBPATH="$LIBPATH":"/usr/lib"
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/classic
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/j9vm
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/classic
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/default
+LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/j9vm
+export LIBPATH="$LIBPATH":

--- a/zowe-install/src/main/resources/component-scripts/start-cache.sh
+++ b/zowe-install/src/main/resources/component-scripts/start-cache.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+CACHING_CODE=CS
+  _BPX_JOBNAME=${ZOWE_PREFIX}${CACHING_CODE} java -Xms16m -Xmx512m -Xquickstart \
+    -Dibm.serversocket.recover=true \
+    -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Dspring.profiles.include=$LOG_LEVEL \
+    -Dserver.ssl.enabled=true \
+    -Dserver.ssl.keyStore=${KEYSTORE} \
+    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
+    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.trustStore=${TRUSTSTORE} \
+    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -jar ${ROOT_DIR}"/components/api-mediation/caching-service.jar" &
+export CACHE_PID=$?

--- a/zowe-install/src/main/resources/component-scripts/start-catalog.sh
+++ b/zowe-install/src/main/resources/component-scripts/start-catalog.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+CATALOG_CODE=AC
+_BPX_JOBNAME=${ZOWE_PREFIX}${CATALOG_CODE} java -Xms16m -Xmx512m -Xquickstart \
+    -Dibm.serversocket.recover=true \
+    -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Denvironment.hostname=${ZOWE_EXPLORER_HOST} \
+    -Denvironment.port=${CATALOG_PORT} \
+    -Denvironment.discoveryLocations=${ZWE_DISCOVERY_SERVICES_LIST} \
+    -Denvironment.ipAddress=${ZOWE_IP_ADDRESS} \
+    -Denvironment.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
+    -Denvironment.gatewayHostname=${ZOWE_EXPLORER_HOST} \
+    -Denvironment.eurekaUserId=eureka \
+    -Denvironment.eurekaPassword=password \
+    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
+    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
+    -Dspring.profiles.include=$LOG_LEVEL \
+    -Dserver.address=0.0.0.0 \
+    -Dserver.ssl.enabled=true \
+    -Dserver.ssl.keyStore=${KEYSTORE} \
+    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
+    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.trustStore=${TRUSTSTORE} \
+    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -jar ${ROOT_DIR}"/components/api-mediation/api-catalog-services.jar" &
+export CATALOG_PID=$?

--- a/zowe-install/src/main/resources/component-scripts/start-discovery.sh
+++ b/zowe-install/src/main/resources/component-scripts/start-discovery.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+DISCOVERY_CODE=AD
+_BPX_JOBNAME=${ZOWE_PREFIX}${DISCOVERY_CODE} java -Xms32m -Xmx256m -Xquickstart \
+    -Dibm.serversocket.recover=true \
+    -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Dspring.profiles.active=https \
+    -Dspring.profiles.include=$LOG_LEVEL \
+    -Dserver.address=0.0.0.0 \
+    -Dapiml.discovery.userid=eureka \
+    -Dapiml.discovery.password=password \
+    -Dapiml.discovery.allPeersUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
+    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
+    -Dapiml.service.hostname=${ZOWE_EXPLORER_HOST} \
+    -Dapiml.service.port=${DISCOVERY_PORT} \
+    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS} \
+    -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
+    -Dapiml.discovery.staticApiDefinitionsDirectories=${APIML_STATIC_DEF} \
+    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
+    -Dserver.ssl.enabled=true \
+    -Dserver.ssl.keyStore=${KEYSTORE} \
+    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
+    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.trustStore=${TRUSTSTORE} \
+    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -jar ${ROOT_DIR}"/components/api-mediation/discovery-service.jar" &
+export DISCOVERY_PID=$?

--- a/zowe-install/src/main/resources/component-scripts/start-gateway.sh
+++ b/zowe-install/src/main/resources/component-scripts/start-gateway.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright IBM Corporation 2019
+################################################################################
+
+GATEWAY_CODE=AG
+_BPX_JOBNAME=${ZOWE_PREFIX}${GATEWAY_CODE} java -Xms32m -Xmx256m -Xquickstart \
+    -Dibm.serversocket.recover=true \
+    -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Dspring.profiles.include=$LOG_LEVEL \
+    -Dapiml.service.hostname=${ZOWE_EXPLORER_HOST} \
+    -Dapiml.service.port=${GATEWAY_PORT} \
+    -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
+    -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
+    -Dapiml.service.allowEncodedSlashes=${APIML_ALLOW_ENCODED_SLASHES} \
+    -Dapiml.service.corsEnabled=${APIML_CORS_ENABLED} \
+    -Dapiml.cache.storage.location=${WORKSPACE_DIR}/api-mediation/ \
+    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
+    -Denvironment.ipAddress=${ZOWE_IP_ADDRESS} \
+    -Dapiml.gateway.timeoutMillis=${APIML_GATEWAY_TIMEOUT_MILLIS} \
+    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
+    -Dapiml.security.auth.zosmfServiceId=zosmf \
+    -Dapiml.security.auth.provider=${APIML_SECURITY_AUTH_PROVIDER} \
+    -Dapiml.zoweManifest=${ZOWE_MANIFEST} \
+    -Dserver.address=0.0.0.0 \
+    -Dserver.ssl.enabled=true \
+    -Dserver.ssl.keyStore=${KEYSTORE} \
+    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
+    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
+    -Dserver.ssl.trustStore=${TRUSTSTORE} \
+    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
+    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
+    -Dapiml.security.x509.enabled=${APIML_SECURITY_X509_ENABLED:-false} \
+    -Dapiml.security.x509.externalMapperUrl=http://localhost:${ZOWE_ZSS_SERVER_PORT}/certificate/x509/map \
+    -Dapiml.security.x509.externalMapperUser=ZWESVUSR \
+    -Dapiml.security.zosmf.applid=${APIML_SECURITY_ZOSMF_APPLID} \
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -cp ${ROOT_DIR}"/components/api-mediation/gateway-service.jar":/usr/include/java_classes/IRRRacf.jar \
+    org.springframework.boot.loader.PropertiesLauncher &
+export GATEWAY_PID=$?

--- a/zowe-install/src/main/resources/component-scripts/start.sh
+++ b/zowe-install/src/main/resources/component-scripts/start.sh
@@ -25,37 +25,9 @@
 # - ALLOW_SLASHES - Allows encoded slashes on on URLs through gateway
 # - ZOWE_MANIFEST - The full path to Zowe's manifest.json file
 
-# API Mediation Layer Debug Mode
-export LOG_LEVEL=
+# Script is ran from run-zowe.sh context so use ROOT_DIR to make a full path to each script
 
-if [[ ! -z ${APIML_DEBUG_MODE_ENABLED} && ${APIML_DEBUG_MODE_ENABLED} == true ]]
-then
-  export LOG_LEVEL="debug"
-fi
-
-stop_jobs()
-{
-  kill -15 "$DISCOVERY_PID" "$CATALOG_PID" "$GATEWAY_PID" "$CACHE_PID"
-}
-
-trap 'stop_jobs' INT
-
-# If set append $ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES to $STATIC_DEF_CONFIG_DIR
-export APIML_STATIC_DEF=${STATIC_DEF_CONFIG_DIR}
-if [[ ! -z "$ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES" ]]
-then
-  export APIML_STATIC_DEF="${APIML_STATIC_DEF};${ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES}"
-fi
-
-LIBPATH="$LIBPATH":"/lib"
-LIBPATH="$LIBPATH":"/usr/lib"
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/classic
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/j9vm
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/classic
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/default
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/j9vm
-export LIBPATH="$LIBPATH":
+. "${ROOT_DIR}"/components/api-mediation/bin/setup.sh
 
 . "${ROOT_DIR}"/components/api-mediation/bin/start-discovery.sh &
 . "${ROOT_DIR}"/components/api-mediation/bin/start-catalog.sh &

--- a/zowe-install/src/main/resources/component-scripts/start.sh
+++ b/zowe-install/src/main/resources/component-scripts/start.sh
@@ -26,25 +26,25 @@
 # - ZOWE_MANIFEST - The full path to Zowe's manifest.json file
 
 # API Mediation Layer Debug Mode
-LOG_LEVEL=
+export LOG_LEVEL=
 
 if [[ ! -z ${APIML_DEBUG_MODE_ENABLED} && ${APIML_DEBUG_MODE_ENABLED} == true ]]
 then
-  LOG_LEVEL="debug"
+  export LOG_LEVEL="debug"
 fi
 
 stop_jobs()
 {
-  kill -15 $discovery_pid $catalog_pid $gateway_pid $cache_pid
+  kill -15 "$DISCOVERY_PID" "$CATALOG_PID" "$GATEWAY_PID" "$CACHE_PID"
 }
 
 trap 'stop_jobs' INT
 
 # If set append $ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES to $STATIC_DEF_CONFIG_DIR
-APIML_STATIC_DEF=${STATIC_DEF_CONFIG_DIR}
+export APIML_STATIC_DEF=${STATIC_DEF_CONFIG_DIR}
 if [[ ! -z "$ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES" ]]
 then
-  APIML_STATIC_DEF="${APIML_STATIC_DEF};${ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES}"
+  export APIML_STATIC_DEF="${APIML_STATIC_DEF};${ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES}"
 fi
 
 LIBPATH="$LIBPATH":"/lib"
@@ -57,126 +57,13 @@ LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/default
 LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/j9vm
 export LIBPATH="$LIBPATH":
 
-DISCOVERY_CODE=AD
-_BPX_JOBNAME=${ZOWE_PREFIX}${DISCOVERY_CODE} java -Xms32m -Xmx256m -Xquickstart \
-    -Dibm.serversocket.recover=true \
-    -Dfile.encoding=UTF-8 \
-    -Djava.io.tmpdir=/tmp \
-    -Dspring.profiles.active=https \
-    -Dspring.profiles.include=$LOG_LEVEL \
-    -Dserver.address=0.0.0.0 \
-    -Dapiml.discovery.userid=eureka \
-    -Dapiml.discovery.password=password \
-    -Dapiml.discovery.allPeersUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
-    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
-    -Dapiml.service.hostname=${ZOWE_EXPLORER_HOST} \
-    -Dapiml.service.port=${DISCOVERY_PORT} \
-    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS} \
-    -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
-    -Dapiml.discovery.staticApiDefinitionsDirectories=${APIML_STATIC_DEF} \
-    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
-    -Dserver.ssl.enabled=true \
-    -Dserver.ssl.keyStore=${KEYSTORE} \
-    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
-    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.trustStore=${TRUSTSTORE} \
-    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
-    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -jar ${ROOT_DIR}"/components/api-mediation/discovery-service.jar" &
-discovery_pid=$?
-
-CATALOG_CODE=AC
-_BPX_JOBNAME=${ZOWE_PREFIX}${CATALOG_CODE} java -Xms16m -Xmx512m -Xquickstart \
-    -Dibm.serversocket.recover=true \
-    -Dfile.encoding=UTF-8 \
-    -Djava.io.tmpdir=/tmp \
-    -Denvironment.hostname=${ZOWE_EXPLORER_HOST} \
-    -Denvironment.port=${CATALOG_PORT} \
-    -Denvironment.discoveryLocations=${ZWE_DISCOVERY_SERVICES_LIST} \
-    -Denvironment.ipAddress=${ZOWE_IP_ADDRESS} \
-    -Denvironment.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
-    -Denvironment.gatewayHostname=${ZOWE_EXPLORER_HOST} \
-    -Denvironment.eurekaUserId=eureka \
-    -Denvironment.eurekaPassword=password \
-    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
-    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
-    -Dspring.profiles.include=$LOG_LEVEL \
-    -Dserver.address=0.0.0.0 \
-    -Dserver.ssl.enabled=true \
-    -Dserver.ssl.keyStore=${KEYSTORE} \
-    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
-    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.trustStore=${TRUSTSTORE} \
-    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
-    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -jar ${ROOT_DIR}"/components/api-mediation/api-catalog-services.jar" &
-catalog_pid=$?
-
-GATEWAY_CODE=AG
-_BPX_JOBNAME=${ZOWE_PREFIX}${GATEWAY_CODE} java -Xms32m -Xmx256m -Xquickstart \
-    -Dibm.serversocket.recover=true \
-    -Dfile.encoding=UTF-8 \
-    -Djava.io.tmpdir=/tmp \
-    -Dspring.profiles.include=$LOG_LEVEL \
-    -Dapiml.service.hostname=${ZOWE_EXPLORER_HOST} \
-    -Dapiml.service.port=${GATEWAY_PORT} \
-    -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
-    -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS} \
-    -Dapiml.service.allowEncodedSlashes=${APIML_ALLOW_ENCODED_SLASHES} \
-    -Dapiml.service.corsEnabled=${APIML_CORS_ENABLED} \
-    -Dapiml.cache.storage.location=${WORKSPACE_DIR}/api-mediation/ \
-    -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
-    -Denvironment.ipAddress=${ZOWE_IP_ADDRESS} \
-    -Dapiml.gateway.timeoutMillis=${APIML_GATEWAY_TIMEOUT_MILLIS} \
-    -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES} \
-    -Dapiml.security.auth.zosmfServiceId=zosmf \
-    -Dapiml.security.auth.provider=${APIML_SECURITY_AUTH_PROVIDER} \
-    -Dapiml.zoweManifest=${ZOWE_MANIFEST} \
-    -Dserver.address=0.0.0.0 \
-    -Dserver.ssl.enabled=true \
-    -Dserver.ssl.keyStore=${KEYSTORE} \
-    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
-    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.trustStore=${TRUSTSTORE} \
-    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
-    -Dapiml.security.x509.enabled=${APIML_SECURITY_X509_ENABLED:-false} \
-    -Dapiml.security.x509.externalMapperUrl=http://localhost:${ZOWE_ZSS_SERVER_PORT}/certificate/x509/map \
-    -Dapiml.security.x509.externalMapperUser=ZWESVUSR \
-    -Dapiml.security.zosmf.applid=${APIML_SECURITY_ZOSMF_APPLID} \
-    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -cp ${ROOT_DIR}"/components/api-mediation/gateway-service.jar":/usr/include/java_classes/IRRRacf.jar \
-    org.springframework.boot.loader.PropertiesLauncher &
-gateway_pid=$?
+. "${ROOT_DIR}"/components/api-mediation/bin/start-discovery.sh &
+. "${ROOT_DIR}"/components/api-mediation/bin/start-catalog.sh &
+. "${ROOT_DIR}"/components/api-mediation/bin/start-gateway.sh &
 
 if [[ ! -z "$ZOWE_CACHING_SERVICE_START" ]]
 then
-  CACHING_CODE=CS
-  _BPX_JOBNAME=${ZOWE_PREFIX}${CACHING_CODE} java -Xms16m -Xmx512m -Xquickstart \
-    -Dibm.serversocket.recover=true \
-    -Dfile.encoding=UTF-8 \
-    -Djava.io.tmpdir=/tmp \
-    -Dspring.profiles.include=$LOG_LEVEL \
-    -Dserver.ssl.enabled=true \
-    -Dserver.ssl.keyStore=${KEYSTORE} \
-    -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.keyAlias=${KEY_ALIAS} \
-    -Dserver.ssl.keyPassword=${KEYSTORE_PASSWORD} \
-    -Dserver.ssl.trustStore=${TRUSTSTORE} \
-    -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
-    -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
-    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
-    -jar ${ROOT_DIR}"/components/api-mediation/caching-service.jar" &
-  cache_pid=$?
+  . "${ROOT_DIR}"/components/api-mediation/bin/start-cache.sh &
 fi
 
 wait


### PR DESCRIPTION
# Description

Adds a script to start each component of the mediation layer, rather than having the startup code all in `start.sh`. Also adds a `setup.sh` script to set needed environment variables. This allows `start.sh` to work with the current Zowe startup process, while preparing modularized scripts for Zowe launcher to start components individually.

Fixes #862 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
