### PR TITLE
Fix for failing build due to Linux/IOS/Windows endofline differnces.

### DIFF
--- a/metrics-service-ui/frontend/.eslintrc
+++ b/metrics-service-ui/frontend/.eslintrc
@@ -88,6 +88,7 @@
         "prettier/prettier": [
             "error",
             {
+                "endOfLine": "auto",
                 "trailingComma": "es5",
                 "singleQuote": true,
                 "printWidth": 120


### PR DESCRIPTION
# Description
After clean clone of api-layer I was not able to build it on Windows machine. Possibly wrong setup of git client, but the fix proposed here solved the issue regardless of the git client config.

## Type of change
Added single line for auto handling of the OndOfLine

- [X ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
