### PR TITLE
feat: Introduce rest provider for SAF tokens

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafIdtProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafIdtProvider.java
@@ -1,0 +1,33 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service.saf;
+
+import java.util.Optional;
+
+/**
+ * It's possible to configure various SafIdtProviders. At the moment only one configured at the time is allowed. If there
+ * are multiple providers configures, the behavior could be unpredictable.
+ */
+public interface SafIdtProvider {
+    /**
+     * If the current user has the proper rights generate the SAF token on its behalf and return it back.
+     *
+     * @return Either empty answer meaning the user is either unauthenticated or doesn't have the proper rights.
+     */
+    Optional<String> generate(String username);
+
+    /**
+     * Verify that the provided saf token is valid.
+     *
+     * @param safToken Token to validate.
+     * @return true if the token is valid, false if it is invalid
+     */
+    boolean verify(String safToken);
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
@@ -10,7 +10,6 @@
 package org.zowe.apiml.gateway.security.service.saf;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,7 +22,7 @@ public class SafProviderBeansConfig {
     @Bean
     @ConditionalOnProperty(name = "apiml.security.saf.provider", havingValue = "rest")
     public SafIdtProvider restSafProvider(
-        @Qualifier("restTemplateWithKeystore") RestTemplate restTemplate,
+        RestTemplate restTemplate,
         AuthenticationService authenticationService
     ) {
         return new SafRestAuthenticationService(restTemplate, authenticationService);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
@@ -15,13 +15,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.zowe.apiml.gateway.security.service.AuthenticationService;
 
 @Configuration
 @RequiredArgsConstructor
 public class SafProviderBeansConfig {
     @Bean
     @ConditionalOnProperty(name = "apiml.security.saf.provider", havingValue = "rest")
-    public SafIdtProvider restSafProvider(@Qualifier("restTemplateWithKeystore") RestTemplate restTemplate) {
-        return new SafRestAuthenticationService(restTemplate);
+    public SafIdtProvider restSafProvider(
+        @Qualifier("restTemplateWithKeystore") RestTemplate restTemplate,
+        AuthenticationService authenticationService
+    ) {
+        return new SafRestAuthenticationService(restTemplate, authenticationService);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
@@ -1,0 +1,27 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service.saf;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class SafProviderBeansConfig {
+    @Bean
+    @ConditionalOnProperty(name = "apiml.security.saf.provider", havingValue = "rest")
+    public SafIdtProvider restSafProvider(@Qualifier("restTemplateWithKeystore") RestTemplate restTemplate) {
+        return new SafRestAuthenticationService(restTemplate);
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
@@ -1,0 +1,66 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service.saf;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+/**
+ * Authentication provider implementation for the SafIdt Tokens.
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class SafRestAuthenticationService implements SafIdtProvider {
+    private final RestTemplate restTemplate;
+
+    @Value("${apiml.security.saf.urls.authenticate}")
+    private String authenticationUrl;
+    @Value("${apiml.security.saf.urls.verify}")
+    private String verifyUrl;
+
+    @Override
+    public Optional<String> generate(String username) {
+        // TODO: Use the JWT token
+        // TODO: Build properly the
+
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(authenticationUrl, HttpMethod.POST,
+                new HttpEntity<>(null), String.class);
+
+            if (re.getStatusCode().is2xxSuccessful()) {
+                return Optional.ofNullable(re.getBody());
+            } else {
+                return Optional.empty();
+            }
+        } catch (HttpClientErrorException.Unauthorized e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean verify(String safToken) {
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(verifyUrl, HttpMethod.POST,
+                new HttpEntity<>(null), String.class);
+
+            return re.getStatusCode().is2xxSuccessful();
+        } catch (HttpClientErrorException.Unauthorized e) {
+            return false;
+        }
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
@@ -70,10 +70,10 @@ public class SafRestAuthenticationService implements SafIdtProvider {
             }
 
             Token responseBody = re.getBody();
-            if(responseBody == null) {
+            if (responseBody == null) {
                 return Optional.empty();
             }
-            
+
             return Optional.of(responseBody.getJwt());
         } catch (HttpClientErrorException.Unauthorized e) {
             return Optional.empty();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
@@ -65,11 +65,15 @@ public class SafRestAuthenticationService implements SafIdtProvider {
 
             ResponseEntity<Token> re = restTemplate.postForEntity(URI.create(authenticationUrl), authentication, Token.class);
 
-            if (!re.getStatusCode().is2xxSuccessful() || re.getBody() == null) {
+            if (!re.getStatusCode().is2xxSuccessful()) {
                 return Optional.empty();
             }
 
             Token responseBody = re.getBody();
+            if(responseBody == null) {
+                return Optional.empty();
+            }
+            
             return Optional.of(responseBody.getJwt());
         } catch (HttpClientErrorException.Unauthorized e) {
             return Optional.empty();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
@@ -65,11 +65,12 @@ public class SafRestAuthenticationService implements SafIdtProvider {
 
             ResponseEntity<Token> re = restTemplate.postForEntity(URI.create(authenticationUrl), authentication, Token.class);
 
-            if (re.getStatusCode().is2xxSuccessful() && re.getBody() != null) {
-                return Optional.ofNullable(re.getBody().getJwt());
-            } else {
+            if (!re.getStatusCode().is2xxSuccessful() || re.getBody() == null) {
                 return Optional.empty();
             }
+
+            Token responseBody = re.getBody();
+            return Optional.of(responseBody.getJwt());
         } catch (HttpClientErrorException.Unauthorized e) {
             return Optional.empty();
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
-import org.zowe.apiml.gateway.security.service.saf.SafRestAuthenticationService;
+import org.zowe.apiml.gateway.security.service.saf.SafIdtProvider;
 import org.zowe.apiml.security.common.token.QueryResponse;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 @RequiredArgsConstructor
 public class SafIdtScheme implements AbstractAuthenticationScheme {
     private final AuthenticationService authenticationService;
-    private final SafRestAuthenticationService safAuthenticationService;
+    private final SafIdtProvider safIdtProvider;
 
     @Override
     public AuthenticationScheme getScheme() {
@@ -61,7 +61,7 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
                 TokenAuthentication authentication = authenticationService.validateJwtToken(jwtToken.get());
                 if (authentication.isAuthenticated()) {
                     // Get principal from the token?
-                    Optional<String> safIdt = safAuthenticationService.generate(authentication.getPrincipal());
+                    Optional<String> safIdt = safIdtProvider.generate(authentication.getPrincipal());
 
                     safIdt.ifPresent(safToken -> context.addZuulRequestHeader("X-SAF-Token", safToken));
                 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
-import org.zowe.apiml.gateway.security.service.SafAuthenticationService;
+import org.zowe.apiml.gateway.security.service.saf.SafRestAuthenticationService;
 import org.zowe.apiml.security.common.token.QueryResponse;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 @RequiredArgsConstructor
 public class SafIdtScheme implements AbstractAuthenticationScheme {
     private final AuthenticationService authenticationService;
-    private final SafAuthenticationService safAuthenticationService;
+    private final SafRestAuthenticationService safAuthenticationService;
 
     @Override
     public AuthenticationScheme getScheme() {
@@ -60,10 +60,10 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
             jwtToken.ifPresent(token -> {
                 TokenAuthentication authentication = authenticationService.validateJwtToken(jwtToken.get());
                 if (authentication.isAuthenticated()) {
-                    String safIdt = safAuthenticationService.generateSafIdt(token);
+                    // Get principal from the token?
+                    Optional<String> safIdt = safAuthenticationService.generate(authentication.getPrincipal());
 
-                    // TODO: Verify whether authentication should be used.
-                    context.addZuulRequestHeader("X-SAF-Token", safIdt);
+                    safIdt.ifPresent(safToken -> context.addZuulRequestHeader("X-SAF-Token", safToken));
                 }
             });
         }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -62,6 +62,11 @@ apiml:
         x509:
             enabled: false
             externalMapperUrl:
+        saf:
+            provider: rest
+            urls:
+                authenticate: https://localhost:10013/zss/saf/authenticate
+                verify: https://localhost:10013/zss/saf/verify
 
 spring:
     application:

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/DeterministicUserBasedRoutingTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/DeterministicUserBasedRoutingTest.java
@@ -54,8 +54,6 @@ class DeterministicUserBasedRoutingTest extends AcceptanceTestWithTwoServices {
         @Nested
         class WhenCallingToServiceMultipleTimes {
 
-            boolean initialized = false;
-
             @RepeatedTest(10)
             void thenCallTheSameInstance(RepetitionInfo repetitionInfo) throws IOException {
 

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/SafIdtSchemeTest.java
@@ -16,8 +16,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.acceptance.common.AcceptanceTest;
 import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
+import org.zowe.apiml.gateway.security.service.saf.SafRestAuthenticationService;
 
 import java.io.IOException;
 
@@ -32,6 +37,17 @@ import static org.mockito.Mockito.*;
  */
 @AcceptanceTest
 class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
+    @Autowired
+    protected SafRestAuthenticationService safRestAuthenticationService;
+
+    private RestTemplate mockTemplate;
+
+    @BeforeEach
+    void prepareTemplate() {
+        mockTemplate = mock(RestTemplate.class);
+        ReflectionTestUtils.setField(safRestAuthenticationService, "restTemplate", mockTemplate);
+    }
+
     @Nested
     class GivenValidJwtToken {
         Cookie validJwtToken;
@@ -45,6 +61,9 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
         class WhenSafIdtRequestedByService {
             @BeforeEach
             void prepareService() throws IOException {
+                applicationRegistry.clearApplications();
+                applicationRegistry.addApplication(serviceWithDefaultConfiguration, false, true, false, "authentication", true);
+                applicationRegistry.addApplication(serviceWithCustomConfiguration, true, false, true, "authentication", true);
                 applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
 
                 reset(mockClient);
@@ -54,6 +73,15 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
             // Valid token is provided within the headers.
             @Test
             void thenValidTokenIsProvided() throws IOException {
+                String resultSafToken = "resultSafToken";
+
+                ResponseEntity<Object> response = mock(ResponseEntity.class);
+                when(mockTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                when(response.getStatusCode()).thenReturn(org.springframework.http.HttpStatus.CREATED);
+                SafRestAuthenticationService.Token responseBody = new SafRestAuthenticationService.Token();
+                responseBody.setJwt(resultSafToken);
+                when(response.getBody()).thenReturn(responseBody);
+
                 given()
                     .cookie(validJwtToken)
                 .when()
@@ -64,7 +92,7 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
                 ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
                 verify(mockClient, times(1)).execute(captor.capture());
 
-                assertHeaderWithValue(captor.getValue(), "X-SAF-Token", "validToken" + validJwtToken.getValue());
+                assertHeaderWithValue(captor.getValue(), "X-SAF-Token", resultSafToken);
             }
         }
     }
@@ -82,7 +110,7 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
             }
 
             @Test
-            void givenInvalidJwtToken() throws IOException {
+            void givenInvalidJwtToken() {
                 Cookie withInvalidToken = new Cookie.Builder("apimlAuthenticationToken=invalidValue").build();
 
                 given()
@@ -90,9 +118,9 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
                 .when()
                     .get(basePath + serviceWithDefaultConfiguration.getPath())
                 .then()
-                    .statusCode(is(HttpStatus.SC_UNAUTHORIZED));
+                    .statusCode(is(HttpStatus.SC_OK));
 
-                verify(mockClient, times(0)).execute(any());
+                verify(mockTemplate, times(0)).postForEntity(any(), any(), any());
             }
         }
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/ApplicationRegistry.java
@@ -49,6 +49,10 @@ public class ApplicationRegistry {
         addApplication(service, addTimeout, corsEnabled, multipleInstances, "headerRequest");
     }
 
+    public void addApplication(Service service, boolean addTimeout, boolean corsEnabled, boolean multipleInstances, String loadBalancerStrategy) {
+        addApplication(service, addTimeout, corsEnabled, multipleInstances, loadBalancerStrategy, false);
+    }
+
     /**
      * Add new route to a service.
      *
@@ -58,7 +62,7 @@ public class ApplicationRegistry {
      * @param loadBalancerStrategy What strategy should be applied by LoadBalancer. E.g use header, base the
      *                             authentication on the user and so on.
      */
-    public void addApplication(Service service, boolean addTimeout, boolean corsEnabled, boolean multipleInstances, String loadBalancerStrategy) {
+    public void addApplication(Service service, boolean addTimeout, boolean corsEnabled, boolean multipleInstances, String loadBalancerStrategy, boolean safIdt) {
         String id = service.getId();
         String locationPattern = service.getLocationPattern();
         String serviceRoute = service.getServiceRoute();
@@ -66,7 +70,7 @@ public class ApplicationRegistry {
         Applications applications = new Applications();
         Application withMetadata = new Application(id);
 
-        Map<String, String> metadata = createMetadata(addTimeout, corsEnabled, loadBalancerStrategy);
+        Map<String, String> metadata = createMetadata(addTimeout, corsEnabled, loadBalancerStrategy, safIdt);
 
         withMetadata.addInstance(getStandardInstance(metadata, id, id));
         if (multipleInstances) {
@@ -149,7 +153,7 @@ public class ApplicationRegistry {
             .build();
     }
 
-    private Map<String, String> createMetadata(boolean addRibbonConfig, boolean corsEnabled, String loadBalancerStrategy) {
+    private Map<String, String> createMetadata(boolean addRibbonConfig, boolean corsEnabled, String loadBalancerStrategy, boolean safIdt) {
         Map<String, String> metadata = new HashMap<>();
         if (addRibbonConfig) {
             metadata.put("apiml.connectTimeout", "5000");
@@ -161,7 +165,9 @@ public class ApplicationRegistry {
         metadata.put("apiml.lb.cacheRecordExpirationTimeInHours", "8");
         metadata.put("apiml.corsEnabled", String.valueOf(corsEnabled));
         metadata.put("apiml.routes.gateway-url", "/");
-        metadata.put("apiml.authentication.scheme", "safIdt");
+        if (safIdt) {
+            metadata.put("apiml.authentication.scheme", "safIdt");
+        }
         return metadata;
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
@@ -7,16 +7,13 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package org.zowe.apiml.gateway.security.service;
+package org.zowe.apiml.gateway.security.service.saf;
 
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-/**
- * Authentication service
- */
-@Component
-public class SafAuthenticationService {
-    public String generateSafIdt(String jwtToken) {
-        return "validToken" + jwtToken;
+public class SafRestAuthenticationServiceTest {
+    @Test
+    void test() {
+
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
@@ -9,11 +9,174 @@
  */
 package org.zowe.apiml.gateway.security.service.saf;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
 
-public class SafRestAuthenticationServiceTest {
-    @Test
-    void test() {
+import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SafRestAuthenticationServiceTest {
+    private SafRestAuthenticationService underTest;
+
+    private AuthenticationService authenticationService;
+    private RestTemplate restTemplate;
+
+    private final String VALID_USERNAME = "am456723";
+
+    @BeforeEach
+    void setUp() {
+        authenticationService = mock(AuthenticationService.class);
+        restTemplate = mock(RestTemplate.class);
+
+        underTest = new SafRestAuthenticationService(restTemplate, authenticationService);
+        underTest.authenticationUrl = "https://localhost:10013/zss/saf/generate";
+        underTest.verifyUrl = "https://localhost:10013/zss/saf/verify";
+    }
+
+    @Nested
+    class WhenGenerating {
+        @Nested
+        class GivenValidJwtToken {
+            @BeforeEach
+            void prepareValidToken() {
+                String validToken = "validToken";
+                TokenAuthentication unauthenticated = new TokenAuthentication(validToken);
+                unauthenticated.setAuthenticated(true);
+
+                when(authenticationService.getJwtTokenFromRequest(any())).thenReturn(Optional.of(validToken));
+                when(authenticationService.validateJwtToken(validToken)).thenReturn(unauthenticated);
+            }
+
+            @Nested
+            class ReturnValidToken {
+                @Test
+                void givenValidResponse() {
+                    String validSafToken = "validSafToken";
+
+                    ResponseEntity<Object> response = mock(ResponseEntity.class);
+                    when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                    when(response.getStatusCode()).thenReturn(HttpStatus.CREATED);
+                    SafRestAuthenticationService.Token responseBody = new SafRestAuthenticationService.Token();
+                    responseBody.setJwt(validSafToken);
+                    when(response.getBody()).thenReturn(responseBody);
+
+                    Optional<String> token = underTest.generate(VALID_USERNAME);
+
+                    assertThat(token.isPresent(), is(true));
+                    assertThat(token.get(), is(validSafToken));
+                }
+            }
+
+            @Nested
+            class ReturnEmpty {
+                @Test
+                void givenUnauthorizedResponse() {
+                    HttpClientErrorException exception = HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "statusText", new HttpHeaders(), new byte[]{}, null);
+                    when(restTemplate.postForEntity(any(), any(), any())).thenThrow(exception);
+
+                    Optional<String> token = underTest.generate(VALID_USERNAME);
+                    assertThat(token.isPresent(), is(false));
+                }
+
+                @Test
+                void givenBadResponse() {
+                    ResponseEntity<Object> response = mock(ResponseEntity.class);
+                    when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                    when(response.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+
+                    Optional<String> token = underTest.generate(VALID_USERNAME);
+                    assertThat(token.isPresent(), is(false));
+                }
+
+                @Test
+                void givenEmptyResponse() {
+                    ResponseEntity<Object> response = mock(ResponseEntity.class);
+                    when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                    when(response.getStatusCode()).thenReturn(HttpStatus.CREATED);
+                    when(response.getBody()).thenReturn(null);
+
+                    Optional<String> token = underTest.generate(VALID_USERNAME);
+                    assertThat(token.isPresent(), is(false));
+                }
+            }
+        }
+
+        @Nested
+        class ReturnEmpty {
+            @Test
+            void givenNoJwtToken() {
+                when(authenticationService.getJwtTokenFromRequest(any())).thenReturn(Optional.empty());
+
+                Optional<String> token = underTest.generate(VALID_USERNAME);
+                assertThat(token.isPresent(), is(false));
+            }
+
+            @Test
+            void givenInvalidJwtToken() {
+                String invalidToken = "invalidToken";
+                TokenAuthentication unauthenticated = new TokenAuthentication(invalidToken);
+                unauthenticated.setAuthenticated(false);
+
+                when(authenticationService.getJwtTokenFromRequest(any())).thenReturn(Optional.of(invalidToken));
+                when(authenticationService.validateJwtToken(invalidToken)).thenReturn(unauthenticated);
+
+                Optional<String> token = underTest.generate(VALID_USERNAME);
+                assertThat(token.isPresent(), is(false));
+            }
+
+        }
+    }
+
+    @Nested
+    class WhenVerifying {
+        @Nested
+        class ReturnFalse {
+            @Test
+            void givenNoSafToken() {
+                assertThat(underTest.verify(null), is(false));
+            }
+
+            @Test
+            void givenUnauthenticated() {
+                HttpClientErrorException exception = HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "statusText", new HttpHeaders(), new byte[]{}, null);
+                when(restTemplate.postForEntity(any(), any(), any())).thenThrow(exception);
+
+                assertThat(underTest.verify("validSafToken"), is(false));
+            }
+
+            @Test
+            void givenOtherWrongResponse() {
+                ResponseEntity<Object> response = mock(ResponseEntity.class);
+                when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                when(response.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+
+                assertThat(underTest.verify("validSafToken"), is(false));
+            }
+        }
+
+        @Nested
+        class ReturnTrue {
+            @Test
+            void givenCorrectResponse() {
+                ResponseEntity<Object> response = mock(ResponseEntity.class);
+                when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+
+                assertThat(underTest.verify("validSafToken"), is(true));
+            }
+        }
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
-import org.zowe.apiml.gateway.security.service.SafAuthenticationService;
+import org.zowe.apiml.gateway.security.service.saf.SafRestAuthenticationService;
 import org.zowe.apiml.security.common.token.QueryResponse;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
@@ -32,12 +32,12 @@ import static org.mockito.Mockito.when;
 class SafIdtSchemeTest {
     private SafIdtScheme underTest;
     private AuthenticationService authenticationService;
-    private SafAuthenticationService safAuthenticationService;
+    private SafRestAuthenticationService safAuthenticationService;
 
     @BeforeEach
     void setUp() {
         authenticationService = mock(AuthenticationService.class);
-        safAuthenticationService = mock(SafAuthenticationService.class);
+        safAuthenticationService = mock(SafRestAuthenticationService.class);
         underTest = new SafIdtScheme(authenticationService, safAuthenticationService);
     }
 
@@ -63,7 +63,7 @@ class SafIdtSchemeTest {
 
                 when(authenticationService.getJwtTokenFromRequest(any())).thenReturn(Optional.of("validJwtToken"));
                 when(authenticationService.validateJwtToken("validJwtToken")).thenReturn(authentication);
-                when(safAuthenticationService.generateSafIdt("validJwtToken")).thenReturn("validTokenValidJwtToken");
+                when(safAuthenticationService.generate("validJwtToken")).thenReturn(Optional.of("validTokenValidJwtToken"));
 
                 commandUnderTest.apply(info);
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
@@ -58,12 +58,13 @@ class SafIdtSchemeTest {
             void givenAuthenticatedJwtToken() {
                 InstanceInfo info = mock(InstanceInfo.class);
 
-                TokenAuthentication authentication = new TokenAuthentication("validJwtToken");
+                String validUsername = "hg679853";
+                TokenAuthentication authentication = new TokenAuthentication(validUsername, "validJwtToken");
                 authentication.setAuthenticated(true);
 
                 when(authenticationService.getJwtTokenFromRequest(any())).thenReturn(Optional.of("validJwtToken"));
                 when(authenticationService.validateJwtToken("validJwtToken")).thenReturn(authentication);
-                when(safAuthenticationService.generate("validJwtToken")).thenReturn(Optional.of("validTokenValidJwtToken"));
+                when(safAuthenticationService.generate(validUsername)).thenReturn(Optional.of("validTokenValidJwtToken"));
 
                 commandUnderTest.apply(info);
 

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -43,6 +43,11 @@ apiml:
             jwtKeyAlias: jwtSecret
         zosmf:
             useJwtToken: true # if true and z/OSMF returns JWT token use it, otherwise create Zowe JWT token with LTPA token from z/OSMF, default is true
+        saf:
+            provider: rest
+            urls:
+                authenticate: https://localhost:10013/zss/saf/authenticate
+                verify: https://localhost:10013/zss/saf/verify
 
 spring:
     application:

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -41,6 +41,11 @@ apiml:
             passTicket:
                 timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
             jwtKeyAlias: jwtSecret
+        saf:
+            provider: rest
+            urls:
+                authenticate: https://localhost:10013/zss/saf/authenticate
+                verify: https://localhost:10013/zss/saf/verify
 
 spring:
     profiles:

--- a/mock-zosmf/README.md
+++ b/mock-zosmf/README.md
@@ -28,4 +28,10 @@ The supported APARs are:
 
 Multiple APARs can be set in `zosmf.appliedApars`. Conflicting functionality will result in only one functionality mocked, but it is not guaranteed which will be mocked. 
 
+# ZSS Mock
 
+The service contains package zss that covers functionality we expect from ZSS to allow us integration testing in the off platform development.
+
+## Configuration properties
+
+There is no configuration for this part at the moment

--- a/mock-zosmf/src/main/java/org/zowe/apiml/MockServicesApplication.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/MockServicesApplication.java
@@ -7,16 +7,16 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package org.zowe.apiml.client;
+package org.zowe.apiml;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class MockZosmfApplication {
+public class MockServicesApplication {
 
     public static void main(String[] args) {
-        SpringApplication app = new SpringApplication(MockZosmfApplication.class);
+        SpringApplication app = new SpringApplication(MockServicesApplication.class);
         app.setLogStartupInfo(false);
         app.run(args);
     }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
@@ -1,0 +1,80 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.zowe.apiml.zss.model.Authentication;
+import org.zowe.apiml.zss.model.Token;
+import org.zowe.apiml.zss.services.SafIdtProvider;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+public class SafIdtController {
+    private final SafIdtProvider provider;
+
+    /**
+     * Create the token for the specific user as long as the username and jwt are provided.
+     *
+     * @param authentication Authentication information to verify that the user is properly authenticated and so the
+     *                       token should be issued.
+     * @return Appropriate response code
+     *   - 401 - Not authenticated
+     *   - 400 - The required information wasn't provided
+     *   - 201 - Valid SAF IDT token.
+     */
+    @PostMapping(value="/zss/saf/authenticate")
+    public ResponseEntity<?> authenticate(
+        @RequestBody Authentication authentication
+    ) {
+        if (StringUtils.isEmpty(authentication.getJwt()) || StringUtils.isEmpty(authentication.getUsername())) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        Optional<Token> token = provider.authenticate(authentication);
+
+        if (token.isPresent()) {
+            return new ResponseEntity<>(token.get(), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    /**
+     * Validate provided token.
+     *
+     * @param token Token to verify
+     * @return Appropriate response code
+     *   - 401 - The token is invalid
+     *   - 400 - The required information wasn't provided
+     *   - 200 - The token is valid
+     */
+    @PostMapping(value="/zss/saf/verify")
+    public ResponseEntity<?> verify(
+        @RequestBody Token token
+    ) {
+        if (StringUtils.isEmpty(token.getJwt())) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        if (provider.verify(token)) {
+            return new ResponseEntity<>(HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
@@ -38,7 +38,7 @@ public class SafIdtController {
      * - 201 - Valid SAF IDT token.
      */
     @PostMapping(value = "/zss/saf/authenticate")
-    public ResponseEntity<?> authenticate(
+    public ResponseEntity<Token> authenticate(
         @RequestBody Authentication authentication
     ) {
         if (StringUtils.isEmpty(authentication.getJwt()) || StringUtils.isEmpty(authentication.getUsername())) {
@@ -47,11 +47,12 @@ public class SafIdtController {
 
         Optional<Token> token = provider.authenticate(authentication);
 
-        if (token.isPresent()) {
-            return new ResponseEntity<>(token.get(), HttpStatus.CREATED);
-        } else {
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
-        }
+        return token
+            .map(value ->
+                new ResponseEntity<>(value, HttpStatus.CREATED))
+            .orElseGet(
+                () -> new ResponseEntity<>(HttpStatus.UNAUTHORIZED)
+            );
     }
 
     /**
@@ -64,7 +65,7 @@ public class SafIdtController {
      * - 200 - The token is valid
      */
     @PostMapping(value = "/zss/saf/verify")
-    public ResponseEntity<?> verify(
+    public ResponseEntity<Token> verify(
         @RequestBody Token token
     ) {
         if (StringUtils.isEmpty(token.getJwt())) {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/api/SafIdtController.java
@@ -33,11 +33,11 @@ public class SafIdtController {
      * @param authentication Authentication information to verify that the user is properly authenticated and so the
      *                       token should be issued.
      * @return Appropriate response code
-     *   - 401 - Not authenticated
-     *   - 400 - The required information wasn't provided
-     *   - 201 - Valid SAF IDT token.
+     * - 401 - Not authenticated
+     * - 400 - The required information wasn't provided
+     * - 201 - Valid SAF IDT token.
      */
-    @PostMapping(value="/zss/saf/authenticate")
+    @PostMapping(value = "/zss/saf/authenticate")
     public ResponseEntity<?> authenticate(
         @RequestBody Authentication authentication
     ) {
@@ -59,11 +59,11 @@ public class SafIdtController {
      *
      * @param token Token to verify
      * @return Appropriate response code
-     *   - 401 - The token is invalid
-     *   - 400 - The required information wasn't provided
-     *   - 200 - The token is valid
+     * - 401 - The token is invalid
+     * - 400 - The required information wasn't provided
+     * - 200 - The token is valid
      */
-    @PostMapping(value="/zss/saf/verify")
+    @PostMapping(value = "/zss/saf/verify")
     public ResponseEntity<?> verify(
         @RequestBody Token token
     ) {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/model/Authentication.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/model/Authentication.java
@@ -1,0 +1,18 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.model;
+
+import lombok.Data;
+
+@Data
+public class Authentication {
+    private String jwt;
+    private String username;
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/model/Token.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/model/Token.java
@@ -1,0 +1,17 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.model;
+
+import lombok.Data;
+
+@Data
+public class Token {
+    private String jwt;
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/services/SafIdtProvider.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/services/SafIdtProvider.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.zowe.apiml.zss.model.Authentication;
 import org.zowe.apiml.zss.model.Token;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,6 +21,14 @@ import java.util.UUID;
 @Service
 public class SafIdtProvider {
     private Map<String, String> providedTokens;
+
+    public SafIdtProvider() {
+        providedTokens = new HashMap<>();
+    }
+
+    public SafIdtProvider(Map<String, String> providedTokens) {
+        this.providedTokens = providedTokens;
+    }
 
     public Optional<Token> authenticate(
         Authentication authentication
@@ -38,6 +47,6 @@ public class SafIdtProvider {
         String safToken = token.getJwt();
         String username = safToken.split(";")[0];
 
-        return providedTokens.containsKey(username) && providedTokens.get(username).equals("sasfToken");
+        return providedTokens.containsKey(username) && providedTokens.get(username).equals(safToken);
     }
 }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/zss/services/SafIdtProvider.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/zss/services/SafIdtProvider.java
@@ -1,0 +1,43 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.services;
+
+import org.springframework.stereotype.Service;
+import org.zowe.apiml.zss.model.Authentication;
+import org.zowe.apiml.zss.model.Token;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class SafIdtProvider {
+    private Map<String, String> providedTokens;
+
+    public Optional<Token> authenticate(
+        Authentication authentication
+    ) {
+        String token = authentication.getUsername() + ";" + UUID.randomUUID();
+        providedTokens.put(authentication.getUsername(), token);
+
+        Token result = new Token();
+        result.setJwt(token);
+        return Optional.of(result);
+    }
+
+    public boolean verify(
+        Token token
+    ) {
+        String safToken = token.getJwt();
+        String username = safToken.split(";")[0];
+
+        return providedTokens.containsKey(username) && providedTokens.get(username).equals("sasfToken");
+    }
+}

--- a/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
@@ -74,6 +74,15 @@ class SafIdtControllerTest {
     }
 
     @Test
+    void whenCallAuthenticateEndpointWithInvalidToken_thenReturnUnauthorized() throws Exception {
+        mockMvc
+            .perform(post("/zss/saf/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\": \"validUser\", \"jwt\": \"invalidToken\"}"))
+            .andExpect(status().is(SC_UNAUTHORIZED));
+    }
+
+    @Test
     void whenCallVerifyEndpointWithoutPayload_thenReturnBadRequest() throws Exception {
         mockMvc
             .perform(post("/zss/saf/verify"))
@@ -98,5 +107,16 @@ class SafIdtControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"jwt\": \"safJwt\"}"))
             .andExpect(status().is(SC_OK));
+    }
+
+    @Test
+    void whenCallVerifyEndpointWithInvalidToken_thenReturnUnauthorized() throws Exception {
+        when(safProvider.verify(any())).thenReturn(false);
+
+        mockMvc
+            .perform(post("/zss/saf/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jwt\": \"invalid\"}"))
+            .andExpect(status().is(SC_UNAUTHORIZED));
     }
 }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
-public class SafIdtControllerTest {
+class SafIdtControllerTest {
     private MockMvc mockMvc;
 
     @Mock
@@ -46,6 +46,15 @@ public class SafIdtControllerTest {
     void whenCallAuthenticateEndpointWithoutPayload_thenReturnBadRequest() throws Exception {
         mockMvc
             .perform(post("/zss/saf/authenticate"))
+            .andExpect(status().is(SC_BAD_REQUEST));
+    }
+
+    @Test
+    void whenCallAuthenticateEndpointWithWrongPayload_thenReturnBadRequest() throws Exception {
+        mockMvc
+            .perform(post("/zss/saf/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\": \"\", \"jwt\": \"\"}"))
             .andExpect(status().is(SC_BAD_REQUEST));
     }
 
@@ -68,6 +77,15 @@ public class SafIdtControllerTest {
     void whenCallVerifyEndpointWithoutPayload_thenReturnBadRequest() throws Exception {
         mockMvc
             .perform(post("/zss/saf/verify"))
+            .andExpect(status().is(SC_BAD_REQUEST));
+    }
+
+    @Test
+    void whenCallVerifyEndpointWithWrongPayload_thenReturnBadRequest() throws Exception {
+        mockMvc
+            .perform(post("/zss/saf/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jwt\": \"\"}"))
             .andExpect(status().is(SC_BAD_REQUEST));
     }
 

--- a/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/zss/api/SafIdtControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.zowe.apiml.zss.model.Token;
+import org.zowe.apiml.zss.services.SafIdtProvider;
+
+import java.util.Optional;
+
+import static javax.servlet.http.HttpServletResponse.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+public class SafIdtControllerTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private SafIdtProvider safProvider;
+
+    @BeforeEach
+    void setUp() {
+        SafIdtController safIdtController = new SafIdtController(safProvider);
+        mockMvc = MockMvcBuilders.standaloneSetup(safIdtController).build();
+    }
+
+    @Test
+    void whenCallAuthenticateEndpointWithoutPayload_thenReturnBadRequest() throws Exception {
+        mockMvc
+            .perform(post("/zss/saf/authenticate"))
+            .andExpect(status().is(SC_BAD_REQUEST));
+    }
+
+    @Test
+    void whenCallAuthenticateEndpointWithValidPayload_thenReturnOkAndToken() throws Exception {
+        Token valid = new Token();
+        valid.setJwt("safJwt");
+
+        when(safProvider.authenticate(any())).thenReturn(Optional.of(valid));
+        mockMvc
+            .perform(
+                post("/zss/saf/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"username\": \"validName\", \"jwt\": \"validJwt\"}"))
+            .andExpect(status().is(SC_CREATED))
+            .andExpect(content().json("{\"jwt\": \"safJwt\"}"));
+    }
+
+    @Test
+    void whenCallVerifyEndpointWithoutPayload_thenReturnBadRequest() throws Exception {
+        mockMvc
+            .perform(post("/zss/saf/verify"))
+            .andExpect(status().is(SC_BAD_REQUEST));
+    }
+
+    @Test
+    void whenCallVerifyEndpointWithPost_thenReturnToken() throws Exception {
+        when(safProvider.verify(any())).thenReturn(true);
+
+        mockMvc
+            .perform(post("/zss/saf/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jwt\": \"safJwt\"}"))
+            .andExpect(status().is(SC_OK));
+    }
+}

--- a/mock-zosmf/src/test/java/org/zowe/apiml/zss/services/SafIdtProviderTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/zss/services/SafIdtProviderTest.java
@@ -1,0 +1,66 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.zss.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.zowe.apiml.zss.model.Authentication;
+import org.zowe.apiml.zss.model.Token;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class SafIdtProviderTest {
+    private SafIdtProvider underTest;
+    private Map<String, String> tokens;
+
+    @BeforeEach
+    void setUp() {
+        tokens = new HashMap<>();
+        underTest = new SafIdtProvider(tokens);
+    }
+
+    @Nested
+    class WhenAuthenticating {
+        @Nested
+        class GivenAuthenticationWithUsername {
+            @Test
+            void tokenIsReturned() {
+                Authentication authentication = new Authentication();
+                authentication.setUsername("validUsername");
+
+                Optional<Token> token = underTest.authenticate(authentication);
+
+                assertThat(token.isPresent(), is(true));
+            }
+        }
+    }
+
+    @Nested
+    class WhenVerifying {
+        @Nested
+        class GivenExistingToken {
+            @Test
+            void tokenIsVerified() {
+                Token token = new Token();
+                token.setJwt("username;validJwt");
+
+                tokens.put("username", token.getJwt());
+
+                assertThat(underTest.verify(token), is(true));
+            }
+        }
+    }
+}

--- a/mock-zosmf/src/test/java/org/zowe/apiml/zss/services/SafIdtProviderTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/zss/services/SafIdtProviderTest.java
@@ -24,16 +24,14 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class SafIdtProviderTest {
     private SafIdtProvider underTest;
-    private Map<String, String> tokens;
-
-    @BeforeEach
-    void setUp() {
-        tokens = new HashMap<>();
-        underTest = new SafIdtProvider(tokens);
-    }
 
     @Nested
     class WhenAuthenticating {
+        @BeforeEach
+        void setUp() {
+            underTest = new SafIdtProvider();
+        }
+
         @Nested
         class GivenAuthenticationWithUsername {
             @Test
@@ -50,6 +48,14 @@ public class SafIdtProviderTest {
 
     @Nested
     class WhenVerifying {
+        private Map<String, String> tokens;
+
+        @BeforeEach
+        void setUp() {
+            tokens = new HashMap<>();
+            underTest = new SafIdtProvider(tokens);
+        }
+
         @Nested
         class GivenExistingToken {
             @Test


### PR DESCRIPTION
# Description

It is possible to create REST API to generate and verify SAF IDT token and as long as it adheres to the specification, it will be usable by the REST provider. 

Linked to #1629 

## Type of change

Please delete options that are not relevant.

- [x] (feat) New feature (non-breaking change which adds functionality)
