### PR TITLE
fix: Move version related endpoint to /application/version

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
@@ -25,7 +25,7 @@ import org.zowe.apiml.product.version.VersionService;
 
 @AllArgsConstructor
 @RestController
-@RequestMapping("/gateway")
+@RequestMapping({"/gateway", "/application"})
 public class VersionController {
 
     private VersionService versionService;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/SecurityConfiguration.java
@@ -141,7 +141,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             // endpoint protection
             .and()
             .authorizeRequests()
-            .antMatchers("/application/health", "/application/info").permitAll()
+            .antMatchers("/application/health", "/application/info", "/application/version").permitAll()
             .antMatchers("/application/**").authenticated()
             .antMatchers("/gateway/services/**").authenticated()
 


### PR DESCRIPTION
The /api/v1/gateway or /gateway/api/v1 are an issue as it may route the request to another Gateway, 

Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>
