### PR TITLE
fix: Gateway SID and Ports incorrect for TLS/ATTLS and Internal port

### DIFF
--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -56,9 +56,3 @@ apiml:
         scheme: http
         discoveryServiceUrls: http://localhost:10001/eureka/
 
-server:
-    internal:
-        enabled: false
-        port: 10010
-        ssl:
-            enabled: false

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
@@ -10,10 +10,9 @@
 package org.zowe.apiml.gateway.config;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.cloud.commons.util.IdUtils;
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
@@ -37,6 +36,7 @@ import java.util.Map;
 @Configuration
 @RequiredArgsConstructor
 @EnableRetry
+@Slf4j
 public class GatewayConfig {
 
     private static final String SEPARATOR = ":";
@@ -68,12 +68,8 @@ public class GatewayConfig {
         boolean preferIpAddress = Boolean
             .parseBoolean(getProperty("eureka.instance.prefer-ip-address"));
         String ipAddress = getProperty("eureka.instance.ip-address");
-        boolean isSecurePortEnabled = Boolean
-            .parseBoolean(getProperty("eureka.instance.secure-port-enabled"));
 
         String serverContextPath = env.getProperty("server.servlet.context-path", "/");
-        int serverPort = Integer
-            .parseInt(env.getProperty("server.internal.port", env.getProperty("port", "8080")));
 
         Integer managementPort = env.getProperty("management.server.port", Integer.class);
 
@@ -81,18 +77,24 @@ public class GatewayConfig {
             .getProperty("management.server.servlet.context-path");
 
         EurekaInstanceConfigBean instance = new EurekaInstanceConfigBean(inetUtils);
-        instance.setNonSecurePort(serverPort);
+
+        int serverPort = Integer
+            .parseInt(getEnabledPort(env));
+
+        boolean isSecurePortEnabled = Boolean
+            .parseBoolean(getProperty("server.ssl.enabled"));
+        instance.setNonSecurePort(isSecurePortEnabled ? 0 : serverPort);
+        instance.setNonSecurePortEnabled(!isSecurePortEnabled);
+        instance.setSecurePort(isSecurePortEnabled ? serverPort : 0);
+        instance.setSecurePortEnabled(isSecurePortEnabled);
+
         instance.setInstanceId(getInstanceId(env));
 
         instance.setPreferIpAddress(preferIpAddress);
-        instance.setSecurePortEnabled(isSecurePortEnabled);
         if (StringUtils.hasText(ipAddress)) {
             instance.setIpAddress(ipAddress);
         }
 
-        if (isSecurePortEnabled) {
-            instance.setSecurePort(serverPort);
-        }
 
         if (StringUtils.hasText(hostname)) {
             instance.setHostname(hostname);
@@ -120,6 +122,9 @@ public class GatewayConfig {
             metadataMap.computeIfAbsent("management.port",
                 k -> String.valueOf(metadata.getManagementPort()));
         }
+
+        log.debug("Eureka Configuration Bean (Environment variables or externalized configuration overrides this configuration and produce different registration in Discovery): {}", instance);
+
         return instance;
     }
 
@@ -133,8 +138,16 @@ public class GatewayConfig {
 
         String namePart = IdUtils.combineParts(hostname, SEPARATOR, appName);
 
-        String indexPart = resolver.getProperty("server.internal.port");
+        String indexPart = getEnabledPort(resolver);
 
         return IdUtils.combineParts(namePart, SEPARATOR, indexPart);
+    }
+
+    public static String getEnabledPort(PropertyResolver resolver) {
+        if ("true".equalsIgnoreCase(resolver.getProperty("server.internal.enabled"))) {
+            return resolver.getProperty("server.internal.port");
+        } else {
+            return resolver.getProperty("apiml.service.port");
+        }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
@@ -144,7 +144,7 @@ public class GatewayConfig {
     }
 
     public static String getEnabledPort(PropertyResolver resolver) {
-        if ("true".equalsIgnoreCase(resolver.getProperty("server.internal.enabled"))) {
+        if (Boolean.parseBoolean(resolver.getProperty("server.internal.enabled"))) {
             return resolver.getProperty("server.internal.port");
         } else {
             return resolver.getProperty("apiml.service.port");

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -175,10 +175,7 @@ eureka:
     instance:
         hostname: ${apiml.service.hostname}
         ipAddress: ${apiml.service.ipAddress}
-        port: ${server.internal.port}
-        securePort: ${server.internal.port}
-        nonSecurePortEnabled: false # must be set to false if you are using SSL
-        securePortEnabled: ${server.ssl.enabled}
+        #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}
         homePageUrl: ${apiml.service.scheme}://${apiml.gateway.hostname}:${apiml.service.port}/
         statusPageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/info
@@ -206,6 +203,7 @@ eureka:
                     description: API Gateway service to route requests to services registered in the API Mediation Layer and provides an API for mainframe security.
                 authentication:
                     sso: true
+
     client:
         fetchRegistry: true
         registerWithEureka: true

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -157,10 +157,7 @@ eureka:
     instance:
         hostname: ${apiml.service.hostname}
         ipAddress: ${apiml.service.ipAddress}
-        port: ${server.port}
-        securePort: ${server.port}
-        nonSecurePortEnabled: false # must be set to false if you are using SSL
-        securePortEnabled: ${server.ssl.enabled}
+        #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}
         homePageUrl: ${apiml.service.scheme}://${apiml.gateway.hostname}:${apiml.service.port}/
         statusPageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/info

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -157,10 +157,7 @@ eureka:
     instance:
         hostname: ${apiml.service.hostname}
         ipAddress: ${apiml.service.ipAddress}
-        port: ${server.port}
-        securePort: ${server.port}
-        nonSecurePortEnabled: false # must be set to false if you are using SSL
-        securePortEnabled: ${server.ssl.enabled}
+        #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}
         homePageUrl: ${apiml.service.scheme}://${apiml.gateway.hostname}:${apiml.service.port}/
         statusPageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/info


### PR DESCRIPTION
Behaving like so now:

```
attls, -Dserver.internal.enabled=false

Eureka Configuration Bean: EurekaInstanceConfigBean{hostInfo=org.springframework.cloud.commons.util.InetUtils$HostInfo@45d1162f, inetUtils=org.springframework.cloud.commons.util.InetUtils@40c0bf62, appname='unknown', appGroupName='null', instanceEnabledOnit=false, nonSecurePort=10010, securePort=0, nonSecurePortEnabled=true, securePortEnabled=false, leaseRenewalIntervalInSeconds=30, leaseExpirationDurationInSeconds=90, virtualHostName='unknown', instanceId='localhost:gateway:10010', secureVirtualHostName='unknown', aSGName='null', metadataMap={management.port=10010}, dataCenterInfo=com.netflix.appinfo.MyDataCenterInfo@1b72ffb1, ipAddress='127.0.0.1', statusPageUrlPath='/actuator/info', statusPageUrl='http://localhost:10010/actuator/info', homePageUrlPath='/', homePageUrl='null', healthCheckUrlPath='/actuator/health', healthCheckUrl='http://localhost:10010/actuator/health', secureHealthCheckUrl='null', namespace='eureka', hostname='localhost', preferIpAddress=false, initialStatus=UP, defaultAddressResolutionOrder=[], environment=null, }

attls, -Dserver.internal.enabled=true

Eureka Configuration Bean: EurekaInstanceConfigBean{hostInfo=org.springframework.cloud.commons.util.InetUtils$HostInfo@81baca, inetUtils=org.springframework.cloud.commons.util.InetUtils@f093d89a, appname='unknown', appGroupName='null', instanceEnabledOnit=false, nonSecurePort=10017, securePort=0, nonSecurePortEnabled=true, securePortEnabled=false, leaseRenewalIntervalInSeconds=30, leaseExpirationDurationInSeconds=90, virtualHostName='unknown', instanceId='localhost:gateway:10017', secureVirtualHostName='unknown', aSGName='null', metadataMap={management.port=10017}, dataCenterInfo=com.netflix.appinfo.MyDataCenterInfo@e7453831, ipAddress='127.0.0.1', statusPageUrlPath='/actuator/info', statusPageUrl='http://localhost:10017/actuator/info', homePageUrlPath='/', homePageUrl='null', healthCheckUrlPath='/actuator/health', healthCheckUrl='http://localhost:10017/actuator/health', secureHealthCheckUrl='null', namespace='eureka', hostname='localhost', preferIpAddress=false, initialStatus=UP, defaultAddressResolutionOrder=[], environment=null, }

tls, -Dserver.internal.enabled=false

Eureka Configuration Bean: EurekaInstanceConfigBean{hostInfo=org.springframework.cloud.commons.util.InetUtils$HostInfo@5bc1a9fd, inetUtils=org.springframework.cloud.commons.util.InetUtils@20348754, appname='unknown', appGroupName='null', instanceEnabledOnit=false, nonSecurePort=0, securePort=10010, nonSecurePortEnabled=false, securePortEnabled=true, leaseRenewalIntervalInSeconds=30, leaseExpirationDurationInSeconds=90, virtualHostName='unknown', instanceId='localhost:gateway:10010', secureVirtualHostName='unknown', aSGName='null', metadataMap={management.port=10010}, dataCenterInfo=com.netflix.appinfo.MyDataCenterInfo@f7671f2e, ipAddress='127.0.0.1', statusPageUrlPath='/actuator/info', statusPageUrl='http://localhost:10010/actuator/info', homePageUrlPath='/', homePageUrl='null', healthCheckUrlPath='/actuator/health', healthCheckUrl='http://localhost:10010/actuator/health', secureHealthCheckUrl='https://localhost:10010/actuator/health', namespace='eureka', hostname='localhost', preferIpAddress=false, initialStatus=UP, defaultAddressResolutionOrder=[], environment=null, }

tls, -Dserver.internal.enabled=true

Eureka Configuration Bean: EurekaInstanceConfigBean{hostInfo=org.springframework.cloud.commons.util.InetUtils$HostInfo@4b2945c1, inetUtils=org.springframework.cloud.commons.util.InetUtils@8dbeecc8, appname='unknown', appGroupName='null', instanceEnabledOnit=false, nonSecurePort=0, securePort=10017, nonSecurePortEnabled=false, securePortEnabled=true, leaseRenewalIntervalInSeconds=30, leaseExpirationDurationInSeconds=90, virtualHostName='unknown', instanceId='localhost:gateway:10017', secureVirtualHostName='unknown', aSGName='null', metadataMap={management.port=10017}, dataCenterInfo=com.netflix.appinfo.MyDataCenterInfo@d23d866d, ipAddress='127.0.0.1', statusPageUrlPath='/actuator/info', statusPageUrl='http://localhost:10017/actuator/info', homePageUrlPath='/', homePageUrl='null', healthCheckUrlPath='/actuator/health', healthCheckUrl='http://localhost:10017/actuator/health', secureHealthCheckUrl='https://localhost:10017/actuator/health', namespace='eureka', hostname='localhost', preferIpAddress=false, initialStatus=UP, defaultAddressResolutionOrder=[], environment=null, }
```

the healthCheckUrl's and such are listed with HTTP scheme even in TLS config, but that is the case where the config gets overridden with what we have in yaml. Registration in Eureka is fine. Maybe next PR can improve on this logging further to find better place where the config is complete.