### PR TITLE
fix: define appfwPlugins instead of desktopIframePlugins for API Catalog

### DIFF
--- a/api-catalog-package/src/main/resources/manifest.yaml
+++ b/api-catalog-package/src/main/resources/manifest.yaml
@@ -26,7 +26,5 @@ autoEncoding:
 apimlServices:
   dynamic:
     - serviceId: apicatalog
-desktopIframePlugins:
-  - id: org.zowe.api.catalog
-    icon: assets/api-catalog.png
-    url: /ui/v1/apicatalog
+appfwPlugins:
+- path: "."

--- a/api-catalog-package/src/main/resources/pluginDefinition.json
+++ b/api-catalog-package/src/main/resources/pluginDefinition.json
@@ -1,0 +1,22 @@
+{
+  "identifier": "org.zowe.api.catalog",
+  "apiVersion": "1.0.0",
+  "pluginVersion": "1.0.0",
+  "pluginType": "application",
+  "webContent": {
+    "framework": "iframe",
+    "destination": "https://${ZOWE_EXTERNAL_HOST}:${GATEWAY_PORT}/ui/v1/apicatalog",
+    "launchDefinition": {
+      "pluginShortNameKey": "API Catalog",
+      "pluginShortNameDefault": "API Catalog",
+      "imageSrc": "assets/api-catalog.png"
+    },
+    "descriptionKey": "",
+    "descriptionDefault": "",
+    "isSingleWindowApp": true,
+    "defaultWindowStyle": {
+      "width": 1400,
+      "height": 800
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/zowe/zowe-install-packaging/issues/2336

Change API Catalog to use new way to register itself to AppServer.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
