### PR TITLE
 chore: Upgrading tests in onboarding-enabler-spring to JUnit5

### DIFF
--- a/onboarding-enabler-spring-sample-app/src/test/java/org/zowe/apiml/sample/enable/controller/SampleControllerUnitTests.java
+++ b/onboarding-enabler-spring-sample-app/src/test/java/org/zowe/apiml/sample/enable/controller/SampleControllerUnitTests.java
@@ -9,8 +9,8 @@
  */
 package org.zowe.apiml.sample.enable.controller;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
@@ -22,7 +22,7 @@ import static org.hamcrest.core.Is.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-public class SampleControllerUnitTests {
+class SampleControllerUnitTests {
 
     private MockMvc mockMvc;
 
@@ -30,8 +30,8 @@ public class SampleControllerUnitTests {
     private SampleController suspectsController;
 
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(suspectsController)
@@ -39,7 +39,7 @@ public class SampleControllerUnitTests {
     }
 
     @Test
-    public void test_get_all_samples() throws Exception {
+    void test_get_all_samples() throws Exception {
         mockMvc.perform(get("/api/v1/samples"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))

--- a/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/config/EnableApiDiscoveryConfigTest.java
+++ b/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/config/EnableApiDiscoveryConfigTest.java
@@ -10,14 +10,14 @@
 package org.zowe.apiml.enable.config;
 
 import com.netflix.appinfo.EurekaInstanceConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.zowe.apiml.enable.EnableApiDiscovery;
 import org.zowe.apiml.enable.register.RegisterToApiLayer;
 import org.zowe.apiml.eurekaservice.client.ApiMediationClient;
@@ -27,15 +27,14 @@ import org.zowe.apiml.exception.ServiceDefinitionException;
 import org.zowe.apiml.message.core.Message;
 import org.zowe.apiml.message.core.MessageService;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
 @EnableApiDiscovery
 @ContextConfiguration(initializers = ConfigFileApplicationContextInitializer.class, classes = {RegisterToApiLayer.class, EnableApiDiscoveryConfig.class})
-public class EnableApiDiscoveryConfigTest {
-
+class EnableApiDiscoveryConfigTest {
 
     @Autowired
     private ApiMediationServiceConfig apiMediationServiceConfig;
@@ -44,7 +43,7 @@ public class EnableApiDiscoveryConfigTest {
     private ApiMediationClient apiMediationClient;
 
     @Test
-    public void messageServiceDiscovery() {
+    void messageServiceDiscovery() {
         String baseUrl = "localhost";
         String ipAddress = "127.0.0.0";
         String discovery = "https://localhost:10011/discovery";
@@ -59,14 +58,13 @@ public class EnableApiDiscoveryConfigTest {
         assertTrue(message.mapToLogMessage().contains(correctMessage));
     }
 
-
     @Test
-    public void resolveServiceIpAddressIfNotProvidedInConfiguration() {
+    void resolveServiceIpAddressIfNotProvidedInConfiguration() {
         assertEquals("127.0.0.1", apiMediationServiceConfig.getServiceIpAddress());
     }
 
     @Test
-    public void givenYamlMetadata_whenIpAddressIsPreferred_thenUseIpAddress() throws ServiceDefinitionException {
+    void givenYamlMetadata_whenIpAddressIsPreferred_thenUseIpAddress() throws ServiceDefinitionException {
         EurekaInstanceConfigCreator eurekaInstanceConfigCreator = new EurekaInstanceConfigCreator();
         EurekaInstanceConfig translatedConfig = eurekaInstanceConfigCreator.createEurekaInstanceConfig(apiMediationServiceConfig);
         assertEquals("https://127.0.0.1:10043/discoverableclient2", translatedConfig.getHomePageUrl());

--- a/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/register/ApimlDisabledRegisterToApiLayerTest.java
+++ b/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/register/ApimlDisabledRegisterToApiLayerTest.java
@@ -14,27 +14,27 @@ import org.zowe.apiml.enable.config.EnableApiDiscoveryConfig;
 import org.zowe.apiml.eurekaservice.client.ApiMediationClient;
 import org.zowe.apiml.eurekaservice.client.config.ApiMediationServiceConfig;
 import org.zowe.apiml.exception.ServiceDefinitionException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
 @EnableApiDiscovery
 @ActiveProfiles("apiml-disabled")
 @ContextConfiguration(initializers = ConfigFileApplicationContextInitializer.class, classes = {RegisterToApiLayer.class, EnableApiDiscoveryConfig.class})
-public class ApimlDisabledRegisterToApiLayerTest {
+class ApimlDisabledRegisterToApiLayerTest {
 
     @Autowired
     private ApiMediationServiceConfig apiMediationServiceConfig;
@@ -43,10 +43,10 @@ public class ApimlDisabledRegisterToApiLayerTest {
     private ApiMediationClient apiMediationClient;
 
     @Test
-    public void testOnContextRefreshedEventEvent() throws ServiceDefinitionException {
+    void testOnContextRefreshedEventEvent() throws ServiceDefinitionException {
 
-        assertNotNull("ApiMediationServiceConfig is null", apiMediationServiceConfig);
-        assertNotNull("Ssl is null", apiMediationServiceConfig.getSsl());
+        assertNotNull(apiMediationServiceConfig, "ApiMediationServiceConfig is null");
+        assertNotNull(apiMediationServiceConfig.getSsl(), "Ssl is null");
 
         verify(apiMediationClient, never()).register(apiMediationServiceConfig);
     }

--- a/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/register/ApimlEnabledRegisterToApiLayerTest.java
+++ b/onboarding-enabler-spring/src/test/java/org/zowe/apiml/enable/register/ApimlEnabledRegisterToApiLayerTest.java
@@ -9,33 +9,33 @@
  */
 package org.zowe.apiml.enable.register;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.zowe.apiml.enable.EnableApiDiscovery;
 import org.zowe.apiml.enable.config.EnableApiDiscoveryConfig;
 import org.zowe.apiml.eurekaservice.client.ApiMediationClient;
 import org.zowe.apiml.eurekaservice.client.config.ApiMediationServiceConfig;
 import org.zowe.apiml.exception.ServiceDefinitionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration
 @EnableApiDiscovery
 @DirtiesContext
 @ContextConfiguration(initializers = ConfigFileApplicationContextInitializer.class, classes = {RegisterToApiLayer.class, EnableApiDiscoveryConfig.class})
-public class ApimlEnabledRegisterToApiLayerTest {
+class ApimlEnabledRegisterToApiLayerTest {
 
     @Autowired
     private ApiMediationServiceConfig apiMediationServiceConfig;
@@ -44,16 +44,15 @@ public class ApimlEnabledRegisterToApiLayerTest {
     private ApiMediationClient apiMediationClient;
 
     @Test
-    public void testOnContextRefreshedEventEvent() throws ServiceDefinitionException {
-        assertNotNull("ApiMediationServiceConfig is null", apiMediationServiceConfig);
-        assertEquals("Service id is not equal", "discoverableclient2", apiMediationServiceConfig.getServiceId());
+    void testOnContextRefreshedEventEvent() throws ServiceDefinitionException {
+        assertNotNull(apiMediationServiceConfig, "ApiMediationServiceConfig is null");
+        assertEquals("discoverableclient2", apiMediationServiceConfig.getServiceId(), "Service id is not equal");
 
-        assertNotNull("SslConfig is null", apiMediationServiceConfig.getSsl());
-        assertEquals("keystore is not equal", "keystore/localhost/localhost.keystore.p12", apiMediationServiceConfig.getSsl().getKeyStore());
-        assertEquals("truststore id is not equal", "keystore/localhost/localhost.truststore.p12", apiMediationServiceConfig.getSsl().getTrustStore());
+        assertNotNull(apiMediationServiceConfig.getSsl(), "SslConfig is null");
+        assertEquals("keystore/localhost/localhost.keystore.p12", apiMediationServiceConfig.getSsl().getKeyStore(), "keystore is not equal");
+        assertEquals("keystore/localhost/localhost.truststore.p12", apiMediationServiceConfig.getSsl().getTrustStore(), "truststore id is not equal");
 
         verify(apiMediationClient, times(1)).register(apiMediationServiceConfig);
     }
-
 
 }


### PR DESCRIPTION
# Description

Upgrades tests in onboarding-enabler-spring and onboarding-enbaler-spring-sample-app to JUnit 5

Linked to #1077

## Type of change

- [x] (chore) Chore, repository cleanup, updates the dependencies.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
