### PR TITLE
Remove duplicate test

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.springframework.http.HttpHeaders;
-import org.zowe.apiml.gatewayservice.SecurityUtils;
 import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.service.DiscoveryUtils;
 
@@ -27,7 +26,6 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
 @RunWith(value = Parameterized.class)

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
@@ -96,46 +96,6 @@ public class ApiCatalogSecurityIntegrationTest {
     }
 
     @Test
-    public void loginToGatewayAndAccessProtectedEndpointWithCookie() {
-        String url = String.format("%s://%s:%d%s%s%s", GATEWAY_SCHEME, GATEWAY_HOST, GATEWAY_PORT, CATALOG_PREFIX,
-            CATALOG_SERVICE_ID, endpoint);
-
-        String statusCodes = "";
-        String tokens = "";
-        // Retry multiple times the call with a short delay to prevent flaky failures.
-        for (int i = 0; i < 3; i++) {
-            String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
-            int statusCode = callToProtected(token, url);
-            // If at least one success the test succeeds.
-            if (statusCode == SC_OK) {
-                return;
-            }
-
-            statusCodes += statusCode + ",";
-            tokens += token + ",\n";
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
-
-        fail("Unable to access the Catalog endpoint: " + url + " Status Codes: " + statusCodes + " Tokens: " + tokens);
-    }
-
-    // Retry the call to the same endpoint.
-    private int callToProtected(String token, String url) {
-        return given()
-            .cookie(COOKIE, token)
-            .when()
-            .get(url)
-            .then()
-            .extract()
-            .statusCode();
-    }
-
-    @Test
     public void accessProtectedEndpointWithInvalidBasicAuth() {
         String expectedMessage = "Invalid username or password for URL '" + CATALOG_SERVICE_ID + endpoint + "'";
 

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogSecurityIntegrationTest.java
@@ -101,15 +101,18 @@ public class ApiCatalogSecurityIntegrationTest {
             CATALOG_SERVICE_ID, endpoint);
 
         String statusCodes = "";
+        String tokens = "";
         // Retry multiple times the call with a short delay to prevent flaky failures.
         for (int i = 0; i < 3; i++) {
-            int statusCode = callToProtected(url);
+            String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
+            int statusCode = callToProtected(token, url);
             // If at least one success the test succeeds.
             if (statusCode == SC_OK) {
                 return;
             }
 
             statusCodes += statusCode + ",";
+            tokens += token + ",\n";
 
             try {
                 Thread.sleep(1000);
@@ -118,13 +121,11 @@ public class ApiCatalogSecurityIntegrationTest {
             }
         }
 
-        fail("Unable to access the Catalog endpoint: " + url + " Status Codes: " + statusCodes);
+        fail("Unable to access the Catalog endpoint: " + url + " Status Codes: " + statusCodes + " Tokens: " + tokens);
     }
 
     // Retry the call to the same endpoint.
-    private int callToProtected(String url) {
-        String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
-
+    private int callToProtected(String token, String url) {
         return given()
             .cookie(COOKIE, token)
             .when()


### PR DESCRIPTION
The test is flaky and is failing due to errors in the zOSMF behavior and on top of that there is another one, that tests the same behavior. 

@Test
@TestsNotMeantForZowe
void loginToGatewayAndAccessProtectedEndpointWithCookie() {
    String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
    given()
        .cookie(COOKIE, token)
    .when()
        .get(String.format("%s://%s:%d%s", SCHEME, HOST, PORT, PROTECTED_ENDPOINT))
    .then()
        .statusCode(is(SC_OK));
}
