### PR TITLE
feat: Ignore Origin header for z/OSMF

### DIFF
--- a/discovery-package/src/main/resources/zosmf-static-definition.yaml.template
+++ b/discovery-package/src/main/resources/zosmf-static-definition.yaml.template
@@ -22,6 +22,7 @@ services:
       customMetadata:
           apiml:
               enableUrlEncodedCharacters: true
+              headersToIgnore: Origin
 
     - serviceId: ibmzosmf
       title: IBM z/OSMF
@@ -43,6 +44,7 @@ services:
       customMetadata:
           apiml:
               enableUrlEncodedCharacters: true
+              headersToIgnore: Origin
 catalogUiTiles:
     zosmf:
         title: z/OSMF services


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Adds configuration to the z/OSMF static definition to direct the Gateway to strip the `Origin` header. This allows the explorer UIs to use z/OSMF APIs.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
