### PR TITLE
Introduce StorageException to transfer information from Storage

### DIFF
--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -96,7 +96,7 @@ public class CachingController {
     }
 
     private ResponseEntity<Object> exceptionToResponse(StorageException exception) {
-        Message message = messageService.createMessage(exception.getKey(), exception.getParameters());
+        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
         return new ResponseEntity<>(message.mapToView(), exception.getStatus());
     }
 
@@ -157,25 +157,26 @@ public class CachingController {
         throw new StorageException(Messages.KEY_NOT_PROVIDED.getKey(), Messages.KEY_NOT_PROVIDED.getStatus());
     }
 
-    private void invalidPayload(KeyValue keyValue, String message) {
-        throw new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(), keyValue.toString(), message);
+    private void invalidPayload(String keyValue, String message) {
+        throw new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(),
+            keyValue, message);
     }
 
     private void checkForInvalidPayload(KeyValue keyValue) {
         if (keyValue == null) {
-            invalidPayload(keyValue, "No KeyValue provided in the payload");
+            invalidPayload(null, "No KeyValue provided in the payload");
         }
 
         if (keyValue.getValue() == null) {
-            invalidPayload(keyValue, "No value provided in the payload");
+            invalidPayload(keyValue.toString(), "No value provided in the payload");
         }
 
         String key = keyValue.getKey();
         if (key == null) {
-            invalidPayload(keyValue, "No key provided in the payload");
+            invalidPayload(keyValue.toString(), "No key provided in the payload");
         }
         if (!StringUtils.isAlphanumeric(key)) {
-            invalidPayload(keyValue, "Key is not alphanumeric");
+            invalidPayload(keyValue.toString(), "Key is not alphanumeric");
         }
     }
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -147,7 +147,7 @@ public class CachingController {
 
             keyValueOperation.storageRequest(serviceId, keyValue);
 
-            return new ResponseEntity<>(null, successStatus);
+            return new ResponseEntity<>(successStatus);
         } catch (StorageException exception) {
             return exceptionToResponse(exception);
         }
@@ -158,7 +158,7 @@ public class CachingController {
     }
 
     private void invalidPayload(KeyValue keyValue, String message) {
-        throw new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(), keyValue, message);
+        throw new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(), keyValue.toString(), message);
     }
 
     private void checkForInvalidPayload(KeyValue keyValue) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -17,9 +17,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.zowe.apiml.caching.exceptions.CachingPayloadException;
 import org.zowe.apiml.caching.model.KeyValue;
+import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.caching.service.Storage;
+import org.zowe.apiml.caching.service.StorageException;
 import org.zowe.apiml.message.core.Message;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.zaasclient.config.DefaultZaasClientConfiguration;
