### PR TITLE
Feat: Enable hystrix metrics stream for core APIML services

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation libraries.spring_boot_starter_actuator
     implementation libraries.spring_boot_configuration_processor
     implementation libraries.spring_cloud_starter_eureka
+    implementation libraries.spring_cloud_starter_hystrix
+    implementation libraries.spring_cloud_hystrix_dashboard
     implementation libraries.spring_retry
     implementation libraries.swagger_core
     implementation libraries.swagger3_core

--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     implementation libraries.spring_boot_configuration_processor
     implementation libraries.spring_cloud_starter_eureka
     implementation libraries.spring_cloud_starter_hystrix
-    implementation libraries.spring_cloud_hystrix_dashboard
     implementation libraries.spring_retry
     implementation libraries.swagger_core
     implementation libraries.swagger3_core

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/ApiCatalogApplication.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/ApiCatalogApplication.java
@@ -13,8 +13,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration;
-import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -36,7 +34,6 @@ import org.zowe.apiml.product.version.BuildInfo;
 @EnableAsync
 @EnableApimlLogger
 @EnableCircuitBreaker
-@EnableHystrixDashboard
 public class ApiCatalogApplication {
 
     public static void main(String[] args) {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/ApiCatalogApplication.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/ApiCatalogApplication.java
@@ -11,8 +11,10 @@ package org.zowe.apiml.apicatalog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration;
+import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -21,7 +23,7 @@ import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
 import org.zowe.apiml.product.version.BuildInfo;
 
-@SpringBootApplication(exclude = HystrixAutoConfiguration.class)
+@SpringBootApplication
 @EnableEurekaClient
 @ComponentScan(value = {
     "org.zowe.apiml.apicatalog",
@@ -33,6 +35,8 @@ import org.zowe.apiml.product.version.BuildInfo;
 @EnableRetry
 @EnableAsync
 @EnableApimlLogger
+@EnableCircuitBreaker
+@EnableHystrixDashboard
 public class ApiCatalogApplication {
 
     public static void main(String[] args) {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.controllers.api;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
@@ -75,6 +76,7 @@ public class ApiCatalogController {
             @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
         }
     )
+    @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAllAPIContainers() throws ContainerStatusRetrievalThrowable {
         try {
             Iterable<APIContainer> allContainers = cachedProductFamilyService.getAllContainers();
@@ -104,6 +106,7 @@ public class ApiCatalogController {
             @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
         }
     )
+    @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAPIContainerById(@PathVariable(value = "id") String id) throws ContainerStatusRetrievalThrowable {
         try {
             List<APIContainer> apiContainers = new ArrayList<>();

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.controllers.api;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +64,7 @@ public class CatalogApiDocController {
         @ApiResponse(code = 404, message = "URI not found"),
         @ApiResponse(code = 500, message = "An unexpected condition occurred"),
     })
+    @HystrixCommand
     public ResponseEntity<String> getApiDocInfo(
         @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,
@@ -89,6 +91,7 @@ public class CatalogApiDocController {
         @ApiResponse(code = 404, message = "URI not found"),
         @ApiResponse(code = 500, message = "An unexpected condition occurred"),
     })
+    @HystrixCommand
     public ResponseEntity<String> getApiDiff(
         @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/NotFoundErrorController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/NotFoundErrorController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.controllers.handlers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -32,6 +33,7 @@ public class NotFoundErrorController implements ErrorController {
 
 
     @GetMapping(value = "/not_found")
+    @HystrixCommand
     public String handleError(HttpServletRequest request) {
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -59,6 +59,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 @EnableApimlAuth
 public class SecurityConfiguration {
+    private static final String HYSTRIX_STREAM_ROUTE = "/application/hystrix.stream";
     private static final String APIDOC_ROUTES = "/apidoc/**";
     private static final String STATIC_REFRESH_ROUTE = "/static-api/refresh";
 
@@ -164,7 +165,7 @@ public class SecurityConfiguration {
                 .antMatchers("/static-api/**").authenticated()
                 .antMatchers("/containers/**").authenticated()
                 .antMatchers(APIDOC_ROUTES).authenticated()
-                .antMatchers("/application/health", "/application/info").permitAll()
+                .antMatchers("/application/health", "/application/info", HYSTRIX_STREAM_ROUTE).permitAll()
                 .antMatchers("/application/**").authenticated();
             if (isAttlsEnabled) {
                 http.addFilterBefore(new SecureConnectionFilter(), BasicContentFilter.class);

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -59,7 +59,6 @@ import java.util.Set;
 @RequiredArgsConstructor
 @EnableApimlAuth
 public class SecurityConfiguration {
-    private static final String HYSTRIX_STREAM_ROUTE = "/application/hystrix.stream";
     private static final String APIDOC_ROUTES = "/apidoc/**";
     private static final String STATIC_REFRESH_ROUTE = "/static-api/refresh";
 
@@ -72,6 +71,9 @@ public class SecurityConfiguration {
     private final Set<String> publicKeyCertificatesBase64;
     @Value("${server.attls.enabled:false}")
     private boolean isAttlsEnabled;
+
+    @Value("${apiml.metrics.enabled:false}")
+    private boolean isMetricsEnabled;
 
     /**
      * Filter chain for protecting /apidoc/** endpoints with MF credentials for client certificate.
@@ -165,8 +167,15 @@ public class SecurityConfiguration {
                 .antMatchers("/static-api/**").authenticated()
                 .antMatchers("/containers/**").authenticated()
                 .antMatchers(APIDOC_ROUTES).authenticated()
-                .antMatchers("/application/health", "/application/info", HYSTRIX_STREAM_ROUTE).permitAll()
-                .antMatchers("/application/**").authenticated();
+                .antMatchers("/application/health", "/application/info").permitAll();
+
+            if (isMetricsEnabled) {
+                http.authorizeRequests().antMatchers("/application/hystrix.stream").permitAll();
+            }
+
+
+            http.authorizeRequests().antMatchers("/application/**").authenticated();
+
             if (isAttlsEnabled) {
                 http.addFilterBefore(new SecureConnectionFilter(), BasicContentFilter.class);
             }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIRefreshController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIRefreshController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.staticapi;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ public class StaticAPIRefreshController {
     private final StaticAPIService staticAPIService;
 
     @PostMapping(value = "/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<String> refreshStaticApis() {
         StaticAPIResponse staticAPIResponse = staticAPIService.refresh();
         return ResponseEntity

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticDefinitionController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticDefinitionController.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.apicatalog.staticapi;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,7 @@ public class StaticDefinitionController {
      * @return the response entity
      */
     @PostMapping(value = "/generate", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<String> generateStaticDef(@RequestBody String payload, @RequestHeader(value = "Service-Id") String serviceId) throws IOException {
         StaticAPIResponse staticAPIResponse = staticDefinitionGenerator.generateFile(payload, serviceId);
         return ResponseEntity
@@ -50,6 +52,7 @@ public class StaticDefinitionController {
      * @return the response entity
      */
     @PostMapping(value = "/override", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<String> overrideStaticDef(@RequestBody String payload, @RequestHeader(value = "Service-Id") String serviceId) throws IOException {
         StaticAPIResponse staticAPIResponse = staticDefinitionGenerator.overrideFile(payload, serviceId);
         return ResponseEntity
@@ -59,6 +62,7 @@ public class StaticDefinitionController {
 
 
     @DeleteMapping(value = "/delete", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<String> deleteStaticDef(@RequestHeader(value = "Service-Id") String serviceId) throws IOException {
         StaticAPIResponse staticAPIResponse = staticDefinitionGenerator.deleteFile(serviceId);
         return ResponseEntity.status(staticAPIResponse.getStatusCode()).body(staticAPIResponse.getBody());

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -165,11 +165,6 @@ management:
         health:
             showDetails: always
 
-hystrix:
-    dashboard:
-        proxy-stream-allow-list: '*'
-    command.default.execution.timeout.enabled: false
-
 logbackServiceName: ZWEAAC1
 ---
 spring:

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -157,13 +157,18 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info
+                include: health,info,hystrix.stream
     health:
         defaults:
             enabled: false
     endpoint:
         health:
             showDetails: always
+
+hystrix:
+    dashboard:
+        proxy-stream-allow-list: '*'
+    command.default.execution.timeout.enabled: false
 
 logbackServiceName: ZWEAAC1
 ---
@@ -175,7 +180,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info,loggers
+                include: health,info,loggers,hystrix.stream
 
 logging:
     level:

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation libraries.spring_boot_starter_actuator
     implementation libraries.spring_retry
     implementation libraries.spring_boot_starter_aop
+    implementation libraries.spring_cloud_starter_hystrix
     implementation libraries.lettuce
     implementation libraries.spring_security_web
     implementation libraries.spring_security_config

--- a/caching-service/src/main/java/org/zowe/apiml/caching/CachingService.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/CachingService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.context.ApplicationListener;
 import org.springframework.retry.annotation.EnableRetry;
 import org.zowe.apiml.enable.EnableApiDiscovery;
@@ -22,6 +23,7 @@ import org.zowe.apiml.product.service.ServiceStartupEventHandler;
 import javax.annotation.Nonnull;
 
 @SpringBootApplication
+@EnableCircuitBreaker
 @EnableApiDiscovery
 @EnableRetry
 @EnableApimlLogger

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -9,13 +9,18 @@
  */
 package org.zowe.apiml.caching.api;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.caching.model.KeyValue;
-import org.zowe.apiml.caching.service.*;
+import org.zowe.apiml.caching.service.Messages;
+import org.zowe.apiml.caching.service.Storage;
+import org.zowe.apiml.caching.service.StorageException;
 import org.zowe.apiml.message.core.Message;
 import org.zowe.apiml.message.core.MessageService;
 
@@ -34,6 +39,7 @@ public class CachingController {
     @ApiOperation(value = "Retrieves all values in the cache",
         notes = "Values returned for the calling service")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> getAllValues(HttpServletRequest request) {
         return getServiceId(request).<ResponseEntity<Object>>map(
             s -> {
@@ -50,6 +56,7 @@ public class CachingController {
     @ApiOperation(value = "Delete all values for service from the cache",
         notes = "Will delete all key-value pairs for specific service")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> deleteAllValues(HttpServletRequest request) {
         return getServiceId(request).map(
             s -> {
@@ -73,6 +80,7 @@ public class CachingController {
     @ApiOperation(value = "Retrieves a specific value in the cache",
         notes = "Value returned is for the provided {key}")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> getValue(@PathVariable String key, HttpServletRequest request) {
         return keyRequest(storage::read,
             key, request, HttpStatus.OK);
@@ -82,6 +90,7 @@ public class CachingController {
     @ApiOperation(value = "Delete key from the cache",
         notes = "Will delete key-value pair for the provided {key}")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> delete(@PathVariable String key, HttpServletRequest request) {
         return keyRequest(storage::delete,
             key, request, HttpStatus.NO_CONTENT);
@@ -91,6 +100,7 @@ public class CachingController {
     @ApiOperation(value = "Create a new key in the cache",
         notes = "A new key-value pair will be added to the cache")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> createKey(@RequestBody KeyValue keyValue, HttpServletRequest request) {
         return keyValueRequest(storage::create,
             keyValue, request, HttpStatus.CREATED);
@@ -100,6 +110,7 @@ public class CachingController {
     @ApiOperation(value = "Update key in the cache",
         notes = "Value at the key in the provided key-value pair will be updated to the provided value")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> update(@RequestBody KeyValue keyValue, HttpServletRequest request) {
         return keyValueRequest(storage::update,
             keyValue, request, HttpStatus.NO_CONTENT);

--- a/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
@@ -43,6 +43,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
         String[] noSecurityAntMatchers = {
             "/application/health",
             "/application/info",
+            "/application/hystrix.stream",
             "/v2/api-docs"
         };
         web.ignoring().antMatchers(noSecurityAntMatchers);
@@ -64,7 +65,6 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
         } else {
             http.authorizeRequests().anyRequest().permitAll();
         }
-
     }
 
     private UserDetailsService x509UserDetailsService() {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
@@ -38,15 +38,21 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${server.attls.enabled:false}")
     private boolean isAttlsEnabled;
 
+    @Value("${apiml.metrics.enabled:false}")
+    private boolean isMetricsEnabled;
+
     @Override
     public void configure(WebSecurity web) throws Exception {
         String[] noSecurityAntMatchers = {
             "/application/health",
             "/application/info",
-            "/application/hystrix.stream",
             "/v2/api-docs"
         };
         web.ignoring().antMatchers(noSecurityAntMatchers);
+
+        if (isMetricsEnabled) {
+            web.ignoring().antMatchers("/application/hystrix.stream");
+        }
     }
 
     @Override

--- a/caching-service/src/main/resources/application.yml
+++ b/caching-service/src/main/resources/application.yml
@@ -127,7 +127,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info
+                include: health,info,hystrix.stream
 
 ---
 spring:

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation libraries.spring_boot_starter_websocket
     implementation libraries.spring_boot_starter_security
     implementation libraries.spring_boot_starter_actuator
+    implementation libraries.spring_cloud_starter_hystrix
     implementation('org.springframework.cloud:spring-cloud-starter-netflix-eureka-server:2.2.9.RELEASE')  {
         exclude group: "javax.servlet", module: "servlet-api"
     }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/DiscoveryServiceApplication.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/DiscoveryServiceApplication.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.discovery;
 
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
 import org.zowe.apiml.product.service.ServiceStartupEventHandler;
@@ -24,7 +25,8 @@ import org.springframework.context.annotation.ComponentScan;
 import javax.annotation.Nonnull;
 
 @EnableEurekaServer
-@SpringBootApplication(exclude = HystrixAutoConfiguration.class)
+@SpringBootApplication
+@EnableCircuitBreaker
 @ComponentScan({
     "org.zowe.apiml.discovery",
     "org.zowe.apiml.product.security",

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/DiscoveryServiceApplication.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/DiscoveryServiceApplication.java
@@ -9,18 +9,17 @@
  */
 package org.zowe.apiml.discovery;
 
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.ComponentScan;
 import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
 import org.zowe.apiml.product.service.ServiceStartupEventHandler;
 import org.zowe.apiml.product.version.BuildInfo;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
-import org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.ComponentScan;
 
 import javax.annotation.Nonnull;
 

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListener.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListener.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.discovery;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.zowe.apiml.util.EurekaUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceCanceledEvent;
@@ -28,6 +29,7 @@ public class EurekaInstanceCanceledListener {
      * Translates service instance Eureka metadata from older versions to the current version
      */
     @EventListener
+    @HystrixCommand
     public void listen(EurekaInstanceCanceledEvent event) {
         gatewayNotifier.serviceCancelledRegistration(EurekaUtils.getServiceIdFromInstanceId(event.getServerId()));
     }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListener.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/EurekaInstanceRegisteredListener.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.discovery;
 
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceRegisteredEvent;
@@ -36,6 +37,7 @@ public class EurekaInstanceRegisteredListener {
      * Translates service instance Eureka metadata from older versions to the current version
      */
     @EventListener
+    @HystrixCommand
     public void listen(EurekaInstanceRegisteredEvent event) {
         final InstanceInfo instanceInfo = event.getInstanceInfo();
         final Map<String, String> metadata = instanceInfo.getMetadata();
@@ -56,6 +58,7 @@ public class EurekaInstanceRegisteredListener {
     }
 
     @EventListener
+    @HystrixCommand
     public void listen(EurekaStatusUpdateEvent event) {
         final String serviceId = EurekaUtils.getServiceIdFromInstanceId(event.getInstanceId());
         gatewayNotifier.serviceUpdated(serviceId, event.getInstanceId());

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
@@ -70,7 +70,7 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
             .httpBasic().realmName(DISCOVERY_REALM)
             .and()
             .authorizeRequests()
-            .antMatchers("/application/info", "/application/health").permitAll()
+            .antMatchers("/application/info", "/application/health", "/application/hystrix.stream").permitAll()
             .antMatchers("/**").authenticated();
     }
 

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
@@ -9,8 +9,6 @@
  */
 package org.zowe.apiml.discovery.config;
 
-import org.zowe.apiml.security.common.config.HandlerInitializer;
-import org.zowe.apiml.security.common.content.BasicContentFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,10 +21,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.zowe.apiml.security.common.config.HandlerInitializer;
+import org.zowe.apiml.security.common.content.BasicContentFilter;
 
 /**
  * Main class configuring Spring security for Discovery Service
- *
+ * <p>
  * This configuration is applied if "https" Spring profile is not active
  */
 @Configuration
@@ -35,7 +35,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 })
 @EnableWebSecurity
 @RequiredArgsConstructor
-@Profile({"!https","!attls"})
+@Profile({"!https", "!attls"})
 public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     private static final String DISCOVERY_REALM = "API Mediation Discovery Service realm";
 
@@ -45,10 +45,14 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     @Value("${apiml.discovery.password:password}")
     private String eurekaPassword;
 
+    @Value("${apiml.metrics.enabled:false}")
+    private boolean isMetricsEnabled;
+
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
         auth.inMemoryAuthentication().withUser(eurekaUserid).password("{noop}" + eurekaPassword).roles("EUREKA");
     }
+
     private final HandlerInitializer handlerInitializer;
 
     @Override
@@ -70,8 +74,12 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
             .httpBasic().realmName(DISCOVERY_REALM)
             .and()
             .authorizeRequests()
-            .antMatchers("/application/info", "/application/health", "/application/hystrix.stream").permitAll()
+            .antMatchers("/application/info", "/application/health").permitAll()
             .antMatchers("/**").authenticated();
+
+        if (isMetricsEnabled) {
+            http.authorizeRequests().antMatchers("/application/hystrix.stream").permitAll();
+        }
     }
 
     private BasicContentFilter basicFilter(AuthenticationManager authenticationManager) {

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -24,8 +24,8 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
-import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.filter.AttlsFilter;
+import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.security.client.EnableApimlAuth;
 import org.zowe.apiml.security.client.login.GatewayLoginProvider;
 import org.zowe.apiml.security.client.token.GatewayTokenProvider;
@@ -73,9 +73,9 @@ public class HttpsWebSecurityConfig {
         protected void configure(HttpSecurity http) throws Exception {
 
             baseConfigure(http.requestMatchers().antMatchers(
-                "/application/**",
-                "/*"
-            )
+                    "/application/**",
+                    "/*"
+                )
                 .and())
                 .addFilterBefore(basicFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(cookieFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
@@ -102,6 +102,8 @@ public class HttpsWebSecurityConfig {
         @Value("${apiml.security.ssl.nonStrictVerifySslCertificatesOfServices:false}")
         private boolean nonStrictVerifySslCertificatesOfServices;
 
+        @Value("${apiml.metrics.enabled:false}")
+        private boolean isMetricsEnabled;
 
         @Override
         public void configure(WebSecurity web) {
@@ -112,10 +114,13 @@ public class HttpsWebSecurityConfig {
                 "/eureka/images/**",
                 "/application/health",
                 "/application/info",
-                "/application/hystrix.stream",
                 "/favicon.ico"
             };
             web.ignoring().antMatchers(noSecurityAntMatchers);
+
+            if (isMetricsEnabled) {
+                web.ignoring().antMatchers("/application/hystrix.stream");
+            }
         }
 
         @Override

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -112,6 +112,7 @@ public class HttpsWebSecurityConfig {
                 "/eureka/images/**",
                 "/application/health",
                 "/application/info",
+                "/application/hystrix.stream",
                 "/favicon.ico"
             };
             web.ignoring().antMatchers(noSecurityAntMatchers);

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticApiRestController.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticApiRestController.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.discovery.staticdef;
 
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,11 +30,13 @@ public class StaticApiRestController {
     }
 
     @GetMapping
+    @HystrixCommand
     public List<InstanceInfo> list() {
         return registrationService.getStaticInstances();
     }
 
     @PostMapping
+    @HystrixCommand
     public StaticRegistrationResult reload() {
         return registrationService.reloadServices();
     }

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -80,7 +80,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info,shutdown
+                include: health,info,shutdown,hystrix.stream
     health:
         defaults:
             enabled: false
@@ -135,7 +135,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info,loggers,shutdown
+                include: health,info,loggers,shutdown,hystrix.stream
     endpoint:
         shutdown:
             enabled: true

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation libraries.spring_boot_starter_thymeleaf
     implementation libraries.spring_boot_starter_cache
     implementation libraries.spring_boot_starter_aop
+    implementation libraries.spring_cloud_starter_hystrix
     implementation libraries.spring_security_web
     implementation libraries.spring_security_config
     implementation libraries.spring_security_core
@@ -115,7 +116,7 @@ dependencies {
     implementation libraries.netty_transport_rxtx
     implementation libraries.netty_transport_sctp
     implementation libraries.netty_transport_udt
-   
+
     implementation libraries.commons_io
     implementation libraries.guava
     implementation libraries.spring_aop

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway;
 
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.zowe.apiml.gateway.ribbon.GatewayRibbonConfig;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
@@ -31,7 +32,8 @@ import javax.annotation.Nonnull;
 
 @EnableZuulProxy
 @EnableWebSecurity
-@SpringBootApplication(exclude = HystrixAutoConfiguration.class)
+@SpringBootApplication
+@EnableCircuitBreaker
 @ComponentScan(
     value = {
         "org.zowe.apiml.gateway",

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
@@ -9,24 +9,23 @@
  */
 package org.zowe.apiml.gateway;
 
-import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.zowe.apiml.gateway.ribbon.GatewayRibbonConfig;
-import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
-import org.zowe.apiml.product.service.ServiceStartupEventHandler;
-import org.zowe.apiml.product.version.BuildInfo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.zowe.apiml.gateway.ribbon.GatewayRibbonConfig;
+import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
+import org.zowe.apiml.product.service.ServiceStartupEventHandler;
+import org.zowe.apiml.product.version.BuildInfo;
 
 import javax.annotation.Nonnull;
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/apidoc/reader/ApiDocController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/apidoc/reader/ApiDocController.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.apidoc.reader;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +27,7 @@ public class ApiDocController {
     private final ApiDocReader apiDocReader;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public String getApiDoc() {
         return apiDocReader.load(API_DOC_LOCATION);
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -59,6 +60,7 @@ public class AuthController {
     public static final String CURRENT_PUBLIC_KEYS_PATH = PUBLIC_KEYS_PATH + "/current";
 
     @DeleteMapping(path = INVALIDATE_PATH)
+    @HystrixCommand
     public void invalidateJwtToken(HttpServletRequest request, HttpServletResponse response) {
         final String endpoint = "/auth/invalidate/";
         final String uri = request.getRequestURI();
@@ -76,6 +78,7 @@ public class AuthController {
     }
 
     @GetMapping(path = DISTRIBUTE_PATH)
+    @HystrixCommand
     public void distributeInvalidate(HttpServletRequest request, HttpServletResponse response) {
         final String endpoint = "/auth/distribute/";
         final String uri = request.getRequestURI();
@@ -94,6 +97,7 @@ public class AuthController {
      */
     @GetMapping(path = ALL_PUBLIC_KEYS_PATH)
     @ResponseBody
+    @HystrixCommand
     public JSONObject getAllPublicKeys() {
         final List<JWK> keys = new LinkedList<>(zosmfService.getPublicKeys().getKeys());
         Optional<JWK> key = jwtSecurity.getJwkPublicKey();
@@ -108,6 +112,7 @@ public class AuthController {
      */
     @GetMapping(path = CURRENT_PUBLIC_KEYS_PATH)
     @ResponseBody
+    @HystrixCommand
     public JSONObject getCurrentPublicKeys() {
         final List<JWK> keys = new LinkedList<>(zosmfService.getPublicKeys().getKeys());
 
@@ -128,6 +133,7 @@ public class AuthController {
      */
     @GetMapping(path = PUBLIC_KEYS_PATH)
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<?> getPublicKeyUsedForSigning() {
         JwtSecurity.JwtProducer producer = jwtSecurity.actualJwtProducer();
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthProviderController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/AuthProviderController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.context.annotation.Profile;
@@ -31,6 +32,7 @@ public class AuthProviderController {
 
     @PostMapping()
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<Object> updateAuthProviderConfig(@RequestBody AuthProvider provider) {
         compoundAuthProvider.setLoginAuthProvider(provider.getProvider());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/CacheServiceController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/CacheServiceController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,12 +36,14 @@ public class CacheServiceController {
     private final ApimlDiscoveryClient discoveryClient;
 
     @DeleteMapping(path = "")
+    @HystrixCommand
     public void evictAll() {
         toEvict.forEach(ServiceCacheEvict::evictCacheAllService);
         discoveryClient.fetchRegistry();
     }
 
     @DeleteMapping(path = "/{serviceId}")
+    @HystrixCommand
     public void evict(@PathVariable("serviceId") String serviceId) {
         toEvict.forEach(s -> s.evictCacheService(serviceId));
         discoveryClient.fetchRegistry();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.ServiceInstance;
@@ -77,6 +78,7 @@ public class GatewayHomepageController {
     }
 
     @GetMapping("/")
+    @HystrixCommand
     public String home(Model model) {
         initializeCatalogAttributes(model);
         initializeMetricsAttributes(model);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/SafResourceAccessController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/SafResourceAccessController.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.*;
 import org.springframework.http.*;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -35,6 +36,7 @@ public class SafResourceAccessController {
     public static final String FULL_CONTEXT_PATH = "/gateway/auth/check";
 
     @PostMapping(path = CONTEXT_PATH, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<ApiMessageView> hasSafAccess(@RequestBody CheckRequestModel request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/VersionController.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.controllers;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -31,6 +32,7 @@ public class VersionController {
     private VersionService versionService;
 
     @GetMapping(value = "/version", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<VersionInfo> getVersion() {
         return new ResponseEntity<>(versionService.getVersion(), HttpStatus.OK);
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/error/NotFoundErrorController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/error/NotFoundErrorController.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.gateway.error;
 
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.zowe.apiml.message.api.ApiMessageView;
 import org.zowe.apiml.message.core.Message;
 import org.zowe.apiml.message.core.MessageService;
@@ -48,6 +49,7 @@ public class NotFoundErrorController implements ErrorController {
      */
     @GetMapping(value = NOT_FOUND_ENDPOINT, produces = "application/json")
     @ResponseBody
+    @HystrixCommand
     public ResponseEntity<ApiMessageView> notFound400HttpResponse(HttpServletRequest request) {
         Message message = messageService.createMessage("org.zowe.apiml.common.endPointNotFound",
             ErrorUtils.getGatewayUri(request));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -478,7 +478,7 @@ public class NewSecurityConfiguration {
         // There is no CORS filter on these endpoints. If you require CORS processing, use a defined filter chain
         web.ignoring()
             .antMatchers(InternalServerErrorController.ERROR_ENDPOINT, "/error",
-                "/application/health", "/application/info", "/application/version",
+                "/application/health", "/application/info", "/application/version", "/application/hystrix.stream",
                 AuthController.CONTROLLER_PATH + AuthController.ALL_PUBLIC_KEYS_PATH,
                 AuthController.CONTROLLER_PATH + AuthController.CURRENT_PUBLIC_KEYS_PATH);
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.gateway.services;
 
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,6 +32,7 @@ public class ServicesInfoController {
     private final ServicesInfoService servicesInfoService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<List<ServiceInfo>> getServices(@RequestParam(required = false) String apiId) {
         List<ServiceInfo> services = servicesInfoService.getServicesInfo(apiId);
         HttpStatus status = (services.isEmpty()) ? HttpStatus.NOT_FOUND : HttpStatus.OK;
@@ -42,6 +44,7 @@ public class ServicesInfoController {
     }
 
     @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @HystrixCommand
     public ResponseEntity<ServiceInfo> getService(@PathVariable String serviceId) {
         ServiceInfo serviceInfo = servicesInfoService.getServiceInfo(serviceId);
         HttpStatus status = (serviceInfo.getStatus() == InstanceInfo.InstanceStatus.UNKNOWN) ?

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -182,7 +182,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info,shutdown
+                include: health,info,shutdown,hystrix.stream
     health:
         defaults:
             enabled: false
@@ -244,7 +244,7 @@ management:
         web:
             base-path: /application
             exposure:
-                include: health,info,routes,loggers,shutdown
+                include: health,info,routes,loggers,shutdown,hystrix.stream
     endpoint:
         shutdown:
             enabled: true

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -118,12 +118,13 @@ management:
 
 turbine:
     aggregator:
-        clusterConfig: DISCOVERABLECLIENT,APICATALOG,CACHINGSERVICE # uppercase serviceId
+        clusterConfig: DISCOVERABLECLIENT,APICATALOG,CACHINGSERVICE,GATEWAY # uppercase serviceId
     instanceUrlSuffix:
         DISCOVERABLECLIENT: /discoverableclient/application/hystrix.stream
         APICATALOG: /apicatalog/application/hystrix.stream
         CACHINGSERVICE: /cachingservice/application/hystrix.stream
-    appConfig: discoverableclient,apicatalog,cachingservice # lowercase serviceId
+        GATEWAY: /application/hystrix.stream
+    appConfig: discoverableclient,apicatalog,cachingservice,gateway # lowercase serviceId
 
 ---
 spring:

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -118,11 +118,12 @@ management:
 
 turbine:
     aggregator:
-        clusterConfig: DISCOVERABLECLIENT,APICATALOG # uppercase serviceId
+        clusterConfig: DISCOVERABLECLIENT,APICATALOG,CACHINGSERVICE # uppercase serviceId
     instanceUrlSuffix:
         DISCOVERABLECLIENT: /discoverableclient/application/hystrix.stream
         APICATALOG: /apicatalog/application/hystrix.stream
-    appConfig: discoverableclient,apicatalog
+        CACHINGSERVICE: /cachingservice/application/hystrix.stream
+    appConfig: discoverableclient,apicatalog,cachingservice # lowercase serviceId
 
 ---
 spring:

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -118,13 +118,14 @@ management:
 
 turbine:
     aggregator:
-        clusterConfig: DISCOVERABLECLIENT,APICATALOG,CACHINGSERVICE,GATEWAY # uppercase serviceId
+        clusterConfig: DISCOVERABLECLIENT,APICATALOG,CACHINGSERVICE,GATEWAY,DISCOVERY # uppercase serviceId
     instanceUrlSuffix:
         DISCOVERABLECLIENT: /discoverableclient/application/hystrix.stream
         APICATALOG: /apicatalog/application/hystrix.stream
         CACHINGSERVICE: /cachingservice/application/hystrix.stream
         GATEWAY: /application/hystrix.stream
-    appConfig: discoverableclient,apicatalog,cachingservice,gateway # lowercase serviceId
+        DISCOVERY: /application/hystrix.stream
+    appConfig: discoverableclient,apicatalog,cachingservice,gateway,discovery # lowercase serviceId
 
 ---
 spring:


### PR DESCRIPTION
# Description

Enables a hystrix metrics for the Gateway, API Catalog, Discovery, and Caching services, at `/application/hystrix.stream`. The flag `apiml.metrics.enabled` must be set to `true` for these endpoints to be accessible without authentication (for preview of metrics service), otherwise these endpoints are protected with standard authentication.

Linked to #1858 

## Type of change

Please delete options that are not relevant.

- [x] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
