### PR TITLE
Fix running local integration tests for zOSMF related tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -37,7 +37,11 @@ Perform a Localhost Quick start when you need to run the tests on your local mac
 
 **Follow these steps:**
 
-1. Deploy and run all services.
+1. Start all services locally. You can do it using:
+
+    ```shell
+    npm run api-layer-ci
+    ```
 
 2. Run the following shell script:
 

--- a/integration-tests/src/test/resources/environment-configuration.yml
+++ b/integration-tests/src/test/resources/environment-configuration.yml
@@ -30,8 +30,8 @@ tlsConfiguration:
     trustStorePassword: password
 zosmfServiceConfiguration:
     scheme: https
-    host: river.zowe.org
-    port: 10443
-    serviceId: zosmf
+    host: localhost
+    port: 10013
+    serviceId: mockzosmf
 auxiliaryUserList:
     value: 'USER1,validPassword;USER2,validPassword'


### PR DESCRIPTION
This PR makes the `runLocalIntegrationTests` gradle task pass again