### PR TITLE
fix: Conditionally close redis connections

### DIFF
--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/redis/RedisOperator.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/redis/RedisOperator.java
@@ -20,6 +20,7 @@ import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.redis.exceptions.RedisEntryException;
@@ -42,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 @NoArgsConstructor
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "caching.storage.mode", havingValue = "redis")
 public class RedisOperator {
     private RedisClient redisClient;
     private StatefulRedisMasterReplicaConnection<String, String> redisConnection;
@@ -60,8 +62,13 @@ public class RedisOperator {
 
     @PreDestroy
     public void closeConnection() {
-        redisConnection.close();
-        redisClient.shutdown();
+        if (redisConnection != null) {
+            redisConnection.close();
+        }
+
+        if (redisClient != null) {
+            redisClient.shutdown();
+        }
     }
 
     /**

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/redis/RedisOperatorTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/redis/RedisOperatorTest.java
@@ -411,10 +411,41 @@ class RedisOperatorTest {
         assertThrows(RetryableRedisException.class, () -> underTest.create(REDIS_ENTRY));
     }
 
-    @Test
-    void givenConnection_whenDestroying_thenCloseConnection() {
-        underTest.closeConnection();
-        verify(redisConnection, times(1)).close();
-        verify(redisClient, times(1)).shutdown();
+    @Nested
+    class WhenDestroying {
+
+        @Test
+        void givenConnectionAndClient_thenCloseConnectionAndClient() {
+            underTest = new RedisOperator(redisClient, redisConnection, redisCommands);
+            underTest.closeConnection();
+
+            verify(redisConnection, times(1)).close();
+            verify(redisClient, times(1)).shutdown();
+        }
+
+        @Test
+        void givenConnection_thenCloseConnectionAndNotClient() {
+            underTest = new RedisOperator(null, redisConnection, redisCommands);
+            underTest.closeConnection();
+
+            verify(redisConnection, times(1)).close();
+            verify(redisClient, times(0)).shutdown();
+        }
+        @Test
+        void givenClient_thenCloseClientAndNotConnection() {
+            underTest = new RedisOperator(redisClient, null, redisCommands);
+            underTest.closeConnection();
+
+            verify(redisConnection, times(0)).close();
+            verify(redisClient, times(1)).shutdown();
+        }
+        @Test
+        void givenNoConnectionOrClient_thenCloseNothing() {
+            underTest = new RedisOperator(null, null, redisCommands);
+            underTest.closeConnection();
+
+            verify(redisConnection, times(0)).close();
+            verify(redisClient, times(0)).shutdown();
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Conditionally close redis connections instead of closing every time the caching service is shut down.

Linked to # 1465

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
