### PR TITLE
fix: Publish spring onboarding enabler in format consistent with other projects

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,13 +18,13 @@ ext.javaLibraries = [
     'certificate-analyser'
 ]
 
-ext.serviceJars = [ 'api-catalog-package', 'discovery-package', 'gateway-package', 'caching-service-package', 'metrics-service-package','apiml-common-lib-package' ]
+ext.serviceJars = ['api-catalog-package', 'discovery-package', 'gateway-package', 'caching-service-package', 'metrics-service-package', 'apiml-common-lib-package']
 
 ext.enablers = [ext.javaEnabler, ext.springBootEnabler, ext.micronautEnabler]
 ext.projectsToPublish = ext.serviceJars + ext.javaLibraries + ext.enablers
 
 ext.publishTasksList = projectsToPublish.collect {
-    it.equals(springBootEnabler) ? "publishEnablers" : ":" + it + ":publish"
+    ":" + it + ":publish"
 }
 
 configure(subprojects.findAll { it.name in projectsToPublish }) {
@@ -51,12 +51,7 @@ configure(subprojects.findAll { it.name in projectsToPublish }) {
             mavenJava(MavenPublication) {
                 groupId 'org.zowe.apiml.sdk'
                 version rootProject.version
-                if (project.name.equals(springBootEnabler)) {
-                    def enablerPrefix = project.hasProperty("enabler") ? project.getProperty("enabler") : "v2"
-                    artifactId "${project.name}-" + enablerPrefix + "-springboot-${springBootVersion}"
-                } else {
-                    artifactId "${project.name}"
-                }
+                artifactId "${project.name}"
 
                 from components.java
 
@@ -95,20 +90,4 @@ task publishSdkArtifacts {
     group 'Zowe Publishing'
     description 'Publish SDK libraries for main version of Spring Boot to Zowe Artifactory'
     dependsOn publishTasksList
-}
-
-task publishEnablerV1(type: Exec) {
-    def username  = project.hasProperty("zowe.deploy.username") ? project.getProperty("zowe.deploy.username") : ""
-    def password = project.hasProperty("zowe.deploy.password") ? project.getProperty("zowe.deploy.password") : ""
-
-    commandLine './gradlew', springBootEnabler + ':publish', '-Penabler=v1', '-Pzowe.deploy.username=' + username, '-Pzowe.deploy.password=' + password
-    mustRunAfter 'publishEnablerV2'
-}
-
-task publishEnablerV2 {
-    dependsOn springBootEnabler + ':publish'
-}
-
-task publishEnablers {
-    dependsOn 'publishEnablerV1', 'publishEnablerV2'
 }

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -37,5 +37,5 @@ dependencies {
 }
 
 jar {
-    enabled: trueZ
+    enabled: true
 }

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'io.spring.dependency-management'
 publish {
     outputs.upToDateWhen { false }
     doLast {
-        println "onboarded-enabler-spring-${springBootVersion} has been successfully published"
+        println "onboarding-enabler-spring has been successfully published"
     }
 }
 
@@ -37,6 +37,5 @@ dependencies {
 }
 
 jar {
-    baseName = "enabler-springboot-${springBootVersion}"
-    archiveName = "${baseName}.jar"
+    enabled: trueZ
 }

--- a/onboarding-enabler-spring/build.gradle
+++ b/onboarding-enabler-spring/build.gradle
@@ -37,5 +37,6 @@ dependencies {
 }
 
 jar {
-    enabled: true
+    baseName = "onboarding-enabler-spring"
+    archiveName = "${baseName}.jar"
 }


### PR DESCRIPTION
# Description

Removes publishing v1 and v2 of `onboarding-spring-enabler` and stops publishing the spring enabler with the spring boot version in the name. Now it will follow the same publishing format as all other projects where there will be `onboarding-enabler-spring/${zoweApimlVersion}`. In addition to consistency and reduced complexity of publishing two equivalent versions, this will make documenting use of the enabler much easier, as the artifact name will be consistent instead of changing each time the Zowe APIML spring boot version changes.

Docs PR to document this is to come.

Linked to #1574 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [x] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
