### PR TITLE
Rip/gh1009/idle eureka connections

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.product.web;
 
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
 import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClient;
 import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl.EurekaJerseyClientBuilder;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import org.zowe.apiml.security.HttpsFactory;
 import org.zowe.apiml.security.SecurityUtils;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.util.Set;
@@ -93,6 +95,10 @@ public class HttpConfig {
 
     private Set<String> publicKeyCertificatesBase64;
 
+    @Resource
+    private AbstractDiscoveryClientOptionalArgs<?> optionalArgs;
+
+
     @PostConstruct
     public void init() {
         try {
@@ -117,7 +123,7 @@ public class HttpConfig {
             secureSslContext = factory.createSslContext();
             secureHostnameVerifier = factory.createHostnameVerifier();
             eurekaJerseyClientBuilder = factory.createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId);
-
+            optionalArgs.setEurekaJerseyClient(eurekaJerseyClient());
             HttpsFactory factoryWithoutKeystore = new HttpsFactory(httpsConfigWithoutKeystore);
             secureHttpClientWithoutKeystore = factoryWithoutKeystore.createSecureHttpClient();
 
@@ -225,4 +231,6 @@ public class HttpConfig {
     public EurekaJerseyClient eurekaJerseyClient() {
         return eurekaJerseyClientBuilder.build();
     }
+
+
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -265,6 +265,7 @@ public class HttpsFactory {
         builder.withMaxTotalConnections(10);
         builder.withMaxConnectionsPerHost(10);
         builder.withConnectionIdleTimeout(10);
+        builder.withConnectionTimeout(5000);
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -265,7 +265,6 @@ public class HttpsFactory {
         builder.withMaxTotalConnections(10);
         builder.withMaxConnectionsPerHost(10);
         builder.withConnectionIdleTimeout(10);
-        builder.withConnectionTimeout(10);
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -264,7 +264,8 @@ public class HttpsFactory {
         builder.withClientName(serviceId);
         builder.withMaxTotalConnections(10);
         builder.withMaxConnectionsPerHost(10);
-
+        builder.withConnectionIdleTimeout(10);
+        builder.withConnectionTimeout(10);
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {


### PR DESCRIPTION
# Description

Eureka client keeps open connections for very long time. This is because eureka is using default jersey client instead of configured one. 

Fixes #1009 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
