### PR TITLE
feat: Per service configuration to direct the APIML to add headers

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilter.java
@@ -1,0 +1,73 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.filters.post;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.exception.ZuulException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.*;
+
+/**
+ * This filter adds headers to the response as configured by the responding service's metadata.
+ */
+@Component
+@RequiredArgsConstructor
+public class PerServiceAddResponseHeadersFilter extends ZuulFilter {
+
+    private final DiscoveryClient discoveryClient;
+
+    @Override
+    public String filterType() {
+        return POST_TYPE;
+    }
+
+    @Override
+    public int filterOrder() {
+        return SEND_RESPONSE_FILTER_ORDER - 1;
+    }
+
+    @Override
+    public boolean shouldFilter() {
+        return true;
+    }
+
+    @Override
+    public Object run() throws ZuulException {
+        RequestContext context = RequestContext.getCurrentContext();
+        String serviceId = (String) context.get(SERVICE_ID_KEY);
+        List<ServiceInstance> serviceInstances = discoveryClient.getInstances(serviceId);
+
+        if (serviceInstances != null && !serviceInstances.isEmpty()) {
+            ServiceInstance serviceInstance = serviceInstances.get(0);
+            Map<String, String> metadata = serviceInstance.getMetadata();
+
+            String headersToAdd = metadata.get("apiml.response.headers");
+            if (headersToAdd != null && !headersToAdd.trim().isEmpty()) {
+                String[] headerValuePairs = StringUtils.stripAll(headersToAdd.split(","));
+
+                for (String headerValuePair : headerValuePairs) {
+                    String[] headerValue = headerValuePair.split(": ?");
+                    context.addZuulResponseHeader(headerValue[0], headerValue[1]);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilter.java
@@ -62,8 +62,11 @@ public class PerServiceAddResponseHeadersFilter extends ZuulFilter {
                 String[] headerValuePairs = StringUtils.stripAll(headersToAdd.split(","));
 
                 for (String headerValuePair : headerValuePairs) {
-                    String[] headerValue = headerValuePair.split(": ?");
-                    context.addZuulResponseHeader(headerValue[0], headerValue[1]);
+                    String[] headerValue = StringUtils.stripAll(headerValuePair.split(":", 2)); // separate header name and header value
+                    String header = headerValue[0];
+                    String value = headerValue.length > 1 ? headerValue[1] : "";
+
+                    context.addZuulResponseHeader(header, value);
                 }
             }
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/AddHeadersPerServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/AddHeadersPerServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.acceptance;
+
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.apache.http.message.BasicHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.zowe.apiml.acceptance.common.AcceptanceTest;
+import org.zowe.apiml.acceptance.common.AcceptanceTestWithTwoServices;
+import org.zowe.apiml.acceptance.netflix.MetadataBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.reset;
+
+@AcceptanceTest
+public class AddHeadersPerServiceTest extends AcceptanceTestWithTwoServices {
+    private static final String HEADER = "my-header";
+    private static final String VALUE = "my-value";
+
+    @BeforeEach
+    void setup() throws IOException {
+        applicationRegistry.clearApplications();
+        reset(mockClient);
+
+        mockValid200HttpResponse();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HEADER, VALUE);
+        MetadataBuilder customBuilder = MetadataBuilder.customInstance()
+            .withAddedHeaders(headers);
+
+        applicationRegistry.addApplication(serviceWithDefaultConfiguration, MetadataBuilder.defaultInstance(), false);
+        applicationRegistry.addApplication(serviceWithCustomConfiguration, customBuilder, false);
+    }
+
+    @Nested
+    class GivenServiceWithAddedHeaders {
+        @BeforeEach
+        void setApplication() {
+            applicationRegistry.setCurrentApplication(serviceWithCustomConfiguration.getId());
+            discoveryClient.createRefreshCacheEvent();
+        }
+
+        @Test
+        void whenIncludeAddedHeader_thenHeaderIsAdded() {
+            given()
+                .when()
+                .get(basePath + serviceWithCustomConfiguration.getPath())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .header(HEADER, VALUE);
+        }
+
+        @Test
+        void whenIncludedHeaderAlreadyAddedByService_thenHeaderIsOverridden() throws IOException {
+            mockValid200HttpResponseWithHeaders(new Header[]{
+                new BasicHeader(HEADER, "other-value")
+            });
+
+            given()
+                .when()
+                .get(basePath + serviceWithCustomConfiguration.getPath())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .header(HEADER, VALUE);
+        }
+    }
+
+    @Nested
+    class GivenServiceWithoutAddedHeaders {
+        @BeforeEach
+        void setApplication() {
+            applicationRegistry.setCurrentApplication(serviceWithDefaultConfiguration.getId());
+            discoveryClient.createRefreshCacheEvent();
+        }
+
+        @Test
+        void whenGetResponse_thenHeaderIsNotAdded() {
+            given()
+                .when()
+                .get(basePath + serviceWithDefaultConfiguration.getPath())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .header(HEADER, (String) null);
+        }
+    }
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/MetadataBuilder.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/netflix/MetadataBuilder.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.stream.Collectors.joining;
+
 public class MetadataBuilder {
     private Map<String, String> metadata;
 
@@ -64,6 +66,15 @@ public class MetadataBuilder {
 
     public MetadataBuilder withIgnoredHeaders(List<String> headerNames) {
         metadata.put("apiml.headersToIgnore", String.join(",", headerNames));
+
+        return this;
+    }
+
+    public MetadataBuilder withAddedHeaders(Map<String, String> headers) {
+        String headersToAdd = headers.entrySet().stream()
+            .map(e -> e.getKey() + ":" + e.getValue())
+            .collect(joining(","));
+        metadata.put("apiml.response.headers", headersToAdd);
 
         return this;
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilterTest.java
@@ -42,8 +42,8 @@ public class PerServiceAddResponseHeadersFilterTest {
 
     @BeforeEach
     void setup() {
-        context = mock(RequestContext.class);
-        when(context.get(SERVICE_ID_KEY)).thenReturn(SERVICE_ID);
+        context = spy(new RequestContext());
+        context.put(SERVICE_ID_KEY, SERVICE_ID);
         RequestContext.testSetCurrentContext(context);
 
         metadata = new HashMap<>();

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/post/PerServiceAddResponseHeadersFilterTest.java
@@ -1,0 +1,136 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.filters.post;
+
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.exception.ZuulException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SERVICE_ID_KEY;
+
+public class PerServiceAddResponseHeadersFilterTest {
+    private static final String SERVICE_ID = "serviceId";
+    private static final String HEADER1 = "header1";
+    private static final String HEADER2 = "header2";
+    private static final String HEADER1_VALUE = "value1";
+    private static final String HEADER2_VALUE = "value2";
+    private static final String HEADER_VALUE_SEPARATOR = ":";
+    private static final String HEADER_DELIMITER = ",";
+    private static final String METADATA_KEY = "apiml.response.headers";
+
+    private PerServiceAddResponseHeadersFilter underTest;
+
+    private DiscoveryClient discoveryClient;
+    private RequestContext context;
+    private Map<String, String> metadata;
+
+    @BeforeEach
+    void setup() {
+        context = mock(RequestContext.class);
+        when(context.get(SERVICE_ID_KEY)).thenReturn(SERVICE_ID);
+        RequestContext.testSetCurrentContext(context);
+
+        metadata = new HashMap<>();
+        ServiceInstance instance = mock(ServiceInstance.class);
+        when(instance.getMetadata()).thenReturn(metadata);
+
+        discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getInstances(SERVICE_ID)).thenReturn(Collections.singletonList(instance));
+        underTest = new PerServiceAddResponseHeadersFilter(discoveryClient);
+    }
+
+    @Nested
+    class WhenAddHeaders {
+        @Test
+        void givenOneHeaderToAdd() throws ZuulException {
+            metadata.put(METADATA_KEY, HEADER1 + HEADER_VALUE_SEPARATOR + HEADER1_VALUE);
+            underTest.run();
+
+            verify(context).addZuulResponseHeader(HEADER1, HEADER1_VALUE);
+        }
+
+        @Test
+        void givenMultipleHeadersToAdd() throws ZuulException {
+            metadata.put(METADATA_KEY, HEADER1 + HEADER_VALUE_SEPARATOR + HEADER1_VALUE + HEADER_DELIMITER + HEADER2 + HEADER_VALUE_SEPARATOR + HEADER2_VALUE);
+            underTest.run();
+
+            verify(context).addZuulResponseHeader(HEADER1, HEADER1_VALUE);
+        }
+
+        @Test
+        void givenMultipleHeadersToAddWithWhitespace_thenWhitespaceIsTrimmed() throws ZuulException {
+            metadata.put(METADATA_KEY, HEADER1 + HEADER_VALUE_SEPARATOR + HEADER1_VALUE + HEADER_DELIMITER + " " + HEADER2 + HEADER_VALUE_SEPARATOR + " " + HEADER2_VALUE);
+            underTest.run();
+
+            verify(context).addZuulResponseHeader(HEADER1, HEADER1_VALUE);
+        }
+
+        @Test
+        void givenHeaderWithNoValue() throws ZuulException {
+            metadata.put(METADATA_KEY, HEADER1);
+            underTest.run();
+
+            verify(context).addZuulResponseHeader(HEADER1, "");
+        }
+
+        @Test
+        void givenHeaderWithSeparatorInHeaderValue() throws ZuulException {
+            String value = HEADER1_VALUE + HEADER_VALUE_SEPARATOR;
+            metadata.put(METADATA_KEY, HEADER1 + HEADER_VALUE_SEPARATOR + value);
+            underTest.run();
+
+            verify(context).addZuulResponseHeader(HEADER1, value);
+        }
+    }
+
+    @Nested
+    class WhenDontAddHeaders {
+        @Test
+        void givenNullServiceInstances() throws ZuulException {
+            when(discoveryClient.getInstances(SERVICE_ID)).thenReturn(null);
+            underTest.run();
+
+            verify(context, never()).addZuulResponseHeader(anyString(), anyString());
+        }
+
+        @Test
+        void givenNoServiceInstances() throws ZuulException {
+            when(discoveryClient.getInstances(SERVICE_ID)).thenReturn(Collections.emptyList());
+            underTest.run();
+
+            verify(context, never()).addZuulResponseHeader(anyString(), anyString());
+        }
+
+        @Test
+        void givenNoResponseHeadersConfig() throws ZuulException {
+            metadata.remove(METADATA_KEY);
+            underTest.run();
+
+            verify(context, never()).addZuulResponseHeader(anyString(), anyString());
+        }
+
+        @Test
+        void givenEmptyResponseHeadersConfig() throws ZuulException {
+            metadata.put(METADATA_KEY, "");
+            underTest.run();
+
+            verify(context, never()).addZuulResponseHeader(anyString(), anyString());
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds `customMetadata.apiml.response.headers` for service configuration that the APIML will use to add or override headers in the response.

Linked to #1743 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
