### PR TITLE
feat: Refresh endpoint for prolonging valid JWT token

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
@@ -42,6 +42,9 @@ public class AuthConfigurationProperties {
     private String gatewayQueryEndpointOldFormat = "/api/v1/gateway/auth/query";
     private String gatewayTicketEndpointOldFormat = "/api/v1/gateway/auth/ticket";
 
+    private String gatewayRefreshEndpointOldFormat = "/api/v1/gateway/auth/refresh";
+    private String gatewayRefreshEndpointNewFormat = "/gateway/api/v1/auth/refresh";
+
     private String serviceLoginEndpoint = "/auth/login";
     private String serviceLogoutEndpoint = "/auth/logout";
 

--- a/config/docker/gateway-service.yml
+++ b/config/docker/gateway-service.yml
@@ -3,6 +3,7 @@ apiml:
         hostname: gateway-service
         discoveryServiceUrls: https://discovery-service:10011/eureka/
     security:
+        allowTokenRefresh: true
         auth:
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -176,7 +176,7 @@ public class NewSecurityConfiguration {
     }
 
     /**
-     * Query and Ticket endpoints share single filter that handles auth with and without certificate. This logic is encapsulated in the queryFilter or ticketFilter.
+     * Query and Ticket and Refresh endpoints share single filter that handles auth with and without certificate. This logic is encapsulated in the queryFilter or ticketFilter.
      * Query endpoint does not require certificate to be present in RequestContext. It verifies JWT token.
      */
     @Configuration
@@ -216,7 +216,7 @@ public class NewSecurityConfiguration {
     }
 
     /**
-     * Query and Ticket endpoints share single filter that handles auth with and without certificate. This logic is encapsulated in the queryFilter or ticketFilter.
+     * Query and Ticket and Refresh endpoints share single filter that handles auth with and without certificate. This logic is encapsulated in the queryFilter or ticketFilter.
      * Ticket endpoint does require certificate to be present in RequestContext. It verifies the JWT token.
      */
 
@@ -267,6 +267,7 @@ public class NewSecurityConfiguration {
      */
     @Configuration
     @RequiredArgsConstructor
+    @ConditionalOnProperty(name = "apiml.security.allowTokenRefresh", havingValue = "true", matchIfMissing = false)
     @Order(6)
     class Refresh extends WebSecurityConfigurerAdapter {
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -33,21 +33,18 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
-import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.filter.AttlsFilter;
+import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.gateway.controllers.AuthController;
 import org.zowe.apiml.gateway.controllers.CacheServiceController;
 import org.zowe.apiml.gateway.error.InternalServerErrorController;
 import org.zowe.apiml.gateway.security.login.x509.X509AuthenticationProvider;
-import org.zowe.apiml.gateway.security.query.QueryFilter;
-import org.zowe.apiml.gateway.security.query.SuccessfulQueryHandler;
-import org.zowe.apiml.gateway.security.query.TokenAuthenticationProvider;
+import org.zowe.apiml.gateway.security.query.*;
+import org.zowe.apiml.gateway.security.refresh.SuccessfulRefreshHandler;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
 import org.zowe.apiml.gateway.security.ticket.SuccessfulTicketHandler;
 import org.zowe.apiml.gateway.services.ServicesInfoController;
-import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
-import org.zowe.apiml.security.common.config.CertificateAuthenticationProvider;
-import org.zowe.apiml.security.common.config.HandlerInitializer;
+import org.zowe.apiml.security.common.config.*;
 import org.zowe.apiml.security.common.content.BasicContentFilter;
 import org.zowe.apiml.security.common.content.CookieContentFilter;
 import org.zowe.apiml.security.common.filter.ApimlX509Filter;
@@ -86,6 +83,7 @@ public class NewSecurityConfiguration {
     private final HandlerInitializer handlerInitializer;
     private final SuccessfulQueryHandler successfulQueryHandler;
     private final SuccessfulTicketHandler successfulTicketHandler;
+    private final SuccessfulRefreshHandler successfulRefreshHandler;
     @Qualifier("publicKeyCertificatesBase64")
     private final Set<String> publicKeyCertificatesBase64;
     private final X509AuthenticationProvider x509AuthenticationProvider;
@@ -254,6 +252,51 @@ public class NewSecurityConfiguration {
             return new QueryFilter(
                 ticketEndpoint,
                 successfulTicketHandler,
+                handlerInitializer.getAuthenticationFailureHandler(),
+                authenticationService,
+                HttpMethod.POST,
+                true,
+                authenticationManager);
+        }
+    }
+
+    /**
+     * Query and Ticket and Refresh endpoints share single filter that handles auth with and without certificate.
+     * Refresh endpoint does require certificate to be present in RequestContext. It verifies the JWT token and based
+     * on valid token and client certificate issues a new valid token
+     */
+    @Configuration
+    @RequiredArgsConstructor
+    @Order(6)
+    class Refresh extends WebSecurityConfigurerAdapter {
+
+        private final AuthenticationProvider tokenAuthenticationProvider;
+
+        @Override
+        protected void configure(AuthenticationManagerBuilder auth) {
+            auth.authenticationProvider(tokenAuthenticationProvider); // for authenticating Tokens
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            baseConfigure(http.requestMatchers().antMatchers(
+                authConfigurationProperties.getGatewayRefreshEndpointNewFormat(),
+                authConfigurationProperties.getGatewayRefreshEndpointOldFormat()
+            ).and()).authorizeRequests()
+                .anyRequest().authenticated()
+                .and()
+                .logout().disable() // logout filter in this chain not needed
+                .x509() //default x509 filter, authenticates trusted cert, ticketFilter(..) depends on this
+                .subjectPrincipalRegex(EXTRACT_USER_PRINCIPAL_FROM_COMMON_NAME)
+                .userDetailsService(new SimpleUserDetailService())
+                .and()
+                .addFilterBefore(refreshFilter("/**", authenticationManager()), UsernamePasswordAuthenticationFilter.class);
+        }
+
+        private QueryFilter refreshFilter(String ticketEndpoint, AuthenticationManager authenticationManager) {
+            return new QueryFilter(
+                ticketEndpoint,
+                successfulRefreshHandler,
                 handlerInitializer.getAuthenticationFailureHandler(),
                 authenticationService,
                 HttpMethod.POST,

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/refresh/SuccessfulRefreshHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/refresh/SuccessfulRefreshHandler.java
@@ -1,0 +1,70 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.security.refresh;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.gateway.security.service.TokenCreationService;
+import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
+import org.zowe.apiml.util.CookieUtil;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+/**
+ * Handler for refreshing the issued JWT token
+ * The handler gets authenticated TokenAuthentication with previous token in credentials
+ * It invalidates the previous token and issues a fresh one
+ */
+@Component
+@RequiredArgsConstructor
+public class SuccessfulRefreshHandler implements AuthenticationSuccessHandler {
+
+    private final AuthConfigurationProperties authConfigurationProperties;
+    private final AuthenticationService authenticationService;
+    private final TokenCreationService tokenCreationService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        if (authentication instanceof TokenAuthentication) {
+            TokenAuthentication tokenAuth = (TokenAuthentication) authentication;
+
+            authenticationService.invalidateJwtToken(tokenAuth.getCredentials(), true);
+            String jwtToken = tokenCreationService.createJwtTokenWithoutCredentials(tokenAuth.getPrincipal());
+            setCookie(jwtToken, response);
+        }
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+    }
+
+    private void setCookie(String token, HttpServletResponse response) {
+        AuthConfigurationProperties.CookieProperties cp = authConfigurationProperties.getCookieProperties();
+        String cookieHeader = CookieUtil.setCookieHeader(
+            cp.getCookieName(),
+            token,
+            cp.getCookieComment(),
+            cp.getCookiePath(),
+            cp.getCookieSameSite().getValue(),
+            cp.getCookieMaxAge(),
+            true,
+            cp.isCookieSecure()
+        );
+
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -56,6 +56,7 @@ apiml:
     security:
         filterChainConfiguration: new
         headersToBeCleared: X-Certificate-Public,X-Certificate-DistinguishedName,X-Certificate-CommonName
+        allowTokenRefresh: false
         auth:
             provider: zosmf
             jwtKeyAlias: jwtsecret

--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -171,8 +171,8 @@
         "/auth/refresh": {
             "post": {
                 "tags": ["Security"],
-                "summary": "Refresh authentication token for a fresh one token.",
-                "description": "**Note:** This endpoint is disabled by default.\n\nUse the `/refresh` API to request a new JWT authentication token for the user associated with provided token.\n\nThis endpoint is protect by a client certificate.\n\n**HTTP Headers:**\n\nThe ticket request requires the token in one of the following formats:  \n  * Cookie named `apimlAuthenticationToken`.\n  * Bearer authentication\n  \n*Header example:* Authorization: Bearer *token*",
+                "summary": "Refresh authentication token.",
+                "description": "**Note:** This endpoint is disabled by default.\n\nUse the `/refresh` API to request a new JWT authentication token for the user associated with provided token.\nThe old token is invalidated and new token is issued with refreshed expiration time.\n\nThis endpoint is protect by a client certificate.\n\n**HTTP Headers:**\n\nThe ticket request requires the token in one of the following formats:  \n  * Cookie named `apimlAuthenticationToken`.\n  * Bearer authentication\n  \n*Header example:* Authorization: Bearer *token*",
                 "operationId": "RefreshTokenUsingPOST",
                 "security": [
                     {

--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -167,6 +167,53 @@
                 }
             }
         },
+
+        "/auth/refresh": {
+            "post": {
+                "tags": ["Security"],
+                "summary": "Refresh authentication token for a fresh one token.",
+                "description": "**Note:** This endpoint is disabled by default.\n\nUse the `/refresh` API to request a new JWT authentication token for the user associated with provided token.\n\nThis endpoint is protect by a client certificate.\n\n**HTTP Headers:**\n\nThe ticket request requires the token in one of the following formats:  \n  * Cookie named `apimlAuthenticationToken`.\n  * Bearer authentication\n  \n*Header example:* Authorization: Bearer *token*",
+                "operationId": "RefreshTokenUsingPOST",
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Authenticated",
+                        "headers": {
+                            "Set-Cookie": {
+                                "description": "Cookie named apimlAuthenticationToken contains authentication token.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Zowe token is not provided, is invalid or is expired."
+                    },
+                    "403": {
+                        "description": "A client certificate is not provided or is expired."
+                    },
+                    "404": {
+                        "description": "Not Found. The endpoint is not enabled or not propperly configured"
+                    },
+                    "405": {
+                        "description": "Method Not Allowed"
+                    },
+                    "500": {
+                        "description": "Process of refreshing token has failed unexpectedly."
+                    }
+                }
+            }
+        },
+
+
         "/auth/logout": {
             "post": {
                 "tags": ["Security"],
@@ -333,7 +380,7 @@
                 "tags": ["Services"],
                 "summary": "Returns detailed information about the requested service",
                 "description": "Use this endpoint to obtain detailed information about the service, its APIs, and its instances. This endpoint is protected by the `APIML.SERVICES` resource in the `ZOWE` class. At least `READ` access is required.",
-                "operationId": "servicesUsingGET",
+                "operationId": "servicesUsingGETSpecific",
                 "parameters": [
                     {
                         "in": "path",

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/refresh/SuccessfulRefreshHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/refresh/SuccessfulRefreshHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.security.refresh;
+
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.gateway.security.service.TokenCreationService;
+import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.token.TokenAuthentication;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+class SuccessfulRefreshHandlerTest {
+
+    AuthConfigurationProperties authConfigurationProperties = new AuthConfigurationProperties();
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    TokenCreationService tokenCreationService = mock(TokenCreationService.class);
+    SuccessfulRefreshHandler underTest = new SuccessfulRefreshHandler(authConfigurationProperties,
+        authenticationService, tokenCreationService);
+    HttpServletRequest request;
+    HttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        when(tokenCreationService.createJwtTokenWithoutCredentials(anyString())).thenReturn("NEWTOKEN");
+    }
+
+    @Nested
+    class GivenAuthenticationInputs {
+        @Test
+        void unknownTypeOfAuthenticationDoesntDoAnything() throws ServletException, IOException {
+            Authentication auth = new TestingAuthenticationToken("Principal", "credentials");
+            underTest.onAuthenticationSuccess(request, response, auth);
+            verify(authenticationService, never()).invalidateJwtToken("TOKEN", true);
+            assertThat(response.getStatus(), is(HttpStatus.NO_CONTENT.value()));
+            assertThat(response.getHeader(HttpHeaders.SET_COOKIE), is(emptyOrNullString()));
+        }
+
+        @Test
+        void tokenTypeOfAuthenticationIssuesToken() throws ServletException, IOException {
+            Authentication auth = new TokenAuthentication("USER", "TOKEN");
+            underTest.onAuthenticationSuccess(request, response, auth);
+            verify(authenticationService, atLeastOnce()).invalidateJwtToken("TOKEN", true);
+            assertThat(response.getStatus(), is(HttpStatus.NO_CONTENT.value()));
+            assertThat(response.getHeader(HttpHeaders.SET_COOKIE),
+                is("apimlAuthenticationToken=NEWTOKEN; Path=/; Secure; HttpOnly; SameSite=Strict"));
+        }
+    }
+
+}

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -32,6 +32,7 @@ apiml:
         timeoutMillis: 30000  # Timeout for connection to the services
     security:
         filterChainConfiguration: new
+        allowTokenRefresh: true
         ssl:
             verifySslCertificatesOfServices: true
         auth:

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -29,6 +29,7 @@ apiml:
         timeoutMillis: 30000  # Timeout for connection to the services
     security:
         filterChainConfiguration: new
+        allowTokenRefresh: false
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -29,7 +29,7 @@ apiml:
         timeoutMillis: 30000  # Timeout for connection to the services
     security:
         filterChainConfiguration: new
-        allowTokenRefresh: false
+        allowTokenRefresh: true
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
@@ -55,7 +55,7 @@ public class RefreshTest implements TestWithStartedInstances {
     }
 
     @Nested
-    class GivenIllegalAccessModes{
+    class GivenIllegalAccessModes {
         @Test
         void noClientCertificateGivesForbidden() {
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
@@ -1,0 +1,110 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.integration.authentication.providers;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
+import org.junit.jupiter.api.*;
+import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.login.LoginRequest;
+import org.zowe.apiml.util.TestWithStartedInstances;
+import org.zowe.apiml.util.categories.*;
+import org.zowe.apiml.util.config.ConfigReader;
+import org.zowe.apiml.util.config.SslContext;
+import org.zowe.apiml.util.http.HttpRequestUtils;
+
+import java.net.URI;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.apache.http.HttpStatus.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.zowe.apiml.util.SecurityUtils.*;
+
+@GeneralAuthenticationTest
+@SAFAuthTest
+@zOSMFAuthTest
+public class RefreshTest implements TestWithStartedInstances {
+
+    public static final AuthConfigurationProperties authConfigurationProperties = new AuthConfigurationProperties();
+
+    private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
+    private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
+    public static final URI LOGIN_URL = HttpRequestUtils.getUriFromGateway(authConfigurationProperties.getGatewayLoginEndpoint());
+    public static final URI REFRESH_URL = HttpRequestUtils.getUriFromGateway(authConfigurationProperties.getGatewayRefreshEndpointNewFormat());
+
+    @BeforeAll
+    public static void init() throws Exception {
+        SslContext.prepareSslAuthentication();
+    }
+    @BeforeEach
+    public void setUp() {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @Nested
+    class GivenIllegalAccessModes{
+        @Test
+        void noClientCertificateGivesForbidden() {
+
+            given().config(SslContext.tlsWithoutCert)
+                .when()
+                .post(REFRESH_URL)
+                .then()
+                .statusCode(is(SC_FORBIDDEN));
+        }
+        @Test
+        void clientCertificateWithoutTokenGivesUnauthorized() {
+            LoginRequest loginRequest = new LoginRequest(USERNAME, PASSWORD);
+
+            given().config(SslContext.clientCertApiml)
+                .when()
+                .contentType(JSON)
+                .body(loginRequest)
+                .post(REFRESH_URL)
+                .then()
+                .statusCode(is(SC_UNAUTHORIZED));
+        }
+    }
+
+    @Nested
+    class givenLegalAccessModes {
+        @Test
+        void whenJwtTokenPostedCanBeRefreshedAndOldCookieInvalidated() {
+
+            String cookie = gatewayToken();
+
+            Cookie refreshedCookie = given().config(SslContext.clientCertApiml)
+                .cookie(COOKIE_NAME, cookie)
+                .when()
+                .post(REFRESH_URL)
+                .then()
+                .statusCode(is(SC_NO_CONTENT))
+                .header("Set-Cookie", containsString("SameSite=Strict"))
+                .cookie(COOKIE_NAME, not(isEmptyString()))
+                .extract().detailedCookie(COOKIE_NAME);
+
+            assertThat(refreshedCookie.getValue(), is(not(cookie)));
+            assertValidAuthToken(refreshedCookie);
+
+            assertIfLogged(refreshedCookie.getValue(), true);
+            assertIfLogged(cookie, false);
+
+        }
+
+    }
+
+
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/RefreshTest.java
@@ -42,7 +42,6 @@ public class RefreshTest implements TestWithStartedInstances {
 
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
-    public static final URI LOGIN_URL = HttpRequestUtils.getUriFromGateway(authConfigurationProperties.getGatewayLoginEndpoint());
     public static final URI REFRESH_URL = HttpRequestUtils.getUriFromGateway(authConfigurationProperties.getGatewayRefreshEndpointNewFormat());
 
     @BeforeAll
@@ -80,7 +79,7 @@ public class RefreshTest implements TestWithStartedInstances {
     }
 
     @Nested
-    class givenLegalAccessModes {
+    class GivenLegalAccessModes {
         @Test
         void whenJwtTokenPostedCanBeRefreshedAndOldCookieInvalidated() {
 


### PR DESCRIPTION
# Description

Adds and documents a `auth/refresh` endpoint for prolonging valid JWT token.

Linked to #1719 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [x] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
