### PR TITLE
Upgrade remaining unit tests to JUnit 5

### DIFF
--- a/apiml-utility/src/test/java/org/zowe/apiml/product/monitoring/LatencyUtilsConfigInitializerTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/monitoring/LatencyUtilsConfigInitializerTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class LatencyUtilsConfigInitializerTest {
     private static final String PROPERTY_KEY = "LatencyUtils.useActualTime";

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -117,9 +117,6 @@ ext {
         rest_assured                       : "io.rest-assured:rest-assured:${restAssuredVersion}",
         spring_mock_mvc                    : "io.rest-assured:spring-mock-mvc:${restAssuredVersion}",
         commons_validator                  : "commons-validator:commons-validator:${commonsValidatorVersion}",
-        powermock_api_mockito2             : "org.powermock:powermock-api-mockito2:${powerMockVersion}",
-        power_mock_junit4                  : "org.powermock:powermock-module-junit4:${powerMockVersion}",
-        power_mock_junit4_rule             : "org.powermock:powermock-module-junit4-rule:${powerMockVersion}",
         jackson_core                       : "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}",
         jackson_databind                   : "com.fasterxml.jackson.core:jackson-databind:${jacksonCoreVersion}",
         jackson_annotations                : "com.fasterxml.jackson.core:jackson-annotations:${jacksonCoreVersion}",
@@ -136,7 +133,6 @@ ext {
         netflix_servo                      : "com.netflix.servo:servo-core:${netflixServoVersion}",
 
         junitJupiter                       : "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}",
-        junitVintage                       : "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}",
         mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
         mockito_jupiter                    : "org.mockito:mockito-junit-jupiter:${mockitoCoreVersion}",
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -32,9 +32,6 @@ dependencies {
     testCompile libraries.rest_assured
     testCompile libraries.awaitility
     testCompile libraries.logback_classic
-    testCompile libraries.powermock_api_mockito2
-    testCompile libraries.power_mock_junit4
-    testCompile libraries.power_mock_junit4_rule
     testCompile libraries.lombok
     testAnnotationProcessor libraries.lombok
     testCompile libraries.jsoup

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -21,7 +21,6 @@ import org.hamcrest.CoreMatchers;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
@@ -34,9 +33,14 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ApiCatalogEndpointIntegrationTest {
+class ApiCatalogEndpointIntegrationTest {
     private static final String GET_ALL_CONTAINERS_ENDPOINT = "/apicatalog/api/v1/containers";
     private static final String INVALID_CONTAINER_ENDPOINT = "/apicatalog/api/v1/containerz";
     private static final String GET_CONTAINER_BY_ID_ENDPOINT = "/apicatalog/api/v1/containers/apimediationlayer";
@@ -55,7 +59,7 @@ public class ApiCatalogEndpointIntegrationTest {
     private String baseHost;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         GatewayServiceConfiguration gatewayServiceConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
         String host = gatewayServiceConfiguration.getHost();
         int port = gatewayServiceConfiguration.getExternalPort();
@@ -73,7 +77,7 @@ public class ApiCatalogEndpointIntegrationTest {
         JSONArray containerStatus = jsonContext.read("$.[*].status");
 
         // Then
-        assertTrue("Tile title did not match: API Mediation Layer API", containerTitles.contains("API Mediation Layer API"));
+        assertTrue(containerTitles.contains("API Mediation Layer API"), "Tile title did not match: API Mediation Layer API");
         assertTrue(containerStatus.contains("UP"));
     }
 
@@ -86,7 +90,7 @@ public class ApiCatalogEndpointIntegrationTest {
         JSONArray containerTitles = jsonContext.read("$.[*].title");
         JSONArray containerStatus = jsonContext.read("$.[*].status");
 
-        assertTrue("Tile title did not match: API Mediation Layer API", containerTitles.contains("API Mediation Layer API"));
+        assertTrue(containerTitles.contains("API Mediation Layer API"), "Tile title did not match: API Mediation Layer API");
         assertTrue(containerStatus.contains("UP"));
     }
 
@@ -116,17 +120,17 @@ public class ApiCatalogEndpointIntegrationTest {
         LinkedHashMap definitions = jsonContext.read("$.definitions");
 
         // Then
-        assertFalse(apiCatalogSwagger, paths.isEmpty());
-        assertFalse(apiCatalogSwagger, definitions.isEmpty());
-        assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "/apicatalog/api/v1", swaggerBasePath);
-        assertNull(apiCatalogSwagger, paths.get("/status/updates"));
-        assertNotNull(apiCatalogSwagger, paths.get("/containers/{id}"));
-        assertNotNull(apiCatalogSwagger, paths.get("/containers"));
-        assertNotNull(apiCatalogSwagger, paths.get("/apidoc/{serviceId}/{apiVersion}"));
-        assertNotNull(apiCatalogSwagger, definitions.get("APIContainer"));
-        assertNotNull(apiCatalogSwagger, definitions.get("APIService"));
-        assertNotNull(apiCatalogSwagger, definitions.get("TimeZone"));
+        assertFalse(paths.isEmpty(), apiCatalogSwagger);
+        assertFalse(definitions.isEmpty(), apiCatalogSwagger);
+        assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+        assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+        assertNull(paths.get("/status/updates"), apiCatalogSwagger);
+        assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
+        assertNotNull(paths.get("/containers"), apiCatalogSwagger);
+        assertNotNull(paths.get("/apidoc/{serviceId}/{apiVersion}"), apiCatalogSwagger);
+        assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
+        assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
+        assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
     }
 
     @Test
@@ -159,16 +163,16 @@ public class ApiCatalogEndpointIntegrationTest {
         LinkedHashMap definitions = jsonContext.read("$.definitions");
         LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
 
-        assertTrue(apiCatalogSwagger, swaggerInfo.get("description").toString().contains("API"));
-        assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "/discoverableclient/api/v2", swaggerBasePath);
-        assertEquals(apiCatalogSwagger, "External documentation", externalDoc.get("description"));
+        assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);
+        assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+        assertEquals("/discoverableclient/api/v2", swaggerBasePath, apiCatalogSwagger);
+        assertEquals("External documentation", externalDoc.get("description"), apiCatalogSwagger);
 
-        assertFalse(apiCatalogSwagger, paths.isEmpty());
-        assertNotNull(apiCatalogSwagger, paths.get("/greeting"));
+        assertFalse(paths.isEmpty(), apiCatalogSwagger);
+        assertNotNull(paths.get("/greeting"), apiCatalogSwagger);
 
-        assertFalse(apiCatalogSwagger, definitions.isEmpty());
-        assertNotNull(apiCatalogSwagger, definitions.get("Greeting"));
+        assertFalse(definitions.isEmpty(), apiCatalogSwagger);
+        assertNotNull(definitions.get("Greeting"), apiCatalogSwagger);
     }
 
     @Test
@@ -238,11 +242,11 @@ public class ApiCatalogEndpointIntegrationTest {
 
         //When
         final String textResponse = EntityUtils.toString(response.getEntity());
-        Assert.assertThat(textResponse, CoreMatchers.startsWith("<!DOCTYPE html><html lang=\"en\">"));
-        Assert.assertThat(textResponse, CoreMatchers.containsString("<header><h1>Api Change Log</h1></header>"));
-        Assert.assertThat(textResponse, CoreMatchers.containsString(
+        assertThat(textResponse, CoreMatchers.startsWith("<!DOCTYPE html><html lang=\"en\">"));
+        assertThat(textResponse, CoreMatchers.containsString("<header><h1>Api Change Log</h1></header>"));
+        assertThat(textResponse, CoreMatchers.containsString(
             "<div><h2>What&#x27;s New</h2><hr><ol><li><span class=\"GET\">GET</span>/greeting/{yourName} <span>Get a greeting</span></li></ol></div>"));
-        Assert.assertThat(textResponse, CoreMatchers.containsString(
+        assertThat(textResponse, CoreMatchers.containsString(
             "<div><h2>What&#x27;s Deleted</h2><hr><ol><li><span class=\"GET\">GET</span><del>/{yourName}/greeting</del><span> Get a greeting</span></li>"));
     }
 
@@ -305,20 +309,20 @@ public class ApiCatalogEndpointIntegrationTest {
         LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
 
         // Then
-        assertTrue(apiCatalogSwagger, swaggerInfo.get("description").toString().contains("API"));
-        assertEquals(apiCatalogSwagger, baseHost, swaggerHost);
-        assertEquals(apiCatalogSwagger, "/discoverableclient/api/v1", swaggerBasePath);
-        assertEquals(apiCatalogSwagger, "External documentation", externalDoc.get("description"));
+        assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);
+        assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+        assertEquals("/discoverableclient/api/v1", swaggerBasePath, apiCatalogSwagger);
+        assertEquals("External documentation", externalDoc.get("description"), apiCatalogSwagger);
 
-        assertFalse(apiCatalogSwagger, paths.isEmpty());
-        assertNotNull(apiCatalogSwagger, paths.get("/greeting"));
+        assertFalse(paths.isEmpty(), apiCatalogSwagger);
+        assertNotNull(paths.get("/greeting"), apiCatalogSwagger);
 
-        assertFalse(apiCatalogSwagger, definitions.isEmpty());
+        assertFalse(definitions.isEmpty(), apiCatalogSwagger);
 
-        assertNotNull(apiCatalogSwagger, definitions.get("ApiMessage"));
-        assertNotNull(apiCatalogSwagger, definitions.get("ApiMessageView"));
-        assertNotNull(apiCatalogSwagger, definitions.get("Greeting"));
-        assertNotNull(apiCatalogSwagger, definitions.get("Pet"));
-        assertNotNull(apiCatalogSwagger, definitions.get("RedirectLocation"));
+        assertNotNull(definitions.get("ApiMessage"), apiCatalogSwagger);
+        assertNotNull(definitions.get("ApiMessageView"), apiCatalogSwagger);
+        assertNotNull(definitions.get("Greeting"), apiCatalogSwagger);
+        assertNotNull(definitions.get("Pet"), apiCatalogSwagger);
+        assertNotNull(definitions.get("RedirectLocation"), apiCatalogSwagger);
     }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogHttpHeadersIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogHttpHeadersIntegrationTest.java
@@ -21,9 +21,9 @@ import java.util.*;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ApiCatalogHttpHeadersIntegrationTest {
+class ApiCatalogHttpHeadersIntegrationTest {
 
     private static final String GET_ALL_CONTAINERS_ENDPOINT = "/ui/v1/apicatalog/#";
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
@@ -34,7 +34,7 @@ public class ApiCatalogHttpHeadersIntegrationTest {
     private final static String COOKIE = "apimlAuthenticationToken";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         RestAssured.useRelaxedHTTPSValidation();
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogLoginIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogLoginIntegrationTest.java
@@ -27,11 +27,11 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 //TODO: Showing original endpoints ... is it correct?
-public class ApiCatalogLoginIntegrationTest {
+class ApiCatalogLoginIntegrationTest {
     private final static String SCHEME = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getScheme();
     private final static String HOST = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getHost();
     private final static int PORT = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getPort();
@@ -45,7 +45,7 @@ public class ApiCatalogLoginIntegrationTest {
     private final static String INVALID_PASSWORD = "incorrectPassword";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         RestAssured.useRelaxedHTTPSValidation();
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingApiIntegrationTest.java
@@ -19,9 +19,9 @@ import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class GreetingApiIntegrationTest {
+class GreetingApiIntegrationTest {
     @Test
     @TestsNotMeantForZowe
     void shouldCallDiscoverableServiceApi() throws Exception {

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingV2ApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/GreetingV2ApiIntegrationTest.java
@@ -19,10 +19,10 @@ import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @TestsNotMeantForZowe
-public class GreetingV2ApiIntegrationTest {
+class GreetingV2ApiIntegrationTest {
     @Test
     void givenDiscoverableClient_whenCallGreetingV2_thenGetResponse() throws Exception {
         final HttpResponse response = HttpRequestUtils.getResponse("/discoverableclient/api/v2/greeting", SC_OK);

--- a/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/UiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoverableclient/UiIntegrationTest.java
@@ -18,7 +18,7 @@ import org.zowe.apiml.util.http.HttpClientUtils;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 class UiIntegrationTest {
     @Test

--- a/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/EurekaInstancesIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/EurekaInstancesIntegrationTest.java
@@ -26,11 +26,15 @@ import java.net.URI;
 import java.util.*;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
 /**
@@ -49,7 +53,7 @@ class EurekaInstancesIntegrationTest {
 
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         discoveryServiceConfiguration = ConfigReader.environmentConfiguration().getDiscoveryServiceConfiguration();
         scheme = discoveryServiceConfiguration.getScheme();
         username = ConfigReader.environmentConfiguration().getCredentials().getUser();

--- a/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/staticdef/StaticClientRoutingEndpointsTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/discoveryservice/staticdef/StaticClientRoutingEndpointsTest.java
@@ -16,15 +16,15 @@ import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class StaticClientRoutingEndpointsTest {
+class StaticClientRoutingEndpointsTest {
     private static final String GREET = "/api/v1/discoverableclient/greeting";
     private static final String STATIC_GREET = "/api/v1/staticclient/greeting";
 
     @Test
     @TestsNotMeantForZowe
-    public void shouldSameResponseAsDynamicService() throws Exception {
+    void shouldSameResponseAsDynamicService() throws Exception {
         // When
         final HttpResponse response = HttpRequestUtils.getResponse(GREET, SC_OK);
         final HttpResponse staticResponse = HttpRequestUtils.getResponse(STATIC_GREET, SC_OK);

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/AuthenticationOnDeploymentTest.java
@@ -32,8 +32,8 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.*;
 
 /**
@@ -54,7 +54,7 @@ class AuthenticationOnDeploymentTest {
     private RequestVerifier verifier;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         RestAssured.useRelaxedHTTPSValidation();
         RestAssured.config = RestAssured.config().sslConfig(getConfiguredSslConfig());
         verifier = RequestVerifier.getInstance();

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewayConcurrentRequestsTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewayConcurrentRequestsTest.java
@@ -26,7 +26,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.zowe.apiml.util.http.HttpRequestUtils.getUriFromGateway;
 
 @TestsNotMeantForZowe

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewaySecurityTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewaySecurityTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 class GatewaySecurityTest {
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewayTimeoutTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/GatewayTimeoutTest.java
@@ -16,15 +16,16 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.util.categories.SlowTests;
-import org.zowe.apiml.util.categories.TestsNotMeantForZowe;import org.zowe.apiml.util.http.HttpClientUtils;
+import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
+import org.zowe.apiml.util.http.HttpClientUtils;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.zowe.apiml.util.http.HttpRequestUtils.getUriFromGateway;
 
 @Slf4j

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PassTicketTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PassTicketTest.java
@@ -28,7 +28,7 @@ import static org.apache.http.HttpStatus.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.*;
 import static org.zowe.apiml.passticket.PassTicketService.DefaultPassTicketImpl.UNKNOWN_APPLID;
 

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PublicKeyIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/PublicKeyIntegrationTest.java
@@ -26,14 +26,14 @@ import java.text.ParseException;
 import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.zowe.apiml.gatewayservice.SecurityUtils.getConfiguredSslConfig;
 
 @TestsNotMeantForZowe
-public class PublicKeyIntegrationTest {
+class PublicKeyIntegrationTest {
 
     private final static String ALL_PUBLIC_KEY_ENDPOINT = "/api/v1/gateway/auth/keys/public/all";
     private final static String CURRENT_PUBLIC_KEY_ENDPOINT = "/api/v1/gateway/auth/keys/public/current";
@@ -45,7 +45,7 @@ public class PublicKeyIntegrationTest {
     private final static String GATEWAY_URL = String.format("%s://%s:%s", GATEWAY_SCHEME, GATEWAY_HOST, GATEWAY_PORT);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         RestAssured.useRelaxedHTTPSValidation();
         RestAssured.config = RestAssured.config().sslConfig(getConfiguredSslConfig());
     }

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/ApiMediationLayerStartTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/ApiMediationLayerStartTest.java
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.zowe.apiml.startup.impl.ApiMediationLayerStartupChecker;
 import org.zowe.apiml.util.categories.StartupCheck;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @StartupCheck
-public class ApiMediationLayerStartTest {
+class ApiMediationLayerStartTest {
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         new ApiMediationLayerStartupChecker().waitUntilReady();
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @Slf4j
 public class HttpRequestUtils {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/service/RequestVerifier.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/service/RequestVerifier.java
@@ -16,8 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 import java.util.function.Predicate;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class is using for verification request in VirtualService. If test call VerifyServlet in there, request data are
@@ -69,7 +69,7 @@ public class RequestVerifier {
     public void existAndClean(VirtualService virtualService, Predicate<HttpRequestCopy> verify) {
         synchronized (requests) {
             List<HttpRequestCopy> list = requests.get(virtualService);
-            assertNotNull("No request exists", list);
+            assertNotNull(list, "No request exists");
             for (Iterator<HttpRequestCopy> i = list.iterator(); i.hasNext(); ) {
                 HttpRequestCopy req = i.next();
                 if (verify.test(req)) {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
@@ -44,7 +44,9 @@ import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
 
 /**

--- a/integration-tests/src/test/java/org/zowe/apiml/ws/WebSocketProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/ws/WebSocketProxyTest.java
@@ -30,8 +30,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.tomcat.websocket.Constants.SSL_CONTEXT_PROPERTY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestsNotMeantForZowe
 class WebSocketProxyTest {

--- a/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/ServletContextListenerTest.java
+++ b/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/ServletContextListenerTest.java
@@ -9,7 +9,7 @@
  */
 package org.zowe.apiml.hwsjersey;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockServletContext;
 import org.zowe.apiml.eurekaservice.client.ApiMediationClient;
@@ -22,9 +22,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 
-public class ServletContextListenerTest {
+class ServletContextListenerTest {
     @Test
-    public void testOnContextCreationRegisterWithEureka() throws ServiceDefinitionException {
+    void testOnContextCreationRegisterWithEureka() throws ServiceDefinitionException {
         ApiMediationClient mock = Mockito.mock(ApiMediationClient.class);
         ServletContext context = setValidParametersTo(
             new MockServletContext()
@@ -38,7 +38,7 @@ public class ServletContextListenerTest {
     }
 
     @Test
-    public void testOnContextDestroyUnregisterWithEureka() {
+    void testOnContextDestroyUnregisterWithEureka() {
         ApiMediationClient mock = Mockito.mock(ApiMediationClient.class);
         setValidParametersTo(
             new MockServletContext()

--- a/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/greeting/GreetingControllerTest.java
+++ b/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/greeting/GreetingControllerTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 
-
+// WARN: JerseyTest does not support Junit 5
 public class GreetingControllerTest extends JerseyTest {
 
     @Override

--- a/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/health/HealthControllerTest.java
+++ b/onboarding-enabler-java-sample-app/src/test/java/org/zowe/apiml/hwsjersey/health/HealthControllerTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+// WARN: JerseyTest does not support Junit 5
 public class HealthControllerTest extends JerseyTest {
 
     @Override

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -40,8 +40,6 @@ dependencies {
 
     annotationProcessor libraries.spring_boot_configuration_processor
     testCompile libraries.gson
-
-    testCompileOnly libraries.junitVintage
 }
 
 jar {


### PR DESCRIPTION
# Description
Removes remaining references to JUnit4, except in modules that have blocking dependencies.

Fixes #1105 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [n/a] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules

