### PR TITLE
chore: Always store test results and logs

### DIFF
--- a/.github/workflows/ci-internal-tests.yml
+++ b/.github/workflows/ci-internal-tests.yml
@@ -47,6 +47,7 @@ jobs:
               run: ./gradlew build runCITestsInternalPort -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017
             - name: Store results
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: Package
                   path: |
@@ -56,6 +57,7 @@ jobs:
                       ./**/test-results/**/*.xml
                       api-catalog-ui/frontend/test-results/
                       api-layer.tar.gz
+                      **/*.log
             - name: Cleanup Gradle Cache
               # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
               # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/.github/workflows/ci-internal-tests.yml
+++ b/.github/workflows/ci-internal-tests.yml
@@ -51,12 +51,8 @@ jobs:
               with:
                   name: Package
                   path: |
-                      api-catalog-services/build/reports/tests/test/
-                      discovery-service/build/reports/tests/test/
-                      gateway-service/build/reports/tests/test/
-                      ./**/test-results/**/*.xml
-                      api-catalog-ui/frontend/test-results/
-                      api-layer.tar.gz
+                      **/reports/**
+                      **/test-results/**
                       **/*.log
             - name: Cleanup Gradle Cache
               # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/ci-tests-with-rsu2012.yml
+++ b/.github/workflows/ci-tests-with-rsu2012.yml
@@ -47,6 +47,7 @@ jobs:
               run: ./gradlew build runCITests -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017 -Dzosmf.appliedApars=PH12143,RSU2012
             - name: Store results
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: Package
                   path: |
@@ -56,6 +57,7 @@ jobs:
                       ./**/test-results/**/*.xml
                       api-catalog-ui/frontend/test-results/
                       api-layer.tar.gz
+                      **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/.github/workflows/ci-tests-with-rsu2012.yml
+++ b/.github/workflows/ci-tests-with-rsu2012.yml
@@ -51,12 +51,8 @@ jobs:
               with:
                   name: Package
                   path: |
-                      api-catalog-services/build/reports/tests/test/
-                      discovery-service/build/reports/tests/test/
-                      gateway-service/build/reports/tests/test/
-                      ./**/test-results/**/*.xml
-                      api-catalog-ui/frontend/test-results/
-                      api-layer.tar.gz
+                      **/reports/**
+                      **/test-results/**
                       **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
+++ b/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
@@ -51,12 +51,8 @@ jobs:
               with:
                   name: Package
                   path: |
-                      api-catalog-services/build/reports/tests/test/
-                      discovery-service/build/reports/tests/test/
-                      gateway-service/build/reports/tests/test/
-                      ./**/test-results/**/*.xml
-                      api-catalog-ui/frontend/test-results/
-                      api-layer.tar.gz
+                      **/reports/**
+                      **/test-results/**
                       **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
+++ b/.github/workflows/ci-tests-without-jwt-with-authenticate.yml
@@ -47,6 +47,7 @@ jobs:
               run: ./gradlew build runCITests -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017 -Dzosmf.appliedApars=AuthenticateApar
             - name: Store results
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: Package
                   path: |
@@ -56,6 +57,7 @@ jobs:
                       ./**/test-results/**/*.xml
                       api-catalog-ui/frontend/test-results/
                       api-layer.tar.gz
+                      **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/.github/workflows/ci-tests-without-jwt.yml
+++ b/.github/workflows/ci-tests-without-jwt.yml
@@ -51,12 +51,8 @@ jobs:
               with:
                   name: Package
                   path: |
-                      api-catalog-services/build/reports/tests/test/
-                      discovery-service/build/reports/tests/test/
-                      gateway-service/build/reports/tests/test/
-                      ./**/test-results/**/*.xml
-                      api-catalog-ui/frontend/test-results/
-                      api-layer.tar.gz
+                      **/reports/**
+                      **/test-results/**
                       **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/ci-tests-without-jwt.yml
+++ b/.github/workflows/ci-tests-without-jwt.yml
@@ -47,6 +47,7 @@ jobs:
               run: ./gradlew build runCITests -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017 -Dzosmf.appliedApars=
             - name: Store results
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: Package
                   path: |
@@ -56,6 +57,7 @@ jobs:
                       ./**/test-results/**/*.xml
                       api-catalog-ui/frontend/test-results/
                       api-layer.tar.gz
+                      **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -47,6 +47,7 @@ jobs:
               run: ./gradlew build runCITests -x test --scan --info -Pgradle.cache.push=true -DexternalJenkinsToggle="true" -Penabler=v1 -DauxiliaryUserList.value="unauthorized,USER1,validPassword;servicesinfo-authorized,USER,validPassword;servicesinfo-unauthorized,USER1,validPassword" -Dcredentials.user=USER -Dcredentials.password=validPassword -Dzosmf.host=localhost -Dzosmf.port=10013 -Dzosmf.serviceId=mockzosmf -Dinternal.gateway.port=10017
             - name: Store results
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: Package
                   path: |
@@ -56,6 +57,7 @@ jobs:
                       ./**/test-results/**/*.xml
                       api-catalog-ui/frontend/test-results/
                       api-layer.tar.gz
+                      **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,12 +51,8 @@ jobs:
               with:
                   name: Package
                   path: |
-                      api-catalog-services/build/reports/tests/test/
-                      discovery-service/build/reports/tests/test/
-                      gateway-service/build/reports/tests/test/
-                      ./**/test-results/**/*.xml
-                      api-catalog-ui/frontend/test-results/
-                      api-layer.tar.gz
+                      **/reports/**
+                      **/test-results/**
                       **/*.log
             - name: Cleanup Gradle Cache
                 # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -36,11 +36,7 @@ import java.util.LinkedHashMap;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances  {
     private static final String GET_ALL_CONTAINERS_ENDPOINT = "/apicatalog/api/v1/containers";
@@ -70,6 +66,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances  {
 
     @Test
     void whenGetContainerStatuses_thenResponseWithAtLeastOneUp() throws Exception {
+        fail();
         final HttpResponse response = getResponse(GET_ALL_CONTAINERS_ENDPOINT, HttpStatus.SC_OK);
 
         // When

--- a/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -66,7 +66,6 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances  {
 
     @Test
     void whenGetContainerStatuses_thenResponseWithAtLeastOneUp() throws Exception {
-        fail();
         final HttpResponse response = getResponse(GET_ALL_CONTAINERS_ENDPOINT, HttpStatus.SC_OK);
 
         // When


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

Linked to #1238

## Type of change

- [x] Chore, repository cleanup, updates the dependencies.

