### PR TITLE
fix: Distinguish lib and fat jars

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -121,6 +121,13 @@ bootRun {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifact 'build/libs/api-catalog-services-lite.jar'
+        }
+
+        mavenJavaFat(MavenPublication) {
+            groupId = 'org.zowe.apiml.sdk'
+            artifactId = 'api-catalog-fat-jar'
+
             artifact bootJar
         }
     }

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -93,6 +93,13 @@ bootRun {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifact 'build/libs/discovery-service-lite.jar'
+        }
+
+        mavenJavaFat(MavenPublication) {
+            groupId = 'org.zowe.apiml.sdk'
+            artifactId = 'discovery-fat-jar'
+
             artifact bootJar
         }
     }

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -112,6 +112,13 @@ bootRun {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifact 'build/libs/gateway-service-lite.jar'
+        }
+
+        mavenJavaFat(MavenPublication) {
+            groupId = 'org.zowe.apiml.sdk'
+            artifactId = 'gateway-fat-jar'
+
             artifact bootJar
         }
     }


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub@balhar.net>

The published libraries in the standard maven path are fat jars and therefore unusable as libraries. 

Linked to #1375 

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
