### PR TITLE
fix(authentication): Support specific zOSMF version, allow override

### DIFF
--- a/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
+++ b/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
@@ -1,0 +1,55 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: CI Testing with zOSMF without JWT APAR applied
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.head_ref }}
+            - name: Set up JDK 1.8
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 1.8
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+            - name: Cache Gradle packages
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                  restore-keys: |
+                      ${{ runner.os }}-gradle-
+            - name: Build with Gradle
+              run: ./gradlew build runCITests -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017 -Dzosmf.appliedApars=AuthenticateApar
+            - name: Store results
+              uses: actions/upload-artifact@v2
+              with:
+                  name: Package
+                  path: |
+                      api-catalog-services/build/reports/tests/test/
+                      discovery-service/build/reports/tests/test/
+                      gateway-service/build/reports/tests/test/
+                      ./**/test-results/**/*.xml
+                      api-catalog-ui/frontend/test-results/
+                      api-layer.tar.gz
+            - name: Cleanup Gradle Cache
+                # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+                # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+              run: |
+                  rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                  rm -f ~/.gradle/caches/modules-2/gc.properties
+

--- a/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
+++ b/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: CI Testing with zOSMF without JWT APAR applied
+name: CI Testing with zOSMF without JWT APAR applied with /zosmf/services/authenticate present
 
 on:
     push:

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.security.common.config;
 
 import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.stereotype.Component;
