### PR TITLE
chore: Update SAF IDT provider and add GW sharedlibs props

### DIFF
--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -81,6 +81,12 @@ else
     GATEWAY_LOADER_PATH=${COMMON_LIB}
 fi
 
+# Check if the directory containing the Gateway shared JARs was set and append it to the GW loader path
+if [[ ! -z ${ZWE_GATEWAY_SHARED_LIBS} ]]
+then
+    GATEWAY_LOADER_PATH=${ZWE_GATEWAY_SHARED_LIBS},${GATEWAY_LOADER_PATH}
+fi
+
 EXPLORER_HOST=${ZOWE_EXPLORER_HOST:-localhost}
 GATEWAY_SERVICE_PORT=${GATEWAY_PORT:-7554}
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafProviderBeansConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.passticket.PassTicketService;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,8 +24,9 @@ public class SafProviderBeansConfig {
     @ConditionalOnProperty(name = "apiml.security.saf.provider", havingValue = "rest")
     public SafIdtProvider restSafProvider(
         RestTemplate restTemplate,
-        AuthenticationService authenticationService
+        AuthenticationService authenticationService,
+        PassTicketService passTicketService
     ) {
-        return new SafRestAuthenticationService(restTemplate, authenticationService);
+        return new SafRestAuthenticationService(restTemplate, authenticationService, passTicketService);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationService.java
@@ -88,7 +88,7 @@ public class SafRestAuthenticationService implements SafIdtProvider {
             return Optional.empty();
         }
         catch (IRRPassTicketGenerationException e) {
-        throw new AuthenticationTokenException("Problem with generating PassTicket");
+            throw new AuthenticationTokenException("Problem with generating PassTicket");
         }
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.passticket.PassTicketService;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
 import java.util.Optional;
@@ -34,14 +35,16 @@ class SafRestAuthenticationServiceTest {
     private AuthenticationService authenticationService;
     private RestTemplate restTemplate;
 
+    private PassTicketService passTicketService;
     private final String VALID_USERNAME = "am456723";
 
     @BeforeEach
     void setUp() {
         authenticationService = mock(AuthenticationService.class);
         restTemplate = mock(RestTemplate.class);
+        passTicketService = mock(PassTicketService.class);
 
-        underTest = new SafRestAuthenticationService(restTemplate, authenticationService);
+        underTest = new SafRestAuthenticationService(restTemplate, authenticationService, passTicketService);
         underTest.authenticationUrl = "https://localhost:10013/zss/saf/generate";
         underTest.verifyUrl = "https://localhost:10013/zss/saf/verify";
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/saf/SafRestAuthenticationServiceTest.java
@@ -18,13 +18,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.gateway.security.service.AuthenticationService;
+import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
 import org.zowe.apiml.passticket.PassTicketService;
+import org.zowe.apiml.security.common.error.AuthenticationTokenException;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -113,6 +116,25 @@ class SafRestAuthenticationServiceTest {
 
                     Optional<String> token = underTest.generate(VALID_USERNAME);
                     assertThat(token.isPresent(), is(false));
+                }
+            }
+
+            @Nested
+            class ThrowException {
+                @Test
+                void givenInvalidPassticket() throws IRRPassTicketGenerationException {
+                    String validSafToken = "validSafToken";
+
+                    ResponseEntity<Object> response = mock(ResponseEntity.class);
+                    when(restTemplate.postForEntity(any(), any(), any())).thenReturn(response);
+                    when(response.getStatusCode()).thenReturn(HttpStatus.CREATED);
+                    SafRestAuthenticationService.Token responseBody = new SafRestAuthenticationService.Token();
+                    responseBody.setJwt(validSafToken);
+                    when(response.getBody()).thenReturn(responseBody);
+
+                    when(passTicketService.generate(any(), any())).thenThrow(new IRRPassTicketGenerationException(1, 2, 3));
+                    assertThrows(AuthenticationTokenException.class,
+                        () -> underTest.generate(VALID_USERNAME), "Exception is not AuthenticationTokenException");
                 }
             }
         }


### PR DESCRIPTION
# Description

This PR is part of https://github.com/zowe/zowe-install-packaging/pull/2416 to support the process of definying and scanning extensions for API ML.

* Since SAF authenticate endpoint also requires the password in the payload, the SAF IDT provider we have implemented will generate the password using Passticket and use it 
* Add props to the gateway `start.sh` to append extenders folder to the class path (the code is in https://github.com/zowe/zowe-install-packaging/pull/2416), the solution is described here https://github.com/zowe/zowe-install-packaging/issues/2405

Linked to #1630 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
