### PR TITLE
fix: support for APAR PH34201

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -314,7 +314,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsZosmfRsu2012
+                    name: CITestsZosmfPH34201
                     path: |
                         integration-tests/build/reports/**
             -   name: Cleanup Gradle Cache

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -207,7 +207,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: PH12143,RSU2012
+                    ZOSMF_APPLIEDAPARS: PH12143,RSU2012
 
         steps:
             -   uses: actions/checkout@v2
@@ -277,7 +277,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: PH12143,RSU2012,PH34201
+                    ZOSMF_APPLIEDAPARS: PH12143,RSU2012,PH34201
 
         steps:
             -   uses: actions/checkout@v2
@@ -347,7 +347,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: ''
+                    ZOSMF_APPLIEDAPARS: ''
 
         steps:
             -   uses: actions/checkout@v2
@@ -418,7 +418,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: AuthenticateApar
+                    ZOSMF_APPLIEDAPARS: AuthenticateApar
 
         steps:
             -   uses: actions/checkout@v2
@@ -560,7 +560,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: AuthenticateApar
+                    ZOSMF_APPLIEDAPARS: AuthenticateApar
             redis-master:
                 image: redis:latest
                 ports:
@@ -648,7 +648,7 @@ jobs:
             mock-zosmf:
                 image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
                 env:
-                    ZOSMF_APPLIED_APARS: AuthenticateApar
+                    ZOSMF_APPLIEDAPARS: AuthenticateApar
             redis-master:
                 image: redis:latest
                 ports:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -253,6 +253,75 @@ jobs:
                     rm -f ~/.gradle/caches/modules-2/gc.properties
                     rm -rf ~/.gradle/caches/build-cache-1
 
+    CITestsZosmfPH34201:
+        needs: PublishJibContainers
+        runs-on: ubuntu-latest
+        container: ubuntu:latest
+        timeout-minutes: 6
+
+        services:
+            api-catalog-services:
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                volumes:
+                    - /api-defs:/api-defs
+            caching-service:
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+            discoverable-client:
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+            discovery-service:
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                volumes:
+                    - /api-defs:/api-defs
+            gateway-service:
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+            mock-zosmf:
+                image: ghcr.io/balhar-jakub/mock-zosmf:${{ github.event.pull_request.number || 'latest' }}
+                env:
+                    ZOSMF_APPLIED_APARS: PH12143,RSU2012,PH34201
+
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    ref: ${{ github.head_ref }}
+            -   name: Set up JDK 1.8
+                uses: actions/setup-java@v1
+                with:
+                    java-version: 1.8
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
+            -   name: Cache Gradle packages
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        ~/.gradle/caches
+                        ~/.gradle/wrapper
+                    key: ${{ runner.os }}-gradle001-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                    restore-keys: |
+                        ${{ runner.os }}-gradle001-
+            -   name: Cache Node.js modules
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        ~/.npm
+                    key: ${{ runner.OS }}-node001-${{ hashFiles('**/package-lock.json, **/package.json') }}
+                    restore-keys: |
+                        ${{ runner.OS }}-node001-
+            -   name: Build with Gradle
+                run: >
+                    ./gradlew :integration-tests:runZosmfAuthTest --info -Denvironment.config=-docker -Denvironment.offPlatform=true
+                    -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
+            -   name: Store results
+                uses: actions/upload-artifact@v2
+                if: always()
+                with:
+                    name: ContainerCITestsZosmfRsu2012
+                    path: |
+                        integration-tests/build/reports/**
+            -   name: Cleanup Gradle Cache
+                run: |
+                    rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                    rm -f ~/.gradle/caches/modules-2/gc.properties
+                    rm -rf ~/.gradle/caches/build-cache-1
 
     CITestsZosmfWithoutJwt:
         needs: PublishJibContainers

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -341,24 +341,20 @@ public class ZosmfService extends AbstractZosmfService {
             log.debug("Trying to validate token with strategy: {}", s.toString());
             try {
                 s.validate(request);
-                if (requestValidationIsDecided(request)) {
+                if (requestIsAuthenticated(request)) {
                     log.debug("Token validity has been successfully determined: {}", request.getAuthenticated());
-                    break;
+                    return true;
                 }
             } catch (RuntimeException re) {
                 log.debug("Exception during token validation:", re);
             }
         }
         log.debug("Token validation strategies exhausted, final validation status: {}", request.getAuthenticated());
-        return requestIsAuthenticated(request);
+        return false;
     }
 
     private boolean requestIsAuthenticated(TokenValidationRequest request) {
         return TokenValidationRequest.STATUS.AUTHENTICATED.equals(request.getAuthenticated());
-    }
-
-    private boolean requestValidationIsDecided(TokenValidationRequest request) {
-        return !TokenValidationRequest.STATUS.UNKNOWN.equals(request.getAuthenticated());
     }
 
     public Map<String, Boolean> getEndpointMap() {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
@@ -23,6 +23,9 @@ public class AuthenticateApar extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
+        if (noAuthentication(headers)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
         if (isUnauthorized(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
@@ -42,6 +45,6 @@ public class AuthenticateApar extends FunctionalApar {
     }
 
     private boolean isUnauthorized(Map<String, String> headers) {
-        return containsInvalidUser(headers) && noLtpaCookie(headers);
+        return containsInvalidOrNoUser(headers) && noLtpaCookie(headers);
     }
 }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -134,7 +134,8 @@ public class FunctionalApar implements Apar {
 
     protected boolean noAuthentication(Map<String, String> headers) {
         String basicAuth = headers.get(AUTHORIZATION_HEADER);
-        return (basicAuth == null || basicAuth.isEmpty()) && noJwtCookie(headers) && noLtpaCookie(headers);
+        String cookie = headers.get(COOKIE_HEADER);
+        return (basicAuth == null || basicAuth.isEmpty()) && (cookie == null || cookie.isEmpty());
     }
 
     protected boolean containsInvalidOrNoUser(Map<String, String> headers) {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -132,7 +132,12 @@ public class FunctionalApar implements Apar {
         return null;
     }
 
-    protected boolean containsInvalidUser(Map<String, String> headers) {
+    protected boolean noAuthentication(Map<String, String> headers) {
+        String basicAuth = headers.get(AUTHORIZATION_HEADER);
+        return (basicAuth == null || basicAuth.isEmpty()) && noJwtCookie(headers) && noLtpaCookie(headers);
+    }
+
+    protected boolean containsInvalidOrNoUser(Map<String, String> headers) {
         String authorization = headers.get(AUTHORIZATION_HEADER);
         if (authorization == null || authorization.isEmpty()) {
             return true;

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
@@ -27,6 +27,9 @@ public class PH12143 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
+        if (noAuthentication(headers)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
         if (isUnauthorized(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
@@ -42,6 +45,9 @@ public class PH12143 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationDelete(Map<String, String> headers) {
+        if (noAuthentication(headers)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
         if (isUnauthorized(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
@@ -54,6 +60,6 @@ public class PH12143 extends FunctionalApar {
     }
 
     private boolean isUnauthorized(Map<String, String> headers) {
-        return containsInvalidUser(headers) && noLtpaCookie(headers);
+        return containsInvalidOrNoUser(headers) && noLtpaCookie(headers);
     }
 }

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
@@ -1,0 +1,54 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+// TODO
+// all other apars return 500 if auth
+// this one return 401 if no auth - make a noAuth function in FunctionalApar
+// run integration tests to verify
+// adjust authenticated endpoint strategy and/or zosmfservice to handle this
+// probably zosmfservice keep trying if get 401, then return when successful auth, or after all tried if one is 401 then 401, else idk
+public class PH34201 extends FunctionalApar {
+    private final String keystorePath;
+
+    public PH34201(List<String> usernames, List<String> passwords, String keystorePath) {
+        super(usernames, passwords);
+        this.keystorePath = keystorePath;
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
+        if (containsInvalidUser(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        String[] credentials = getPiecesOfCredentials(headers);
+        return validJwtResponse(response, credentials[0], keystorePath);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
+        return handleAuthenticationCreate(headers, response);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationDelete(Map<String, String> headers) {
+        if (containsInvalidUser(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
@@ -15,12 +15,7 @@ import org.springframework.http.ResponseEntity;
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
-// TODO
-// all other apars return 500 if auth
-// this one return 401 if no auth - make a noAuth function in FunctionalApar
-// run integration tests to verify
-// adjust authenticated endpoint strategy and/or zosmfservice to handle this
-// probably zosmfservice keep trying if get 401, then return when successful auth, or after all tried if one is 401 then 401, else idk
+
 public class PH34201 extends FunctionalApar {
     private final String keystorePath;
 
@@ -31,7 +26,7 @@ public class PH34201 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
-        if (containsInvalidUser(headers)) {
+        if (containsInvalidOrNoUser(headers) && noJwtCookie(headers) && noLtpaCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
@@ -46,7 +41,7 @@ public class PH34201 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationDelete(Map<String, String> headers) {
-        if (containsInvalidUser(headers)) {
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers) && noJwtCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
@@ -26,7 +26,8 @@ public class PH34201 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
-        if (containsInvalidOrNoUser(headers) && noJwtCookie(headers) && noLtpaCookie(headers)) {
+        // JWT token not accepted for create method
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
@@ -36,7 +37,12 @@ public class PH34201 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
-        return handleAuthenticationCreate(headers, response);
+        if (containsInvalidOrNoUser(headers) && noJwtCookie(headers) && noLtpaCookie(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        String[] credentials = getPiecesOfCredentials(headers);
+        return validJwtResponse(response, credentials[0], keystorePath);
     }
 
     @Override

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
@@ -25,7 +25,10 @@ public class PHBase extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
-        if (containsInvalidUser(headers) && noLtpaCookie(headers)) {
+        if (noAuthentication(headers)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
@@ -40,7 +43,7 @@ public class PHBase extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleInformation(Map<String, String> headers, HttpServletResponse response) {
-        if (containsInvalidUser(headers)) {
+        if (containsInvalidOrNoUser(headers)) {
             return validInfo();
         }
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/RSU2012.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/RSU2012.java
@@ -28,7 +28,7 @@ public class RSU2012 extends FunctionalApar {
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
         // JWT token not accepted for create method
-        if (containsInvalidUser(headers) && noLtpaCookie(headers)) {
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -38,7 +38,7 @@ public class RSU2012 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
-        if (containsInvalidUser(headers) && noLtpaCookie(headers) && noJwtCookie(headers)) {
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers) && noJwtCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -48,7 +48,7 @@ public class RSU2012 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationDelete(Map<String, String> headers) {
-        if (containsInvalidUser(headers) && noLtpaCookie(headers) && noJwtCookie(headers)) {
+        if (containsInvalidOrNoUser(headers) && noLtpaCookie(headers) && noJwtCookie(headers)) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
@@ -24,6 +24,7 @@ public class AvailableApars {
         implementedApars.put("PH17867", new NoApar());
         implementedApars.put("PH28507", new NoApar());
         implementedApars.put("PH28532", new NoApar());
+        implementedApars.put("PH34201", new PH34201(usernames, passwords, jwtKeystorePath));
         implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath));
         implementedApars.put("JwtKeys", new JwtKeys(usernames, passwords));
         implementedApars.put("AuthenticateApar", new AuthenticateApar(usernames, passwords));

--- a/mock-zosmf/src/main/resources/application.yml
+++ b/mock-zosmf/src/main/resources/application.yml
@@ -32,7 +32,7 @@ zosmf:
     username: USER,APIMTST,USER1,USER2
     password: validPassword,PASSTICKET
     baseVersion: 2.4
-    appliedApars: PH34201
+    appliedApars: PH12143
     jwtKeyStorePath: keystore/localhost/localhost.keystore.p12
 
 ---

--- a/mock-zosmf/src/main/resources/application.yml
+++ b/mock-zosmf/src/main/resources/application.yml
@@ -32,7 +32,7 @@ zosmf:
     username: USER,APIMTST,USER1,USER2
     password: validPassword,PASSTICKET
     baseVersion: 2.4
-    appliedApars: PH12143
+    appliedApars: PH34201
     jwtKeyStorePath: keystore/localhost/localhost.keystore.p12
 
 ---

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
@@ -49,7 +49,7 @@ class AuthenticationAparTest {
             assertThat(result.isPresent(), is(true));
 
             ResponseEntity<?> response = result.get();
-            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+            assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
         }
 
         @Test
@@ -60,7 +60,7 @@ class AuthenticationAparTest {
             assertThat(result.isPresent(), is(true));
 
             ResponseEntity<?> response = result.get();
-            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+            assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
         }
 
         @Test

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
@@ -51,7 +51,7 @@ class PH12143Test {
         @ParameterizedTest
         @ValueSource(strings = {"create", "verify", "delete"})
         void givenNoAuthorization_thenReturnUnauthorized(String method) {
-            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
 
             Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
 
@@ -61,7 +61,7 @@ class PH12143Test {
         @ParameterizedTest
         @ValueSource(strings = {"create", "verify", "delete"})
         void givenEmptyAuthorization_thenReturnUnauthorized(String method) {
-            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
 
             headers.put("authorization", "");
             Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH34201Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH34201Test.java
@@ -27,12 +27,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
-class PH12143Test {
+class PH34201Test {
     private static final String SERVICE = "authentication";
     private static final String USERNAME = "USER";
     private static final String PASSWORD = "validPassword";
 
-    private PH12143 underTest;
+    private PH34201 underTest;
     private HttpServletResponse mockResponse;
     private Map<String, String> headers;
 
@@ -41,7 +41,7 @@ class PH12143Test {
         List<String> usernames = Collections.singletonList(USERNAME);
         List<String> passwords = Collections.singletonList(PASSWORD);
 
-        underTest = new PH12143(usernames, passwords, "../keystore/localhost/localhost.keystore.p12");
+        underTest = new PH34201(usernames, passwords, "../keystore/localhost/localhost.keystore.p12");
         mockResponse = mock(HttpServletResponse.class);
         headers = new HashMap<>();
     }
@@ -50,8 +50,8 @@ class PH12143Test {
     class whenAuthenticating {
         @ParameterizedTest
         @ValueSource(strings = {"create", "verify", "delete"})
-        void givenNoAuthorization_thenReturnInternalServerError(String method) {
-            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+        void givenNoAuthorization_thenReturnUnauthorized(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
 
             Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
 
@@ -60,8 +60,8 @@ class PH12143Test {
 
         @ParameterizedTest
         @ValueSource(strings = {"create", "verify", "delete"})
-        void givenEmptyAuthorization_thenReturnInternalServerError(String method) {
-            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+        void givenEmptyAuthorization_thenReturnUnauthorized(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
 
             headers.put("authorization", "");
             Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
@@ -173,36 +173,6 @@ class PH12143Test {
 
             Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "delete", Optional.empty(), mockResponse, headers);
             assertThat(result, is(expected));
-        }
-    }
-
-    @Nested
-    class whenApplyApar {
-        @Test
-        void givenAuthenticationMethodNotHandled_thenReturnOriginalResult() {
-            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
-
-            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "default", previousResult, mockResponse, headers);
-            assertThat(result, is(previousResult));
-        }
-
-        @Test
-        void givenServiceNotHandled_thenReturnOriginalResult() {
-            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
-
-            Optional<ResponseEntity<?>> result = underTest.apply("badservice", "", previousResult, mockResponse, headers);
-            assertThat(result, is(previousResult));
-        }
-    }
-
-    @Nested
-    class whenRetrieveJwtKeys {
-        @Test
-        void thenOkIsReturned() {
-            Optional<ResponseEntity<?>> result = underTest.apply("jwtKeys", "get", null, null, null);
-
-            assertThat(result.isPresent(), is(true));
-            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
         }
     }
 

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
@@ -69,23 +69,23 @@ class PHBaseTest {
     @Nested
     class whenAuthenticateIsCalled {
         @Test
-        void givenVerifyMethodWithNoAuthorization_returnUnauthorized() {
+        void givenVerifyMethodWithNoAuthorization_returnInternalServerError() {
             Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
             assertThat(result.isPresent(), is(true));
 
             ResponseEntity<?> response = result.get();
-            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+            assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
         }
 
         @Test
-        void givenVerifyMethodWithEmptyAuthorization_returnUnauthorized() {
+        void givenVerifyMethodWithEmptyAuthorization_returnInternalServerError() {
             headers.put("authorization", "");
 
             Optional<ResponseEntity<?>> result = underTest.apply("authentication", "verify", Optional.empty(), mockResponse, headers);
             assertThat(result.isPresent(), is(true));
 
             ResponseEntity<?> response = result.get();
-            assertThat(response.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+            assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
         }
 
         @Test


### PR DESCRIPTION
# Description

Support for apar PH34201 where no authentication in a request to zOSMF will return a 401 instead of a 500.

Linked to #1326 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
