### PR TITLE
chore: Github actions workflow name typo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # This workflow will release project with Gradle
-name: Relase new version (automated)
+name: Release new version (automated)
 
 on:
     schedule:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,6 +1,6 @@
 # This workflow will release project with Gradle
 
-name: Relase new version (snapshot)
+name: Release new version (snapshot)
 
 on:
     push:

--- a/.github/workflows/specific-release.yml
+++ b/.github/workflows/specific-release.yml
@@ -1,5 +1,5 @@
 # This workflow will release project with Gradle
-name: Relase new version (specific)
+name: Release new version (specific)
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Fix `relase` typo in workflow names

## Type of change

Please delete options that are not relevant.

- [x] (chore) Chore, repository cleanup, updates the dependencies.

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
