### PR TITLE
chore: Configure the timeout for JWT token in mock zOSMF

### DIFF
--- a/config/local/mock-zosmf.yml
+++ b/config/local/mock-zosmf.yml
@@ -1,0 +1,2 @@
+zosmf:
+    timeout: 1800

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/AuthenticateApar.java
@@ -11,14 +11,15 @@ package org.zowe.apiml.client.services.apars;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
 public class AuthenticateApar extends FunctionalApar {
-    public AuthenticateApar(List<String> usernames, List<String> passwords) {
-        super(usernames, passwords);
+    public AuthenticateApar(List<String> usernames, List<String> passwords, Integer timeout) {
+        super(usernames, passwords, new JwtTokenService(timeout));
     }
 
     @Override

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -31,11 +31,16 @@ public class FunctionalApar implements Apar {
 
     private final List<String> usernames;
     private final List<String> passwords;
-    private final JwtTokenService jwtTokenService = new JwtTokenService(60);
+    private JwtTokenService jwtTokenService;
 
     protected FunctionalApar(List<String> usernames, List<String> passwords) {
+        this(usernames, passwords, new JwtTokenService(60));
+    }
+
+    protected FunctionalApar(List<String> usernames, List<String> passwords, JwtTokenService tokenService) {
         this.usernames = usernames;
         this.passwords = passwords;
+        this.jwtTokenService = tokenService;
     }
 
     @Override

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH12143.java
@@ -11,6 +11,7 @@ package org.zowe.apiml.client.services.apars;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -20,8 +21,8 @@ import java.util.Map;
 public class PH12143 extends FunctionalApar {
     private final String keystorePath;
 
-    public PH12143(List<String> usernames, List<String> passwords, String keystorePath) {
-        super(usernames, passwords);
+    public PH12143(List<String> usernames, List<String> passwords, String keystorePath, Integer timeout) {
+        super(usernames, passwords, new JwtTokenService(timeout));
         this.keystorePath = keystorePath;
     }
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/PH34201.java
@@ -11,6 +11,7 @@ package org.zowe.apiml.client.services.apars;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -19,8 +20,8 @@ import java.util.Map;
 public class PH34201 extends FunctionalApar {
     private final String keystorePath;
 
-    public PH34201(List<String> usernames, List<String> passwords, String keystorePath) {
-        super(usernames, passwords);
+    public PH34201(List<String> usernames, List<String> passwords, String keystorePath, Integer timeout) {
+        super(usernames, passwords, new JwtTokenService(timeout));
         this.keystorePath = keystorePath;
     }
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/RSU2012.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/apars/RSU2012.java
@@ -11,6 +11,7 @@ package org.zowe.apiml.client.services.apars;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -20,8 +21,8 @@ import java.util.Map;
 public class RSU2012 extends FunctionalApar {
     private final String keystorePath;
 
-    public RSU2012(List<String> usernames, List<String> passwords, String keystorePath) {
-        super(usernames, passwords);
+    public RSU2012(List<String> usernames, List<String> passwords, String keystorePath, Integer timeout) {
+        super(usernames, passwords, new JwtTokenService(timeout));
         this.keystorePath = keystorePath;
     }
 

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
@@ -19,15 +19,15 @@ import java.util.Map;
 public class AvailableApars {
     private final Map<String, Apar> implementedApars = new HashMap<>();
 
-    public AvailableApars(List<String> usernames, List<String> passwords, String jwtKeystorePath) {
-        implementedApars.put("PH12143", new PH12143(usernames, passwords, jwtKeystorePath));
+    public AvailableApars(List<String> usernames, List<String> passwords, String jwtKeystorePath, Integer timeout) {
+        implementedApars.put("PH12143", new PH12143(usernames, passwords, jwtKeystorePath, timeout));
         implementedApars.put("PH17867", new NoApar());
         implementedApars.put("PH28507", new NoApar());
         implementedApars.put("PH28532", new NoApar());
-        implementedApars.put("PH34201", new PH34201(usernames, passwords, jwtKeystorePath));
-        implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath));
+        implementedApars.put("PH34201", new PH34201(usernames, passwords, jwtKeystorePath, timeout));
+        implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath, timeout));
         implementedApars.put("JwtKeys", new JwtKeys(usernames, passwords));
-        implementedApars.put("AuthenticateApar", new AuthenticateApar(usernames, passwords));
+        implementedApars.put("AuthenticateApar", new AuthenticateApar(usernames, passwords, timeout));
     }
 
     public List<Apar> getApars(List<String> names) {

--- a/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/Versions.java
+++ b/mock-zosmf/src/main/java/org/zowe/apiml/client/services/versions/Versions.java
@@ -30,8 +30,8 @@ public class Versions {
 
     @Autowired
     public Versions(@Value("${zosmf.username}") List<String> usernames, @Value("${zosmf.password}") List<String> passwords,
-                    @Value("${zosmf.jwtKeyStorePath}") String jwtKeyStorePath) {
-        this.availableApars = new AvailableApars(usernames, passwords, jwtKeyStorePath);
+                    @Value("${zosmf.jwtKeyStorePath}") String jwtKeyStorePath, @Value("${zosmf.timeout}") Integer timeout) {
+        this.availableApars = new AvailableApars(usernames, passwords, jwtKeyStorePath, timeout);
 
         ArrayList<Apar> baseApars = new ArrayList<>();
         baseApars.add(new PHBase(usernames, passwords));

--- a/mock-zosmf/src/main/resources/application.yml
+++ b/mock-zosmf/src/main/resources/application.yml
@@ -35,6 +35,7 @@ zosmf:
     baseVersion: 2.4
     appliedApars: PH12143
     jwtKeyStorePath: keystore/localhost/localhost.keystore.p12
+    timeout: 60
 
 
 ---

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/AuthenticationAparTest.java
@@ -36,7 +36,7 @@ class AuthenticationAparTest {
         List<String> usernames = Collections.singletonList("USER");
         List<String> passwords = Collections.singletonList("validPassword");
 
-        underTest = new AuthenticateApar(usernames, passwords);
+        underTest = new AuthenticateApar(usernames, passwords, 60);
         headers = new HashMap<>();
         mockResponse = mock(HttpServletResponse.class);
     }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH12143Test.java
@@ -41,7 +41,7 @@ class PH12143Test {
         List<String> usernames = Collections.singletonList(USERNAME);
         List<String> passwords = Collections.singletonList(PASSWORD);
 
-        underTest = new PH12143(usernames, passwords, "../keystore/localhost/localhost.keystore.p12");
+        underTest = new PH12143(usernames, passwords, "../keystore/localhost/localhost.keystore.p12", 60);
         mockResponse = mock(HttpServletResponse.class);
         headers = new HashMap<>();
     }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH34201Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/PH34201Test.java
@@ -41,7 +41,7 @@ class PH34201Test {
         List<String> usernames = Collections.singletonList(USERNAME);
         List<String> passwords = Collections.singletonList(PASSWORD);
 
-        underTest = new PH34201(usernames, passwords, "../keystore/localhost/localhost.keystore.p12");
+        underTest = new PH34201(usernames, passwords, "../keystore/localhost/localhost.keystore.p12", 60);
         mockResponse = mock(HttpServletResponse.class);
         headers = new HashMap<>();
     }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/RSU2012Test.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/apars/RSU2012Test.java
@@ -41,7 +41,7 @@ class RSU2012Test {
         List<String> usernames = Collections.singletonList(USERNAME);
         List<String> passwords = Collections.singletonList(PASSWORD);
 
-        underTest = new RSU2012(usernames, passwords, "../keystore/localhost/localhost.keystore.p12");
+        underTest = new RSU2012(usernames, passwords, "../keystore/localhost/localhost.keystore.p12", 60);
         mockResponse = mock(HttpServletResponse.class);
         headers = new HashMap<>();
     }

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/AvailableAparsTest.java
@@ -24,7 +24,7 @@ class AvailableAparsTest {
 
     @BeforeEach
     void setUp() {
-        underTest = new AvailableApars(Collections.singletonList("USER"), Collections.singletonList("validPassword"), "keystore/localhost/localhost.keystore.p12");
+        underTest = new AvailableApars(Collections.singletonList("USER"), Collections.singletonList("validPassword"), "keystore/localhost/localhost.keystore.p12", 60);
     }
 
     @Test

--- a/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/VersionsTest.java
+++ b/mock-zosmf/src/test/java/org/zowe/apiml/client/services/versions/VersionsTest.java
@@ -30,7 +30,7 @@ class VersionsTest {
 
     @BeforeEach
     void setUp() {
-        underTest = new Versions(USERNAMES, PASSWORDS, "keystore/localhost/localhost.keystore.p12");
+        underTest = new Versions(USERNAMES, PASSWORDS, "keystore/localhost/localhost.keystore.p12", 60);
     }
 
     @ParameterizedTest

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "api-catalog-service-1": "java -jar api-catalog-services/build/libs/api-catalog-services.jar --spring.config.additional-location=file:./config/local-multi/api-catalog-service-1.yml",
         "api-catalog-service-2": "java -jar api-catalog-services/build/libs/api-catalog-services.jar --spring.config.additional-location=file:./config/local-multi/api-catalog-service-2.yml",
         "discoverable-client-1": "java -jar discoverable-client/build/libs/discoverable-client.jar --spring.config.additional-location=file:./config/local-multi/discoverable-client.yml",
-        "mock-zosmf": "java -jar mock-zosmf/build/libs/mock-zosmf.jar",
+        "mock-zosmf": "java -jar mock-zosmf/build/libs/mock-zosmf.jar --spring.config.additional-location=file:./config/local/mock-zosmf.yml",
         "mock-zosmf-1": "java -jar mock-zosmf/build/libs/mock-zosmf.jar --spring.config.additional-location=file:./config/local-multi/mock-zosmf.yml",
         "test": "./gradlew runAllIntegrationTests",
         "test:local": "./gradlew runLocalIntegrationTests",


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.net>

# Description

There was a change in the creation and verification of the token in the mock zOSMF, this makes the property configurable with 10-minute default for a local run. 

Linked to #1883 

## Type of change

- [x] (chore) Chore, repository cleanup, updates the dependencies.
