### PR TITLE
Fix wrong using of certificates in ZAAS client

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
@@ -9,10 +9,14 @@
  */
 package org.zowe.apiml.zaasclient.config;
 
+import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.Tolerate;
 
 @Data
+@Builder
 public class ConfigProperties {
+
     private String apimlHost;
     private String apimlPort;
     private String apimlBaseUrl;
@@ -24,4 +28,23 @@ public class ConfigProperties {
     private char[] trustStorePassword;
     private boolean httpOnly;
     private boolean nonStrictVerifySslCertificatesOfServices;
+
+    @Tolerate
+    public ConfigProperties() {
+        // no args constructor
+    }
+
+    public ConfigProperties withoutKeyStore() {
+        return ConfigProperties.builder()
+            .apimlHost(apimlHost)
+            .apimlPort(apimlPort)
+            .apimlBaseUrl(apimlBaseUrl)
+            .trustStoreType(trustStoreType)
+            .trustStorePath(trustStorePath)
+            .trustStorePassword(trustStorePassword)
+            .httpOnly(httpOnly)
+            .nonStrictVerifySslCertificatesOfServices(nonStrictVerifySslCertificatesOfServices)
+            .build();
+    }
+
 }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImpl.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImpl.java
@@ -27,7 +27,7 @@ public class ZaasClientImpl implements ZaasClient {
     private final PassTicketService passTickets;
 
     public ZaasClientImpl(ConfigProperties configProperties) throws ZaasConfigurationException {
-        if (configProperties.getKeyStorePath() == null) {
+        if (!configProperties.isHttpOnly() && (configProperties.getKeyStorePath() == null)) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.KEY_STORE_NOT_PROVIDED);
         }
 

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImpl.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImpl.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.zowe.apiml.zaasclient.config.ConfigProperties;
 import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+import org.zowe.apiml.zaasclient.exception.ZaasConfigurationErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
 import org.zowe.apiml.zaasclient.service.ZaasToken;
@@ -26,12 +27,17 @@ public class ZaasClientImpl implements ZaasClient {
     private final PassTicketService passTickets;
 
     public ZaasClientImpl(ConfigProperties configProperties) throws ZaasConfigurationException {
+        if (configProperties.getKeyStorePath() == null) {
+            throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.KEY_STORE_NOT_PROVIDED);
+        }
+
         CloseableClientProvider httpClientProvider = getTokenProvider(configProperties);
+        CloseableClientProvider httpClientProviderWithoutCert = getTokenProviderWithoutCert(configProperties, httpClientProvider);
+
         String baseUrl = String.format("%s://%s:%s%s", getScheme(configProperties.isHttpOnly()), configProperties.getApimlHost(), configProperties.getApimlPort(),
             configProperties.getApimlBaseUrl());
-        tokens = new ZaasJwtService(httpClientProvider, baseUrl);
+        tokens = new ZaasJwtService(httpClientProviderWithoutCert, baseUrl);
         passTickets = new PassTicketServiceImpl(httpClientProvider, baseUrl);
-
     }
 
     private CloseableClientProvider getTokenProvider(ConfigProperties configProperties) throws ZaasConfigurationException {
@@ -40,7 +46,16 @@ public class ZaasClientImpl implements ZaasClient {
         } else {
             return new ZaasHttpsClientProvider(configProperties);
         }
+    }
 
+    private CloseableClientProvider getTokenProviderWithoutCert (
+        ConfigProperties configProperties,
+        CloseableClientProvider defaultCloseableClientProvider) throws ZaasConfigurationException
+    {
+        if (configProperties.isHttpOnly()) {
+            return defaultCloseableClientProvider;
+        }
+        return getTokenProvider(configProperties.withoutKeyStore());
     }
 
     private Object getScheme(boolean httpOnly) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -71,11 +71,8 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     @Override
     public synchronized CloseableHttpClient getHttpClient() throws ZaasConfigurationException {
-        if (keyStorePath == null) {
-            throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.KEY_STORE_NOT_PROVIDED);
-        }
         if (httpsClientWithKeyStoreAndTrustStore == null) {
-            if (kmf == null) {
+            if ((kmf == null) && (keyStorePath != null)) {
                 initializeKeyStoreManagerFactory();
             }
             httpsClientWithKeyStoreAndTrustStore = sharedHttpClientConfiguration(getSSLContext())

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpTests.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpTests.java
@@ -25,6 +25,7 @@ class ZaasClientImplHttpTests {
         configProperties.setApimlPort("10010");
         configProperties.setApimlBaseUrl("/api/v1/gateway/auth");
         configProperties.setNonStrictVerifySslCertificatesOfServices(false);
+        configProperties.setKeyStorePath("keystorePath");
         ZaasClient client = new ZaasClientImpl(configProperties);
         assertNotNull(client);
     }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
 import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
@@ -144,6 +145,17 @@ class ZaasClientTest {
     @Test
     void givenValidToken_whenLogoutIsCalled_thenSuccessLogout() {
         assertDoesNotThrow(() -> underTest.logout("apimlAuthenticationToken=" + VALID_TOKEN));
+    }
+
+    @Test
+    void givenNullKeyStorePath_whenTheClientIsConstructed_thenExceptionIsThrown() {
+        ConfigProperties config = new ConfigProperties();
+        config.setTrustStorePassword(VALID_PASSWORD.toCharArray());
+        config.setTrustStorePath("src/test/resources/localhost.truststore.p12");
+        config.setTrustStoreType("PKCS12");
+        ZaasConfigurationException zaasException = assertThrows(ZaasConfigurationException.class, () -> new ZaasClientImpl(config));
+
+        assertThat(zaasException.getErrorCode().getId(), is("ZWEAS501E"));
     }
 
 }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProviderTests.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProviderTests.java
@@ -103,18 +103,6 @@ class ZaasHttpsClientProviderTests {
     }
 
     @Test
-    void givenNullKeyStorePath_whenTheClientIsConstructed_thenExceptionIsThrown() throws ZaasConfigurationException {
-        ConfigProperties config = new ConfigProperties();
-        config.setTrustStorePassword(PASSWORD);
-        config.setTrustStorePath("src/test/resources/localhost.truststore.p12");
-        config.setTrustStoreType("PKCS12");
-        ZaasHttpsClientProvider provider = new ZaasHttpsClientProvider(config);
-        ZaasConfigurationException zaasException = assertThrows(ZaasConfigurationException.class, provider::getHttpClient);
-
-        assertThat(zaasException.getErrorCode().getId(), is("ZWEAS501E"));
-    }
-
-    @Test
     void givenInvalidKeyStorePath_whenTheClientIsConstructed_thenExceptionIsThrown() throws ZaasConfigurationException {
         ConfigProperties config = new ConfigProperties();
         config.setTrustStorePassword(PASSWORD);


### PR DESCRIPTION
Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>

# Description
This PR changes the setting of HTTP clients in ZAAS client. It uses now two different clients: 
- for passticket endpoint '/ticket' with signing by a certificate
- for the rest of the endpoints (login, query, logout) without keyring in configuration

Change also required to move verification about settings of keyring to another class. Therefore few tests should be moved and fixed.

It will be great to put In the right documentation warning about using ZAAS client (but I am not sure where). ZAAS client before this PR should be used only against Gateway with disabled client certificates and each application using ZAAS client should be upgraded as soon as possible to avoid this issue.

Linked to #1513  (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
