### PR TITLE
InMemory is used only when no other is configured.

### DIFF
--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.caching.service.inmemory.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zowe.apiml.caching.service.Storage;
@@ -20,7 +20,7 @@ import org.zowe.apiml.caching.service.inmemory.InMemoryStorage;
 @RequiredArgsConstructor
 public class InMemoryConfiguration {
 
-    @ConditionalOnMissingBean(Storage.class)
+    @ConditionalOnProperty(name = "caching.storage.mode", matchIfMissing = true)
     @Bean
     public Storage inMemory() {
         return new InMemoryStorage();


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

# Description
Fixing configuration when VSAM is used. 

Linked to #998 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)