### PR TITLE
Rip/ac/locking user

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
@@ -49,8 +49,11 @@ class ZaasClientIntegrationTest {
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
     private static final String INVALID_USER = "usr";
+    private static final String INVALID_PASS = "usr";
     private static final String NULL_USER = null;
+    private static final String NULL_PASS = null;
     private static final String EMPTY_USER = "";
+    private static final String EMPTY_PASS = "";
     private static final String NULL_AUTH_HEADER = null;
     private static final String EMPTY_AUTH_HEADER = "";
     private static final String EMPTY_STRING = "";

--- a/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
@@ -49,11 +49,8 @@ class ZaasClientIntegrationTest {
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
     private static final String INVALID_USER = "usr";
-    private static final String INVALID_PASS = "usr";
     private static final String NULL_USER = null;
-    private static final String NULL_PASS = null;
     private static final String EMPTY_USER = "";
-    private static final String EMPTY_PASS = "";
     private static final String NULL_AUTH_HEADER = null;
     private static final String EMPTY_AUTH_HEADER = "";
     private static final String EMPTY_STRING = "";
@@ -117,9 +114,7 @@ class ZaasClientIntegrationTest {
     private static Stream<Arguments> provideInvalidUsernamePassword() {
         return Stream.of(
             Arguments.of(INVALID_USER, PASSWORD, ZaasClientErrorCodes.INVALID_AUTHENTICATION),
-            Arguments.of(USERNAME, INVALID_PASS, ZaasClientErrorCodes.INVALID_AUTHENTICATION),
             Arguments.of(NULL_USER, PASSWORD, ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD),
-            Arguments.of(USERNAME, NULL_PASS, ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD),
             Arguments.of(EMPTY_USER, PASSWORD, ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD)
         );
     }
@@ -135,11 +130,8 @@ class ZaasClientIntegrationTest {
     private static Stream<Arguments> provideInvalidAuthHeaders() {
         return Stream.of(
             Arguments.of(getAuthHeader(INVALID_USER, PASSWORD), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
-            Arguments.of(getAuthHeader(USERNAME, INVALID_PASS), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
             Arguments.of(getAuthHeader(NULL_USER, PASSWORD), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
-            Arguments.of(getAuthHeader(USERNAME, NULL_PASS), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
             Arguments.of(getAuthHeader(EMPTY_USER, PASSWORD), ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD),
-            Arguments.of(getAuthHeader(USERNAME, EMPTY_PASS), ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD),
             Arguments.of(NULL_AUTH_HEADER, ZaasClientErrorCodes.EMPTY_NULL_AUTHORIZATION_HEADER),
             Arguments.of(EMPTY_AUTH_HEADER, ZaasClientErrorCodes.EMPTY_NULL_AUTHORIZATION_HEADER)
         );

--- a/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.zowe.apiml.util.categories.NotForMainframeTest;
 import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.config.ConfigReaderZaasClient;
 import org.zowe.apiml.zaasclient.config.ConfigProperties;
@@ -122,9 +123,26 @@ class ZaasClientIntegrationTest {
         );
     }
 
+
     @ParameterizedTest
     @MethodSource("provideInvalidUsernamePassword")
     void giveInvalidCredentials_whenLoginIsRequested_thenProperExceptionIsRaised(String username, String password, ZaasClientErrorCodes expectedCode) {
+        ZaasClientException exception = assertThrows(ZaasClientException.class, () -> tokenService.login(username, password));
+
+        assertThatExceptionContainValidCode(exception, expectedCode);
+    }
+
+    private static Stream<Arguments> provideInvalidPassword() {
+        return Stream.of(
+            Arguments.of(USERNAME, INVALID_PASS, ZaasClientErrorCodes.INVALID_AUTHENTICATION),
+            Arguments.of(USERNAME, NULL_PASS, ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD)
+        );
+    }
+
+    @NotForMainframeTest
+    @ParameterizedTest
+    @MethodSource("provideInvalidPassword")
+    void giveInvalidPassword_whenLoginIsRequested_thenProperExceptionIsRaised(String username, String password, ZaasClientErrorCodes expectedCode) {
         ZaasClientException exception = assertThrows(ZaasClientException.class, () -> tokenService.login(username, password));
 
         assertThatExceptionContainValidCode(exception, expectedCode);
@@ -140,9 +158,27 @@ class ZaasClientIntegrationTest {
         );
     }
 
+
     @ParameterizedTest
     @MethodSource("provideInvalidAuthHeaders")
-    void doLoginWithAuthHeaderInValidUsername(String authHeader, ZaasClientErrorCodes expectedCode) {
+    void doLoginWithAuthHeaderInvalidUsername(String authHeader, ZaasClientErrorCodes expectedCode) {
+        ZaasClientException exception = assertThrows(ZaasClientException.class, () -> tokenService.login(authHeader));
+
+        assertThatExceptionContainValidCode(exception, expectedCode);
+    }
+
+    private static Stream<Arguments> provideInvalidPasswordAuthHeaders() {
+        return Stream.of(
+            Arguments.of(getAuthHeader(USERNAME, INVALID_PASS), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
+            Arguments.of(getAuthHeader(USERNAME, NULL_PASS), ZaasClientErrorCodes.INVALID_AUTHENTICATION),
+            Arguments.of(getAuthHeader(USERNAME, EMPTY_PASS), ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD)
+        );
+    }
+
+    @NotForMainframeTest
+    @ParameterizedTest
+    @MethodSource("provideInvalidPasswordAuthHeaders")
+    void doLoginWithAuthHeaderInvalidPassword(String authHeader, ZaasClientErrorCodes expectedCode) {
         ZaasClientException exception = assertThrows(ZaasClientException.class, () -> tokenService.login(authHeader));
 
         assertThatExceptionContainValidCode(exception, expectedCode);

--- a/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/zaasclient/ZaasClientIntegrationTest.java
@@ -25,8 +25,8 @@ import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
-import org.zowe.apiml.zaasclient.service.internal.ZaasClientImpl;
 import org.zowe.apiml.zaasclient.service.ZaasToken;
+import org.zowe.apiml.zaasclient.service.internal.ZaasClientImpl;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -94,7 +94,7 @@ class ZaasClientIntegrationTest {
     private void assertThatExceptionContainValidCode(ZaasClientException zce, ZaasClientErrorCodes code) {
         ZaasClientErrorCodes producedErrorCode = zce.getErrorCode();
         assertThat(code.getId(), Is.is(producedErrorCode.getId()));
-        assertThat( code.getMessage(), Is.is(producedErrorCode.getMessage()));
+        assertThat(code.getMessage(), Is.is(producedErrorCode.getMessage()));
         assertThat(code.getReturnCode(), Is.is(producedErrorCode.getReturnCode()));
     }
 
@@ -194,7 +194,7 @@ class ZaasClientIntegrationTest {
     }
 
     @Test
-    void givenInvalidToken_whenPassTicketIsRequested_thenExceptionIsThrown()  {
+    void givenInvalidToken_whenPassTicketIsRequested_thenExceptionIsThrown() {
         assertThrows(ZaasClientException.class, () -> {
             String invalidToken = "INVALID_TOKEN";
             tokenService.passTicket(invalidToken, "ZOWEAPPL");


### PR DESCRIPTION
# Description

Tests for zaas client can lead to password suspension as they are trying to log in with invalid password. After 3 attempts, user is suspended. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
