### PR TITLE
Remove risk around the concurrent access to Map created after constructor

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/AuthenticationScheme.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/AuthenticationScheme.java
@@ -13,10 +13,6 @@ package org.zowe.apiml.security.common.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 @Getter
 public enum AuthenticationScheme {
     @JsonProperty("bypass")
@@ -31,9 +27,7 @@ public enum AuthenticationScheme {
     @JsonProperty("zosmf")
     ZOSMF("zosmf");
 
-    private final String scheme;
-
-    private static Map<String, AuthenticationScheme> schemeToEnum;
+    public final String scheme;
 
     AuthenticationScheme(String scheme) {
         this.scheme = scheme;
@@ -42,22 +36,6 @@ public enum AuthenticationScheme {
     @Override
     public String toString() {
         return scheme;
-    }
-
-    public static AuthenticationScheme fromScheme(String scheme) {
-        if (schemeToEnum != null) return schemeToEnum.get(scheme);
-
-        synchronized (AuthenticationScheme.class) {
-            if (schemeToEnum != null) return schemeToEnum.get(scheme);
-
-            final Map<String, AuthenticationScheme> map = new HashMap<>();
-            for (final AuthenticationScheme as : values()) {
-                map.put(as.scheme, as);
-            }
-            schemeToEnum = Collections.unmodifiableMap(map);
-
-            return schemeToEnum.get(scheme);
-        }
     }
 
 }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/AuthenticationSchemes.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/AuthenticationSchemes.java
@@ -1,0 +1,30 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.security.common.auth;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AuthenticationSchemes {
+    private final Map<String, AuthenticationScheme> schemeToEnum;
+
+    public AuthenticationSchemes() {
+        final Map<String, AuthenticationScheme> map = new HashMap<>();
+        for (final AuthenticationScheme as : AuthenticationScheme.values()) {
+            map.put(as.scheme, as);
+        }
+        schemeToEnum = Collections.unmodifiableMap(map);
+    }
+
+    public AuthenticationScheme map(String schemeName) {
+        return schemeToEnum.get(schemeName);
+    }
+}

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/auth/AuthenticationSchemesTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/auth/AuthenticationSchemesTest.java
@@ -12,16 +12,17 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class AuthenticationSchemeTest {
+public class AuthenticationSchemesTest {
 
     @Test
     public void testFromScheme() {
+        AuthenticationSchemes underTest = new AuthenticationSchemes();
         for (AuthenticationScheme as : AuthenticationScheme.values()) {
-            AuthenticationScheme as2 = AuthenticationScheme.fromScheme(as.getScheme());
+            AuthenticationScheme as2 = underTest.map(as.getScheme());
             assertSame(as, as2);
         }
-        assertNull(AuthenticationScheme.fromScheme("absolute nonsense"));
-        assertEquals("bypass", AuthenticationScheme.fromScheme("bypass").toString());
+        assertNull(underTest.map("absolute nonsense"));
+        assertEquals("bypass", underTest.map("bypass").toString());
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -29,7 +29,7 @@ import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationSchemeFactory;
 import org.zowe.apiml.gateway.security.service.schema.ServiceAuthenticationService;
 import org.zowe.apiml.security.common.auth.Authentication;
-import org.zowe.apiml.security.common.auth.AuthenticationScheme;
+import org.zowe.apiml.security.common.auth.AuthenticationSchemes;
 import org.zowe.apiml.util.CacheUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -69,6 +69,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
     private static final String CACHE_BY_AUTHENTICATION = "serviceAuthenticationByAuthentication";
 
     private final LoadBalancerAuthenticationCommand loadBalancerCommand = new LoadBalancerAuthenticationCommand();
+    private final AuthenticationSchemes schemes = new AuthenticationSchemes();
 
     private final EurekaClient discoveryClient;
     private final AuthenticationSchemeFactory authenticationSchemeFactory;
@@ -81,7 +82,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
 
         final Authentication out = new Authentication();
         out.setApplid(metadata.get(AUTHENTICATION_APPLID));
-        out.setScheme(AuthenticationScheme.fromScheme(metadata.get(AUTHENTICATION_SCHEME)));
+        out.setScheme(schemes.map(metadata.get(AUTHENTICATION_SCHEME)));
         return out;
     }
 


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

Fixes issue around the thread-unsafe access to the map with the mapping of the authentication scheme. 
