### PR TITLE
fix: Load balancer remote cache bugs

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/CachingServiceClient.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/CachingServiceClient.java
@@ -125,14 +125,4 @@ public class CachingServiceClient {
         }
     }
 
-    public class CachingServiceClientException extends Exception {
-
-        public CachingServiceClientException(String message, Throwable cause) {
-            super(message, cause);
-        }
-
-        public CachingServiceClientException(String message) {
-            super(message);
-        }
-    }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/CachingServiceClientException.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/cache/CachingServiceClientException.java
@@ -1,0 +1,22 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.cache;
+
+public class CachingServiceClientException extends Exception {
+
+    public CachingServiceClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CachingServiceClientException(String message) {
+        super(message);
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PostStoreLoadBalancerCacheFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PostStoreLoadBalancerCacheFilter.java
@@ -74,8 +74,8 @@ public class PostStoreLoadBalancerCacheFilter extends ZuulFilter {
         RequestContext context = RequestContext.getCurrentContext();
         String currentServiceId = (String) context.get(SERVICE_ID_KEY);
         Optional<String> principal = authenticationService.getPrincipalFromRequest(context.getRequest());
-        if (principal.isPresent() && !instanceIsCached(principal.get(), currentServiceId)) {
-            // Dont store instance info when failed.
+        if (principal.isPresent()) {
+            // Dont store instance info when there is exception in request processing. This means failed request.
             if (context.get("throwable") != null) {
                 return null;
             }
@@ -86,9 +86,5 @@ public class PostStoreLoadBalancerCacheFilter extends ZuulFilter {
         }
 
         return null;
-    }
-
-    private boolean instanceIsCached(String user, String service) {
-        return loadBalancerCache.retrieve(user, service) != null;
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicate.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicate.java
@@ -50,20 +50,20 @@ public class AuthenticationBasedPredicate extends RequestAwarePredicate {
         Optional<String> authenticatedUser = authenticationService.getPrincipalFromRequest(requestContext.getRequest());
 
         if (!authenticatedUser.isPresent()) {
-            log.debug("No authentication present on request, not filtering instance: {}", serviceId);
+            log.debug("No authentication present on request, not filtering instance: {}", context.getInstanceInfo().getInstanceId());
             return true;
         }
 
         String username = authenticatedUser.get();
         LoadBalancerCacheRecord loadBalancerCacheRecord = cache.retrieve(username, serviceId);
         if (loadBalancerCacheRecord == null || loadBalancerCacheRecord.getInstanceId() == null) {
-            log.debug("No preference exists, not filtering instance: {}", serviceId);
+            log.debug("No preference exists, not filtering instance: {}", context.getInstanceInfo().getInstanceId());
             return true;
         }
 
         if (isTooOld(loadBalancerCacheRecord.getCreationTime())) {
             cache.delete(username, serviceId);
-            log.debug("Expired preference exists and was deleted. not filtering instance: {}", serviceId);
+            log.debug("Expired preference exists and was deleted. not filtering instance: {}", context.getInstanceInfo().getInstanceId());
             return true;
         }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicate.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicate.java
@@ -41,6 +41,7 @@ public class AuthenticationBasedPredicate extends RequestAwarePredicate {
     @Override
     public boolean apply(LoadBalancingContext context, DiscoveryEnabledServer server) {
         RequestContext requestContext = context.getRequestContext();
+        String instanceId = context.getInstanceInfo().getInstanceId();
         String serviceId = (String) requestContext.get(SERVICE_ID_KEY);
         if (serviceId == null) {
             // This should never happen
@@ -50,20 +51,20 @@ public class AuthenticationBasedPredicate extends RequestAwarePredicate {
         Optional<String> authenticatedUser = authenticationService.getPrincipalFromRequest(requestContext.getRequest());
 
         if (!authenticatedUser.isPresent()) {
-            log.debug("No authentication present on request, not filtering instance: {}", context.getInstanceInfo().getInstanceId());
+            log.debug("No authentication present on request, not filtering instance: {}", instanceId);
             return true;
         }
 
         String username = authenticatedUser.get();
         LoadBalancerCacheRecord loadBalancerCacheRecord = cache.retrieve(username, serviceId);
         if (loadBalancerCacheRecord == null || loadBalancerCacheRecord.getInstanceId() == null) {
-            log.debug("No preference exists, not filtering instance: {}", context.getInstanceInfo().getInstanceId());
+            log.debug("No preference exists, not filtering instance: {}", instanceId);
             return true;
         }
 
         if (isTooOld(loadBalancerCacheRecord.getCreationTime())) {
             cache.delete(username, serviceId);
-            log.debug("Expired preference exists and was deleted. not filtering instance: {}", context.getInstanceInfo().getInstanceId());
+            log.debug("Expired preference exists and was deleted. not filtering instance: {}", instanceId);
             return true;
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/cache/CachingServiceClientTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/cache/CachingServiceClientTest.java
@@ -44,7 +44,7 @@ class CachingServiceClientTest {
         @Test
         void createWithExceptionFromRestTemplateThrowsDefined() {
             doThrow(new RestClientException("oops")).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(String.class));
-            assertThrows(CachingServiceClient.CachingServiceClientException.class,() -> underTest.create(new CachingServiceClient.KeyValue("Britney", "Spears")));
+            assertThrows(CachingServiceClientException.class,() -> underTest.create(new CachingServiceClient.KeyValue("Britney", "Spears")));
         }
     }
 
@@ -60,7 +60,7 @@ class CachingServiceClientTest {
         @Test
         void updateWithExceptionFromRestTemplateThrowsDefined() {
             doThrow(new RestClientException("oops")).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(String.class));
-            assertThrows(CachingServiceClient.CachingServiceClientException.class,() -> underTest.update(new CachingServiceClient.KeyValue("Britney", "Spears")));
+            assertThrows(CachingServiceClientException.class,() -> underTest.update(new CachingServiceClient.KeyValue("Britney", "Spears")));
         }
     }
 
@@ -71,16 +71,16 @@ class CachingServiceClientTest {
 
         @Test
         void readWithNullResponseOrNullBody() {
-            assertThrows(CachingServiceClient.CachingServiceClientException.class, () -> underTest.read(keyToRead));
+            assertThrows(CachingServiceClientException.class, () -> underTest.read(keyToRead));
             verify(restTemplate).exchange(eq(urlBase + "/" + keyToRead), eq(HttpMethod.GET), any(HttpEntity.class), eq(CachingServiceClient.KeyValue.class));
             ResponseEntity<CachingServiceClient.KeyValue> responseEntity = mock(ResponseEntity.class);
             doReturn(false).when(responseEntity).hasBody();
             doReturn(responseEntity).when(restTemplate).exchange(eq(urlBase + "/" + keyToRead), eq(HttpMethod.GET), any(HttpEntity.class), eq(CachingServiceClient.KeyValue.class));
-            assertThrows(CachingServiceClient.CachingServiceClientException.class, () -> underTest.read(keyToRead));
+            assertThrows(CachingServiceClientException.class, () -> underTest.read(keyToRead));
         }
 
         @Test
-        void readWithoutProblem() throws CachingServiceClient.CachingServiceClientException {
+        void readWithoutProblem() throws CachingServiceClientException {
             ResponseEntity<CachingServiceClient.KeyValue> responseEntity = mock(ResponseEntity.class);
             doReturn(true).when(responseEntity).hasBody();
             doReturn(new CachingServiceClient.KeyValue(keyToRead, "Wonder")).when(responseEntity).getBody();
@@ -91,7 +91,7 @@ class CachingServiceClientTest {
         @Test
         void readWithExceptonFromRestTemplateThrowsDefined() {
             doThrow(new RestClientException("oops")).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(String.class));
-            assertThrows(CachingServiceClient.CachingServiceClientException.class, () -> underTest.read(keyToRead));
+            assertThrows(CachingServiceClientException.class, () -> underTest.read(keyToRead));
         }
     }
 
@@ -107,7 +107,7 @@ class CachingServiceClientTest {
         @Test
         void deleteWithExceptionFromRestTemplateThrowsDefined() {
             doThrow(new RestClientException("oops")).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(String.class));
-            assertThrows(CachingServiceClient.CachingServiceClientException.class,() -> underTest.delete(keyToDelete));
+            assertThrows(CachingServiceClientException.class,() -> underTest.delete(keyToDelete));
         }
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicateTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/loadbalancer/predicate/AuthenticationBasedPredicateTest.java
@@ -48,6 +48,9 @@ class AuthenticationBasedPredicateTest {
         context = mock(LoadBalancingContext.class);
         requestContext = mock(RequestContext.class);
         when(context.getRequestContext()).thenReturn(requestContext);
+        InstanceInfo info = mock(InstanceInfo.class);
+        when(info.getInstanceId()).thenReturn("hostname:service:port");
+        when(context.getInstanceInfo()).thenReturn(info);
 
         underTest = new AuthenticationBasedPredicate(authenticationService, cache, 8);
     }


### PR DESCRIPTION
# Description

Fix several bugs and some refactors to make the remote cache behave consistently

Description of the bugs

- When cache record exists locally but not on remote, the check in post-store filter (whether the instance is already cached) returned true (local) cache and remote cache was never updated.

- Another one is when cache is stored locally, and then retrieved from remote, then inconsistent behavior happens when remote disappears or fails. The stores to local never happens.

- Another bug is that cache record did never get updated thanks to 409 Conflict from caching service. This led to cache record never updating and expiring after 8 hours since "first" usage, and not the "last" usage.

Linked to #1412 
