### PR TITLE
initial commit

### DIFF
--- a/certificate-analyser/src/main/java/org/zowe/apiml/HttpClient.java
+++ b/certificate-analyser/src/main/java/org/zowe/apiml/HttpClient.java
@@ -25,6 +25,8 @@ public class HttpClient {
     public int executeCall(URL url) throws IOException {
         HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
         HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
+        con.setConnectTimeout(2000);
+        con.setReadTimeout(2000);
         con.setRequestMethod("GET");
         return con.getResponseCode();
     }


### PR DESCRIPTION
# Description

certificate-analyser:test > Executing test org.zowe.apiml.AnalyserTest 

fails hanging on waiting to connect to local server.

This PR adds timeout to the connection configuration so the single test now passes,
Not so the other tests from the same package which still expect a successful connection.
The core reason remains, but the timeout is needed anyways.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
