### PR TITLE
Upgrade dependencies

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compile libraries.apache_commons_lang3
     compile libraries.spring_boot_starter_thymeleaf
     compile libraries.apache_velocity
+    compile libraries.jetty_util
 
     compile libraries.springFox
 

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -117,11 +117,9 @@ public class HttpConfig {
             factory.setSystemSslProperties();
 
             publicKeyCertificatesBase64 = SecurityUtils.loadCertificateChainBase64(httpsConfig);
-        }
-        catch (HttpsConfigError e) {
+        } catch (HttpsConfigError e) {
             System.exit(1); // NOSONAR
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             apimlLog.log("org.zowe.apiml.common.unknownHttpsConfigError", e.getMessage());
             System.exit(1); // NOSONAR
         }
@@ -134,8 +132,9 @@ public class HttpConfig {
     }
 
     @Bean
-    public SslContextFactory jettySslContextFactory() {
-        SslContextFactory sslContextFactory = new SslContextFactory(SecurityUtils.replaceFourSlashes(keyStore));
+    public SslContextFactory.Server jettySslContextFactory() {
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath(SecurityUtils.replaceFourSlashes(keyStore));
         sslContextFactory.setProtocol(protocol);
         sslContextFactory.setKeyStorePassword(keyStorePassword == null ? null : String.valueOf(keyStorePassword));
         sslContextFactory.setKeyStoreType(keyStoreType);

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -134,7 +134,9 @@ public class HttpConfig {
     @Bean
     public SslContextFactory.Server jettySslContextFactory() {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-        sslContextFactory.setKeyStorePath(SecurityUtils.replaceFourSlashes(keyStore));
+        if (keyStore != null) {
+            sslContextFactory.setKeyStorePath(SecurityUtils.replaceFourSlashes(keyStore));
+        }
         sslContextFactory.setProtocol(protocol);
         sslContextFactory.setKeyStorePassword(keyStorePassword == null ? null : String.valueOf(keyStorePassword));
         sslContextFactory.setKeyStoreType(keyStoreType);

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile libraries.spring_boot_starter_actuator
     compile libraries.spring_cloud_starter_eureka_server
     compile libraries.jackson_dataformat_yaml
+    compile libraries.jetty_util
 
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     compile libraries.spring_cloud_starter_eureka
     compile libraries.spring_cloud_starter_ribbon
     compile libraries.jetty_websocket_client
+    compile libraries.jetty_websocket_common
     compile libraries.jetty_util
     compile libraries.jjwt
     compile libraries.nimbusJoseJwt

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ServletSslContextFactoryProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ServletSslContextFactoryProvider.java
@@ -15,15 +15,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ServletSslContextFactoryProvider implements SslContextFactoryProvider {
-    private final SslContextFactory sslContextFactory;
+    private final SslContextFactory.Server sslContextFactory;
 
     @Autowired
-    public ServletSslContextFactoryProvider(SslContextFactory sslContextFactory) {
+    public ServletSslContextFactoryProvider(SslContextFactory.Server sslContextFactory) {
         this.sslContextFactory = sslContextFactory;
     }
 
     @Override
-    public SslContextFactory getSslFactory() {
+    public SslContextFactory.Server getSslFactory() {
         return sslContextFactory;
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/SslContextFactoryProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/SslContextFactoryProvider.java
@@ -12,5 +12,5 @@ package org.zowe.apiml.gateway.ws;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public interface SslContextFactoryProvider {
-    SslContextFactory getSslFactory();
+    SslContextFactory.Server getSslFactory();
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -43,7 +43,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
     private final Map<String, WebSocketRoutedSession> routedSessions;
     private final Map<String, RoutedServices> routedServicesMap = new ConcurrentHashMap<>();
     private final DiscoveryClient discovery;
-    private final SslContextFactory jettySslContextFactory;
+    private final SslContextFactory.Server jettySslContextFactory;
     private final WebSocketRoutedSessionFactory webSocketRoutedSessionFactory;
     private static final String SEPARATOR = "/";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.gateway.ws;
 
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.springframework.http.HttpHeaders;
@@ -37,7 +38,7 @@ public class WebSocketRoutedSession {
     private final WebSocketSession webSocketClientSession;
     private final WebSocketSession webSocketServerSession;
 
-    public WebSocketRoutedSession(WebSocketSession webSocketServerSession, String targetUrl, SslContextFactory jettySslContextFactory) {
+    public WebSocketRoutedSession(WebSocketSession webSocketServerSession, String targetUrl, SslContextFactory.Server jettySslContextFactory) {
         log.debug("Creating WebSocketRoutedSession jettySslContextFactory={}", jettySslContextFactory);
         this.webSocketServerSession = webSocketServerSession;
         this.webSocketClientSession = createWebSocketClientSession(webSocketServerSession, targetUrl, jettySslContextFactory);
@@ -68,22 +69,20 @@ public class WebSocketRoutedSession {
         return webSocketServerSession;
     }
 
-    private WebSocketSession createWebSocketClientSession(WebSocketSession webSocketServerSession, String targetUrl, SslContextFactory sslContextFactory) {
+    private WebSocketSession createWebSocketClientSession(WebSocketSession webSocketServerSession, String targetUrl, SslContextFactory.Server sslContextFactory) {
         try {
             log.debug("createWebSocketClientSession(session={},targetUrl={},jettySslContextFactory={})",
-                    webSocketClientSession, targetUrl, sslContextFactory);
-            JettyWebSocketClient client = new JettyWebSocketClient(new WebSocketClient(sslContextFactory));
+                webSocketClientSession, targetUrl, sslContextFactory);
+            JettyWebSocketClient client = new JettyWebSocketClient(new WebSocketClient(new HttpClient(sslContextFactory)));
             client.start();
             URI targetURI = new URI(targetUrl);
             WebSocketHttpHeaders headers = getWebSocketHttpHeaders(webSocketServerSession);
             ListenableFuture<WebSocketSession> futureSession = client
                 .doHandshake(new WebSocketProxyClientHandler(webSocketServerSession), headers, targetURI);
             return futureSession.get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw webSocketProxyException(targetUrl, e, webSocketServerSession, true);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw webSocketProxyException(targetUrl, e, webSocketServerSession, false);
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
@@ -20,5 +20,5 @@ public interface WebSocketRoutedSessionFactory {
      * @param sslContextFactory Factory producing the current SSL Context.
      * @return Valid routed session handling the client session
      */
-    WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory sslContextFactory);
+    WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory.Server sslContextFactory);
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
@@ -17,7 +17,7 @@ import org.springframework.web.socket.WebSocketSession;
  */
 public class WebSocketRoutedSessionFactoryImpl implements WebSocketRoutedSessionFactory {
     @Override
-    public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory sslContextFactory) {
+    public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory.Server sslContextFactory) {
         return new WebSocketRoutedSession(webSocketSession, targetUrl, sslContextFactory);
     }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,7 +16,7 @@ ext {
     hamcrestVersion = '1.3'
     javaxServletApiVersion = '3.1.0'
     restAssuredVersion = '3.0.7'
-    commonsValidatorVersion = "1.6"
+    commonsValidatorVersion = "1.7"
     powerMockVersion = "2.0.4"
     jacksonCoreVersion = "2.10.1"
     javaxValidationApiVersion = "2.0.1.Final"
@@ -27,7 +27,7 @@ ext {
     commonsLang3Version = '3.7'
     commonsTextVersion = '1.8'
     gradleGitPropertiesVersion = '1.5.1'
-    jettyWebSocketClientVersion = '9.4.11.v20180605'
+    jettyWebSocketClientVersion = '9.4.34.v20201102'
     junitVersion = '4.12'
     junitVintageVersion = '5.5.2'
     eurekaClientVersion = '1.9.13'
@@ -40,7 +40,7 @@ ext {
     velocityVersion = '2.0'
     jsoupVersion = '1.8.3'
     httpCoreVersion = '4.4.10'
-    snakeyamlVersion = '1.23'
+    snakeyamlVersion = '1.27'
     springHateoasVersion = '0.23.0.RELEASE'
     springRetryVersion = '1.2.2.RELEASE'
     jsonUnitVersion = '1.25.0'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,7 +27,7 @@ ext {
     commonsLang3Version = '3.7'
     commonsTextVersion = '1.8'
     gradleGitPropertiesVersion = '1.5.1'
-    jettyWebSocketClientVersion = '9.4.34.v20201102'
+    jettyWebSocketClientVersion = '9.4.35.v20201120'
     junitVersion = '4.12'
     junitVintageVersion = '5.5.2'
     eurekaClientVersion = '1.9.13'
@@ -129,6 +129,7 @@ ext {
         apache_commons_lang3               : "org.apache.commons:commons-lang3:${commonsLang3Version}",
         apache_commons_text                : "org.apache.commons:commons-text:${commonsTextVersion}",
         jetty_websocket_client             : "org.eclipse.jetty.websocket:websocket-client:${jettyWebSocketClientVersion}",
+        jetty_websocket_common             : "org.eclipse.jetty.websocket:websocket-common:${jettyWebSocketClientVersion}",
         jetty_util                         : "org.eclipse.jetty:jetty-util:${jettyWebSocketClientVersion}",
         eureka_client                      : "com.netflix.eureka:eureka-client:${eurekaClientVersion}",
         netflix_servo                      : "com.netflix.servo:servo-core:${netflixServoVersion}",

--- a/integration-tests/src/test/java/org/zowe/apiml/ws/WebSocketProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/ws/WebSocketProxyTest.java
@@ -10,7 +10,6 @@
 package org.zowe.apiml.ws;
 
 import org.apache.http.client.utils.URIBuilder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -36,16 +35,11 @@ import static org.junit.Assert.assertTrue;
 
 @TestsNotMeantForZowe
 class WebSocketProxyTest {
-    private GatewayServiceConfiguration serviceConfiguration;
+    private final GatewayServiceConfiguration serviceConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
 
     private final static int WAIT_TIMEOUT_MS = 10000;
     private final static String UPPERCASE_URL = "/ws/v1/discoverableclient/uppercase";
     private final static String HEADER_URL = "/ws/v1/discoverableclient/header";
-
-    @BeforeEach
-    void setUp() {
-        serviceConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
-    }
 
     private TextWebSocketHandler appendResponseHandler(StringBuilder target, int countToNotify) {
         final AtomicInteger counter = new AtomicInteger(countToNotify);
@@ -81,7 +75,7 @@ class WebSocketProxyTest {
     }
 
     private WebSocketSession appendingWebSocketSession(String url, WebSocketHttpHeaders headers, StringBuilder response, int countToNotify)
-            throws Exception {
+        throws Exception {
         StandardWebSocketClient client = new StandardWebSocketClient();
         client.getUserProperties().put(SSL_CONTEXT_PROPERTY, HttpClientUtils.ignoreSslContext());
         URI uri = UriComponentsBuilder.fromUriString(url).build().encode().toUri();
@@ -89,7 +83,7 @@ class WebSocketProxyTest {
     }
 
     private WebSocketSession appendingWebSocketSession(String url, StringBuilder response, int countToNotify)
-            throws Exception {
+        throws Exception {
         return appendingWebSocketSession(url, null, response, countToNotify);
     }
 
@@ -158,20 +152,19 @@ class WebSocketProxyTest {
     @WebsocketTest
     void shouldFailIfServiceIsNotCorrect() throws Exception {
         final StringBuilder response = new StringBuilder();
-        WebSocketSession session = appendingWebSocketSession(
-                discoverableClientGatewayUrl("/ws/v1/wrong-service/uppercase"), response, 1);
+        appendingWebSocketSession(discoverableClientGatewayUrl("/ws/v1/wrong-service/uppercase"), response, 1);
 
         synchronized (response) {
             response.wait(WAIT_TIMEOUT_MS);
         }
 
         assertEquals("CloseStatus[code=1003, reason=Requested service wrong-service is not known by the gateway]",
-                response.toString());
+            response.toString());
     }
 
     @Test
     @WebsocketTest
-    void shouldFailIfUrlFormatIsNotCorrent() throws Exception {
+    void shouldFailIfUrlFormatIsNotCorrect() throws Exception {
         final StringBuilder response = new StringBuilder();
         appendingWebSocketSession(discoverableClientGatewayUrl("/ws/wrong"), response, 1);
 


### PR DESCRIPTION
# Description

Upgrade dependencies that were identified as security risks to the most recent version.

* snakeyaml 1.23 -> 1.27
* commons-validator 1.6 -> 1.7
* jetty:websocket-client and jetty-util 9.4.11.v20180605 -> 9.4.35v20201120

Due to the jetty upgrade, jetty:websocket-common was added as an explicit dependency and where `SslContextFactory` was used was refactored to use `SslContextFactory.Server` as required by jetty.

Fixes #933 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
