### PR TITLE
Remove deprecated use of MediaType.APPLICATION_JSON_UTF8_VALUE

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -68,7 +68,7 @@ public class ApiCatalogController {
      *
      * @return a list of all containers
      */
-    @GetMapping(value = "/containers", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/containers", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Lists catalog dashboard tiles",
         notes = "Returns a list of tiles including status and tile description",
         authorizations = {
@@ -97,7 +97,7 @@ public class ApiCatalogController {
      *
      * @return a containers by id
      */
-    @GetMapping(value = "/containers/{id}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/containers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves a specific dashboard tile information",
         notes = "Returns information for a specific tile {id} including status and tile description",
         authorizations = {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -47,7 +47,7 @@ public class CatalogApiDocController {
      * @param apiVersion the version of the api
      * @return api-doc info (as JSON)
      */
-    @GetMapping(value = "/{serviceId}/{apiVersion}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/{serviceId}/{apiVersion}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves the API documentation for a specific service version",
         notes = "Returns the API documentation for a specific service {serviceId} and version {apiVersion}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AbstractExceptionHandler.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AbstractExceptionHandler.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public abstract class AbstractExceptionHandler {
     protected static final String ERROR_MESSAGE_400 = "400 Status Code: {}";
     protected static final String ERROR_MESSAGE_500 = "500 Status Code: {}";
-    private static final String CONTENT_TYPE = MediaType.APPLICATION_JSON_UTF8_VALUE;
+    private static final String CONTENT_TYPE = MediaType.APPLICATION_JSON_VALUE;
 
     protected final MessageService messageService;
     protected final ObjectMapper mapper;

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/auth/SafMethodSecurityExpressionControllerTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/auth/SafMethodSecurityExpressionControllerTest.java
@@ -172,25 +172,25 @@ class SafMethodSecurityExpressionControllerTest {
             return new ResponseEntity<>("It is OK", HttpStatus.OK);
         }
 
-        @GetMapping(value = "/hasSafResourceAccessRead", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+        @GetMapping(value = "/hasSafResourceAccessRead", produces = MediaType.APPLICATION_JSON_VALUE)
         @PreAuthorize("hasSafResourceAccess('CLASS', 'RESOURCE', 'READ')")
         public ResponseEntity<String> test1read() {
             return getResponse();
         }
 
-        @GetMapping(value = "/hasSafResourceAccessUpdate", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+        @GetMapping(value = "/hasSafResourceAccessUpdate", produces = MediaType.APPLICATION_JSON_VALUE)
         @PreAuthorize("hasSafResourceAccess('CLASS', 'RESOURCE', 'UPDATE')")
         public ResponseEntity<String> test1update() {
             return getResponse();
         }
 
-        @GetMapping(value = "/hasSafServiceResourceAccessRead", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+        @GetMapping(value = "/hasSafServiceResourceAccessRead", produces = MediaType.APPLICATION_JSON_VALUE)
         @PreAuthorize("hasSafServiceResourceAccess('RESOURCE', 'READ')")
         public ResponseEntity<String> test2read() {
             return getResponse();
         }
 
-        @GetMapping(value = "/hasSafServiceResourceAccessUpdate", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+        @GetMapping(value = "/hasSafServiceResourceAccessUpdate", produces = MediaType.APPLICATION_JSON_VALUE)
         @PreAuthorize("hasSafServiceResourceAccess('RESOURCE', 'UPDATE')")
         public ResponseEntity<String> test2update() {
             return getResponse();

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/AuthExceptionHandlerTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/AuthExceptionHandlerTest.java
@@ -71,7 +71,7 @@ class AuthExceptionHandlerTest {
             new InsufficientAuthenticationException("ERROR"));
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.AUTH_REQUIRED.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -85,7 +85,7 @@ class AuthExceptionHandlerTest {
             new BadCredentialsException("ERROR"));
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.BAD_CREDENTIALS.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -99,7 +99,7 @@ class AuthExceptionHandlerTest {
             new AuthenticationCredentialsNotFoundException("ERROR"));
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.AUTH_CREDENTIALS_NOT_FOUND.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -111,7 +111,7 @@ class AuthExceptionHandlerTest {
         authExceptionHandler.handleException(httpServletRequest, httpServletResponse, authMethodNotSupportedException);
 
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.AUTH_METHOD_NOT_SUPPORTED.getErrorMessageKey(), authMethodNotSupportedException.getMessage(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -125,7 +125,7 @@ class AuthExceptionHandlerTest {
             new TokenNotValidException("ERROR"));
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.TOKEN_NOT_VALID.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -139,7 +139,7 @@ class AuthExceptionHandlerTest {
             new TokenNotProvidedException("ERROR"));
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.TOKEN_NOT_PROVIDED.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -153,7 +153,7 @@ class AuthExceptionHandlerTest {
             new TokenFormatNotValidException("ERROR"));
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.TOKEN_NOT_VALID.getErrorMessageKey(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
@@ -166,7 +166,7 @@ class AuthExceptionHandlerTest {
         authExceptionHandler.handleException(httpServletRequest, httpServletResponse, serviceException);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), httpServletResponse.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
 
         Message message = messageService.createMessage(ErrorType.AUTH_GENERAL.getErrorMessageKey(), serviceException.getMessage(), httpServletRequest.getRequestURI());
         verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -30,7 +30,7 @@ public class CachingController {
     private final MessageService messageService;
 
 
-    @GetMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves all values in the cache",
         notes = "Values returned for the calling service")
     @ResponseBody
@@ -46,7 +46,7 @@ public class CachingController {
         ).orElseGet(this::getUnauthorizedResponse);
     }
 
-    @DeleteMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @DeleteMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Delete all values for service from the cache",
         notes = "Will delete all key-value pairs for specific service")
     @ResponseBody
@@ -69,7 +69,7 @@ public class CachingController {
         return new ResponseEntity<>(message.mapToView(), missingCert.getStatus());
     }
 
-    @GetMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves a specific value in the cache",
         notes = "Value returned is for the provided {key}")
     @ResponseBody
@@ -78,7 +78,7 @@ public class CachingController {
             key, request, HttpStatus.OK);
     }
 
-    @DeleteMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @DeleteMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Delete key from the cache",
         notes = "Will delete key-value pair for the provided {key}")
     @ResponseBody
@@ -87,7 +87,7 @@ public class CachingController {
             key, request, HttpStatus.NO_CONTENT);
     }
 
-    @PostMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Create a new key in the cache",
         notes = "A new key-value pair will be added to the cache")
     @ResponseBody
@@ -96,7 +96,7 @@ public class CachingController {
             keyValue, request, HttpStatus.CREATED);
     }
 
-    @PutMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PutMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Update key in the cache",
         notes = "Value at the key in the provided key-value pair will be updated to the provided value")
     @ResponseBody

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PageRedirectionController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PageRedirectionController.java
@@ -40,7 +40,7 @@ public class PageRedirectionController {
      */
     @PostMapping(
         value = "/api/v1/redirect",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE,
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.TEMPORARY_REDIRECT)

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetController.java
@@ -55,7 +55,7 @@ public class PetController {
      */
     @GetMapping(
         value = "/pets",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     @ApiOperation(
         value = "List all existing pets",
@@ -79,7 +79,7 @@ public class PetController {
      */
     @PostMapping(
         value = "/pets",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE,
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.CREATED)
@@ -110,7 +110,7 @@ public class PetController {
      */
     @GetMapping(
         value = "/pets/{id}",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     @ApiOperation(value = "Find pet by id", notes = "Returns a single pet",
         authorizations = {
@@ -141,7 +141,7 @@ public class PetController {
      */
     @PutMapping(
         value = "/pets/{id}",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE,
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.OK)
@@ -178,7 +178,7 @@ public class PetController {
      */
     @DeleteMapping(
         value = "/pets/{id}",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiOperation(value = "Delete a pet", notes = "Removes an existing pet",

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/RequestInfoController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/RequestInfoController.java
@@ -43,7 +43,7 @@ public class RequestInfoController {
 
     @GetMapping(
         value = "",
-        produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     @ApiOperation(
         value = "Returns all base information about request",

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/apidoc/reader/ApiDocController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/apidoc/reader/ApiDocController.java
@@ -25,7 +25,7 @@ public class ApiDocController {
 
     private final ApiDocReader apiDocReader;
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public String getApiDoc() {
         return apiDocReader.load(API_DOC_LOCATION);
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
@@ -30,7 +30,7 @@ public class VersionController {
 
     private VersionService versionService;
 
-    @GetMapping(value = "/version", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/version", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VersionInfo> getVersion() {
         return new ResponseEntity<>(versionService.getVersion(), HttpStatus.OK);
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/TomcatFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/TomcatFilter.java
@@ -53,7 +53,7 @@ public class TomcatFilter implements Filter {
         Message message = messageService.createMessage("org.zowe.apiml.gateway.requestContainEncodedSlash", uri);
         if (!allowEncodedSlashes && isRequestEncoded) {
             res.setStatus(HttpStatus.BAD_REQUEST.value());
-            res.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
             try {
                 mapper.writeValue(res.getWriter(), message.mapToView());
             } catch (IOException e) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandler.java
@@ -50,7 +50,7 @@ public class SuccessfulQueryHandler implements AuthenticationSuccessHandler {
         TokenAuthentication tokenAuthentication = (TokenAuthentication) authentication;
         String token = tokenAuthentication.getCredentials();
 
-        response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(HttpStatus.OK.value());
 
         mapper.writeValue(response.getWriter(), authenticationService.parseJwtToken(token));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/ticket/SuccessfulTicketHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/ticket/SuccessfulTicketHandler.java
@@ -50,7 +50,7 @@ public class SuccessfulTicketHandler implements AuthenticationSuccessHandler {
     @SneakyThrows
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         try {
             response.setStatus(HttpStatus.OK.value());

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
@@ -32,7 +32,7 @@ public class ServicesInfoController {
 
     private final ServicesInfoService servicesInfoService;
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ServiceInfo>> getServices(@RequestParam(required = false) String apiId) {
         List<ServiceInfo> services = servicesInfoService.getServicesInfo(apiId);
         HttpStatus status = (services.isEmpty()) ? HttpStatus.NOT_FOUND : HttpStatus.OK;
@@ -43,7 +43,7 @@ public class ServicesInfoController {
                 .body(services);
     }
 
-    @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ServiceInfo> getService(@PathVariable String serviceId) {
         ServiceInfo serviceInfo = servicesInfoService.getServiceInfo(serviceId);
         HttpStatus status = (serviceInfo.getStatus() == InstanceInfo.InstanceStatus.UNKNOWN) ?

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/TomcatFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/TomcatFilterTest.java
@@ -71,7 +71,7 @@ class TomcatFilterTest {
         filter.doFilter(request, response, filterChain);
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, response.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, response.getContentType());
 
         Message message = messageService.createMessage("org.zowe.apiml.gateway.requestContainEncodedSlash", request.getRequestURI());
         verify(objectMapper).writeValue(response.getWriter(), message.mapToView());

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
@@ -106,7 +106,7 @@ class SuccessfulQueryHandlerTest {
 
         successfulQueryHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, tokenAuthentication);
 
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
         assertEquals(HttpStatus.OK.value(), httpServletResponse.getStatus());
         assertTrue(httpServletResponse.isCommitted());
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ticket/SuccessfulTicketHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ticket/SuccessfulTicketHandlerTest.java
@@ -56,7 +56,7 @@ class SuccessfulTicketHandlerTest {
 
         successfulTicketHandlerHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, tokenAuthentication);
 
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
         assertEquals(HttpStatus.OK.value(), httpServletResponse.getStatus());
         assertTrue(httpServletResponse.getContentAsString().contains(ZOWE_DUMMY_PASS_TICKET_PREFIX));
         assertTrue(httpServletResponse.isCommitted());
@@ -66,7 +66,7 @@ class SuccessfulTicketHandlerTest {
     void shouldFailWhenNoApplicationName() throws UnsupportedEncodingException, JsonProcessingException {
         successfulTicketHandlerHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, tokenAuthentication);
 
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
         assertEquals(HttpStatus.BAD_REQUEST.value(), httpServletResponse.getStatus());
         assertTrue(httpServletResponse.getContentAsString().contains("ZWEAG140E"));
         assertTrue(httpServletResponse.isCommitted());
@@ -75,7 +75,7 @@ class SuccessfulTicketHandlerTest {
         httpServletResponse.setStatus(HttpStatus.EXPECTATION_FAILED.value());
         successfulTicketHandlerHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, tokenAuthentication);
 
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
         assertEquals(HttpStatus.BAD_REQUEST.value(), httpServletResponse.getStatus());
         assertTrue(httpServletResponse.getContentAsString().contains("ZWEAG140E"));
         assertTrue(httpServletResponse.isCommitted());
@@ -87,7 +87,7 @@ class SuccessfulTicketHandlerTest {
 
         successfulTicketHandlerHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, tokenAuthentication);
 
-        assertEquals(MediaType.APPLICATION_JSON_UTF8_VALUE, httpServletResponse.getContentType());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
         assertEquals(HttpStatus.BAD_REQUEST.value(), httpServletResponse.getStatus());
         assertTrue(httpServletResponse.getContentAsString().contains("ZWEAG141E"));
         assertTrue(httpServletResponse.isCommitted());

--- a/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/ZosmfAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/gatewayservice/ZosmfAuthenticationTest.java
@@ -248,7 +248,7 @@ class ZosmfAuthenticationTest implements TestWithStartedInstances {
                 resp.setHeader(HttpHeaders.SET_COOKIE, cookiesOnSuccess);
             }
             if (bodyOnSuccess != null) {
-                resp.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE);
+                resp.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
                 resp.getOutputStream().write(bodyOnSuccess.getBytes());
                 resp.setStatus(HttpStatus.OK.value());
             } else {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/service/VirtualService.java
@@ -259,7 +259,7 @@ public class VirtualService implements AutoCloseable {
             while (true) {
                 try {
                     final ResponseBody responseBody = given().when()
-                        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .get(url)
                         .body();
                     assertEquals(instanceId, responseBody.print());
@@ -304,7 +304,7 @@ public class VirtualService implements AutoCloseable {
                 try {
                     for (int i = 0; i < instanceCountBefore; i++) {
                         final ResponseBody responseBody = given().when()
-                            .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .get(url)
                             .body();
                         assertNotEquals(instanceId, responseBody.print());
@@ -393,7 +393,7 @@ public class VirtualService implements AutoCloseable {
 
     public Response postRegistration(String status) throws UnknownHostException {
         return given().when()
-            .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .body(new JSONObject()
                 .put("instance", new JSONObject()
                     .put("instanceId", instanceId)
@@ -632,7 +632,7 @@ public class VirtualService implements AutoCloseable {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setStatus(HttpStatus.SC_OK);
-            resp.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
+            resp.setContentType(MediaType.APPLICATION_JSON_VALUE);
             final Status status = healthService == null ? Status.UNKNOWN : healthService.getStatus();
             resp.getWriter().print("{\"status\":\"" + status + "\"}");
             resp.getWriter().close();

--- a/onboarding-enabler-spring-v1-sample-app/src/test/java/org/zowe/apiml/sample/enable/v1/controller/SampleControllerUnitTests.java
+++ b/onboarding-enabler-spring-v1-sample-app/src/test/java/org/zowe/apiml/sample/enable/v1/controller/SampleControllerUnitTests.java
@@ -42,7 +42,7 @@ public class SampleControllerUnitTests {
     public void test_get_all_samples() throws Exception {
         mockMvc.perform(get("/api/v1/samples"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$", hasSize(4)))
                 .andExpect(jsonPath("$[0].name", is("one")))
                 .andExpect(jsonPath("$[0].details", is("first one")))


### PR DESCRIPTION
Signed-off-by: Boris Petkov <boris.petkov@broadcom.com>

# Description
Replace deprecated constant MediaType.APPLICATION_JSON_UTF8_VALUE with MediaType.APPLICATION_JSON_VALUE

Linked to #1132 

## Type of change
- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [x] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

