### PR TITLE
Use the apiml.service.id the same way as in other services.

### DIFF
--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 
 spring:
     application:
-        name: apicatalog
+        name: ${apiml.service.id}
     cloud:
         client:
             hostname: ${apiml.service.hostname}
@@ -38,6 +38,7 @@ logging:
 ##############################################################################################
 apiml:
     service:
+        id: apicatalog
         hostname: ${apiml.service.hostname}
         ipAddress: ${apiml.service.ipAddress}
         port: ${apiml.service.port}


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub@balhar.net>

# Description

The API Catalog wasn't using the apiml.service.id at all, unlike other services. 

Linked to #1426

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
