### PR TITLE
Fix: Release Metrics Service connection when change stream

### DIFF
--- a/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
+++ b/metrics-service-ui/frontend/public/hystrix-dashboard/monitor/monitor.js
@@ -20,6 +20,8 @@ function getUrlVars() {
 }
 
 var hystrixStreams = [];
+// CHANGE: make source a global variable so it can be closed when set a new stream
+var source = null; // EventSource that holds SSE connection
 
 function addStreams(proxyStream, title) {
     // CHANGE: rely on function parameters instead of parsing window.location.href
@@ -72,8 +74,13 @@ function addStreams(proxyStream, title) {
 
         // CHANGE: removed proxyStream variable declaration in favour of function parameter
 
+        // CHANGE: make source a global variable so it can be closed when set a new stream
+        if (source !== null ) {
+            source.close();
+        }
         // start the EventSource which will open a streaming connection to the server
-        var source = new EventSource(proxyStream);
+        source = new EventSource(proxyStream);
+        // END OF CHANGE
 
         // add the listener that will process incoming events
         // CHANGE: add filter for adding listener so listener is only added for streams that match the selected stream to display


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

When stream is changed in Metrics Service release connection to previous stream. This stops leaky connections that fill connection pools and memory.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
