### PR TITLE
fix: Fix login error handling when auth service is not available

### DIFF
--- a/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/handler/RestResponseHandler.java
+++ b/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/handler/RestResponseHandler.java
@@ -49,7 +49,7 @@ public class RestResponseHandler {
             throw new GatewayNotAvailableException(ErrorType.GATEWAY_NOT_AVAILABLE.getDefaultMessage(), exception);
         } else if (exception instanceof HttpServerErrorException) {
             HttpServerErrorException hseException = (HttpServerErrorException) exception;
-            if (hseException.getStatusCode().equals(HttpStatus.SERVICE_UNAVAILABLE)) {
+            if (hseException.getStatusCode().equals(HttpStatus.SERVICE_UNAVAILABLE) || hseException.getStatusCode().equals(HttpStatus.INTERNAL_SERVER_ERROR)) {
                 throw new ServiceNotAccessibleException(ErrorType.SERVICE_UNAVAILABLE.getDefaultMessage(), exception);
             } else {
                 throw hseException;

--- a/security-service-client-spring/src/test/java/org/zowe/apiml/security/client/handler/RestResponseHandlerTest.java
+++ b/security-service-client-spring/src/test/java/org/zowe/apiml/security/client/handler/RestResponseHandlerTest.java
@@ -129,7 +129,7 @@ class RestResponseHandlerTest {
     @Test
     void handleBadResponseWithHttpServerError() {
         HttpServerErrorException exception = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Some server error");
-        assertThrows(HttpServerErrorException.class, () -> {
+        assertThrows(ServiceNotAccessibleException.class, () -> {
             handler.handleBadResponse(exception, null, GENERIC_LOG_MESSAGE, LOG_PARAMETERS);
         });
     }


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description


If there is a misconfiguration for the authentication service, when trying to login the API Catalog logs this message:

```
2021-07-02 14:55:22.516 <ZWEAAC1:https-jsse-nio-127.0.0.1-10014-exec-4:65854> at670475 ERROR (o.a.c.c.C.[.[.[.[dispatcherServlet]) Servlet.service() for servlet [dispatcherServlet] in context with path [/apicatalog] threw exception
org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 : [{"messages":[{"messageType":"ERROR","messageNumber":"ZWEAG708E","messageContent":"The request to the URL '/gateway/api/v1/auth/login' failed after retrying on all known service instances. Caused by: java.net.ConnectException: Connection refused (Connection refused)","messageKey":"org.zowe.apiml.gateway.connectionRefused"}]}]
```
throwing a `HttpServerErrorException$InternalServerError` exception. However, our error handler in the security-service-spring is checking only for `503` status code in case of `HttpServerErrorException`. 

**Note**:  Not sure whether it should be handled differently.
Linked to https://github.com/zowe/api-layer/issues/1563

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
