### PR TITLE
fix: Reuse Jetty client to prevent out of memory

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -1,0 +1,53 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
+
+import javax.annotation.PreDestroy;
+
+/**
+ * Factory for provisioning web socket client
+ *
+ * Manages the client lifecycle
+ */
+@Component
+@Slf4j
+public class WebSocketClientFactory {
+
+    private final JettyWebSocketClient client;
+
+    public WebSocketClientFactory(SslContextFactoryProvider sslContextFactoryProvider) {
+        SslContextFactory.Server jettySslContextFactory = sslContextFactoryProvider.getSslFactory();
+        log.debug("Creating Jetty WebSocket client, with SslFactory: {} and SslContextFactoryProvider: {}",
+            jettySslContextFactory, sslContextFactoryProvider);
+        client = new JettyWebSocketClient(new WebSocketClient(new HttpClient(jettySslContextFactory)));
+        client.start();
+    }
+
+    JettyWebSocketClient getClientInstance() {
+        return client;
+    }
+
+    @PreDestroy
+    private void closeClient() {
+        if (client.isRunning()) {
+            log.debug("Closing Jetty WebSocket client");
+            closeClient();
+        }
+    }
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.gateway.ws;
 
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.web.socket.WebSocketSession;
 
 public interface WebSocketRoutedSessionFactory {
@@ -20,5 +19,5 @@ public interface WebSocketRoutedSessionFactory {
      * @param sslContextFactory Factory producing the current SSL Context.
      * @return Valid routed session handling the client session
      */
-    WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory.Server sslContextFactory);
+    WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory);
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.gateway.ws;
 
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.web.socket.WebSocketSession;
 
 /**
@@ -17,7 +16,7 @@ import org.springframework.web.socket.WebSocketSession;
  */
 public class WebSocketRoutedSessionFactoryImpl implements WebSocketRoutedSessionFactory {
     @Override
-    public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, SslContextFactory.Server sslContextFactory) {
-        return new WebSocketRoutedSession(webSocketSession, targetUrl, sslContextFactory);
+    public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory) {
+        return new WebSocketRoutedSession(webSocketSession, targetUrl, webSocketClientFactory);
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -14,16 +14,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.web.socket.CloseStatus;
-import org.springframework.web.socket.WebSocketMessage;
-import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.*;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.RoutedServices;
 
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -48,7 +44,7 @@ class WebSocketProxyServerHandlerTest {
 
         underTest = new WebSocketProxyServerHandler(
             discoveryClient,
-            sslContextFactoryProvider,
+            mock(WebSocketClientFactory.class),
             routedSessions,
             webSocketRoutedSessionFactory
         );


### PR DESCRIPTION
Signed-off-by: jandadav <janda.david@gmail.com>

# Description

Jetty client was originally incorrectly created on every websocket session creation. The websocket session itself was being closed but it did not close the underlying client, causing memory leak and additional overhead in creating the client instance.

Now the change creates just one shared client, which is economic. Also the websocket session creation is much faster now, resulting in increased performance. The thread count and memory footprint over some amount of time is constant.

Profiling before the fixes:
![image](https://user-images.githubusercontent.com/6776217/127491179-b98a7c24-c5c8-46c1-ba3f-faaf8376599e.png)

Profiling result after the fixes:
![2021-07-29 13_52_59-Window](https://user-images.githubusercontent.com/6776217/127490876-683c1bff-f257-4098-a068-cd83500f5af6.png)


Linked to #1622 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)
