### PR TITLE
Fix: SSE bugs

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
@@ -140,7 +140,7 @@ public class ServerSentEventProxyHandler implements RoutedServicesUser {
     }
 
     private String getTargetUrl(ServiceInstance serviceInstance, String serviceUrl, String path, String queryParameterString) {
-        String parameters = queryParameterString == null ? "" : queryParameterString;
+        String parameters = queryParameterString == null ? "" : "?" + queryParameterString;
         String protocol = serviceInstance.isSecure() ? "https" : "http";
         return String.format("%s://%s:%d/%s/%s%s",
             protocol,

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
@@ -208,13 +208,13 @@ class ServerSentEventProxyHandlerTest {
 
             @Test
             void givenUriParameters() throws IOException {
-                String params = "?param=123";
+                String params = "param=123";
                 when(mockHttpServletRequest.getRequestURI()).thenReturn(GATEWAY_PATH);
                 when(mockHttpServletRequest.getQueryString()).thenReturn(params);
                 mockServiceInstance(true);
 
                 verifyConsumerUsed();
-                verify(underTest).getSseStream(URL_SECURE + ENDPOINT + params);
+                verify(underTest).getSseStream(URL_SECURE + ENDPOINT + "?" + params);
             }
         }
 


### PR DESCRIPTION
# Description

- `serviceUrl` for SSE routes not required to end in `/`
- Query parameters are properly forwarded to the SSE endpoint

Linked to #1834 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
