### PR TITLE
fix: api-catalog app failed to load in desktop if Gateway service is …

### DIFF
--- a/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
+++ b/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
@@ -5,7 +5,7 @@
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",
-    "destination": "https://${ZOWE_EXTERNAL_HOST}:${GATEWAY_PORT}/ui/v1/apicatalog",
+    "destination": "/ui/v1/apicatalog",
     "launchDefinition": {
       "pluginShortNameKey": "API Catalog",
       "pluginShortNameDefault": "API Catalog",


### PR DESCRIPTION
…registered as NodePort

Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


Sorry we found another issue related to the API Catalog `pluginDefinition.json`. If gateway Kubernetes service is registered as `NodePort`, by default on port `32554`, API catalog app will still try to point to raw gateway port `7554`. This will result failure to load the app. Remove the hardcode domain/port can solve the problem. It will use browser provide value, which is always same as how people visit zlux.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
