### PR TITLE
Fix: Zuul semaphore concurrency configuration

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -116,7 +116,7 @@ server:
         ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
         keyStoreType: PKCS12
         trustStoreType: PKCS12
-    maxConnectionsPerRoute: 101
+    maxConnectionsPerRoute: 100
     maxTotalConnections: 1000
     webSocket:
         supportedProtocols: v12.stomp,v11.stomp

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -136,8 +136,8 @@ zuul:
     host:
         connectTimeoutMillis: ${apiml.gateway.timeoutMillis}
         socketTimeoutMillis: ${apiml.gateway.timeoutMillis}
-        maxTotalConnetions: ${server.maxConnectionsPerRoute}
-        maxPerRouteConnections: ${server.maxTotalConnections}
+        maxTotalConnetions: ${server.maxTotalConnections}
+        maxPerRouteConnections: ${server.maxConnectionsPerRoute}
     forceOriginalQueryStringEncoding: true
     retryable: true
     decodeUrl: false # Flag to indicate whether to decode the matched URL or use it as is

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -136,7 +136,7 @@ zuul:
     host:
         connectTimeoutMillis: ${apiml.gateway.timeoutMillis}
         socketTimeoutMillis: ${apiml.gateway.timeoutMillis}
-        maxTotalConnetions: ${server.maxTotalConnections}
+        maxTotalConnections: ${server.maxTotalConnections}
         maxPerRouteConnections: ${server.maxConnectionsPerRoute}
     forceOriginalQueryStringEncoding: true
     retryable: true

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -116,7 +116,7 @@ server:
         ciphers: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
         keyStoreType: PKCS12
         trustStoreType: PKCS12
-    maxConnectionsPerRoute: 100
+    maxConnectionsPerRoute: 101
     maxTotalConnections: 1000
     webSocket:
         supportedProtocols: v12.stomp,v11.stomp
@@ -128,6 +128,8 @@ zuul:
     ignoreSecurityHeaders: false
     includeDebugHeader: false
     sensitiveHeaders: Expires,Date
+    semaphore:
+        maxSemaphores: ${server.maxTotalConnections}
     ignoredPatterns:
         - /**/ws/**
         - /**/sse/**


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Fixes Zuul concurrency configuration when semaphore strategy is used. Unifies it with the `APIML_MAX_TOTAL_CONNECTIONS` property.

Linked to #1779 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
