### PR TITLE
Support the Size limitation in the InMemory cache. 

### DIFF
--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/Messages.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/Messages.java
@@ -19,7 +19,8 @@ public enum Messages {
     DUPLICATE_KEY("org.zowe.apiml.cache.keyCollision", HttpStatus.CONFLICT),
     KEY_NOT_PROVIDED("org.zowe.apiml.cache.keyNotProvided", HttpStatus.BAD_REQUEST),
     KEY_NOT_IN_CACHE("org.zowe.apiml.cache.keyNotInCache", HttpStatus.NOT_FOUND),
-    INVALID_PAYLOAD("org.zowe.apiml.cache.invalidPayload", HttpStatus.BAD_REQUEST);
+    INVALID_PAYLOAD("org.zowe.apiml.cache.invalidPayload", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_STORAGE("org.zowe.apiml.cache.insufficientStorage", HttpStatus.INSUFFICIENT_STORAGE);
 
     private final String key;
     private final HttpStatus status;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
@@ -44,7 +44,10 @@ public class InMemoryStorage implements Storage {
             throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey());
         }
 
-        verifyTotalSize(toCreate.getKey());
+        String evictionStrategy = inMemoryConfig.getGeneralConfig().getEvictionStrategy();
+        if (evictionStrategy.equals("reject")) {
+            verifyTotalSize(toCreate.getKey());
+        }
 
         serviceStorage.put(toCreate.getKey(), toCreate);
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
@@ -102,7 +102,7 @@ public class InMemoryStorage implements Storage {
 
     private void verifyTotalSize(String key) {
         int currentSize = 0;
-        for(String serviceKey: storage.keySet()) {
+        for (String serviceKey: storage.keySet()) {
             currentSize += storage.get(serviceKey).size();
         }
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
@@ -105,8 +105,8 @@ public class InMemoryStorage implements Storage {
 
     private void verifyTotalSize(String key) {
         int currentSize = 0;
-        for (String serviceKey: storage.keySet()) {
-            currentSize += storage.get(serviceKey).size();
+        for (Map.Entry<String, Map<String, KeyValue>> serviceStorage: storage.entrySet()) {
+            currentSize += serviceStorage.getValue().size();
         }
 
         log.info("Current Size {}.", currentSize);

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfig.java
@@ -23,6 +23,7 @@ import org.zowe.apiml.caching.config.GeneralConfig;
 public class InMemoryConfig {
     private final GeneralConfig generalConfig;
 
-    @Value("${caching.storage.inmemory.size:10000}")
+    @Value("${caching.storage.inmemory.size:10}")
     private int maxDataSize;
+
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfig.java
@@ -23,7 +23,7 @@ import org.zowe.apiml.caching.config.GeneralConfig;
 public class InMemoryConfig {
     private final GeneralConfig generalConfig;
 
-    @Value("${caching.storage.inmemory.size:10}")
+    @Value("${caching.storage.inmemory.size:100}")
     private int maxDataSize;
 
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.caching.service.inmemory.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zowe.apiml.caching.service.Storage;
@@ -20,7 +20,7 @@ import org.zowe.apiml.caching.service.inmemory.InMemoryStorage;
 @RequiredArgsConstructor
 public class InMemoryConfiguration {
 
-    @ConditionalOnMissingBean(Storage.class)
+    @ConditionalOnProperty(name = "caching.storage.mode", matchIfMissing = true)
     @Bean
     public Storage inMemory() {
         return new InMemoryStorage();

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/config/InMemoryConfiguration.java
@@ -19,10 +19,11 @@ import org.zowe.apiml.caching.service.inmemory.InMemoryStorage;
 @Configuration
 @RequiredArgsConstructor
 public class InMemoryConfiguration {
+    private final InMemoryConfig inMemoryConfig;
 
-    @ConditionalOnProperty(name = "caching.storage.mode", matchIfMissing = true)
+    @ConditionalOnProperty(name = "caching.storage.mode", havingValue = "inMemory", matchIfMissing = true)
     @Bean
     public Storage inMemory() {
-        return new InMemoryStorage();
+        return new InMemoryStorage(inMemoryConfig);
     }
 }

--- a/caching-service/src/main/resources/caching-log-messages.yml
+++ b/caching-service/src/main/resources/caching-log-messages.yml
@@ -50,6 +50,14 @@ messages:
         reason: "Key is already in the cache."
         action: "Update or delete the key, or add a different key."
 
+    -   key: org.zowe.apiml.cache.insufficientStorage
+        number: ZWECS134
+        type: ERROR
+        text: "Insufficient storage space limit. Key '%s' cannot be added in the cache."
+        reason: "The storage space is full."
+        action: "Disable the 'rejected' eviction strategy."
+
+
     # Service specific messages (700 - 799)
     -   key: org.zowe.apiml.cache.gatewayUnavailable
         number: ZWECS700

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -11,8 +11,10 @@ package org.zowe.apiml.caching.service.inmemory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.zowe.apiml.caching.config.GeneralConfig;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.StorageException;
+import org.zowe.apiml.caching.service.inmemory.config.InMemoryConfig;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InMemoryStorageTest {
     private InMemoryStorage underTest;
+    private InMemoryConfig config;
 
     private Map<String, Map<String, KeyValue>> testingStorage;
     private final String serviceId = "acme";
@@ -30,12 +33,14 @@ public class InMemoryStorageTest {
     @BeforeEach
     void setUp() {
         testingStorage = new HashMap<>();
-        underTest = new InMemoryStorage(testingStorage);
+        config = new InMemoryConfig(new GeneralConfig());
+        config.setMaxDataSize(100000);
+        underTest = new InMemoryStorage(config, testingStorage);
     }
 
     @Test
     void givenDefaultStorageConstructor_whenStorageConstructed_thenCanUseStorage() {
-        underTest = new InMemoryStorage();
+        underTest = new InMemoryStorage(config);
         underTest.create(serviceId, new KeyValue("key", "value"));
 
         KeyValue result = underTest.read(serviceId, "key");
@@ -132,5 +137,28 @@ public class InMemoryStorageTest {
 
         underTest.delete(serviceId, "username");
         assertThat(serviceStorage.containsKey("username"), is(false));
+    }
+
+    @Test
+    void givenTheStorageIsFull_whenNewKeyValueIsAdded_thenTheInsufficientStorageExceptionIsRaised() {
+        config = new InMemoryConfig(new GeneralConfig());
+        config.setMaxDataSize(10);
+
+        underTest = new InMemoryStorage(config);
+        assertThrows(StorageException.class, () -> {
+            underTest.create(serviceId, new KeyValue("key", "reallyLongValueWhichShouldntPossiblyBeStoredInTheMemory"));
+        });
+    }
+
+    @Test
+    void givenTheStorageIsFull_whenKeyValueIsUpdated_thenTheInsufficientStorageExceptionIsRaised() {
+        config = new InMemoryConfig(new GeneralConfig());
+        config.setMaxDataSize(20);
+
+        underTest = new InMemoryStorage(config);
+        underTest.create(serviceId, new KeyValue("key", "value"));
+        assertThrows(StorageException.class, () -> {
+            underTest.update(serviceId, new KeyValue("key", "reallyLongValueWhichShouldntPossiblyBeStoredInTheMemory"));
+        });
     }
 }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -150,8 +150,9 @@ public class InMemoryStorageTest {
 
         underTest = new InMemoryStorage(config);
                         underTest.create("customService", new KeyValue("key", "willFit"));
+        KeyValue wontFit = new KeyValue("key", "wontFit");
         assertThrows(StorageException.class, () -> {
-            underTest.create(serviceId, new KeyValue("key", "wontFit"));
+            underTest.create(serviceId, wontFit);
         });
     }
 }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -34,7 +34,7 @@ public class InMemoryStorageTest {
     void setUp() {
         testingStorage = new HashMap<>();
         config = new InMemoryConfig(new GeneralConfig());
-        config.setMaxDataSize(100000);
+        config.setMaxDataSize(10);
         underTest = new InMemoryStorage(config, testingStorage);
     }
 
@@ -142,23 +142,12 @@ public class InMemoryStorageTest {
     @Test
     void givenTheStorageIsFull_whenNewKeyValueIsAdded_thenTheInsufficientStorageExceptionIsRaised() {
         config = new InMemoryConfig(new GeneralConfig());
-        config.setMaxDataSize(10);
+        config.setMaxDataSize(1);
 
         underTest = new InMemoryStorage(config);
+        underTest.create("customService", new KeyValue("key", "willFit"));
         assertThrows(StorageException.class, () -> {
-            underTest.create(serviceId, new KeyValue("key", "reallyLongValueWhichShouldntPossiblyBeStoredInTheMemory"));
-        });
-    }
-
-    @Test
-    void givenTheStorageIsFull_whenKeyValueIsUpdated_thenTheInsufficientStorageExceptionIsRaised() {
-        config = new InMemoryConfig(new GeneralConfig());
-        config.setMaxDataSize(20);
-
-        underTest = new InMemoryStorage(config);
-        underTest.create(serviceId, new KeyValue("key", "value"));
-        assertThrows(StorageException.class, () -> {
-            underTest.update(serviceId, new KeyValue("key", "reallyLongValueWhichShouldntPossiblyBeStoredInTheMemory"));
+            underTest.create(serviceId, new KeyValue("key", "wontFit"));
         });
     }
 }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorageTest.java
@@ -33,7 +33,9 @@ public class InMemoryStorageTest {
     @BeforeEach
     void setUp() {
         testingStorage = new HashMap<>();
-        config = new InMemoryConfig(new GeneralConfig());
+        GeneralConfig generalConfig = new GeneralConfig();
+        generalConfig.setEvictionStrategy("reject");
+        config = new InMemoryConfig(generalConfig);
         config.setMaxDataSize(10);
         underTest = new InMemoryStorage(config, testingStorage);
     }
@@ -141,11 +143,13 @@ public class InMemoryStorageTest {
 
     @Test
     void givenTheStorageIsFull_whenNewKeyValueIsAdded_thenTheInsufficientStorageExceptionIsRaised() {
-        config = new InMemoryConfig(new GeneralConfig());
+        GeneralConfig generalConfig = new GeneralConfig();
+        generalConfig.setEvictionStrategy("reject");
+        config = new InMemoryConfig(generalConfig);
         config.setMaxDataSize(1);
 
         underTest = new InMemoryStorage(config);
-        underTest.create("customService", new KeyValue("key", "willFit"));
+                        underTest.create("customService", new KeyValue("key", "willFit"));
         assertThrows(StorageException.class, () -> {
             underTest.create(serviceId, new KeyValue("key", "wontFit"));
         });

--- a/integration-tests/src/test/java/org/zowe/apiml/cachingservice/RejectEvictionTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/cachingservice/RejectEvictionTest.java
@@ -1,0 +1,100 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cachingservice;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.restassured.RestAssured;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.zowe.apiml.gatewayservice.SecurityUtils;
+import org.zowe.apiml.util.categories.NotForMainframeTest;
+import org.zowe.apiml.util.http.HttpRequestUtils;
+
+import java.net.URI;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_INSUFFICIENT_STORAGE;
+import static org.hamcrest.core.Is.is;
+
+@NotForMainframeTest // Remove later when implemented for VSAM as well.
+public class RejectEvictionTest {
+    private static final URI CACHING_PATH = HttpRequestUtils.getUriFromGateway("/cachingservice/api/v1/cache");
+    private final static String COOKIE_NAME = "apimlAuthenticationToken";
+    private static String jwtToken = SecurityUtils.gatewayToken();
+
+    @BeforeAll
+    static void setup() {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @Test
+    void givenStorageIsFull_whenAnotherKeyIsInserted_thenItIsRejected() {
+        int amountOfAllowedRecords = 100;
+        try {
+            KeyValue keyValue;
+
+            // The default configuration is to allow 100 records.
+            for (int i = 0; i < amountOfAllowedRecords; i++) {
+                keyValue = new KeyValue("key" + i, "testValue");
+                create(keyValue);
+            }
+
+            keyValue = new KeyValue("keyThatWontPass", "testValue");
+            given()
+                .contentType(JSON)
+                .body(keyValue)
+                .cookie(COOKIE_NAME, jwtToken)
+            .when()
+                .post(CACHING_PATH)
+            .then()
+                .statusCode(is(SC_INSUFFICIENT_STORAGE));
+        } finally {
+            for (int i = 0; i < amountOfAllowedRecords; i++) {
+                deteleValueUnderServiceIdWithoutValidation("key" + i, jwtToken);
+            }
+        }
+    }
+
+    private void create(KeyValue keyValue) {
+        given()
+            .contentType(JSON)
+            .body(keyValue)
+            .cookie(COOKIE_NAME, jwtToken)
+        .when()
+            .post(CACHING_PATH)
+        .then()
+            .statusCode(is(SC_CREATED));
+    }
+
+    private static void deteleValueUnderServiceIdWithoutValidation(String value, String jwtToken) {
+        given()
+            .contentType(JSON)
+            .cookie(COOKIE_NAME, jwtToken)
+            .when()
+            .delete(CACHING_PATH + "/" + value);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Data
+    private static class KeyValue {
+        private final String key;
+        private final String value;
+
+        @JsonCreator
+        public KeyValue(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/cachingservice/RejectEvictionTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/cachingservice/RejectEvictionTest.java
@@ -28,7 +28,7 @@ import static org.apache.http.HttpStatus.SC_INSUFFICIENT_STORAGE;
 import static org.hamcrest.core.Is.is;
 
 @NotForMainframeTest // Remove later when implemented for VSAM as well.
-public class RejectEvictionTest {
+class RejectEvictionTest {
     private static final URI CACHING_PATH = HttpRequestUtils.getUriFromGateway("/cachingservice/api/v1/cache");
     private final static String COOKIE_NAME = "apimlAuthenticationToken";
     private static String jwtToken = SecurityUtils.gatewayToken();


### PR DESCRIPTION
# Description

As a part of the work on the Eviction strategies this PR implements the size for the InMemory cache and an Integration test which works for the InMemory and should work for other storages as well. 

Linked to #998 

## Type of change

- [x] New feature (non-breaking change which adds functionality)