### PR TITLE
fix: Add remove null from packaged service files

### DIFF
--- a/api-catalog-package/build.gradle
+++ b/api-catalog-package/build.gradle
@@ -1,6 +1,6 @@
 ext {
     artifactName = 'api-catalog-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {

--- a/apiml-common-lib-package/build.gradle
+++ b/apiml-common-lib-package/build.gradle
@@ -10,7 +10,7 @@
 
 ext {
     artifactName = 'apiml-common-lib-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {

--- a/caching-service-package/build.gradle
+++ b/caching-service-package/build.gradle
@@ -1,6 +1,6 @@
 ext {
     artifactName = 'caching-service-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {

--- a/discovery-package/build.gradle
+++ b/discovery-package/build.gradle
@@ -1,6 +1,6 @@
 ext {
     artifactName = 'discovery-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {

--- a/gateway-package/build.gradle
+++ b/gateway-package/build.gradle
@@ -1,6 +1,6 @@
 ext {
     artifactName = 'gateway-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {

--- a/metrics-service-package/build.gradle
+++ b/metrics-service-package/build.gradle
@@ -1,6 +1,6 @@
 ext {
     artifactName = 'metrics-service-package'
-    pullNo = project.hasProperty("pullRequest")? "-" + project.getProperty("pullRequest") : ""
+    pullNo = project.hasProperty("pullRequest") && project.getProperty("pullRequest") != null ? "-" + project.getProperty("pullRequest") : ""
 }
 
 configurations {


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Adds an explicit null check for `pullRequest` property in package builds, so `-null` is not added in place of the pull request number in the zip file.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
