### PR TITLE
fix: hide log messages with no value

### DIFF
--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDependencyLogHider.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDependencyLogHider.java
@@ -42,7 +42,10 @@ public class ApimlDependencyLogHider extends TurboFilter {
         "The Hystrix timeout",
         ".*Error during filtering.*Token is not valid.*",
         ".*Endpoint ID .* contains invalid characters.*",
-        "org.zowe.apiml.gateway.error.NotFound");
+        "org.zowe.apiml.gateway.error.NotFound",
+        "Weak cipher suite", // https://github.com/zowe/api-layer/issues/1663
+        "HV000001: Hibernate Validator",
+        "You already have RibbonLoadBalancerClient on your classpath.*"); // Known fact, fix in Zowe V2
 
     private boolean isFilterActive;
 


### PR DESCRIPTION
Signed-off-by: jandadav <janda.david@gmail.com>

# Description

Hide log messages that provide no value to the customer.

Linked to #1663 

