### PR TITLE
fix: Fix flaky unit test

### DIFF
--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -565,8 +565,8 @@ public class AuthenticationServiceTest {
         QueryResponse qr1 = authService.parseJwtToken(jwt1);
         QueryResponse qr2 = authService.parseJwtToken(jwt2);
 
-        Date toBeExpired = DateUtils.addHours(qr1.getCreation(), 8);
-        Date toBeExpired2 = DateUtils.addSeconds(qr2.getCreation(), 1);
+        Date toBeExpired = DateUtils.addSeconds(qr1.getCreation(), authConfigurationProperties.getTokenProperties().getExpirationInSeconds());
+        Date toBeExpired2 = DateUtils.addSeconds(qr2.getCreation(), (int) authConfigurationProperties.getTokenProperties().getShortTtlExpirationInSeconds());
         assertEquals(qr1.getExpiration(), toBeExpired);
         assertEquals(qr2.getExpiration(), toBeExpired2);
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/AuthenticationServiceTest.java
@@ -558,17 +558,17 @@ public class AuthenticationServiceTest {
     }
 
     @Test
-    void testCreateJwtTokenUserExpire() {
+    void testCreateJwtTokensAndCheckExpiration() {
         String jwt1 = authService.createJwtToken("user", "domain", "ltpaToken");
         String jwt2 = authService.createJwtToken("expire", "domain", "ltpaToken");
 
         QueryResponse qr1 = authService.parseJwtToken(jwt1);
         QueryResponse qr2 = authService.parseJwtToken(jwt2);
 
-        assertEquals(
-            qr1.getExpiration().getTime() - authConfigurationProperties.getTokenProperties().getExpirationInSeconds() * 1000,
-            qr2.getExpiration().getTime() - authConfigurationProperties.getTokenProperties().getShortTtlExpirationInSeconds() * 1000
-        );
+        Date toBeExpired = DateUtils.addHours(qr1.getCreation(), 8);
+        Date toBeExpired2 = DateUtils.addSeconds(qr2.getCreation(), 1);
+        assertEquals(qr1.getExpiration(), toBeExpired);
+        assertEquals(qr2.getExpiration(), toBeExpired2);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

The `AuthenticationServiceTest.testCreateJwtTokenUserExpire` is pretty flaky, due to a wrong comparison of the two tokens expiration time values which takes in consideration also the current time in the calculation.
Because of that, the test is randomly failing based on its execution speed.

Example:

```
org.opentest4j.AssertionFailedError: 
Expected :1631266367000
Actual   :1631266368000
```

Linked to #1745 

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
