### PR TITLE
Remove deprecated use of MediaType.APPLICATION_JSON_UTF8

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
@@ -268,7 +268,7 @@ public class APIDocRetrievalService {
      */
     private String getApiDocContentByUrl(@NonNull String serviceId, String apiDocUrl) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
         ResponseEntity<String> response = restTemplate.exchange(
             apiDocUrl,

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
@@ -164,7 +164,7 @@ public class APIServiceStatusService {
      */
     private HttpHeaders createHeaders() {
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         return headers;
     }
 }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/LocalApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/LocalApiDocServiceTest.java
@@ -421,7 +421,7 @@ class LocalApiDocServiceTest {
 
     private HttpEntity<Object> getObjectHttpEntity() {
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
         return new HttpEntity<>(headers);
     }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetControllerExceptionHandler.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetControllerExceptionHandler.java
@@ -55,7 +55,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 
@@ -71,7 +71,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 
@@ -87,7 +87,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 
@@ -118,7 +118,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(new ApiMessageView(listApiMessage));
     }
 
@@ -134,7 +134,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 
@@ -150,7 +150,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 
@@ -167,7 +167,7 @@ public class PetControllerExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(message.mapToView());
     }
 }

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/PageRedirectionControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/PageRedirectionControllerTest.java
@@ -41,7 +41,7 @@ class PageRedirectionControllerTest {
 
         this.mockMvc.perform(
             post("/api/v1/redirect")
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isTemporaryRedirect())
             .andExpect(redirectedUrl(redirectLocation.getLocation()));

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/PetControllerPostPetTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/PetControllerPostPetTest.java
@@ -55,7 +55,7 @@ class PetControllerPostPetTest {
 
         this.mockMvc.perform(
             post("/api/v1/pets")
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id", is(id)))

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/PetControllerPutTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/PetControllerPutTest.java
@@ -58,7 +58,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + id)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id", is(id)))
@@ -78,7 +78,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + id)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0001E')].messageContent", hasItem(message)));
@@ -96,7 +96,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + id)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0004E')].messageContent", hasItem(message)));
@@ -119,7 +119,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + id)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString()))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0005E')].messageContent", hasItem(message)));
@@ -136,7 +136,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + pathId)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0003E')].messageContent", hasItem(message)));
@@ -153,7 +153,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + pathId)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0002E')].messageContent", hasItem(message)));
@@ -174,7 +174,7 @@ class PetControllerPutTest {
 
         this.mockMvc.perform(
             put("/api/v1/pets/" + pathId)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(json.toString()))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'CSR0007E')].messageContent", hasItem(message)));

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/ZaasClientTestControllerTest.java
@@ -55,7 +55,7 @@ class ZaasClientTestControllerTest {
         this.mockMvc.perform(
             post("/api/v1/zaasClient/login")
                 .content(mapper.writeValueAsString(loginRequest))
-                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(content().string("token"));
     }
 
@@ -68,7 +68,7 @@ class ZaasClientTestControllerTest {
         this.mockMvc.perform(
             post("/api/v1/zaasClient/login")
                 .content(mapper.writeValueAsString(loginRequest))
-                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().is(401))
             .andExpect(content().string("Invalid username or password"));
     }
@@ -79,7 +79,7 @@ class ZaasClientTestControllerTest {
         this.mockMvc.perform(
             post("/api/v1/zaasClient/logout")
                 .cookie(new Cookie(TOKEN_PREFIX, token))
-                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().is(204));
     }
 
@@ -87,7 +87,7 @@ class ZaasClientTestControllerTest {
     void givenNoToken_whenPerformingLogout_thenFailLogout() throws Exception {
         this.mockMvc.perform(
             post("/api/v1/zaasClient/logout")
-                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().is(500))
             .andExpect(content().string("Missing cookie or authorization header in the request"));
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/RibbonRetryErrorCheck.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/RibbonRetryErrorCheck.java
@@ -67,7 +67,7 @@ public class RibbonRetryErrorCheck implements ErrorCheck {
 
     private ResponseEntity<ApiMessageView> getApiMessageViewResponseEntity(ApiMessageView messageView) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(messageView);
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheck.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheck.java
@@ -52,7 +52,7 @@ public class SecurityErrorCheck implements ErrorCheck {
                     ErrorUtils.getGatewayUri(request)
                 ).mapToView();
             }
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).contentType(MediaType.APPLICATION_JSON_UTF8).body(messageView);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).contentType(MediaType.APPLICATION_JSON).body(messageView);
         }
 
         return null;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheck.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheck.java
@@ -37,10 +37,10 @@ public class ServiceErrorCheck implements ErrorCheck {
                     ErrorUtils.getGatewayUri(request),
                     t.getCause()
                 ).mapToView();
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON_UTF8).body(messageView);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON).body(messageView);
             } else if (exception.nStatusCode == HttpStatus.NOT_FOUND.value()) {
                 messageView = messageService.createMessage("org.zowe.apiml.common.endPointNotFound", exception.errorCause).mapToView();
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON_UTF8).body(messageView);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON).body(messageView);
             }
         }
 

--- a/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
+++ b/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
@@ -57,7 +57,7 @@ public class GatewaySecurityService {
         loginRequest.put("password", password);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
         try {
             ResponseEntity<String> response = restTemplate.exchange(

--- a/security-service-client-spring/src/test/java/org/zowe/apiml/security/client/service/GatewaySecurityServiceTest.java
+++ b/security-service-client-spring/src/test/java/org/zowe/apiml/security/client/service/GatewaySecurityServiceTest.java
@@ -178,7 +178,7 @@ class GatewaySecurityServiceTest {
         loginRequest.put("password", PASSWORD);
 
         HttpHeaders requestHeaders = new HttpHeaders();
-        requestHeaders.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        requestHeaders.setContentType(MediaType.APPLICATION_JSON);
         return new HttpEntity<>(loginRequest, requestHeaders);
     }
 }


### PR DESCRIPTION
Signed-off-by: Boris Petkov <boris.petkov@broadcom.com>

# Description
Replaces the use of the deprecated constant MediaType.APPLICATION_JSON_UTF8 with MediaType.APPLICATION_JSON.

Linked to #1132 

## Type of change
- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [x] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
