### PR TITLE
Invalidate JWT with multiple GW instances

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.gateway.security.service.JwtSecurityInitializer;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
+import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -59,9 +60,14 @@ public class AuthController {
         final int index = uri.indexOf(endpoint);
 
         final String jwtToken = uri.substring(index + endpoint.length());
-        final boolean invalidated = authenticationService.invalidateJwtToken(jwtToken, false);
+        try {
+            final boolean invalidated = authenticationService.invalidateJwtToken(jwtToken, false);
+            response.setStatus(invalidated ? SC_OK : SC_SERVICE_UNAVAILABLE);
+        } catch (TokenNotValidException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
 
-        response.setStatus(invalidated ? SC_OK : SC_SERVICE_UNAVAILABLE);
+
     }
 
     @GetMapping(path = DISTRIBUTE_PATH)

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -159,7 +159,7 @@ public class AuthenticationService {
             try {
                 restTemplate.delete(url);
             } catch (HttpClientErrorException e) {
-                log.error("Error", e);
+                log.debug("Problem invalidating token on another instance url " + url, e);
             }
 
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.gateway.controllers.AuthController;
@@ -154,8 +155,13 @@ public class AuthenticationService {
         for (final InstanceInfo instanceInfo : application.getInstances()) {
             if (StringUtils.equals(myInstanceId, instanceInfo.getInstanceId())) continue;
 
-            final String url = EurekaUtils.getUrl(instanceInfo) + AuthController.CONTROLLER_PATH + "/invalidate/{}";
-            restTemplate.delete(url, jwtToken);
+            final String url = EurekaUtils.getUrl(instanceInfo) + AuthController.CONTROLLER_PATH + "/invalidate/" + jwtToken;
+            try {
+                restTemplate.delete(url);
+            } catch (HttpClientErrorException e) {
+                log.error("Error", e);
+            }
+
         }
 
         return Boolean.TRUE;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -37,7 +37,10 @@ import org.zowe.apiml.gateway.config.CacheConfig;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.security.SecurityUtils;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
-import org.zowe.apiml.security.common.token.*;
+import org.zowe.apiml.security.common.token.QueryResponse;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
+import org.zowe.apiml.security.common.token.TokenExpireException;
+import org.zowe.apiml.security.common.token.TokenNotValidException;
 import org.zowe.apiml.util.CacheUtils;
 import org.zowe.apiml.util.EurekaUtils;
 
@@ -308,8 +311,8 @@ public class AuthenticationServiceTest {
         tokenAuthentication = authService.validateJwtToken(jwt1);
         assertFalse(tokenAuthentication.isAuthenticated());
         verify(restTemplate, times(2)).delete(anyString(), (Object[]) any());
-        verify(restTemplate).delete("https://hostname1:10433/gateway/auth/invalidate/{}", jwt1);
-        verify(restTemplate).delete("http://hostname2:10001/gateway/auth/invalidate/{}", jwt1);
+        verify(restTemplate).delete("https://hostname1:10433/gateway/auth/invalidate/" + jwt1);
+        verify(restTemplate).delete("http://hostname2:10001/gateway/auth/invalidate/" + jwt1);
         verify(restTemplate, times(1))
             .exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), any(), eq(String.class));
     }
@@ -455,7 +458,7 @@ public class AuthenticationServiceTest {
 
     @Test
     void testGetLtpaTokenException() {
-        for (String jwtToken : new String[] {"header.body.sign", "wrongJwtToken", ""}) {
+        for (String jwtToken : new String[]{"header.body.sign", "wrongJwtToken", ""}) {
             try {
                 authService.getLtpaToken(jwtToken);
                 fail();

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/IntegratedZaasClientTest.java
@@ -152,6 +152,7 @@ class IntegratedZaasClientTest {
             .when()
             .post(ZAAS_CLIENT_URI_OLD_FORMAT + LOGOUT)
             .then()
+            .body(is("Invalid token provided"))
             .statusCode(is(SC_BAD_REQUEST));
     }
 
@@ -163,6 +164,7 @@ class IntegratedZaasClientTest {
             .when()
             .post(ZAAS_CLIENT_URI + LOGOUT)
             .then()
+            .body(is("Invalid token provided"))
             .statusCode(is(SC_BAD_REQUEST));
     }
 


### PR DESCRIPTION
# Description

Logout endpoint behaves in different way when running in HA mode. This fix should consolidate the behaviour.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
