### PR TITLE
Rip/ac/zosmf cache

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/AuthenticationService.java
@@ -313,7 +313,7 @@ public class AuthenticationService {
      * @throws TokenNotValidException if the token is not valid
      */
     public TokenAuthentication validateJwtToken(TokenAuthentication token) {
-        return meAsProxy.validateJwtToken(Optional.ofNullable(token).map(TokenAuthentication::getCredentials).orElse(null));
+        return meAsProxy.validateJwtToken( token != null ? token.getCredentials() : null);
     }
 
     /**

--- a/gateway-service/src/main/resources/ehcache.xml
+++ b/gateway-service/src/main/resources/ehcache.xml
@@ -11,5 +11,6 @@
     <cache name="serviceAuthenticationByAuthentication" diskPersistent="false" maxEntriesLocalHeap="1000" eternal="false" timeToIdleSeconds="86400" timeToLiveSeconds="86400" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
     <cache name="zosmfInfo" diskPersistent="false" maxEntriesLocalHeap="10" eternal="false" timeToIdleSeconds="3600" timeToLiveSeconds="3600" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
     <cache name="zosmfServiceImplementation" diskPersistent="false" maxEntriesLocalHeap="10" eternal="false" timeToIdleSeconds="3600" timeToLiveSeconds="3600" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
+    <cache name="zosmfAuthenticationEndpoint" diskPersistent="false" maxEntriesLocalHeap="10" eternal="false" timeToIdleSeconds="3600" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
 
 </ehcache>

--- a/gateway-service/src/test/java/org/zowe/apiml/config/service/security/MockedAuthenticationServiceContext.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/config/service/security/MockedAuthenticationServiceContext.java
@@ -59,7 +59,7 @@ public class MockedAuthenticationServiceContext {
             getAuthConfigurationProperties(),
             getDiscoveryClient(),
             getRestTemplate(),
-            AuthenticationServiceTest.securityObjectMapper
+            AuthenticationServiceTest.securityObjectMapper,applicationContext
         );
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
@@ -19,10 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationContext;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -40,368 +37,384 @@ import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class ZosmfAuthenticationProviderTest {
 
-   private static final String USERNAME = "user";
-   private static final String PASSWORD = "password";
-   private static final String SERVICE_ID = "service";
-   private static final String HOST = "localhost";
-   private static final int PORT = 0;
-   private static final String ZOSMF = "zosmf";
-   private static final String COOKIE1 = "Cookie1=testCookie1";
-   private static final String COOKIE2 = "LtpaToken2=test";
-   private static final String DOMAIN = "realm";
-   private static final String RESPONSE = "{\"zosmf_saf_realm\": \"" + DOMAIN + "\"}";
-   private static final String INVALID_RESPONSE = "{\"saf_realm\": \"" + DOMAIN + "\"}";
-
-   private UsernamePasswordAuthenticationToken usernamePasswordAuthentication;
-   private AuthConfigurationProperties authConfigurationProperties;
-   private DiscoveryClient discovery;
-   private RestTemplate restTemplate;
-   private InstanceInfo zosmfInstance;
-   private AuthenticationService authenticationService;
-   private ObjectMapper securityObjectMapper = new ObjectMapper();
+    private static final String USERNAME = "user";
+    private static final String PASSWORD = "password";
+    private static final String SERVICE_ID = "service";
+    private static final String HOST = "localhost";
+    private static final int PORT = 0;
+    private static final String ZOSMF = "zosmf";
+    private static final String COOKIE1 = "Cookie1=testCookie1";
+    private static final String COOKIE2 = "LtpaToken2=test";
+    private static final String DOMAIN = "realm";
+    private static final String RESPONSE = "{\"zosmf_saf_realm\": \"" + DOMAIN + "\"}";
+    private static final String INVALID_RESPONSE = "{\"saf_realm\": \"" + DOMAIN + "\"}";
+    private UsernamePasswordAuthenticationToken usernamePasswordAuthentication;
+    private AuthConfigurationProperties authConfigurationProperties;
+    private DiscoveryClient discovery;
+    private RestTemplate restTemplate;
+    private InstanceInfo zosmfInstance;
+    private AuthenticationService authenticationService;
+    private ObjectMapper securityObjectMapper = new ObjectMapper();
+    protected static final String ZOSMF_CSRF_HEADER = "X-CSRF-ZOSMF-HEADER";
 
     private ZosmfService.AuthenticationResponse getResponse(boolean valid) {
         if (valid) return new ZosmfService.AuthenticationResponse(RESPONSE, null);
         return new ZosmfService.AuthenticationResponse(INVALID_RESPONSE, null);
     }
 
-   @BeforeEach
-   void setUp() {
-       usernamePasswordAuthentication = new UsernamePasswordAuthenticationToken(USERNAME, PASSWORD);
-       authConfigurationProperties = new AuthConfigurationProperties();
-       discovery = mock(DiscoveryClient.class);
-       authenticationService = mock(AuthenticationService.class);
-       restTemplate = mock(RestTemplate.class);
-       zosmfInstance = createInstanceInfo(SERVICE_ID, HOST, PORT);
+    @BeforeEach
+    void setUp() {
+        usernamePasswordAuthentication = new UsernamePasswordAuthenticationToken(USERNAME, PASSWORD);
+        authConfigurationProperties = new AuthConfigurationProperties();
+        discovery = mock(DiscoveryClient.class);
+        authenticationService = mock(AuthenticationService.class);
+        restTemplate = mock(RestTemplate.class);
+        zosmfInstance = createInstanceInfo(SERVICE_ID, HOST, PORT);
 
-       doAnswer((Answer<TokenAuthentication>) invocation -> TokenAuthentication.createAuthenticated(invocation.getArgument(0), invocation.getArgument(1))).when(authenticationService).createTokenAuthentication(anyString(), anyString());
-       when(authenticationService.createJwtToken(anyString(), anyString(), anyString())).thenReturn("someJwtToken");
-   }
+        doAnswer((Answer<TokenAuthentication>) invocation -> TokenAuthentication.createAuthenticated(invocation.getArgument(0), invocation.getArgument(1))).when(authenticationService).createTokenAuthentication(anyString(), anyString());
+        when(authenticationService.createJwtToken(anyString(), anyString(), anyString())).thenReturn("someJwtToken");
+    }
 
-   private InstanceInfo createInstanceInfo(String serviceId, String host, int port) {
-       InstanceInfo out = mock(InstanceInfo.class);
-       when(out.getAppName()).thenReturn(serviceId);
-       when(out.getHostName()).thenReturn(host);
-       when(out.getPort()).thenReturn(port);
-       return out;
-   }
+    private InstanceInfo createInstanceInfo(String serviceId, String host, int port) {
+        InstanceInfo out = mock(InstanceInfo.class);
+        when(out.getAppName()).thenReturn(serviceId);
+        when(out.getHostName()).thenReturn(host);
+        when(out.getPort()).thenReturn(port);
+        return out;
+    }
 
-   private Application createApplication(InstanceInfo...instanceInfos) {
-       Application out = mock(Application.class);
-       when(out.getInstances()).thenReturn(Arrays.asList(instanceInfos));
-       return out;
-   }
+    private Application createApplication(InstanceInfo... instanceInfos) {
+        Application out = mock(Application.class);
+        when(out.getInstances()).thenReturn(Arrays.asList(instanceInfos));
+        return out;
+    }
 
-   private ZosmfService createZosmfService() {
-       ApplicationContext applicationContext = mock(ApplicationContext.class);
-       ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper,applicationContext);
-       ZosmfService output = spy(zosmfService);
-       when(applicationContext.getBean(ZosmfService.class)).thenReturn(output);
-       return output;
-   }
+    private ZosmfService createZosmfService() {
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper, applicationContext);
+        ReflectionTestUtils.setField(zosmfService, "meAsProxy", zosmfService);
+        ZosmfService output = spy(zosmfService);
+        when(applicationContext.getBean(ZosmfService.class)).thenReturn(output);
+        return output;
+    }
 
-   @Test
-   void loginWithExistingUser() throws IOException {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void loginWithExistingUser() throws IOException {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       HttpHeaders headers = new HttpHeaders();
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
-       doReturn("realm").when(zosmfService).getZosmfRealm(Mockito.anyString());
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Authentication tokenAuthentication
-           = zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication);
+        mockZosmfRealmRestCallResponse();
+        mockZosmfRealmRestCallResponse();
+        Authentication tokenAuthentication
+            = zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication);
 
-       assertTrue(tokenAuthentication.isAuthenticated());
-       assertEquals(USERNAME, tokenAuthentication.getPrincipal());
-   }
+        assertTrue(tokenAuthentication.isAuthenticated());
+        assertEquals(USERNAME, tokenAuthentication.getPrincipal());
+    }
 
-   @Test
-   void loginWithBadUser() throws IOException {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void loginWithBadUser() throws IOException {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       HttpHeaders headers = new HttpHeaders();
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
-       doReturn("realm").when(zosmfService).getZosmfRealm(Mockito.anyString());
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(BadCredentialsException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not BadCredentialsException");
-       assertEquals("Username or password are invalid.", exception.getMessage());
-   }
+        mockZosmfRealmRestCallResponse();
+        Exception exception = assertThrows(BadCredentialsException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not BadCredentialsException");
+        assertEquals("Username or password are invalid.", exception.getMessage());
+    }
 
-   @Test
-   void noZosmfInstance() {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void noZosmfInstance() {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication();
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication();
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(ServiceNotAccessibleException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not ServiceNotAccessibleException");
-       assertEquals("z/OSMF instance not found or incorrectly configured.", exception.getMessage());
-   }
+        Exception exception = assertThrows(ServiceNotAccessibleException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not ServiceNotAccessibleException");
+        assertEquals("z/OSMF instance not found or incorrectly configured.", exception.getMessage());
+    }
 
-   @Test
-   void noZosmfServiceId() {
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+    @Test
+    void noZosmfServiceId() {
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(AuthenticationServiceException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not AuthenticationServiceException");
-       assertEquals("The parameter 'zosmfServiceId' is not configured.", exception.getMessage());
-   }
+        Exception exception = assertThrows(AuthenticationServiceException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not AuthenticationServiceException");
+        assertEquals("The parameter 'zosmfServiceId' is not configured.", exception.getMessage());
+    }
 
-   @Test
-   void notValidZosmfResponse() throws Exception {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void notValidZosmfResponse() throws Exception {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       HttpHeaders headers = new HttpHeaders();
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(new ZosmfService.ZosmfInfo(), headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(new ZosmfService.ZosmfInfo(), headers, HttpStatus.OK));
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(AuthenticationServiceException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not AuthenticationServiceException");
-       assertEquals("z/OSMF domain cannot be read.", exception.getMessage());
-   }
+        Exception exception = assertThrows(AuthenticationServiceException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not AuthenticationServiceException");
+        assertEquals("z/OSMF domain cannot be read.", exception.getMessage());
+    }
 
-   @Test
-   void noDomainInResponse() throws IOException {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void noDomainInResponse() throws IOException {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       ZosmfService.ZosmfInfo zosmfInfoNoDomain =
-           securityObjectMapper.reader().forType(ZosmfService.ZosmfInfo.class).readValue(INVALID_RESPONSE);
+        ZosmfService.ZosmfInfo zosmfInfoNoDomain =
+            securityObjectMapper.reader().forType(ZosmfService.ZosmfInfo.class).readValue(INVALID_RESPONSE);
 
-       HttpHeaders headers = new HttpHeaders();
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
-       headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(zosmfInfoNoDomain, headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE1);
+        headers.add(HttpHeaders.SET_COOKIE, COOKIE2);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(zosmfInfoNoDomain, headers, HttpStatus.OK));
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(AuthenticationServiceException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not AuthenticationServiceException");
-       assertEquals("z/OSMF domain cannot be read.", exception.getMessage());
-   }
+        Exception exception = assertThrows(AuthenticationServiceException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not AuthenticationServiceException");
+        assertEquals("z/OSMF domain cannot be read.", exception.getMessage());
+    }
 
-   @Test
-   void invalidCookieInResponse() throws IOException {
-       String invalidCookie = "LtpaToken=test";
+    @Test
+    void invalidCookieInResponse() throws IOException {
+        String invalidCookie = "LtpaToken=test";
 
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       HttpHeaders headers = new HttpHeaders();
-       headers.add(HttpHeaders.SET_COOKIE, invalidCookie);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, invalidCookie);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
+        mockZosmfRealmRestCallResponse();
+        ZosmfService zosmfService = createZosmfService();
+        doReturn(false).when(zosmfService).loginEndpointExists();
 
-       ZosmfService zosmfService = createZosmfService();
-       doReturn(false).when(zosmfService).loginEndpointExists();
-       doReturn("realm").when(zosmfService).getZosmfRealm(Mockito.anyString());
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        mockZosmfRealmRestCallResponse();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        Exception exception = assertThrows(BadCredentialsException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not BadCredentialsException");
+        assertEquals("Username or password are invalid.", exception.getMessage());
+    }
 
-       Exception exception = assertThrows(BadCredentialsException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not BadCredentialsException");
-       assertEquals("Username or password are invalid.", exception.getMessage());
-   }
+    private void mockZosmfRealmRestCallResponse() {
+        final HttpHeaders zosmfheaders = new HttpHeaders();
+        zosmfheaders.add(ZOSMF_CSRF_HEADER, "");
+        ZosmfService.ZosmfInfo info = new ZosmfService.ZosmfInfo();
+        info.setSafRealm("realm");
+        when(restTemplate.exchange(eq("http://localhost:0/zosmf/info"),
+            Mockito.eq(HttpMethod.GET),
+            eq(new HttpEntity<>(null, zosmfheaders)),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(info, zosmfheaders, HttpStatus.OK));
+    }
 
-   @Test
-   void cookieWithSemicolon() throws IOException {
-       String cookie = "LtpaToken2=test;";
+    @Test
+    void cookieWithSemicolon() throws IOException {
+        String cookie = "LtpaToken2=test;";
 
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
 
-       HttpHeaders headers = new HttpHeaders();
-       headers.add(HttpHeaders.SET_COOKIE, cookie);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, cookie);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenReturn(new ResponseEntity<>(getResponse(true), headers, HttpStatus.OK));
 
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
-       doReturn("realm").when(zosmfService).getZosmfRealm(Mockito.anyString());
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Authentication tokenAuthentication = zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication);
+        mockZosmfRealmRestCallResponse();
+        Authentication tokenAuthentication = zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication);
 
-       assertTrue(tokenAuthentication.isAuthenticated());
-       assertEquals(USERNAME, tokenAuthentication.getPrincipal());
-   }
+        assertTrue(tokenAuthentication.isAuthenticated());
+        assertEquals(USERNAME, tokenAuthentication.getPrincipal());
+    }
 
-   @Test
-   void shouldThrowNewExceptionIfRestClientException() {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void shouldThrowNewExceptionIfRestClientException() {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenThrow(RestClientException.class);
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenThrow(RestClientException.class);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(AuthenticationServiceException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not AuthenticationServiceException");
-       assertEquals("A failure occurred when authenticating.", exception.getMessage());
-   }
+        Exception exception = assertThrows(AuthenticationServiceException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not AuthenticationServiceException");
+        assertEquals("A failure occurred when authenticating.", exception.getMessage());
+    }
 
-   @Test
-   void shouldThrowNewExceptionIfResourceAccessException() {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void shouldThrowNewExceptionIfResourceAccessException() {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
-       when(restTemplate.exchange(Mockito.anyString(),
-           Mockito.eq(HttpMethod.GET),
-           Mockito.any(),
-           Mockito.<Class<Object>>any()))
-           .thenThrow(ResourceAccessException.class);
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        when(restTemplate.exchange(Mockito.anyString(),
+            Mockito.eq(HttpMethod.GET),
+            Mockito.any(),
+            Mockito.<Class<Object>>any()))
+            .thenThrow(ResourceAccessException.class);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       Exception exception = assertThrows(ServiceNotAccessibleException.class,
-           () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
-           "Expected exception is not ServiceNotAccessibleException");
-       assertEquals("Could not get an access to z/OSMF service.", exception.getMessage());
-   }
+        Exception exception = assertThrows(ServiceNotAccessibleException.class,
+            () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
+            "Expected exception is not ServiceNotAccessibleException");
+        assertEquals("Could not get an access to z/OSMF service.", exception.getMessage());
+    }
 
-   @Test
-   void shouldReturnTrueWhenSupportMethodIsCalledWithCorrectClass() {
-       authConfigurationProperties.setZosmfServiceId(ZOSMF);
+    @Test
+    void shouldReturnTrueWhenSupportMethodIsCalledWithCorrectClass() {
+        authConfigurationProperties.setZosmfServiceId(ZOSMF);
 
-       final Application application = createApplication(zosmfInstance);
-       when(discovery.getApplication(ZOSMF)).thenReturn(application);
-       ZosmfService zosmfService = createZosmfService();
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-           new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        final Application application = createApplication(zosmfInstance);
+        when(discovery.getApplication(ZOSMF)).thenReturn(application);
+        ZosmfService zosmfService = createZosmfService();
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider =
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
 
-       boolean supports = zosmfAuthenticationProvider.supports(usernamePasswordAuthentication.getClass());
-       assertTrue(supports);
-   }
+        boolean supports = zosmfAuthenticationProvider.supports(usernamePasswordAuthentication.getClass());
+        assertTrue(supports);
+    }
 
-   @Test
-   void testSupports() {
-       ZosmfAuthenticationProvider mock = new ZosmfAuthenticationProvider(null, null);
+    @Test
+    void testSupports() {
+        ZosmfAuthenticationProvider mock = new ZosmfAuthenticationProvider(null, null);
 
-       assertTrue(mock.supports(UsernamePasswordAuthenticationToken.class));
-       assertFalse(mock.supports(Object.class));
-       assertFalse(mock.supports(AbstractAuthenticationToken.class));
-       assertFalse(mock.supports(JaasAuthenticationToken.class));
-       assertFalse(mock.supports(null));
-   }
+        assertTrue(mock.supports(UsernamePasswordAuthenticationToken.class));
+        assertFalse(mock.supports(Object.class));
+        assertFalse(mock.supports(AbstractAuthenticationToken.class));
+        assertFalse(mock.supports(JaasAuthenticationToken.class));
+        assertFalse(mock.supports(null));
+    }
 
-   @Test
-   void testAuthenticateJwt() {
-       AuthenticationService authenticationService = mock(AuthenticationService.class);
-       ZosmfService zosmfService = mock(ZosmfService.class);
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
-       ReflectionTestUtils.setField(zosmfAuthenticationProvider, "useJwtToken", Boolean.TRUE);
-       Authentication authentication = mock(Authentication.class);
-       when(authentication.getPrincipal()).thenReturn("user1");
-       TokenAuthentication authentication2 = mock(TokenAuthentication.class);
+    @Test
+    void testAuthenticateJwt() {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        ZosmfService zosmfService = mock(ZosmfService.class);
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ReflectionTestUtils.setField(zosmfAuthenticationProvider, "useJwtToken", Boolean.TRUE);
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn("user1");
+        TokenAuthentication authentication2 = mock(TokenAuthentication.class);
 
-       when(zosmfService.authenticate(authentication)).thenReturn(new ZosmfService.AuthenticationResponse(
-           "domain1",
-           Collections.singletonMap(ZosmfService.TokenType.JWT, "jwtToken1")
-       ));
-       when(authenticationService.createTokenAuthentication("user1", "jwtToken1")).thenReturn(authentication2);
+        when(zosmfService.authenticate(authentication)).thenReturn(new ZosmfService.AuthenticationResponse(
+            "domain1",
+            Collections.singletonMap(ZosmfService.TokenType.JWT, "jwtToken1")
+        ));
+        when(authenticationService.createTokenAuthentication("user1", "jwtToken1")).thenReturn(authentication2);
 
-       assertSame(authentication2, zosmfAuthenticationProvider.authenticate(authentication));
-   }
+        assertSame(authentication2, zosmfAuthenticationProvider.authenticate(authentication));
+    }
 
-   @Test
-   void testJwt_givenZosmfJwt_whenItIsIgnoring_thenCreateZoweJwt() {
-       AuthenticationService authenticationService = mock(AuthenticationService.class);
-       ZosmfService zosmfService = mock(ZosmfService.class);
-       ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
-       ReflectionTestUtils.setField(zosmfAuthenticationProvider, "useJwtToken", Boolean.FALSE);
+    @Test
+    void testJwt_givenZosmfJwt_whenItIsIgnoring_thenCreateZoweJwt() {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        ZosmfService zosmfService = mock(ZosmfService.class);
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ReflectionTestUtils.setField(zosmfAuthenticationProvider, "useJwtToken", Boolean.FALSE);
 
-       EnumMap<ZosmfService.TokenType, String> tokens = new EnumMap<>(ZosmfService.TokenType.class);
-       tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
-       tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
-       when(zosmfService.authenticate(any())).thenReturn(new ZosmfService.AuthenticationResponse("domain", tokens));
+        EnumMap<ZosmfService.TokenType, String> tokens = new EnumMap<>(ZosmfService.TokenType.class);
+        tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
+        tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+        when(zosmfService.authenticate(any())).thenReturn(new ZosmfService.AuthenticationResponse("domain", tokens));
 
-       zosmfAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken("userId", "password"));
+        zosmfAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken("userId", "password"));
 
-       verify(authenticationService, times(1)).createJwtToken("userId", "domain", "ltpaToken");
-   }
+        verify(authenticationService, times(1)).createJwtToken("userId", "domain", "ltpaToken");
+    }
 
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
@@ -100,8 +100,8 @@ class ZosmfAuthenticationProviderTest {
    }
 
    private ZosmfService createZosmfService() {
-       ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper);
        ApplicationContext applicationContext = mock(ApplicationContext.class);
+       ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper,applicationContext);
        ZosmfService output = spy(zosmfService);
        when(applicationContext.getBean(ZosmfService.class)).thenReturn(output);
        return output;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
@@ -76,7 +76,7 @@ class SuccessfulQueryHandlerTest {
         if (keyPair != null) {
             privateKey = keyPair.getPrivate();
         }
-        ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discoveryClient, restTemplate, new ObjectMapper());
+        ZosmfService zosmfService = new ZosmfService(authConfigurationProperties, discoveryClient, restTemplate, new ObjectMapper(),applicationContext);
         AuthenticationService authenticationService = new AuthenticationService(
             applicationContext, authConfigurationProperties, jwtSecurityInitializer, zosmfService,
             discoveryClient, restTemplate, cacheManager, new CacheUtils()

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -366,12 +366,12 @@ public class AuthenticationServiceTest {
         when(applicationInfoManager.getInfo()).thenReturn(myInstance);
         when(discoveryClient.getApplicationInfoManager()).thenReturn(applicationInfoManager);
 
-        when(restTemplate.exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, null)), eq(String.class)))
+        when(restTemplate.exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, null), String.class))
             .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
         final HttpHeaders headers = new HttpHeaders();
         headers.add(ZOSMF_CSRF_HEADER, "");
         headers.add(HttpHeaders.COOKIE, ZosmfService.TokenType.LTPA.getCookieName() + "=" + "ltpa1");
-        when(restTemplate.exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, headers)), eq(String.class)))
+        when(restTemplate.exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, headers), String.class))
             .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
         Application application = mock(Application.class);
@@ -391,7 +391,7 @@ public class AuthenticationServiceTest {
         verify(restTemplate).delete("https://hostname1:10433/gateway/auth/invalidate/" + jwt1);
         verify(restTemplate).delete("http://hostname2:10001/gateway/auth/invalidate/" + jwt1);
         verify(restTemplate, times(1))
-            .exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, headers)), eq(String.class));
+            .exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, headers), String.class);
     }
 
     @Test
@@ -412,18 +412,18 @@ public class AuthenticationServiceTest {
         assertTrue(authService.validateJwtToken(jwtToken02).isAuthenticated());
         verify(jwtSecurityInitializer, times(2)).getJwtPublicKey();
 
-        when(restTemplate.exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, null)), eq(String.class)))
+        when(restTemplate.exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, null), String.class))
             .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
         final HttpHeaders headers = new HttpHeaders();
         headers.add(ZOSMF_CSRF_HEADER, "");
         headers.add(HttpHeaders.COOKIE, ZosmfService.TokenType.LTPA.getCookieName() + "=" + "ltpa01");
-        when(restTemplate.exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, headers)), eq(String.class)))
+        when(restTemplate.exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, headers), String.class))
             .thenReturn(new ResponseEntity<>(HttpStatus.OK));
         authService.invalidateJwtToken(jwtToken01, false);
         assertTrue(authService.validateJwtToken(jwtToken02).isAuthenticated());
         verify(jwtSecurityInitializer, times(2)).getJwtPublicKey();
         verify(restTemplate, times(1))
-            .exchange(eq(zosmfUrl + "/zosmf/services/authenticate"), eq(HttpMethod.DELETE), eq(new HttpEntity<>(null, headers)), eq(String.class));
+            .exchange(zosmfUrl + "/zosmf/services/authenticate", HttpMethod.DELETE, new HttpEntity<>(null, headers), String.class);
 
         assertFalse(authService.validateJwtToken(jwtToken01).isAuthenticated());
         verify(jwtSecurityInitializer, times(3)).getJwtPublicKey();

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -423,7 +423,8 @@ public class AuthenticationServiceTest {
                 authConfigurationProperties,
                 discoveryClient,
                 restTemplate,
-                securityObjectMapper
+                securityObjectMapper,
+                applicationContext
             )
         );
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.*;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -45,7 +46,8 @@ class ZosmfServiceTest {
     private ObjectMapper securityObjectMapper;
 
     private ZosmfService getZosmfServiceSpy() {
-        ZosmfService zosmfServiceObj = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        ZosmfService zosmfServiceObj = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper,applicationContext);
         ZosmfService zosmfService = spy(zosmfServiceObj);
         doReturn(ZOSMF_ID).when(zosmfService).getZosmfServiceId();
         doReturn("http://zosmf:1433").when(zosmfService).getURI(ZOSMF_ID);
@@ -338,7 +340,7 @@ class ZosmfServiceTest {
 
     @Test
     void testReadTokenFromCookie() {
-        assertNull(new ZosmfService(null, null, null, null).readTokenFromCookie(null, null));
+        assertNull(new ZosmfService(null, null, null, null, null).readTokenFromCookie(null, null));
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -1,10 +1,10 @@
-/**
+/*
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
- * <p>
+ *
  * Copyright Contributors to the Zowe Project.
  */
 package org.zowe.apiml.gateway.security.service.zosmf;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -2,9 +2,9 @@
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
- *
+ * <p>
  * Copyright Contributors to the Zowe Project.
  */
 package org.zowe.apiml.gateway.security.service.zosmf;
@@ -24,6 +24,7 @@ import org.springframework.http.*;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
@@ -42,23 +43,23 @@ class ZosmfServiceTest {
     private AuthConfigurationProperties authConfigurationProperties;
     private DiscoveryClient discovery = mock(DiscoveryClient.class);
     private RestTemplate restTemplate = mock(RestTemplate.class);
+    ApplicationContext applicationContext = mock(ApplicationContext.class);
     @Spy
     private ObjectMapper securityObjectMapper;
 
     private ZosmfService getZosmfServiceSpy() {
-        ApplicationContext applicationContext = mock(ApplicationContext.class);
-        ZosmfService zosmfServiceObj = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper,applicationContext);
+        ZosmfService zosmfServiceObj = new ZosmfService(authConfigurationProperties, discovery, restTemplate, securityObjectMapper, applicationContext);
         ZosmfService zosmfService = spy(zosmfServiceObj);
         doReturn(ZOSMF_ID).when(zosmfService).getZosmfServiceId();
         doReturn("http://zosmf:1433").when(zosmfService).getURI(ZOSMF_ID);
+        ReflectionTestUtils.setField(zosmfService, "meAsProxy", zosmfService);
         return zosmfService;
     }
 
     private HttpHeaders getBasicRequestHeaders() {
         HttpHeaders requestHeaders = new HttpHeaders();
         requestHeaders.add(HttpHeaders.AUTHORIZATION, "Basic dXNlcjpwYXNz");
-        requestHeaders = addCSRFHeader(requestHeaders);
-        return requestHeaders;
+        return addCSRFHeader(requestHeaders);
     }
 
     private HttpHeaders addCSRFHeader(HttpHeaders headers) {


### PR DESCRIPTION
# Description

Check calls to Zosmf endpoints, such as authenticationEndpointExists, were not cached as they supposed to be. This is part of validation issues fixes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
