### PR TITLE
fix: Handle multiple discovery service instances in static refresh

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/discovery/DiscoveryConfigProperties.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/discovery/DiscoveryConfigProperties.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Configuration;
 public class DiscoveryConfigProperties {
 
     @Value("${apiml.service.discoveryServiceUrls}")
-    private String locations;
+    private String[] locations;
 
     @Value("${apiml.service.eurekaUserName:eureka}")
     private String eurekaUserName;

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
@@ -194,7 +194,7 @@ public class InstanceRetrievalService {
      * @return request information
      */
     private List<Pair<String, Pair<String, String>>> constructServiceInfoQueryRequest(String serviceId, boolean getDelta) {
-        String[] discoveryServiceUrls = discoveryConfigProperties.getLocations().split(",");
+        String[] discoveryServiceUrls = discoveryConfigProperties.getLocations();
         List<Pair<String, Pair<String, String>>> discoveryPairs = new ArrayList<>(discoveryServiceUrls.length);
         for (String discoveryUrl : discoveryServiceUrls) {
             String discoveryServiceLocatorUrl = discoveryUrl + APPS_ENDPOINT;

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -66,7 +66,7 @@ public class StaticAPIService {
             }
         }
 
-        return new StaticAPIResponse(500, null);
+        return new StaticAPIResponse(500, "Error making static API refresh request to the Discovery Service");
     }
 
     private HttpEntity<?> getHttpEntity(String discoveryServiceUrl) {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.apicatalog.staticapi;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -20,10 +21,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
 
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StaticAPIService {
 
     private static final String REFRESH_ENDPOINT = "discovery/api/v1/staticApi";
@@ -43,11 +47,26 @@ public class StaticAPIService {
     private final DiscoveryConfigProperties discoveryConfigProperties;
 
     public StaticAPIResponse refresh() {
-        String discoveryServiceUrl = getDiscoveryServiceUrl();
-        HttpEntity<?> entity = getHttpEntity(discoveryServiceUrl);
-        ResponseEntity<String> restResponse = restTemplate.exchange(discoveryServiceUrl,
-            HttpMethod.POST, entity, String.class);
-        return new StaticAPIResponse(restResponse.getStatusCode().value(), restResponse.getBody());
+        List<String> discoveryServiceUrls = getDiscoveryServiceUrls();
+        for (int i = 0; i < discoveryServiceUrls.size(); i++) {
+
+            String discoveryServiceUrl = discoveryServiceUrls.get(i);
+            HttpEntity<?> entity = getHttpEntity(discoveryServiceUrl);
+
+            try {
+                ResponseEntity<String> response = restTemplate.exchange(discoveryServiceUrl, HttpMethod.POST, entity, String.class);
+
+                // Return response if successful response or if none have been successful and this is the last URL to try
+                if (response.getStatusCode().is2xxSuccessful() || i == discoveryServiceUrls.size() - 1) {
+                    return new StaticAPIResponse(response.getStatusCode().value(), response.getBody());
+                }
+
+            } catch (Exception e) {
+                log.debug("Error refreshing static APIs from {}, error message: {}", discoveryServiceUrl, e.getMessage());
+            }
+        }
+
+        return new StaticAPIResponse(500, null);
     }
 
     private HttpEntity<?> getHttpEntity(String discoveryServiceUrl) {
@@ -62,7 +81,13 @@ public class StaticAPIService {
         return new HttpEntity<>(null, httpHeaders);
     }
 
-    private String getDiscoveryServiceUrl() {
-        return discoveryConfigProperties.getLocations().replace("/eureka", "") + REFRESH_ENDPOINT;
+    private List<String> getDiscoveryServiceUrls() {
+        String[] discoveryServiceLocations = discoveryConfigProperties.getLocations().split(",");
+
+        List<String> discoveryServiceUrls = new ArrayList<>();
+        for (String location : discoveryServiceLocations) {
+            discoveryServiceUrls.add(location.replace("/eureka", "") + REFRESH_ENDPOINT);
+        }
+        return discoveryServiceUrls;
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -82,7 +82,7 @@ public class StaticAPIService {
     }
 
     private List<String> getDiscoveryServiceUrls() {
-        String[] discoveryServiceLocations = discoveryConfigProperties.getLocations().split(",");
+        String[] discoveryServiceLocations = discoveryConfigProperties.getLocations();
 
         List<String> discoveryServiceUrls = new ArrayList<>();
         for (String location : discoveryServiceLocations) {

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalServiceTest.java
@@ -67,7 +67,7 @@ class InstanceRetrievalServiceTest {
     void setup() {
 
         instanceRetrievalService = new InstanceRetrievalService(discoveryConfigProperties, restTemplate);
-        discoveryServiceList = discoveryConfigProperties.getLocations().split(",");
+        discoveryServiceList = discoveryConfigProperties.getLocations();
         discoveryServiceAllAppsUrl = discoveryServiceList[0] + APPS_ENDPOINT;
     }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -50,7 +50,7 @@ class StaticAPIServiceTest {
 
         @Test
         void givenRefreshAPIWithSecureDiscoveryService_thenReturnApiResponseCodeWithBody() {
-            when(discoveryConfigProperties.getLocations()).thenReturn(DISCOVERY_LOCATION);
+            when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{DISCOVERY_LOCATION});
 
             mockRestTemplateExchange(DISCOVERY_URL, new ResponseEntity<>("This is body", HttpStatus.OK));
 
@@ -61,7 +61,7 @@ class StaticAPIServiceTest {
 
         @Test
         void givenRefreshAPIWithUnSecureDiscoveryService_thenReturnApiResponseCodeWithBody() {
-            when(discoveryConfigProperties.getLocations()).thenReturn(DISCOVERY_LOCATION_HTTP);
+            when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{DISCOVERY_LOCATION_HTTP});
 
             mockRestTemplateExchange(DISCOVERY_URL_HTTP, new ResponseEntity<>("This is body", HttpStatus.OK));
 
@@ -72,7 +72,7 @@ class StaticAPIServiceTest {
 
         @Nested
         class GivenTwoDiscoveryUrls {
-            private final String discoveryLocations = DISCOVERY_LOCATION + "," + DISCOVERY_LOCATION_2;
+            private final String[] discoveryLocations = {DISCOVERY_LOCATION, DISCOVERY_LOCATION_2};
 
             @Test
             void whenFirstFails_thenReturnResponseFromSecond() {
@@ -113,7 +113,7 @@ class StaticAPIServiceTest {
 
     @Test
     void givenNoDiscoveryLocations_whenAttemptRefresh_thenReturn500AndNullBody() {
-        when(discoveryConfigProperties.getLocations()).thenReturn("");
+        when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{});
 
         StaticAPIResponse actualResponse = staticAPIService.refresh();
         StaticAPIResponse expectedResponse = new StaticAPIResponse(500, null);

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.staticapi;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,6 +29,14 @@ class StaticAPIServiceTest {
 
     private static final String REFRESH_ENDPOINT = "discovery/api/v1/staticApi";
 
+    private static final String DISCOVERY_LOCATION = "https://localhost:60004/eureka/";
+    private static final String DISCOVERY_LOCATION_2 = "https://localhost:60005/eureka/";
+    private static final String DISCOVERY_URL = "https://localhost:60004/";
+    private static final String DISCOVERY_URL_2 = "https://localhost:60005/";
+
+    private static final String DISCOVERY_LOCATION_HTTP = "http://localhost:60004/eureka/";
+    private static final String DISCOVERY_URL_HTTP = "http://localhost:60004/";
+
     @InjectMocks
     private StaticAPIService staticAPIService;
 
@@ -36,35 +45,86 @@ class StaticAPIServiceTest {
     @Mock
     private DiscoveryConfigProperties discoveryConfigProperties;
 
-    @Test
-    void givenRefreshAPIWithSecureDiscoveryService_whenRefreshEndpointPresentResponse_thenReturnApiResponseCodeWithBody() {
-        String discoveryUrl = "https://localhost:60004/";
-        when(discoveryConfigProperties.getLocations()).thenReturn("https://localhost:60004/eureka/");
+    @Nested
+    class WhenRefreshEndpointPresentsResponse {
 
-        when(restTemplate.exchange(
-            discoveryUrl + REFRESH_ENDPOINT,
-            HttpMethod.POST, getHttpEntity(discoveryUrl), String.class))
-            .thenReturn(new ResponseEntity<>("This is body", HttpStatus.OK));
+        @Test
+        void givenRefreshAPIWithSecureDiscoveryService_thenReturnApiResponseCodeWithBody() {
+            when(discoveryConfigProperties.getLocations()).thenReturn(DISCOVERY_LOCATION);
 
+            mockRestTemplateExchange(DISCOVERY_URL, new ResponseEntity<>("This is body", HttpStatus.OK));
 
-        StaticAPIResponse actualResponse = staticAPIService.refresh();
-        StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "This is body");
-        assertEquals(expectedResponse, actualResponse);
+            StaticAPIResponse actualResponse = staticAPIService.refresh();
+            StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "This is body");
+            assertEquals(expectedResponse, actualResponse);
+        }
+
+        @Test
+        void givenRefreshAPIWithUnSecureDiscoveryService_thenReturnApiResponseCodeWithBody() {
+            when(discoveryConfigProperties.getLocations()).thenReturn(DISCOVERY_LOCATION_HTTP);
+
+            mockRestTemplateExchange(DISCOVERY_URL_HTTP, new ResponseEntity<>("This is body", HttpStatus.OK));
+
+            StaticAPIResponse actualResponse = staticAPIService.refresh();
+            StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "This is body");
+            assertEquals(expectedResponse, actualResponse);
+        }
+
+        @Nested
+        class GivenTwoDiscoveryUrls {
+            private final String discoveryLocations = DISCOVERY_LOCATION + "," + DISCOVERY_LOCATION_2;
+
+            @Test
+            void whenFirstFails_thenReturnResponseFromSecond() {
+                when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+
+                mockRestTemplateExchange(DISCOVERY_URL, new ResponseEntity<>(HttpStatus.NOT_FOUND));
+                mockRestTemplateExchange(DISCOVERY_URL_2, new ResponseEntity<>("body", HttpStatus.OK));
+
+                StaticAPIResponse actualResponse = staticAPIService.refresh();
+                StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "body");
+                assertEquals(expectedResponse, actualResponse);
+            }
+
+            @Test
+            void whenFirstSucceeds_thenReturnResponseFromFirst() {
+                when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+
+                mockRestTemplateExchange(DISCOVERY_URL, new ResponseEntity<>("body", HttpStatus.OK));
+
+                StaticAPIResponse actualResponse = staticAPIService.refresh();
+                StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "body");
+                assertEquals(expectedResponse, actualResponse);
+            }
+
+            @Test
+            void whenBothFail_thenReturnResponseFromSecond() {
+                when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+
+                mockRestTemplateExchange(DISCOVERY_URL, new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                mockRestTemplateExchange(DISCOVERY_URL_2, new ResponseEntity<>("body", HttpStatus.NOT_FOUND));
+
+                StaticAPIResponse actualResponse = staticAPIService.refresh();
+                StaticAPIResponse expectedResponse = new StaticAPIResponse(404, "body");
+                assertEquals(expectedResponse, actualResponse);
+            }
+        }
     }
 
     @Test
-    void givenRefreshAPIWithUnSecureDiscoveryService_whenRefreshEndpointPresentResponse_thenReturnApiResponseCodeWithBody() {
-        String discoveryUrl = "http://localhost:60004/";
-        when(discoveryConfigProperties.getLocations()).thenReturn("http://localhost:60004/eureka/");
-
-        when(restTemplate.exchange(
-            discoveryUrl + REFRESH_ENDPOINT,
-            HttpMethod.POST, getHttpEntity(discoveryUrl), String.class))
-            .thenReturn(new ResponseEntity<>("This is body", HttpStatus.OK));
+    void givenNoDiscoveryLocations_whenAttemptRefresh_thenReturn500AndNullBody() {
+        when(discoveryConfigProperties.getLocations()).thenReturn("");
 
         StaticAPIResponse actualResponse = staticAPIService.refresh();
-        StaticAPIResponse expectedResponse = new StaticAPIResponse(200, "This is body");
+        StaticAPIResponse expectedResponse = new StaticAPIResponse(500, null);
         assertEquals(expectedResponse, actualResponse);
+    }
+
+    private void mockRestTemplateExchange(String discoveryUrl, ResponseEntity expectedResponse) {
+        when(restTemplate.exchange(
+            discoveryUrl + REFRESH_ENDPOINT,
+            HttpMethod.POST, getHttpEntity(discoveryUrl), String.class
+        )).thenReturn(expectedResponse);
     }
 
     private HttpEntity<?> getHttpEntity(String discoveryServiceUrl) {
@@ -72,7 +132,7 @@ class StaticAPIServiceTest {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Accept", "application/json");
         if (isHttp) {
-            String basicToken = "Basic " + Base64.getEncoder().encodeToString( "null:null".getBytes());
+            String basicToken = "Basic " + Base64.getEncoder().encodeToString("null:null".getBytes());
             httpHeaders.add("Authorization", basicToken);
         }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -112,11 +112,11 @@ class StaticAPIServiceTest {
     }
 
     @Test
-    void givenNoDiscoveryLocations_whenAttemptRefresh_thenReturn500AndNullBody() {
+    void givenNoDiscoveryLocations_whenAttemptRefresh_thenReturn500() {
         when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{});
 
         StaticAPIResponse actualResponse = staticAPIService.refresh();
-        StaticAPIResponse expectedResponse = new StaticAPIResponse(500, null);
+        StaticAPIResponse expectedResponse = new StaticAPIResponse(500, "Error making static API refresh request to the Discovery Service");
         assertEquals(expectedResponse, actualResponse);
     }
 


### PR DESCRIPTION
# Description

Fixes bug where multiple discovery service instances broke the static API refresh functionality in the API Catalog.

Linked to #1512 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
