### PR TITLE
Update the default username and password in the documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Alternatively, to use Docker to use the api-layer, consult the [Docker README](d
 
 ## Security
 
-The API Mediation Layer can use dummy credentials for development purposes. For development purposes, log in using the default setting `user` for the username, and again `user` as the password.   
+The API Mediation Layer can use dummy credentials for development purposes. For development purposes, log in using the default setting `USER` for the username, and `validPassword` as the password.   
 
 For more information, see [API Mediation Layer Security](https://docs.zowe.org/stable/extend/extend-apiml/api-mediation-security.html).
 


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

Update the documentation to replace the dummy related info to mock zosmf related info. 