### PR TITLE
feat: Certificate authentication for static refresh endpoint

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -163,7 +163,7 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                 .antMatchers("/static-api/**").authenticated()
                 .antMatchers("/containers/**").authenticated()
-                .antMatchers(APIDOC_ROUTES, STATIC_REFRESH_ROUTE).authenticated()
+                .antMatchers(APIDOC_ROUTES).authenticated()
                 .antMatchers("/application/health", "/application/info").permitAll()
                 .antMatchers("/application/**").authenticated();
             if (isAttlsEnabled) {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -30,8 +30,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.filter.AttlsFilter;
+import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.security.client.EnableApimlAuth;
 import org.zowe.apiml.security.client.login.GatewayLoginProvider;
 import org.zowe.apiml.security.client.token.GatewayTokenProvider;
@@ -60,6 +60,7 @@ import java.util.Set;
 @EnableApimlAuth
 public class SecurityConfiguration {
     private static final String APIDOC_ROUTES = "/apidoc/**";
+    private static final String STATIC_REFRESH_ROUTE = "/static-api/refresh";
 
     private final ObjectMapper securityObjectMapper;
     private final AuthConfigurationProperties authConfigurationProperties;
@@ -84,7 +85,6 @@ public class SecurityConfiguration {
         @Value("${apiml.security.ssl.nonStrictVerifySslCertificatesOfServices:false}")
         private boolean nonStrictVerifySslCertificatesOfServices;
 
-
         @Override
         protected void configure(AuthenticationManagerBuilder auth) {
             auth.authenticationProvider(gatewayLoginProvider);
@@ -95,11 +95,11 @@ public class SecurityConfiguration {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
             mainframeCredentialsConfiguration(
-                baseConfiguration(http.antMatcher(APIDOC_ROUTES)),
+                baseConfiguration(http.requestMatchers().antMatchers(APIDOC_ROUTES, STATIC_REFRESH_ROUTE).and()),
                 authenticationManager()
             )
                 .authorizeRequests()
-                .antMatchers(APIDOC_ROUTES).authenticated();
+                .antMatchers(APIDOC_ROUTES, STATIC_REFRESH_ROUTE).authenticated();
 
             if (verifySslCertificatesOfServices || nonStrictVerifySslCertificatesOfServices) {
                 if (isAttlsEnabled) {
@@ -163,7 +163,7 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                 .antMatchers("/static-api/**").authenticated()
                 .antMatchers("/containers/**").authenticated()
-                .antMatchers(APIDOC_ROUTES).authenticated()
+                .antMatchers(APIDOC_ROUTES, STATIC_REFRESH_ROUTE).authenticated()
                 .antMatchers("/application/health", "/application/info").permitAll()
                 .antMatchers("/application/**").authenticated();
             if (isAttlsEnabled) {
@@ -187,6 +187,9 @@ public class SecurityConfiguration {
             )
             .defaultAuthenticationEntryPointFor(
                 handlerInitializer.getBasicAuthUnauthorizedHandler(), new AntPathRequestMatcher(APIDOC_ROUTES)
+            )
+            .defaultAuthenticationEntryPointFor(
+                handlerInitializer.getBasicAuthUnauthorizedHandler(), new AntPathRequestMatcher(STATIC_REFRESH_ROUTE)
             )
             .defaultAuthenticationEntryPointFor(
                 handlerInitializer.getUnAuthorizedHandler(), new AntPathRequestMatcher("/**")

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.zowe.apiml.util.categories.GeneralAuthenticationTest;
-import org.zowe.apiml.util.config.ConfigReader;
-import org.zowe.apiml.util.config.ItSslConfigFactory;
+import org.zowe.apiml.util.config.*;
 import org.zowe.apiml.util.service.DiscoveryUtils;
 
 import java.util.List;


### PR DESCRIPTION
# Description

Adds ability to authenticate via certificates for the static refresh endpoint in the API Catalog.

Linked to #1767

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
