### PR TITLE
fix: Discovery health and info endpoints auth and enablement

### DIFF
--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -148,6 +148,8 @@ management:
     endpoints:
         web:
             base-path: /application
+            exposure:
+                include: health,info
     health:
         defaults:
             enabled: false

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -77,7 +77,6 @@ public class HttpsWebSecurityConfig {
                 .addFilterBefore(basicFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(cookieFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .authorizeRequests()
-                .antMatchers("/application/health", "/application/info", "/favicon.ico").permitAll()
                 .antMatchers("/**").authenticated()
                 .and()
                 .httpBasic().realmName(DISCOVERY_REALM);
@@ -106,7 +105,10 @@ public class HttpsWebSecurityConfig {
                 "/eureka/css/**",
                 "/eureka/js/**",
                 "/eureka/fonts/**",
-                "/eureka/images/**"
+                "/eureka/images/**",
+                "/application/health",
+                "/application/info",
+                "/favicon.ico"
             };
             web.ignoring().antMatchers(noSecurityAntMatchers);
         }

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -80,7 +80,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: shutdown
+                include: health,info,shutdown
     health:
         defaults:
             enabled: false

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/discovery/EurekaInstancesIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/discovery/EurekaInstancesIntegrationTest.java
@@ -14,24 +14,17 @@ import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.zowe.apiml.util.SecurityUtils;
 import org.zowe.apiml.util.TestWithStartedInstances;
-import org.zowe.apiml.util.categories.AttlsTest;
-import org.zowe.apiml.util.categories.DiscoveryServiceTest;
-import org.zowe.apiml.util.categories.NotAttlsTest;
+import org.zowe.apiml.util.categories.*;
 import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.config.DiscoveryServiceConfiguration;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -243,7 +236,8 @@ class EurekaInstancesIntegrationTest implements TestWithStartedInstances {
 
         Response response = RestAssured
             .given()
-            .get(getDiscoveryUriWithPath("/application/info"));
+            .auth().basic(username, password)
+            .get(getDiscoveryUriWithPath("/application"));
         Map<String, String> responseHeaders = new HashMap<>();
         response.getHeaders().forEach(h -> responseHeaders.put(h.getName(), h.getValue()));
 


### PR DESCRIPTION
unprotects health and info endpoints

Fixes https://github.com/zowe/api-layer/issues/1609