### PR TITLE
Fix Zaas client to not send a certificate during authentication 

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -23,7 +23,6 @@ import org.zowe.apiml.zaasclient.exception.ZaasConfigurationErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 
 import javax.net.ssl.*;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,7 +48,7 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     private final CookieStore cookieStore = new BasicCookieStore();
 
-    private CloseableHttpClient httpsClientWithKeyStoreAndTrustStore;
+    private CloseableHttpClient httpsClient;
 
     public ZaasHttpsClientProvider(ConfigProperties configProperties) throws ZaasConfigurationException {
         this.requestConfig = this.buildCustomRequestConfig();
@@ -71,14 +70,13 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     @Override
     public synchronized CloseableHttpClient getHttpClient() throws ZaasConfigurationException {
-        if (httpsClientWithKeyStoreAndTrustStore == null) {
-            if ((kmf == null) && (keyStorePath != null)) {
+        if (httpsClient == null) {
+            if (kmf == null) {
                 initializeKeyStoreManagerFactory();
             }
-            httpsClientWithKeyStoreAndTrustStore = sharedHttpClientConfiguration(getSSLContext())
-                .build();
+            httpsClient = sharedHttpClientConfiguration(getSSLContext()).build();
         }
-        return httpsClientWithKeyStoreAndTrustStore;
+        return httpsClient;
     }
 
     private void initializeTrustManagerFactory(String trustStorePath, String trustStoreType, char[] trustStorePassword)
@@ -97,8 +95,14 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     private void initializeKeyStoreManagerFactory() throws ZaasConfigurationException {
         try {
+            KeyStore keyStore;
+            if (keyStorePath != null) {
+                keyStore = getKeystore(keyStorePath, keyStoreType, keyStorePassword);
+            } else {
+                keyStore = getEmptyKeystore();
+            }
+
             kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            KeyStore keyStore = getKeystore(keyStorePath, keyStoreType, keyStorePassword);
             kmf.init(keyStore, keyStorePassword);
         } catch (NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException | KeyStoreException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.WRONG_CRYPTO_CONFIGURATION, e);
@@ -115,12 +119,19 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
         }
     }
 
+    private KeyStore getEmptyKeystore() throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+        KeyStore emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
+        emptyKeystore.load(null, null);
+
+        return emptyKeystore;
+    }
+
     private InputStream getCorrectInputStream(String uri) throws IOException {
         if (uri.startsWith(SAFKEYRING + ":////")) {
             URL url = new URL(replaceFourSlashes(uri));
             return url.openStream();
         }
-        return new FileInputStream(new File(uri));
+        return new FileInputStream(uri);
     }
 
     public static String replaceFourSlashes(String storeUri) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -119,6 +119,7 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
         }
     }
 
+    // Necessary because IBM JDK will automatically add keyStore based on system variables when there is no keyStore
     private KeyStore getEmptyKeystore() throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
         KeyStore emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
         emptyKeystore.load(null, null);

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProviderTests.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProviderTests.java
@@ -73,6 +73,15 @@ class ZaasHttpsClientProviderTests {
     }
 
     @Test
+    void giveNoKeyStorePath_whenTheClientIsConstructed_thenEmptyKeyStoreIsUsed() throws ZaasConfigurationException, IOException {
+        ConfigProperties config = getConfigProperties();
+        config.setKeyStorePath(null);
+        ZaasHttpsClientProvider provider = new ZaasHttpsClientProvider(config);
+
+        assertNotNull(provider.getHttpClient());
+    }
+
+    @Test
     void whenGetHttpsClientWithKeyStoreAndTrustStore_thenIdenticalClientReturned() throws ZaasConfigurationException {
         CloseableHttpClient client1 = zaasHttpsClientProvider.getHttpClient();
         CloseableHttpClient client2 = zaasHttpsClientProvider.getHttpClient();


### PR DESCRIPTION
# Description

ZAAS HTTPS client is sending also a certificate during authentication. It is expected to send only credentials without certificates. This can lead to incorrect behavior in Zowe 1.23 and lower.

https://github.com/zowe/api-layer/issues/1513

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Note: My tests are not really good. Feel free to suggest how to test it in a better way.

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
