### PR TITLE
fix: Remove duplicated hystrix streams in Metrics Service dashboard

### DIFF
--- a/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
+++ b/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
@@ -79,7 +79,6 @@ function addStreams(proxyStream, title) {
         // CHANGE: add filter for adding listener so listener is only added for streams that match the selected stream to display
         source.addEventListener('message', (m) => {
             if (m.currentTarget && m.currentTarget.url && m.currentTarget.url.endsWith(urlVars.title)) {
-                console.log('Adding ' + m.currentTarget.url + ' with title ' + urlVars.title);
                 hystrixMonitor.eventSourceMessageListener(m);
             }
         }, false);
@@ -90,10 +89,6 @@ function addStreams(proxyStream, title) {
         }, false);
         // END OF CHANGE
 
-        //	source.addEventListener('open', function(e) {
-        //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-        //		// Connection was opened.
-        //	}, false);
         source.addEventListener('error', function(e) {
             $("#" + dependenciesId + " .loading").html("Unable to connect to Command Metric Stream.");
             $("#" + dependenciesId + " .loading").addClass("failed");
@@ -111,8 +106,6 @@ function addStreams(proxyStream, title) {
 
 function addMonitors() {
     $("#content").html(_.reduce(hystrixStreams, function(html, s, i) {
-        console.log('hystrix streams');
-        console.log(hystrixStreams);
         var hystrixMonitor = 'hystrixStreams[' + i + '].hystrixMonitor';
         var dependencyThreadPoolMonitor = 'hystrixStreams[' + i + '].dependencyThreadPoolMonitor';
         var dependenciesId = 'dependencies_' + i;

--- a/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
+++ b/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
@@ -76,14 +76,24 @@ function addStreams(proxyStream, title) {
         var source = new EventSource(proxyStream);
 
         // add the listener that will process incoming events
-        source.addEventListener('message', hystrixMonitor.eventSourceMessageListener, false);
-        source.addEventListener('message', dependencyThreadPoolMonitor.eventSourceMessageListener, false);
+        // CHANGE: add filter for adding listener so listener is only added for streams that match the selected stream to display
+        source.addEventListener('message', (m) => {
+            if (m.currentTarget && m.currentTarget.url && m.currentTarget.url.endsWith(urlVars.title)) {
+                console.log('Adding ' + m.currentTarget.url + ' with title ' + urlVars.title);
+                hystrixMonitor.eventSourceMessageListener(m);
+            }
+        }, false);
+        source.addEventListener('message', (m) => {
+            if (m.currentTarget && m.currentTarget.url && m.currentTarget.url.endsWith(urlVars.title)) {
+                dependencyThreadPoolMonitor.eventSourceMessageListener(m);
+            }
+        }, false);
+        // END OF CHANGE
 
         //	source.addEventListener('open', function(e) {
         //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
         //		// Connection was opened.
         //	}, false);
-
         source.addEventListener('error', function(e) {
             $("#" + dependenciesId + " .loading").html("Unable to connect to Command Metric Stream.");
             $("#" + dependenciesId + " .loading").addClass("failed");
@@ -101,6 +111,8 @@ function addStreams(proxyStream, title) {
 
 function addMonitors() {
     $("#content").html(_.reduce(hystrixStreams, function(html, s, i) {
+        console.log('hystrix streams');
+        console.log(hystrixStreams);
         var hystrixMonitor = 'hystrixStreams[' + i + '].hystrixMonitor';
         var dependencyThreadPoolMonitor = 'hystrixStreams[' + i + '].dependencyThreadPoolMonitor';
         var dependenciesId = 'dependencies_' + i;


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Add a check such that only the hystrix streams that match the selected one to display are added in the hystrix dashboard UI.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