@@ -34,38 +35,9 @@ import javax.servlet.http.HttpServletRequest;
 @RequestMapping("/api/v1")
 @Import(DefaultZaasClientConfiguration.class)
 public class CachingController {
-    private static final String KEY_NOT_IN_CACHE_MESSAGE = "org.zowe.apiml.cache.keyNotInCache";
-
     private final Storage storage;
     private final ZaasClient zaasClient;
     private final MessageService messageService;
-
-    @GetMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    @ApiOperation(value = "Retrieves a specific value in the cache",
-        notes = "Value returned is for the provided {key}")
-    @ResponseBody
-    public ResponseEntity<Object> getValue(@PathVariable String key, HttpServletRequest request) {
-        String serviceId;
-        try {
-            ZaasToken token = zaasClient.query(request);
-            serviceId = token.getUserId();
-        } catch (ZaasClientException e) {
-            return handleZaasClientException(e, request);
-        }
-
-        if (key == null) {
-            return noKeyProvidedResponse(serviceId);
-        }
-
-        KeyValue readPair = storage.read(serviceId, key);
-
-        if (readPair == null) {
-            Message message = messageService.createMessage(KEY_NOT_IN_CACHE_MESSAGE, key, serviceId);
-            return new ResponseEntity<>(message.mapToView(), HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(readPair, HttpStatus.OK);
-    }
 
     @GetMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ApiOperation(value = "Retrieves all values in the cache",
@@ -74,8 +46,7 @@ public class CachingController {
     public ResponseEntity<Object> getAllValues(HttpServletRequest request) {
         String serviceId;
         try {
-            ZaasToken token = zaasClient.query(request);
-            serviceId = token.getUserId();
+            serviceId = authenticate(request);
         } catch (ZaasClientException e) {
             return handleZaasClientException(e, request);
         }
@@ -83,58 +54,13 @@ public class CachingController {
         return new ResponseEntity<>(storage.readForService(serviceId), HttpStatus.OK);
     }
 
-    @PostMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    @ApiOperation(value = "Create a new key in the cache",
-        notes = "A new key-value pair will be added to the cache")
+    @GetMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ApiOperation(value = "Retrieves a specific value in the cache",
+        notes = "Value returned is for the provided {key}")
     @ResponseBody
-    public ResponseEntity<Object> createKey(@RequestBody KeyValue keyValue, HttpServletRequest request) {
-        String serviceId;
-        try {
-            ZaasToken token = zaasClient.query(request);
-            serviceId = token.getUserId();
-
-            checkForInvalidPayload(keyValue);
-        } catch (ZaasClientException e) {
-            return handleZaasClientException(e, request);
-        } catch (CachingPayloadException e) {
-            return invalidPayloadResponse(e, keyValue);
-        }
-
-        KeyValue createdPair = storage.create(serviceId, keyValue);
-
-        if (createdPair == null) {
-            Message message = messageService.createMessage("org.zowe.apiml.cache.keyCollision", keyValue.getKey());
-            return new ResponseEntity<>(message.mapToView(), HttpStatus.CONFLICT);
-        }
-
-        return new ResponseEntity<>(HttpStatus.CREATED);
-    }
-
-    @PutMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    @ApiOperation(value = "Update key in the cache",
-        notes = "Value at the key in the provided key-value pair will be updated to the provided value")
-    @ResponseBody
-    public ResponseEntity<Object> update(@RequestBody KeyValue keyValue, HttpServletRequest request) {
-        String serviceId;
-        try {
-            ZaasToken token = zaasClient.query(request);
-            serviceId = token.getUserId();
-
-            checkForInvalidPayload(keyValue);
-        } catch (ZaasClientException e) {
-            return handleZaasClientException(e, request);
-        } catch (CachingPayloadException e) {
-            return invalidPayloadResponse(e, keyValue);
-        }
-
-        KeyValue updatedPair = storage.update(serviceId, keyValue);
-
-        if (updatedPair == null) {
-            Message message = messageService.createMessage(KEY_NOT_IN_CACHE_MESSAGE, keyValue.getKey(), serviceId);
-            return new ResponseEntity<>(message.mapToView(), HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    public ResponseEntity<Object> getValue(@PathVariable String key, HttpServletRequest request) {
+        return keyRequest(storage::read,
+            key, request, HttpStatus.OK);
     }
 
     @DeleteMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -142,54 +68,115 @@ public class CachingController {
         notes = "Will delete key-value pair for the provided {key}")
     @ResponseBody
     public ResponseEntity<Object> delete(@PathVariable String key, HttpServletRequest request) {
+        return keyRequest(storage::delete,
+            key, request, HttpStatus.NO_CONTENT);
+    }
+
+    @PostMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ApiOperation(value = "Create a new key in the cache",
+        notes = "A new key-value pair will be added to the cache")
+    @ResponseBody
+    public ResponseEntity<Object> createKey(@RequestBody KeyValue keyValue, HttpServletRequest request) {
+        return keyValueRequest(storage::create,
+            keyValue, request, HttpStatus.CREATED);
+    }
+
+    @PutMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ApiOperation(value = "Update key in the cache",
+        notes = "Value at the key in the provided key-value pair will be updated to the provided value")
+    @ResponseBody
+    public ResponseEntity<Object> update(@RequestBody KeyValue keyValue, HttpServletRequest request) {
+        return keyValueRequest(storage::update,
+            keyValue, request, HttpStatus.NO_CONTENT);
+    }
+
+    private String authenticate(HttpServletRequest request) throws ZaasClientException {
+        ZaasToken token = zaasClient.query(request);
+        return token.getUserId();
+    }
+
+    private ResponseEntity<Object> exceptionToResponse(StorageException exception) {
+        Message message = messageService.createMessage(exception.getKey(), exception.getParameters());
+        return new ResponseEntity<>(message.mapToView(), exception.getStatus());
+    }
+
+    /**
+     * Authenticate the user.
+     * Verify validity of the data
+     * Do the storage operation passed in as Lambda
+     * Properly handle and package Exceptions.
+     */
+    private ResponseEntity<Object> keyRequest(KeyOperation keyOperation, String key, HttpServletRequest request, HttpStatus successStatus) {
         String serviceId;
         try {
-            ZaasToken token = zaasClient.query(request);
-            serviceId = token.getUserId();
+            serviceId = authenticate(request);
         } catch (ZaasClientException e) {
             return handleZaasClientException(e, request);
         }
 
-        if (key == null) {
-            return noKeyProvidedResponse(serviceId);
+        try {
+            if (key == null) {
+                keyNotInCache();
+            }
+
+            KeyValue pair = keyOperation.storageRequest(serviceId, key);
+
+            return new ResponseEntity<>(pair, successStatus);
+        } catch (StorageException exception) {
+            return exceptionToResponse(exception);
         }
-
-        KeyValue deletedPair = storage.delete(serviceId, key);
-
-        if (deletedPair == null) {
-            Message message = messageService.createMessage(KEY_NOT_IN_CACHE_MESSAGE, key, serviceId);
-            return new ResponseEntity<>(message.mapToView(), HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    private void checkForInvalidPayload(KeyValue keyValue) throws CachingPayloadException {
+    /**
+     * Authenticate the user.
+     * verify validity of the data.
+     * Do the storage operation passed in as Lambda
+     * Properly handle and package Exceptions.
+     */
+    private ResponseEntity<Object> keyValueRequest(KeyValueOperation keyValueOperation, KeyValue keyValue,
+                                                   HttpServletRequest request, HttpStatus successStatus) {
+        String serviceId;
+        try {
+            serviceId = authenticate(request);
+        } catch (ZaasClientException e) {
+            return handleZaasClientException(e, request);
+        }
+
+        try {
+            checkForInvalidPayload(keyValue);
+
+            keyValueOperation.storageRequest(serviceId, keyValue);
+
+            return new ResponseEntity<>(null, successStatus);
+        } catch (StorageException exception) {
+            return exceptionToResponse(exception);
+        }
+    }
+
+    private void keyNotInCache() {
+        throw new StorageException(Messages.KEY_NOT_PROVIDED.getKey(), Messages.KEY_NOT_PROVIDED.getStatus());
+    }
+
+    private void invalidPayload(KeyValue keyValue, String message) {
+        throw new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(), keyValue, message);
+    }
+
+    private void checkForInvalidPayload(KeyValue keyValue) {
         if (keyValue == null) {
-            throw new CachingPayloadException("No KeyValue provided in the payload");
+            invalidPayload(keyValue, "No KeyValue provided in the payload");
         }
 
         if (keyValue.getValue() == null) {
-            throw new CachingPayloadException("No value provided in the payload");
+            invalidPayload(keyValue, "No value provided in the payload");
         }
 
         String key = keyValue.getKey();
         if (key == null) {
-            throw new CachingPayloadException("No key provided in the payload");
+            invalidPayload(keyValue, "No key provided in the payload");
         }
         if (!StringUtils.isAlphanumeric(key)) {
-            throw new CachingPayloadException("Key is not alphanumeric");
+            invalidPayload(keyValue, "Key is not alphanumeric");
         }
-    }
-
-    private ResponseEntity<Object> invalidPayloadResponse(CachingPayloadException e, KeyValue keyValue) {
-        Message message = messageService.createMessage("org.zowe.apiml.cache.invalidPayload", keyValue, e.getMessage());
-        return new ResponseEntity<>(message.mapToView(), HttpStatus.BAD_REQUEST);
-    }
-
-    private ResponseEntity<Object> noKeyProvidedResponse(String serviceId) {
-        Message message = messageService.createMessage("org.zowe.apiml.cache.keyNotProvided", serviceId);
-        return new ResponseEntity<>(message.mapToView(), HttpStatus.BAD_REQUEST);
     }
 
     private ResponseEntity<Object> handleZaasClientException(ZaasClientException e, HttpServletRequest request) {
@@ -221,5 +208,15 @@ public class CachingController {
         }
 
         return new ResponseEntity<>(message.mapToView(), statusCode);
+    }
+
+    @FunctionalInterface
+    interface KeyOperation {
+        KeyValue storageRequest(String serviceId, String key);
+    }
+
+    @FunctionalInterface
+    interface KeyValueOperation {
+        KeyValue storageRequest(String serviceId, KeyValue keyValue);
     }
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/Messages.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/Messages.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.caching.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum Messages {
+    DUPLICATE_KEY("org.zowe.apiml.cache.keyCollision", HttpStatus.CONFLICT),
+    KEY_NOT_PROVIDED("org.zowe.apiml.cache.keyNotProvided", HttpStatus.BAD_REQUEST),
+    KEY_NOT_IN_CACHE("org.zowe.apiml.cache.keyNotInCache", HttpStatus.NOT_FOUND),
+    INVALID_PAYLOAD("org.zowe.apiml.cache.invalidPayload", HttpStatus.BAD_REQUEST);
+
+    private final String key;
+    private final HttpStatus status;
+}

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/StorageException.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/StorageException.java
@@ -1,0 +1,28 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.caching.service;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class StorageException extends RuntimeException {
+    private final String key;
+    private final Object[] parameters;
+    private final HttpStatus status;
+
+    public StorageException(String key, HttpStatus status, Object... messageParameters) {
+        super(key);
+
+        this.key = key;
+        this.status = status;
+        this.parameters = messageParameters;
+    }
+}

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/StorageException.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/StorageException.java
@@ -15,10 +15,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class StorageException extends RuntimeException {
     private final String key;
-    private final Object[] parameters;
+    private final String[] parameters;
     private final HttpStatus status;
 
-    public StorageException(String key, HttpStatus status, Object... messageParameters) {
+    public StorageException(String key, HttpStatus status, String... messageParameters) {
         super(key);
 
         this.key = key;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamStorage.java
@@ -13,7 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Retryable;
 import org.zowe.apiml.caching.config.VsamConfig;
 import org.zowe.apiml.caching.model.KeyValue;
+import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.caching.service.Storage;
+import org.zowe.apiml.caching.service.StorageException;
 import org.zowe.apiml.util.ObjectUtil;
 
 import java.util.*;
@@ -61,6 +63,10 @@ public class VsamStorage implements Storage {
 
         }
 
+        if (result == null) {
+            throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey(), serviceId);
+        }
+
         return result;
     }
 
@@ -77,6 +83,10 @@ public class VsamStorage implements Storage {
             if (returned.isPresent()) {
                 result = returned.get().getKeyValue();
             }
+        }
+
+        if (result == null) {
+            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
         }
 
         return result;
@@ -96,6 +106,10 @@ public class VsamStorage implements Storage {
             if (returned.isPresent()) {
                 result = returned.get().getKeyValue();
             }
+        }
+
+        if (result == null) {
+            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toUpdate.getKey(), serviceId);
         }
 
         return result;
@@ -118,6 +132,10 @@ public class VsamStorage implements Storage {
             }
         }
 
+        if (result == null) {
+            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toDelete, serviceId);
+        }
+
         return result;
     }
 
@@ -126,7 +144,7 @@ public class VsamStorage implements Storage {
 
         log.info("Reading All Records: {}|{}|{}", serviceId, "-", "-");
         Map<String, KeyValue> result = new HashMap<>();
-        List<VsamRecord> returned = new ArrayList<>();
+        List<VsamRecord> returned;
 
         try (VsamFile file = new VsamFile(vsamConfig, VsamConfig.VsamOptions.READ)) {
             returned = file.readForService(serviceId);

--- a/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
@@ -18,7 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.zowe.apiml.caching.model.KeyValue;
+import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.caching.service.Storage;
+import org.zowe.apiml.caching.service.StorageException;
 import org.zowe.apiml.message.api.ApiMessageView;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.message.yaml.YamlMessageService;
@@ -88,7 +90,7 @@ public class CachingControllerTest {
     @Test
     void givenStoreWithNoKey_whenGetByKey_thenResponseNotFound() {
         ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
-        when(mockStorage.read(any(), any())).thenReturn(null);
+        when(mockStorage.read(any(), any())).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), KEY, SERVICE_ID));
 
         ResponseEntity<?> response = underTest.getValue(KEY, mockRequest);
         assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
@@ -119,7 +121,7 @@ public class CachingControllerTest {
 
     @Test
     void givenStorageWithExistingKey_whenCreateKey_thenResponseConflict() {
-        when(mockStorage.create(SERVICE_ID, KEY_VALUE)).thenReturn(null);
+        when(mockStorage.create(SERVICE_ID, KEY_VALUE)).thenThrow(new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), KEY));
         ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyCollision", KEY).mapToView();
 
         ResponseEntity<?> response = underTest.createKey(KEY_VALUE, mockRequest);
@@ -138,7 +140,7 @@ public class CachingControllerTest {
 
     @Test
     void givenStorageWithNoKey_whenUpdateKey_thenResponseNotFound() {
-        when(mockStorage.update(SERVICE_ID, KEY_VALUE)).thenReturn(null);
+        when(mockStorage.update(SERVICE_ID, KEY_VALUE)).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), KEY, SERVICE_ID));
         ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
 
         ResponseEntity<?> response = underTest.update(KEY_VALUE, mockRequest);
@@ -152,7 +154,7 @@ public class CachingControllerTest {
 
         ResponseEntity<?> response = underTest.delete(KEY, mockRequest);
         assertThat(response.getStatusCode(), is(HttpStatus.NO_CONTENT));
-        assertThat(response.getBody(), is(nullValue()));
+        assertThat(response.getBody(), is(KEY_VALUE));
     }
 
     @Test
@@ -167,7 +169,7 @@ public class CachingControllerTest {
     @Test
     void givenStorageWithNoKey_whenDeleteKey_thenResponseNotFound() {
         ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
-        when(mockStorage.delete(any(), any())).thenReturn(null);
+        when(mockStorage.delete(any(), any())).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), KEY, SERVICE_ID));
 
         ResponseEntity<?> response = underTest.delete(KEY, mockRequest);
         assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -12,13 +12,14 @@ package org.zowe.apiml.caching.service.inmemory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.caching.model.KeyValue;
+import org.zowe.apiml.caching.service.StorageException;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InMemoryStorageTest {
     private InMemoryStorage underTest;
@@ -65,15 +66,17 @@ public class InMemoryStorageTest {
 
     @Test
     void givenThereIsNoServiceCache_whenValueIsUpdated_thenNullIsReturned() {
-        KeyValue result = underTest.update(serviceId, new KeyValue("username", "Name 1"));
-        assertThat(result, is(nullValue()));
+        assertThrows(StorageException.class, () -> {
+            underTest.update(serviceId, new KeyValue("username", "Name 1"));
+        });
     }
 
     @Test
     void givenThereIsNoKey_whenValueIsUpdated_thenNullIsReturned() {
         testingStorage.put(serviceId, new HashMap<>());
-        KeyValue result = underTest.update(serviceId, new KeyValue("bad key", "Name 1"));
-        assertThat(result, is(nullValue()));
+        assertThrows(StorageException.class, () -> {
+            underTest.update(serviceId, new KeyValue("bad key", "Name 1"));
+        });
     }
 
     @Test
@@ -89,8 +92,9 @@ public class InMemoryStorageTest {
 
     @Test
     void givenNoValueWasStoredForTheService_whenRequested_thenNullWillBeReturned() {
-        KeyValue result = underTest.read(serviceId, "username");
-        assertThat(result, is(nullValue()));
+        assertThrows(StorageException.class, () -> {
+            underTest.read(serviceId, "username");
+        });
     }
 
     @Test
@@ -106,14 +110,16 @@ public class InMemoryStorageTest {
     @Test
     void givenKeyDoesntExist_whenDeletionRequested_thenNullIsReturned() {
         testingStorage.put(serviceId, new HashMap<>());
-        KeyValue result = underTest.delete(serviceId, "nonexistent");
-        assertThat(result, is(nullValue()));
+        assertThrows(StorageException.class, () -> {
+            underTest.delete(serviceId, "nonexistent");
+        });
     }
 
     @Test
     void givenServiceStorageDoesntExist_whenDeletionRequest_thenNullIsReturned() {
-        KeyValue result = underTest.delete(serviceId, "nonexistent");
-        assertThat(result, is(nullValue()));
+        assertThrows(StorageException.class, () -> {
+            underTest.delete(serviceId, "nonexistent");
+        });
     }
 
     @Test

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -66,16 +66,18 @@ public class InMemoryStorageTest {
 
     @Test
     void givenThereIsNoServiceCache_whenValueIsUpdated_thenNullIsReturned() {
+        KeyValue keyValue = new KeyValue("username", "Name 1");
         assertThrows(StorageException.class, () -> {
-            underTest.update(serviceId, new KeyValue("username", "Name 1"));
+            underTest.update(serviceId, keyValue);
         });
     }
 
     @Test
     void givenThereIsNoKey_whenValueIsUpdated_thenNullIsReturned() {
         testingStorage.put(serviceId, new HashMap<>());
+        KeyValue keyValue = new KeyValue("bad key", "Name 1");
         assertThrows(StorageException.class, () -> {
-            underTest.update(serviceId, new KeyValue("bad key", "Name 1"));
+            underTest.update(serviceId, keyValue);
         });
     }
 

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation libraries.tomcat_embed_core
     implementation libraries.spring_cloud_starter_eureka
     implementation libraries.spring_cloud_starter_ribbon
+    implementation libraries.jetty_websocket_common
     implementation libraries.jetty_websocket_client
     implementation libraries.jetty_util
     implementation libraries.jjwt


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description

In order to introduce the eviction mechanism later on, there was need to propagate the information about problems encountered within the storage. 

The exception was added and the refactoring is part of this effort to propagate other states from the storage via the exception. 

The changes in the Controller were done to prevent another 4 catch clauses duplicating the behavior and to limit duplicity that was already present. I am not hundred percent persuaded about the move to lambdas so if you feel it's making the solution more confusing, I will adapt the Controller to handle the Exception properly in another way. 

Part of #998 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
