### PR TITLE
fix: configure WebSocket cipher suites

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -62,7 +62,7 @@ public class HttpConfig {
     @Value("${server.ssl.keyStoreType:PKCS12}")
     private String keyStoreType;
 
-    @Value("${server.ssl.ciphers}")
+    @Value("${server.ssl.ciphers:.*}")
     private String[] ciphers;
 
     @Value("${apiml.security.ssl.verifySslCertificatesOfServices:true}")

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -18,17 +18,12 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
-import org.zowe.apiml.security.HttpsConfig;
-import org.zowe.apiml.security.HttpsConfigError;
-import org.zowe.apiml.security.HttpsFactory;
-import org.zowe.apiml.security.SecurityUtils;
+import org.zowe.apiml.security.*;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
@@ -66,6 +61,9 @@ public class HttpConfig {
 
     @Value("${server.ssl.keyStoreType:PKCS12}")
     private String keyStoreType;
+
+    @Value("${server.ssl.ciphers}")
+    private String[] ciphers;
 
     @Value("${apiml.security.ssl.verifySslCertificatesOfServices:true}")
     private boolean verifySslCertificatesOfServices;
@@ -176,6 +174,7 @@ public class HttpConfig {
         sslContextFactory.setKeyStoreType(keyStoreType);
         sslContextFactory.setCertAlias(keyAlias);
         sslContextFactory.setExcludeCipherSuites("^.*_(MD5|SHA|SHA1)$");
+        sslContextFactory.setIncludeCipherSuites(ciphers);
 
         if (StringUtils.isNotEmpty(trustStore)) {
             sslContextFactory.setTrustStorePath(SecurityUtils.replaceFourSlashes(trustStore));


### PR DESCRIPTION
Signed-off-by: jandadav <janda.david@gmail.com>

# Description

There are log messages in Gateway log, showing that weak cipher suites are configured on websocket client. These are not configured suites. Therefore this pull request aims to configure them as per gateway's confguration.

```
2021-08-03 09:06:49.923 <ZWEAGW1:main:3380> dj657854 WARN  (org.eclipse.jetty.util.ssl.SslContextFactory.config) Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA256 enabled for Server@7145dad9[provider=null,keyStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.keystore.p12,trustStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.truststore.p12]
2021-08-03 09:06:49.923 <ZWEAGW1:main:3380> dj657854 WARN  (org.eclipse.jetty.util.ssl.SslContextFactory.config) Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA256 enabled for Server@7145dad9[provider=null,keyStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.keystore.p12,trustStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.truststore.p12]
2021-08-03 09:06:49.923 <ZWEAGW1:main:3380> dj657854 WARN  (org.eclipse.jetty.util.ssl.SslContextFactory.config) Weak cipher suite TLS_RSA_WITH_AES_256_GCM_SHA384 enabled for Server@7145dad9[provider=null,keyStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.keystore.p12,trustStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.truststore.p12]
2021-08-03 09:06:49.924 <ZWEAGW1:main:3380> dj657854 WARN  (org.eclipse.jetty.util.ssl.SslContextFactory.config) Weak cipher suite TLS_RSA_WITH_AES_128_GCM_SHA256 enabled for Server@7145dad9[provider=null,keyStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.keystore.p12,trustStore=file:///C:/workspace/prod/api-layer/keystore/localhost/localhost.truststore.p12]
```

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


