### PR TITLE
associate https connections with user token, configure timeouts

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -84,6 +84,13 @@ public class HttpConfig {
     @Value("${server.maxTotalConnections:#{100}}")
     private Integer maxTotalConnections;
 
+    @Value("${apiml.httpclient.conn-pool.idleConnTimeoutSeconds:#{5}}")
+    private int idleConnTimeoutSeconds;
+    @Value("${apiml.httpclient.conn-pool.requestConnectionTimeout:#{10000}}")
+    private int requestConnectionTimeout;
+    @Value("${apiml.httpclient.conn-pool.readTimeout:#{10000}}")
+    private int readTimeout;
+
     private CloseableHttpClient secureHttpClient;
     private CloseableHttpClient secureHttpClientWithoutKeystore;
     private SSLContext secureSslContext;
@@ -107,7 +114,8 @@ public class HttpConfig {
                     .protocol(protocol)
                     .trustStore(trustStore).trustStoreType(trustStoreType).trustStorePassword(trustStorePassword).trustStoreRequired(trustStoreRequired)
                     .verifySslCertificatesOfServices(verifySslCertificatesOfServices)
-                    .maxConnectionsPerRoute(maxConnectionsPerRoute).maxTotalConnections(maxTotalConnections);
+                    .maxConnectionsPerRoute(maxConnectionsPerRoute).maxTotalConnections(maxTotalConnections)
+                    .idleConnTimeoutSeconds(idleConnTimeoutSeconds).requestConnectionTimeout(requestConnectionTimeout);
 
             HttpsConfig httpsConfig = httpsConfigSupplier.get()
                 .keyAlias(keyAlias).keyStore(keyStore).keyPassword(keyPassword)
@@ -181,6 +189,8 @@ public class HttpConfig {
     @Qualifier("restTemplateWithKeystore")
     public RestTemplate restTemplateWithKeystore() {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(secureHttpClient);
+        factory.setReadTimeout(readTimeout);
+        factory.setConnectTimeout(requestConnectionTimeout);
         return new RestTemplate(factory);
     }
 
@@ -195,6 +205,8 @@ public class HttpConfig {
     @Qualifier("restTemplateWithoutKeystore")
     public RestTemplate restTemplateWithoutKeystore() {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(secureHttpClientWithoutKeystore);
+        factory.setReadTimeout(readTimeout);
+        factory.setConnectTimeout(requestConnectionTimeout);
         return new RestTemplate(factory);
     }
 

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -90,6 +90,8 @@ public class HttpConfig {
     private int requestConnectionTimeout;
     @Value("${apiml.httpclient.conn-pool.readTimeout:#{10000}}")
     private int readTimeout;
+    @Value("${apiml.httpclient.conn-pool.timeToLive:#{10000}}")
+    private int timeToLive;
 
     private CloseableHttpClient secureHttpClient;
     private CloseableHttpClient secureHttpClientWithoutKeystore;
@@ -112,10 +114,12 @@ public class HttpConfig {
             Supplier<HttpsConfig.HttpsConfigBuilder> httpsConfigSupplier = () ->
                 HttpsConfig.builder()
                     .protocol(protocol)
-                    .trustStore(trustStore).trustStoreType(trustStoreType).trustStorePassword(trustStorePassword).trustStoreRequired(trustStoreRequired)
+                    .trustStore(trustStore).trustStoreType(trustStoreType)
+                    .trustStorePassword(trustStorePassword).trustStoreRequired(trustStoreRequired)
                     .verifySslCertificatesOfServices(verifySslCertificatesOfServices)
                     .maxConnectionsPerRoute(maxConnectionsPerRoute).maxTotalConnections(maxTotalConnections)
-                    .idleConnTimeoutSeconds(idleConnTimeoutSeconds).requestConnectionTimeout(requestConnectionTimeout);
+                    .idleConnTimeoutSeconds(idleConnTimeoutSeconds).requestConnectionTimeout(requestConnectionTimeout)
+                    .timeToLive(timeToLive);
 
             HttpsConfig httpsConfig = httpsConfigSupplier.get()
                 .keyAlias(keyAlias).keyStore(keyStore).keyPassword(keyPassword)

--- a/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
@@ -19,6 +19,8 @@ import org.apache.http.pool.PoolStats;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Used for custom pooling http connection management.
  */
@@ -28,6 +30,10 @@ public class ApimlPoolingHttpClientConnectionManager extends PoolingHttpClientCo
 
     public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry) {
         super(socketFactoryRegistry);
+    }
+
+    public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry, int timeToLive){
+        super(socketFactoryRegistry, null, null, null, timeToLive, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -53,4 +59,5 @@ public class ApimlPoolingHttpClientConnectionManager extends PoolingHttpClientCo
 
         return super.requestConnection(route, state);
     }
+
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
@@ -32,7 +32,7 @@ public class ApimlPoolingHttpClientConnectionManager extends PoolingHttpClientCo
         super(socketFactoryRegistry);
     }
 
-    public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry, int timeToLive){
+    public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry, int timeToLive) {
         super(socketFactoryRegistry, null, null, null, timeToLive, TimeUnit.MILLISECONDS);
     }
 

--- a/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManager.java
@@ -28,10 +28,6 @@ public class ApimlPoolingHttpClientConnectionManager extends PoolingHttpClientCo
 
     private final ApimlLogger apimlLog = ApimlLogger.of(ApimlPoolingHttpClientConnectionManager.class, YamlMessageServiceInstance.getInstance());
 
-    public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry) {
-        super(socketFactoryRegistry);
-    }
-
     public ApimlPoolingHttpClientConnectionManager(@NonNull Registry<ConnectionSocketFactory> socketFactoryRegistry, int timeToLive) {
         super(socketFactoryRegistry, null, null, null, timeToLive, TimeUnit.MILLISECONDS);
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
@@ -41,5 +41,7 @@ public class HttpsConfig {
     @Builder.Default
     private int idleConnTimeoutSeconds = 5;
     @Builder.Default
-    private int requestConnectionTimeout = 10000;
+    private int requestConnectionTimeout = 10_000;
+    @Builder.Default
+    private int timeToLive = 10_000;
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsConfig.java
@@ -38,4 +38,8 @@ public class HttpsConfig {
     private int maxConnectionsPerRoute = 10;
     @Builder.Default
     private int maxTotalConnections = 100;
+    @Builder.Default
+    private int idleConnTimeoutSeconds = 5;
+    @Builder.Default
+    private int requestConnectionTimeout = 10000;
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -58,12 +58,14 @@ public class HttpsFactory {
         Registry<ConnectionSocketFactory> socketFactoryRegistry;
         RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder = RegistryBuilder
             .<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory());
-        UserTokenHandler userTokenHandler = (context) -> context.getAttribute("my-token");
+        UserTokenHandler userTokenHandler = context -> context.getAttribute("my-token");
 
         socketFactoryRegistryBuilder.register("https", createSslSocketFactory());
         socketFactoryRegistry = socketFactoryRegistryBuilder.build();
-        RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(config.getRequestConnectionTimeout()).build();
-        ApimlPoolingHttpClientConnectionManager connectionManager = new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistry, 10000);
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(config.getRequestConnectionTimeout()).build();
+        ApimlPoolingHttpClientConnectionManager connectionManager =
+            new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistry, config.getTimeToLive());
         connectionManager.setDefaultMaxPerRoute(config.getMaxConnectionsPerRoute());
         connectionManager.closeIdleConnections(config.getIdleConnTimeoutSeconds(), TimeUnit.SECONDS);
         connectionManager.setMaxTotal(config.getMaxTotalConnections());

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -12,6 +12,8 @@ package org.zowe.apiml.security;
 import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl.EurekaJerseyClientBuilder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.UserTokenHandler;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
@@ -56,17 +58,18 @@ public class HttpsFactory {
         Registry<ConnectionSocketFactory> socketFactoryRegistry;
         RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder = RegistryBuilder
             .<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory());
+        UserTokenHandler userTokenHandler = (context) -> context.getAttribute("my-token");
 
         socketFactoryRegistryBuilder.register("https", createSslSocketFactory());
         socketFactoryRegistry = socketFactoryRegistryBuilder.build();
-
-        ApimlPoolingHttpClientConnectionManager connectionManager = new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistry);
+        RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(config.getRequestConnectionTimeout()).build();
+        ApimlPoolingHttpClientConnectionManager connectionManager = new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistry, 10000);
         connectionManager.setDefaultMaxPerRoute(config.getMaxConnectionsPerRoute());
-        connectionManager.closeIdleConnections(20, TimeUnit.SECONDS);
+        connectionManager.closeIdleConnections(config.getIdleConnTimeoutSeconds(), TimeUnit.SECONDS);
         connectionManager.setMaxTotal(config.getMaxTotalConnections());
 
-        return HttpClientBuilder.create()
-            .setConnectionManager(connectionManager).disableCookieManagement()
+        return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig)
+            .setConnectionManager(connectionManager).disableCookieManagement().setUserTokenHandler(userTokenHandler)
             .setKeepAliveStrategy(ApimlKeepAliveStrategy.INSTANCE)
             .disableAuthCaching().build();
 
