### PR TITLE
fix: static definition generation tweaks

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -57,6 +57,13 @@ then
     LOG_LEVEL=${APIML_DIAG_MODE_ENABLED}
 fi
 
+# If set append $ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES to $STATIC_DEF_CONFIG_DIR
+export APIML_STATIC_DEF=${STATIC_DEF_CONFIG_DIR}
+if [[ ! -z "$ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES" ]]
+then
+  export APIML_STATIC_DEF="${APIML_STATIC_DEF};${ZWEAD_EXTERNAL_STATIC_DEF_DIRECTORIES}"
+fi
+
 EXPLORER_HOST=${ZOWE_EXPLORER_HOST:-localhost}
 
 if [[ -z "${GATEWAY_HOST}" ]]
@@ -94,6 +101,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${CATALOG_CODE} java \
     -Dapiml.service.eurekaUserId=eureka \
     -Dapiml.service.eurekaPassword=password \
     -Dapiml.logs.location=${WORKSPACE_DIR}/api-mediation/logs \
+    -Dapiml.discovery.staticApiDefinitionsDirectories=${APIML_STATIC_DEF} \
     -Dapiml.security.ssl.verifySslCertificatesOfServices=${VERIFY_CERTIFICATES:-false} \
     -Dapiml.security.ssl.nonStrictVerifySslCertificatesOfServices=${NONSTRICT_VERIFY_CERTIFICATES:-false} \
     -Dspring.profiles.include=$LOG_LEVEL \

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticDefinitionGenerator.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticDefinitionGenerator.java
@@ -15,9 +15,7 @@ import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -84,14 +82,14 @@ public class StaticDefinitionGenerator {
         return new StaticAPIResponse(400, "The service ID format is not valid.");
     }
 
-    private String formatFile(String file) {
-        file = file.replace("\\n", System.lineSeparator());
-        file = file.substring(1, file.length() - 1);
+    private String normalizeToUnixLineEndings(String file) {
+        file = file.replaceAll("\\r\\n", "\n");
+        file = file.replaceAll("\\r", "\n");
         return file;
     }
 
     private StaticAPIResponse writeContentToFile(String fileContent, String fileName, String message) throws IOException {
-        fileContent = formatFile(fileContent);
+        fileContent = normalizeToUnixLineEndings(fileContent);
         try (FileOutputStream fos = new FileOutputStream(fileName)) {
             fos.write(fileContent.getBytes(StandardCharsets.UTF_8));
             log.debug(message);


### PR DESCRIPTION
# Description

Integration test with cleanup
Do not truncate serialized data
force unix line separators in serialized data

Linked to #1725 

## Type of change