@@ -53,6 +54,9 @@ public class AuthConfigurationProperties {
     private AuthConfigurationProperties.PassTicket passTicket;
 
     private String jwtKeyAlias;
+
+    @Value("${apiml.security.auth.zosmfJwtEndpoint:/jwt/ibm/api/zOSMFBuilder/jwk}")
+    private String zosmfJwtEndpoint;
 
     //Token properties
     @Data

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -107,6 +107,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${GATEWAY_CODE} java \
     -Dserver.ssl.trustStore=${TRUSTSTORE} \
     -Dserver.ssl.trustStoreType=${KEYSTORE_TYPE} \
     -Dserver.ssl.trustStorePassword=${KEYSTORE_PASSWORD} \
+    -Dapiml.security.auth.zosmfJwtAutoconfiguration=${APIML_SECURITY_ZOSMF_JWT_AUTOCONFIGURATION_MODE:auto}
     -Dapiml.security.x509.enabled=${APIML_SECURITY_X509_ENABLED:-false} \
     -Dapiml.security.x509.externalMapperUrl=http://localhost:${ZOWE_ZSS_SERVER_PORT}/certificate/x509/map \
     -Dapiml.security.x509.externalMapperUser=ZWESVUSR \

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ComponentsConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ComponentsConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.zowe.apiml.gateway.security.login.Providers;
+import org.zowe.apiml.gateway.security.login.zosmf.ZosmfConfiguration;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.passticket.PassTicketService;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
@@ -50,9 +51,10 @@ public class ComponentsConfiguration {
         DiscoveryClient discoveryClient,
         AuthConfigurationProperties authConfigurationProperties,
         ZosmfService zosmfService,
-        @Lazy CompoundAuthProvider compoundAuthProvider
+        @Lazy CompoundAuthProvider compoundAuthProvider,
+        ZosmfConfiguration zosmfConfiguration
     ) {
-        return new Providers(discoveryClient, authConfigurationProperties, compoundAuthProvider, zosmfService);
+        return new Providers(discoveryClient, authConfigurationProperties, compoundAuthProvider, zosmfService, zosmfConfiguration);
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/Providers.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/Providers.java
@@ -68,6 +68,6 @@ public class Providers {
      * @return True is the instance support JWT
      */
     public boolean zosmfSupportsJwt() {
-        return zosmfService.loginEndpointExists();
+        return zosmfService.loginEndpointExists() && zosmfService.jwtBuilderEndpointExists();
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/Providers.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/Providers.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.zowe.apiml.gateway.security.config.CompoundAuthProvider;
+import org.zowe.apiml.gateway.security.login.zosmf.ZosmfConfiguration;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
@@ -25,6 +26,7 @@ public class Providers {
     private final AuthConfigurationProperties authConfigurationProperties;
     private final CompoundAuthProvider compoundAuthProvider;
     private final ZosmfService zosmfService;
+    private final ZosmfConfiguration zosmfConfiguration;
 
     /**
      * This method decides whether the Zosmf service is available.
@@ -68,6 +70,14 @@ public class Providers {
      * @return True is the instance support JWT
      */
     public boolean zosmfSupportsJwt() {
-        return zosmfService.loginEndpointExists() && zosmfService.jwtBuilderEndpointExists();
+        switch (zosmfConfiguration.jwtAutoconfigurationMode) {
+            case JWT:
+                return true;
+            case LTPA:
+                return false;
+            default: // AUTO
+                return zosmfService.loginEndpointExists() && zosmfService.jwtBuilderEndpointExists();
+        }
+
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/SaveZosmfPublicKeyConsoleApplication.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/SaveZosmfPublicKeyConsoleApplication.java
@@ -37,7 +37,8 @@ public class SaveZosmfPublicKeyConsoleApplication {
 
         String jwkUrl = args[0];
         String filename = args[1];
-        ZosmfJwkToPublicKey zosmfJwkToPublicKey = new ZosmfJwkToPublicKey(restTemplate);
+        String zosmfJwtBuilderPath = System.getProperty("apiml.security.auth.zosmfJwtEndpoint", "/jwt/ibm/api/zOSMFBuilder/jwk");
+        ZosmfJwkToPublicKey zosmfJwkToPublicKey = new ZosmfJwkToPublicKey(restTemplate, zosmfJwtBuilderPath);
 
         System.out.printf("Loading public key of z/OSMF at %s%n", jwkUrl);
         try {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
@@ -10,16 +10,15 @@
 package org.zowe.apiml.gateway.security.login.zosmf;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
 
-import static  org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.JWT;
-import static  org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.LTPA;
+import static org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.JWT;
+import static org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.LTPA;
 
 /**
  * Authentication provider that verifies credentials against z/OSMF service
@@ -30,6 +29,7 @@ public class ZosmfAuthenticationProvider implements AuthenticationProvider {
 
     private final AuthenticationService authenticationService;
     private final ZosmfService zosmfService;
+    private final ZosmfConfiguration zosmfConfiguration;
 
     /**
      * Authenticate the credentials with the z/OSMF service
@@ -43,21 +43,41 @@ public class ZosmfAuthenticationProvider implements AuthenticationProvider {
 
         final ZosmfService.AuthenticationResponse ar = zosmfService.authenticate(authentication);
 
-        // if z/OSMF support JWT, use it as Zowe JWT token
-        if (ar.getTokens().containsKey(JWT)) {
-            return authenticationService.createTokenAuthentication(user, ar.getTokens().get(JWT));
-        }
+        switch (zosmfConfiguration.jwtAutoconfigurationMode) {
+            case LTPA:
+                if (ar.getTokens().containsKey(LTPA)) {
+                    return getApimlJwtToken(user, ar);
+                }
+                break;
+            case JWT:
+                if (ar.getTokens().containsKey(JWT)) {
+                    return getZosmfJwtToken(user, ar);
+                }
+                break;
+            default: //AUTO
+                if (ar.getTokens().containsKey(JWT)) {
+                    return getZosmfJwtToken(user, ar);
+                }
 
-        if (ar.getTokens().containsKey(LTPA)) {
-            // construct own JWT token, including LTPA from z/OSMF
-            final String domain = ar.getDomain();
-            final String jwtToken = authenticationService.createJwtToken(user, domain, ar.getTokens().get(LTPA));
-
-            return authenticationService.createTokenAuthentication(user, jwtToken);
+                if (ar.getTokens().containsKey(LTPA)) {
+                    return getApimlJwtToken(user, ar);
+                }
+                break;
         }
 
         // JWT and LTPA tokens are missing, authentication was wrong
         throw new BadCredentialsException("Username or password are invalid.");
+    }
+
+    public TokenAuthentication getZosmfJwtToken(String user, ZosmfService.AuthenticationResponse ar) {
+        return authenticationService.createTokenAuthentication(user, ar.getTokens().get(JWT));
+    }
+
+    private TokenAuthentication getApimlJwtToken(String user, ZosmfService.AuthenticationResponse ar) {
+        final String domain = ar.getDomain();
+        final String jwtToken = authenticationService.createJwtToken(user, domain, ar.getTokens().get(LTPA));
+
+        return authenticationService.createTokenAuthentication(user, jwtToken);
     }
 
     @Override

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.security.login.zosmf;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ZosmfConfiguration {
+
+    public enum JWT_AUTOCONFIGURATION_MODE {
+        AUTO,
+        LTPA,
+        JWT
+    }
+
+    @Value("${apiml.security.auth.zosmfJwtAutoconfiguration:AUTO}")
+    public JWT_AUTOCONFIGURATION_MODE jwtAutoconfigurationMode;
+
+    public static ZosmfConfiguration of(JWT_AUTOCONFIGURATION_MODE mode) {
+        ZosmfConfiguration configuration = new ZosmfConfiguration();
+        configuration.jwtAutoconfigurationMode = mode;
+        return configuration;
+    }
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKey.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKey.java
@@ -19,12 +19,12 @@ import org.springframework.web.client.RestTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class ZosmfJwkToPublicKey {
 
     protected final RestTemplate restTemplateWithoutKeystore;
+    private final String zosmfJwtBuilderPath;
 
     /**
      * Write public key that can be used to validate z/OSMF JWT tokens.
@@ -36,7 +36,7 @@ public class ZosmfJwkToPublicKey {
     public boolean updateJwtPublicKeyFile(String zosmfUrl, String filename, String caAlias, String caKeyStore,
     String caKeyStoreType, char[] caKeyStorePassword, char[] caKeyPassword) throws FileNotFoundException {
         try {
-            String jwkJson = restTemplateWithoutKeystore.getForObject(zosmfUrl + "/jwt/ibm/api/zOSMFBuilder/jwk",
+            String jwkJson = restTemplateWithoutKeystore.getForObject(zosmfUrl + zosmfJwtBuilderPath,
                     String.class);
             JwkToPublicKeyConverter converter = new JwkToPublicKeyConverter();
             String pem = converter.convertFirstPublicKeyJwkToPem(jwkJson, caAlias, caKeyStore, caKeyStoreType, caKeyStorePassword, caKeyPassword) ;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKey.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKey.java
@@ -9,15 +9,13 @@
  */
 package org.zowe.apiml.gateway.security.login.zosmf;
 
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-
-import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -28,24 +26,26 @@ public class ZosmfJwkToPublicKey {
 
     /**
      * Write public key that can be used to validate z/OSMF JWT tokens.
+     *
      * @param zosmfUrl Base URL of z/OSMF without trailing /
      * @param filename File name of the resulting PEM file
      * @return True when the file has been updated
      * @throws FileNotFoundException when the filename is invalid
      */
     public boolean updateJwtPublicKeyFile(String zosmfUrl, String filename, String caAlias, String caKeyStore,
-    String caKeyStoreType, char[] caKeyStorePassword, char[] caKeyPassword) throws FileNotFoundException {
+                                          String caKeyStoreType, char[] caKeyStorePassword, char[] caKeyPassword) throws FileNotFoundException {
         try {
             String jwkJson = restTemplateWithoutKeystore.getForObject(zosmfUrl + zosmfJwtBuilderPath,
-                    String.class);
+                String.class);
             JwkToPublicKeyConverter converter = new JwkToPublicKeyConverter();
-            String pem = converter.convertFirstPublicKeyJwkToPem(jwkJson, caAlias, caKeyStore, caKeyStoreType, caKeyStorePassword, caKeyPassword) ;
+            String pem = converter.convertFirstPublicKeyJwkToPem(jwkJson, caAlias, caKeyStore, caKeyStoreType, caKeyStorePassword, caKeyPassword);
             try (PrintWriter out = new PrintWriter(filename)) {
                 out.println(pem);
             }
             return true;
         } catch (HttpClientErrorException.NotFound e) {
-            log.warn("Unable to read z/OSMF JWT public key. JWT support might be not configured in z/OSMF: {}", e.getMessage());;
+            log.warn("Unable to read z/OSMF JWT public key. JWT support might be not configured in z/OSMF: {}", e.getMessage());
+            ;
             return false;
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
@@ -31,7 +31,6 @@ public abstract class AbstractZosmfService {
 
     protected static final String ZOSMF_INFO_END_POINT = "/zosmf/info";
     protected static final String ZOSMF_AUTHENTICATE_END_POINT = "/zosmf/services/authenticate";
-    protected static final String ZOSMF_JWT_END_POINT = "/jwt/ibm/api/zOSMFBuilder/jwk"; // TODO config and other place this url exists
     protected static final String ZOSMF_CSRF_HEADER = "X-CSRF-ZOSMF-HEADER";
     protected static final String ZOSMF_DOMAIN = "zosmf_saf_realm";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
@@ -31,6 +31,7 @@ public abstract class AbstractZosmfService {
 
     protected static final String ZOSMF_INFO_END_POINT = "/zosmf/info";
     protected static final String ZOSMF_AUTHENTICATE_END_POINT = "/zosmf/services/authenticate";
+    protected static final String ZOSMF_JWT_END_POINT = "/jwt/ibm/api/zOSMFBuilder/jwk"; // TODO config and other place this url exists
     protected static final String ZOSMF_CSRF_HEADER = "X-CSRF-ZOSMF-HEADER";
     protected static final String ZOSMF_DOMAIN = "zosmf_saf_realm";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -14,27 +14,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
 import com.nimbusds.jose.jwk.JWKSet;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.http.*;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import javax.annotation.PostConstruct;
 import java.text.ParseException;
-import java.util.*;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.JWT;
 import static org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenType.LTPA;
@@ -189,6 +201,7 @@ public class ZosmfService extends AbstractZosmfService {
 
     /**
      * Verify whether the service is actually accessible.
+     *
      * @return true when it's possible to access the Info endpoint via GET.
      */
     public boolean isAccessible() {
@@ -269,6 +282,15 @@ public class ZosmfService extends AbstractZosmfService {
     }
 
     /**
+     * Check if call to ZOSMF_JWT_END_POINT resolves
+     * @return true if endpoint resolves, otherwise false
+     */
+    @Cacheable(value = "zosmfJwtEndpoint", key = "#httpMethod.name()")
+    public boolean jwtEndpointExists(HttpHeaders headers) {
+        return false; // TODO
+    }
+
+    /**
      * Tries to call ZOSMF authentication endpoint with HTTP Post method
      *
      * @return true, if zosmf login endpoint is presented
@@ -285,9 +307,20 @@ public class ZosmfService extends AbstractZosmfService {
      *
      * @return true, if zosmf logout endpoint is presented
      */
-
     public boolean logoutEndpointExists() {
         return meAsProxy.authenticationEndpointExists(HttpMethod.DELETE, null);
+    }
+
+    /**
+     * Tries to call ZOSMF JWT Builder endpoint
+     *
+     * @return true if endpoint exists, otherwise false
+     */
+    public boolean jwtBuilderEndpointExists() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(ZOSMF_CSRF_HEADER, "");
+        headers.add("Authorization", "Basic Og==");
+        return meAsProxy.jwtEndpointExists(headers);
     }
 
     public boolean validate(String token) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -287,7 +287,7 @@ public class ZosmfService extends AbstractZosmfService {
      */
     @Cacheable(value = "zosmfJwtEndpoint", key = "#httpMethod.name()")
     public boolean jwtEndpointExists(HttpHeaders headers) {
-        String url = getURI(getZosmfServiceId()) + ZOSMF_JWT_END_POINT;
+        String url = getURI(getZosmfServiceId()) + authConfigurationProperties.getZosmfJwtEndpoint();
 
         try {
             restTemplateWithoutKeystore.exchange(url, HttpMethod.GET, new HttpEntity<>(null, headers), String.class);
@@ -420,7 +420,7 @@ public class ZosmfService extends AbstractZosmfService {
     }
 
     public JWKSet getPublicKeys() {
-        final String url = getURI(getZosmfServiceId()) + ZOSMF_JWT_END_POINT;
+        final String url = getURI(getZosmfServiceId()) + authConfigurationProperties.getZosmfJwtEndpoint();
 
         try {
             final String json = restTemplateWithoutKeystore.getForObject(url, String.class);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/ProvidersTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/ProvidersTest.java
@@ -118,8 +118,9 @@ class ProvidersTest {
     @Nested
     class whenJwtSupportIsVerified {
         @Test
-        void givenLoginEndpointExists_thenSupportJwtReturnsTrue() {
+        void givenLoginEndpointAndJwtBuilderEndpointExist_thenSupportJwtReturnsTrue() {
             when(zosmfService.loginEndpointExists()).thenReturn(true);
+            when(zosmfService.jwtBuilderEndpointExists()).thenReturn(true);
 
             assertThat(underTest.zosmfSupportsJwt(), is(true));
         }
@@ -127,6 +128,15 @@ class ProvidersTest {
         @Test
         void givenLoginEndpointDoesntExist_thenSupportJwtReturnsFalse() {
             when(zosmfService.loginEndpointExists()).thenReturn(false);
+            when(zosmfService.jwtBuilderEndpointExists()).thenReturn(true);
+
+            assertThat(underTest.zosmfSupportsJwt(), is(false));
+        }
+
+        @Test
+        void givenJwtBuilderEndpointDoesntExist_thenSupportJwtReturnsFalse() {
+            when(zosmfService.loginEndpointExists()).thenReturn(true);
+            when(zosmfService.jwtBuilderEndpointExists()).thenReturn(false);
 
             assertThat(underTest.zosmfSupportsJwt(), is(false));
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/ProvidersTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/ProvidersTest.java
@@ -9,12 +9,11 @@
  */
 package org.zowe.apiml.gateway.security.login;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.zowe.apiml.gateway.security.config.CompoundAuthProvider;
+import org.zowe.apiml.gateway.security.login.zosmf.ZosmfConfiguration;
 import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
@@ -25,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.zowe.apiml.gateway.security.login.zosmf.ZosmfConfiguration.JWT_AUTOCONFIGURATION_MODE.*;
 
 class ProvidersTest {
     private AuthConfigurationProperties authConfigurationProperties;
@@ -33,6 +33,7 @@ class ProvidersTest {
     private CompoundAuthProvider compoundAuthProvider;
     private ZosmfService zosmfService;
     private static final String ZOSMF_ID = "zosmf";
+    private ZosmfConfiguration zosmfConfiguration = ZosmfConfiguration.of(AUTO);
 
     @BeforeEach
     void setUp() {
@@ -40,8 +41,8 @@ class ProvidersTest {
         compoundAuthProvider = mock(CompoundAuthProvider.class);
         discovery = mock(DiscoveryClient.class);
         zosmfService = mock(ZosmfService.class);
-
-        underTest = new Providers(discovery, authConfigurationProperties, compoundAuthProvider, zosmfService);
+        zosmfConfiguration = ZosmfConfiguration.of(AUTO);
+        underTest = new Providers(discovery, authConfigurationProperties, compoundAuthProvider, zosmfService, zosmfConfiguration);
     }
 
     @Nested
@@ -139,6 +140,24 @@ class ProvidersTest {
             when(zosmfService.jwtBuilderEndpointExists()).thenReturn(false);
 
             assertThat(underTest.zosmfSupportsJwt(), is(false));
+        }
+
+        @Test
+        void givenEndpointsExistAndLtpaOverrideSet_thenSupportJwtRetundsFalse() {
+            zosmfConfiguration.jwtAutoconfigurationMode = LTPA;
+            underTest = new Providers(discovery, authConfigurationProperties, compoundAuthProvider, zosmfService, zosmfConfiguration);
+            when(zosmfService.loginEndpointExists()).thenReturn(true);
+            when(zosmfService.jwtBuilderEndpointExists()).thenReturn(true);
+            assertThat(underTest.zosmfSupportsJwt(), is(false));
+        }
+
+        @Test
+        void givenEndpointsDontExistAndJwtOverrideSet_thenSupportJwtRetundsTrue() {
+            zosmfConfiguration.jwtAutoconfigurationMode = JWT;
+            underTest = new Providers(discovery, authConfigurationProperties, compoundAuthProvider, zosmfService, zosmfConfiguration);
+            when(zosmfService.loginEndpointExists()).thenReturn(false);
+            when(zosmfService.jwtBuilderEndpointExists()).thenReturn(false);
+            assertThat(underTest.zosmfSupportsJwt(), is(true));
         }
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
@@ -14,8 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.shared.Application;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationContext;
@@ -37,6 +36,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.zowe.apiml.gateway.security.login.zosmf.ZosmfConfiguration.JWT_AUTOCONFIGURATION_MODE.*;
 
 class ZosmfAuthenticationProviderTest {
 
@@ -124,7 +124,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         mockZosmfRealmRestCallResponse();
         mockZosmfRealmRestCallResponse();
@@ -151,7 +151,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         mockZosmfRealmRestCallResponse();
         Exception exception = assertThrows(BadCredentialsException.class,
@@ -169,7 +169,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(ServiceNotAccessibleException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -181,7 +181,7 @@ class ZosmfAuthenticationProviderTest {
     void noZosmfServiceId() {
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(AuthenticationServiceException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -207,7 +207,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(AuthenticationServiceException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -236,7 +236,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(AuthenticationServiceException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -266,7 +266,7 @@ class ZosmfAuthenticationProviderTest {
 
         mockZosmfRealmRestCallResponse();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
         Exception exception = assertThrows(BadCredentialsException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
             "Expected exception is not BadCredentialsException");
@@ -304,7 +304,7 @@ class ZosmfAuthenticationProviderTest {
 
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         mockZosmfRealmRestCallResponse();
         Authentication tokenAuthentication = zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication);
@@ -326,7 +326,7 @@ class ZosmfAuthenticationProviderTest {
             .thenThrow(RestClientException.class);
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(AuthenticationServiceException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -347,7 +347,7 @@ class ZosmfAuthenticationProviderTest {
             .thenThrow(ResourceAccessException.class);
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         Exception exception = assertThrows(ServiceNotAccessibleException.class,
             () -> zosmfAuthenticationProvider.authenticate(usernamePasswordAuthentication),
@@ -363,7 +363,7 @@ class ZosmfAuthenticationProviderTest {
         when(discovery.getApplication(ZOSMF)).thenReturn(application);
         ZosmfService zosmfService = createZosmfService();
         ZosmfAuthenticationProvider zosmfAuthenticationProvider =
-            new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+            new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         boolean supports = zosmfAuthenticationProvider.supports(usernamePasswordAuthentication.getClass());
         assertTrue(supports);
@@ -371,7 +371,7 @@ class ZosmfAuthenticationProviderTest {
 
     @Test
     void testSupports() {
-        ZosmfAuthenticationProvider mock = new ZosmfAuthenticationProvider(null, null);
+        ZosmfAuthenticationProvider mock = new ZosmfAuthenticationProvider(null, null, null);
 
         assertTrue(mock.supports(UsernamePasswordAuthenticationToken.class));
         assertFalse(mock.supports(Object.class));
@@ -384,7 +384,7 @@ class ZosmfAuthenticationProviderTest {
     void testAuthenticateJwt() {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         ZosmfService zosmfService = mock(ZosmfService.class);
-        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
         Authentication authentication = mock(Authentication.class);
         when(authentication.getPrincipal()).thenReturn("user1");
         TokenAuthentication authentication2 = mock(TokenAuthentication.class);
@@ -402,7 +402,7 @@ class ZosmfAuthenticationProviderTest {
     void testJwt_givenZosmfJwt_whenItIsIgnoring_thenCreateZoweJwt() {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         ZosmfService zosmfService = mock(ZosmfService.class);
-        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService);
+        ZosmfAuthenticationProvider zosmfAuthenticationProvider = new ZosmfAuthenticationProvider(authenticationService, zosmfService, ZosmfConfiguration.of(AUTO));
 
         EnumMap<ZosmfService.TokenType, String> tokens = new EnumMap<>(ZosmfService.TokenType.class);
         tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
@@ -411,6 +411,79 @@ class ZosmfAuthenticationProviderTest {
         zosmfAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken("userId", "password"));
 
         verify(authenticationService, times(1)).createJwtToken("userId", "domain", "ltpaToken");
+    }
+
+    @Nested
+    class givenOverride {
+
+        private ZosmfAuthenticationProvider underTest;
+        private ZosmfConfiguration zosmfConfiguration;
+        private AuthenticationService authenticationService;
+        private EnumMap<ZosmfService.TokenType, String> tokens;
+        private UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken("userId", "password");
+
+        @BeforeEach
+        void setUp() {
+            authenticationService = mock(AuthenticationService.class);
+            when(authenticationService.createJwtToken(any(), any(), any())).thenReturn("ltpaToken");
+            ZosmfService zosmfService = mock(ZosmfService.class);
+            zosmfConfiguration = ZosmfConfiguration.of(AUTO);
+            underTest = new ZosmfAuthenticationProvider(authenticationService, zosmfService, zosmfConfiguration);
+
+            tokens = new EnumMap<>(ZosmfService.TokenType.class);
+
+
+            when(zosmfService.authenticate(any())).thenReturn(new ZosmfService.AuthenticationResponse("domain", tokens));
+        }
+
+        @Test
+        void willChooseJwtWhenPresent() {
+            tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+            tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
+
+            underTest.authenticate(usernamePasswordAuthenticationToken);
+            verify(authenticationService, atLeastOnce()).createTokenAuthentication("userId", "jwtToken");
+        }
+
+        @Test
+        void willChooseLtpaWhenOnlyLtpa() {
+            tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+
+            underTest.authenticate(usernamePasswordAuthenticationToken);
+            verify(authenticationService, atLeastOnce()).createTokenAuthentication("userId", "ltpaToken");
+        }
+
+        @Test
+        void willChooseLtpaWhenOverride() {
+            tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+            tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
+            zosmfConfiguration.jwtAutoconfigurationMode = LTPA;
+            underTest.authenticate(usernamePasswordAuthenticationToken);
+            verify(authenticationService, atLeastOnce()).createTokenAuthentication("userId", "ltpaToken");
+        }
+
+        @Test
+        void willChooseJwtWhenOverride() {
+            tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+            tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
+            zosmfConfiguration.jwtAutoconfigurationMode = JWT;
+            underTest.authenticate(usernamePasswordAuthenticationToken);
+            verify(authenticationService, atLeastOnce()).createTokenAuthentication("userId", "jwtToken");
+        }
+
+        @Test
+        void willThrowWhenOverrideAndNoTokens() {
+            tokens.put(ZosmfService.TokenType.LTPA, "ltpaToken");
+            zosmfConfiguration.jwtAutoconfigurationMode = JWT;
+            assertThrows(BadCredentialsException.class, () -> underTest.authenticate(usernamePasswordAuthenticationToken));
+        }
+
+        @Test
+        void willThrowWhenOverrideAndNoTokens2() {
+            tokens.put(ZosmfService.TokenType.JWT, "jwtToken");
+            zosmfConfiguration.jwtAutoconfigurationMode = LTPA;
+            assertThrows(BadCredentialsException.class, () -> underTest.authenticate(usernamePasswordAuthenticationToken));
+        }
     }
 
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKeyTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfJwkToPublicKeyTest.java
@@ -32,7 +32,7 @@ class ZosmfJwkToPublicKeyTest {
         when(restTemplate.getForObject("https://zosmf:1433/jwt/ibm/api/zOSMFBuilder/jwk", String.class))
                 .thenReturn(jwk);
 
-        ZosmfJwkToPublicKey zosmfJwkToPublicKey = new ZosmfJwkToPublicKey(restTemplate);
+        ZosmfJwkToPublicKey zosmfJwkToPublicKey = new ZosmfJwkToPublicKey(restTemplate, "/jwt/ibm/api/zOSMFBuilder/jwk");
 
         File f = File.createTempFile("jwt", null, new File(System.getProperty("java.io.tmpdir")));
         try {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -33,7 +33,6 @@ import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -453,9 +452,11 @@ class ZosmfServiceTest {
 
     @Test
     void testGetPublicKeys_success() throws JSONException {
+        String zosmfJwtUrl = "/jwt/ibm/api/zOSMFBuilder/jwk";
+        when(authConfigurationProperties.getZosmfJwtEndpoint()).thenReturn(zosmfJwtUrl);
         ZosmfService zosmfService = getZosmfServiceSpy();
         when(restTemplate.getForObject(
-            "http://zosmf:1433/jwt/ibm/api/zOSMFBuilder/jwk",
+            "http://zosmf:1433" + zosmfJwtUrl,
             String.class
         )).thenReturn(ZOSMF_PUBLIC_KEY_JSON);
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/api/AuthenticationController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/api/AuthenticationController.java
@@ -10,7 +10,6 @@
 package org.zowe.apiml.client.api;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.client.services.AparBasedService;
@@ -38,11 +37,6 @@ public class AuthenticationController {
         @RequestHeader Map<String, String> headers
     ) {
         return authentication.process(AUTHENTICATION_SERVICE, "create", response, headers);
-    }
-
-    @GetMapping(value = "/jwt/ibm/api/zOSMFBuilder/**", produces = "application/json; charset=utf-8")
-    public ResponseEntity<?> jwk() {
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping(value = "/zosmf/notifications/inbox", produces = "application/json; charset=utf-8")

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/api/JwtController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/api/JwtController.java
@@ -1,0 +1,32 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.zowe.apiml.client.services.AparBasedService;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class JwtController {
+    private final AparBasedService jwtHandler;
+
+    @GetMapping(value = "/jwt/ibm/api/zOSMFBuilder/**", produces = "application/json; charset=utf-8")
+    public ResponseEntity<?> jwk(HttpServletResponse response,
+                                 @RequestHeader Map<String, String> headers) {
+        return jwtHandler.process("jwtKeys", "get", response, headers);
+    }
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/api/JwtController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/api/JwtController.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@SuppressWarnings("squid:S1452")
 public class JwtController {
     private final AparBasedService jwtHandler;
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
@@ -1,0 +1,28 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+public class AuthenticateApar extends FunctionalApar {
+    public AuthenticateApar(List<String> usernames, List<String> passwords) {
+        super(usernames, passwords);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
+        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
@@ -23,6 +23,20 @@ public class AuthenticateApar extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
-        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        if (isUnauthorized(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        setLtpaToken(response);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
+        return handleAuthenticationCreate(headers, response);
+    }
+
+    private boolean isUnauthorized(Map<String, String> headers) {
+        return containsInvalidUser(headers) && noLtpaCookie(headers);
     }
 }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
@@ -36,6 +36,11 @@ public class AuthenticateApar extends FunctionalApar {
         return handleAuthenticationCreate(headers, response);
     }
 
+    @Override
+    protected ResponseEntity<?> handleAuthenticationDefault(Map<String, String> headers) {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
     private boolean isUnauthorized(Map<String, String> headers) {
         return containsInvalidUser(headers) && noLtpaCookie(headers);
     }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -72,7 +72,18 @@ public class FunctionalApar implements Apar {
             result = handleFiles(headers);
         }
 
+        if (calledService.equals("jwtKeys")) {
+            result = handleJwtKeys();
+        }
+
         return result == null ? originalResult : Optional.of(result);
+    }
+
+    /**
+     * Override to provide response entity when the JWT keys are requested from the zOSMF
+     */
+    protected ResponseEntity<?> handleJwtKeys() {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
     /**

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/JwtKeys.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/JwtKeys.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public class JwtKeys extends FunctionalApar {
+    public JwtKeys(List<String> usernames, List<String> passwords) {
+        super(usernames, passwords);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleJwtKeys() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
@@ -48,6 +48,11 @@ public class PH12143 extends FunctionalApar {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @Override
+    protected ResponseEntity<?> handleJwtKeys() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     private boolean isUnauthorized(Map<String, String> headers) {
         return containsInvalidUser(headers) && noLtpaCookie(headers);
     }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
@@ -26,6 +26,7 @@ public class AvailableApars {
         implementedApars.put("PH28532", new NoApar());
         implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath));
         implementedApars.put("JwtKeys", new JwtKeys(usernames, passwords));
+        implementedApars.put("AuthenticateApar", new AuthenticateApar(usernames, passwords));
     }
 
     public List<Apar> getApars(List<String> names) {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
@@ -9,10 +9,7 @@
  */
 package org.zowe.apiml.client.services.versions;
 
-import org.zowe.apiml.client.services.apars.Apar;
-import org.zowe.apiml.client.services.apars.NoApar;
-import org.zowe.apiml.client.services.apars.PH12143;
-import org.zowe.apiml.client.services.apars.RSU2012;
+import org.zowe.apiml.client.services.apars.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +25,7 @@ public class AvailableApars {
         implementedApars.put("PH28507", new NoApar());
         implementedApars.put("PH28532", new NoApar());
         implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath));
+        implementedApars.put("JwtKeys", new JwtKeys(usernames, passwords));
     }
 
     public List<Apar> getApars(List<String> names) {

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/api/JwtControllerTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/api/JwtControllerTest.java
@@ -23,11 +23,11 @@ import org.zowe.apiml.client.services.AparBasedService;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
-class AuthenticationControllerTest {
+public class JwtControllerTest {
     private static final ResponseEntity<?> DEFAULT_RESPONSE = new ResponseEntity<>(HttpStatus.OK);
 
     private MockMvc mockMvc;
@@ -37,25 +37,13 @@ class AuthenticationControllerTest {
 
     @BeforeEach
     void setUp() {
-        AuthenticationController authenticationController = new AuthenticationController(aparService);
-        mockMvc = MockMvcBuilders.standaloneSetup(authenticationController).build();
+        JwtController jwtController = new JwtController(aparService);
+        mockMvc = MockMvcBuilders.standaloneSetup(jwtController).build();
     }
 
     @Test
-    void whenCallAuthenticateEndpointWithDelete_thenReturnAparServiceProcessResult() throws Exception {
+    void whenCallZosmfBuilderEndpointWithGet_thenReturnOk() throws Exception {
         doReturn(DEFAULT_RESPONSE).when(aparService).process(any(), any(), any(), any());
-        mockMvc.perform(delete("/zosmf/services/authenticate")).andExpect(status().is(SC_OK));
-    }
-
-    @Test
-    void whenCallAuthenticateEndpointWithPost_thenReturnAparServiceProcessResult() throws Exception {
-        doReturn(DEFAULT_RESPONSE).when(aparService).process(any(), any(), any(), any());
-        mockMvc.perform(post("/zosmf/services/authenticate")).andExpect(status().is(SC_OK));
-    }
-
-    @Test
-    void whenCallZosmfNotificationEndpointWithGet_thenReturnAparServiceProcessResult() throws Exception {
-        doReturn(DEFAULT_RESPONSE).when(aparService).process(any(), any(), any(), any());
-        mockMvc.perform(get("/zosmf/notifications/inbox")).andExpect(status().is(SC_OK));
+        mockMvc.perform(get("/jwt/ibm/api/zOSMFBuilder")).andExpect(status().is(SC_OK));
     }
 }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/api/JwtControllerTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/api/JwtControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
-public class JwtControllerTest {
+class JwtControllerTest {
     private static final ResponseEntity<?> DEFAULT_RESPONSE = new ResponseEntity<>(HttpStatus.OK);
 
     private MockMvc mockMvc;

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class AuthenticationAparTest {
-    private PHBase underTest;
+    private AuthenticateApar underTest;
     private Map<String, String> headers;
     private HttpServletResponse mockResponse;
 
@@ -36,7 +36,7 @@ class AuthenticationAparTest {
         List<String> usernames = Collections.singletonList("USER");
         List<String> passwords = Collections.singletonList("validPassword");
 
-        underTest = new PHBase(usernames, passwords);
+        underTest = new AuthenticateApar(usernames, passwords);
         headers = new HashMap<>();
         mockResponse = mock(HttpServletResponse.class);
     }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
@@ -1,0 +1,127 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AuthenticationAparTest {
+    private PHBase underTest;
+    private Map<String, String> headers;
+    private HttpServletResponse mockResponse;
+
+    @BeforeEach
+    void setUp() {
+        List<String> usernames = Collections.singletonList("USER");
+        List<String> passwords = Collections.singletonList("validPassword");
+
+        underTest = new PHBase(usernames, passwords);
+        headers = new HashMap<>();
+        mockResponse = mock(HttpServletResponse.class);
+    }
+
+    @Nested
+    class whenAuthenticateIsCalled {
+        @Test
+        void givenVerifyMethodWithNoAuthorization_returnUnauthorized() {
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+
+            ResponseEntity<?> response = result.get();
+            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+        }
+
+        @Test
+        void givenVerifyMethodWithEmptyAuthorization_returnUnauthorized() {
+            headers.put("authorization", "");
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+
+            ResponseEntity<?> response = result.get();
+            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+        }
+
+        @Test
+        void givenVerifyMethodWithInvalidUser_returnUnauthorized() {
+            headers.put("authorization", org.apache.tomcat.util.codec.binary.Base64.encodeBase64String("baduser:badpassword".getBytes()));
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+
+            ResponseEntity<?> response = result.get();
+            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+        }
+
+        @Test
+        void givenVerifyMethodWithInvalidCookie_returnUnauthorized() {
+            headers.put("cookie", "bad cookie");
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+
+            ResponseEntity<?> response = result.get();
+            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+        }
+
+        @Test
+        void givenVerifyMethodWithValidUser_returnOkLtpa2Token() {
+            headers.put("authorization", Base64.encodeBase64String("USER:validPassword".getBytes()));
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+
+            ArgumentCaptor<Cookie> called = ArgumentCaptor.forClass(Cookie.class);
+            verify(mockResponse).addCookie(called.capture());
+
+            Cookie ltpa = called.getValue();
+            assertThat(ltpa.getName(), is("LtpaToken2"));
+        }
+
+        @Test
+        void givenVerifyMethodWithValidCookie_returnOkLtpa2Token() {
+            headers.put("cookie", "LtpaToken2=randomValidValue");
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+
+            ArgumentCaptor<Cookie> called = ArgumentCaptor.forClass(Cookie.class);
+            verify(mockResponse).addCookie(called.capture());
+
+            Cookie ltpa = called.getValue();
+            assertThat(ltpa.getName(), is("LtpaToken2"));
+        }
+
+        @Test
+        void givenUnimplementedMethod_notFoundIsReturned() {
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "fake method", Optional.empty(), mockResponse, headers);
+            assertThat(result.isPresent(), is(true));
+
+            ResponseEntity<?> response = result.get();
+            assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+        }
+    }
+}

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/JwtKeysTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/JwtKeysTest.java
@@ -1,0 +1,46 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JwtKeysTest {
+    private JwtKeys underTest;
+
+    @BeforeEach
+    void setUp() {
+        List<String> usernames = Collections.singletonList("USER");
+        List<String> passwords = Collections.singletonList("validPassword");
+
+        underTest = new JwtKeys(usernames, passwords);
+    }
+
+    @Nested
+    class whenRetrieveJwtKeys {
+        @Test
+        void thenOkIsReturned() {
+            Optional<ResponseEntity<?>> result = underTest.apply("jwtKeys", "get", null, null, null);
+
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+        }
+    }
+}

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
@@ -176,20 +176,34 @@ class PH12143Test {
         }
     }
 
-    @Test
-    void givenAuthenticationMethodNotHandled_whenApplyApar_thenReturnOriginalResult() {
-        Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+    @Nested
+    class whenApplyApar {
+        @Test
+        void givenAuthenticationMethodNotHandled_thenReturnOriginalResult() {
+            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
-        Optional<ResponseEntity<?>> result = underTest.apply("authentication", "default", previousResult, mockResponse, headers);
-        assertThat(result, is(previousResult));
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "default", previousResult, mockResponse, headers);
+            assertThat(result, is(previousResult));
+        }
+
+        @Test
+        void givenServiceNotHandled_thenReturnOriginalResult() {
+            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+            Optional<ResponseEntity<?>> result = underTest.apply("badservice", "", previousResult, mockResponse, headers);
+            assertThat(result, is(previousResult));
+        }
     }
 
-    @Test
-    void givenServiceNotHandled_whenApplyApar_thenReturnOriginalResult() {
-        Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+    @Nested
+    class whenRetrieveJwtKeys {
+        @Test
+        void thenOkIsReturned() {
+            Optional<ResponseEntity<?>> result = underTest.apply("jwtKeys", "get", null, null, null);
 
-        Optional<ResponseEntity<?>> result = underTest.apply("badservice", "", previousResult, mockResponse, headers);
-        assertThat(result, is(previousResult));
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+        }
     }
 
     private String getBasicAuthorizationHeader(String user, String password) {

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
@@ -172,4 +172,15 @@ class PHBaseTest {
             assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
         }
     }
+
+    @Nested
+    class whenRetrieveJwtKeys {
+        @Test
+        void thenNotFoundIsReturned() {
+            Optional<ResponseEntity<?>> result = underTest.apply("jwtKeys", "get", null, null, null);
+
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.NOT_FOUND));
+        }
+    }
 }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
@@ -36,6 +36,7 @@ class AvailableAparsTest {
         knownApars.add("PH28532");
         knownApars.add("RSU2012");
         knownApars.add("JwtKeys");
+        knownApars.add("AuthenticateApar");
 
         List<String> aparsToSearchFor = new ArrayList<>(knownApars);
         aparsToSearchFor.add("bad apar");

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
@@ -35,6 +35,7 @@ class AvailableAparsTest {
         knownApars.add("PH28507");
         knownApars.add("PH28532");
         knownApars.add("RSU2012");
+        knownApars.add("JwtKeys");
 
         List<String> aparsToSearchFor = new ArrayList<>(knownApars);
         aparsToSearchFor.add("bad apar");


### PR DESCRIPTION
# Description

Allow the user to force the authentication token to be used. LTPA, JWT
Improve the default auto configuration to handle the case when the zOSMF has /zosmf/services/authenticate endpoint but doesn't support JWT.

Linked to #1239

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)