@@ -266,6 +269,7 @@ public class HttpsFactory {
         builder.withMaxConnectionsPerHost(10);
         builder.withConnectionIdleTimeout(10);
         builder.withConnectionTimeout(5000);
+        builder.withReadTimeout(5000);
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {

--- a/common-service-core/src/test/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManagerTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/ApimlPoolingHttpClientConnectionManagerTest.java
@@ -34,7 +34,7 @@ class ApimlPoolingHttpClientConnectionManagerTest {
 
         RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder = RegistryBuilder
             .<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory());
-        connectionManager = new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistryBuilder.build());
+        connectionManager = new ApimlPoolingHttpClientConnectionManager(socketFactoryRegistryBuilder.build(),10_000);
     }
 
     @Test
@@ -45,6 +45,6 @@ class ApimlPoolingHttpClientConnectionManagerTest {
 
     @Test
     void givenNoSocketRegistry_whenCreateConnection_thenThrowError() {
-        assertThrows(IllegalArgumentException.class, () -> new ApimlPoolingHttpClientConnectionManager(null));
+        assertThrows(IllegalArgumentException.class, () -> new ApimlPoolingHttpClientConnectionManager(null,10_000));
     }
 }


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

SSL context is not allowed to be shared if it is not user specific. This will lead to opening new connection for every request, storing the connection as available but never reuse it.

from documentation: "HttpClient relies on UserTokenHandler interface to determine if the given execution context is user specific or not. The token object returned by this handler is expected to uniquely identify the current user if the context is user specific or to be null if the context does not contain any resources or details specific to the current user. The user token will be used to ensure that user specific resources will not be shared with or reused by other users. " 
Fixes #1009 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
