### PR TITLE
Fix: Swagger server url transform

### DIFF
--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -77,7 +77,7 @@ export default class SwaggerUI extends Component {
         try {
             // If no version selected use the default apiDoc
             if (
-                selectedVersion === null &&
+                (selectedVersion === null || selectedVersion === undefined) &&
                 selectedService.apiDoc !== null &&
                 selectedService.apiDoc !== undefined &&
                 selectedService.apiDoc.length !== 0
@@ -91,7 +91,7 @@ export default class SwaggerUI extends Component {
                     plugins: [this.customPlugins],
                 });
             }
-            if (selectedVersion !== null) {
+            if (selectedVersion !== null && selectedVersion !== undefined) {
                 const url = `${process.env.REACT_APP_GATEWAY_URL +
                     process.env.REACT_APP_CATALOG_HOME +
                     process.env.REACT_APP_APIDOC_UPDATE}/${selectedService.serviceId}/${selectedVersion}`;

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.jsx
@@ -9,8 +9,14 @@ function transformSwaggerToCurrentHost(swagger) {
 
     if (swagger.servers !== null && swagger.servers !== undefined) {
         for (let i = 0; i < swagger.servers.length; i += 1) {
-            const url = `${window.location.protocol}//${window.location.host}/${swagger.servers[i].url}`;
-            swagger.servers[i].url = url;
+            const location = `${window.location.protocol}//${window.location.host}`;
+            try {
+                const swaggerUrl = new URL(swagger.servers[i].url);
+                swagger.servers[i].url = location + swaggerUrl.pathname;
+            } catch (e) {
+                // not a proper url, assume it is an endpoint
+                swagger.servers[i].url = location + swagger.servers[i];
+            }
         }
     }
 

--- a/api-catalog-ui/frontend/src/components/Swagger/Swagger.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/Swagger.test.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 import { shallow } from 'enzyme';
 import SwaggerUI from './Swagger';
+import { act } from "react-dom/test-utils";
+import { render } from 'react-dom';
 
 describe('>>> Swagger component tests', () => {
     it('should not render swagger if apiDoc is null', () => {
@@ -16,11 +18,37 @@ describe('>>> Swagger component tests', () => {
         };
         const wrapper = shallow(
             <div>
-                <SwaggerUI service={service} />
+                <SwaggerUI selectedService={service} />
             </div>
         );
         const swaggerDiv = wrapper.find('#swaggerContainer');
 
         expect(swaggerDiv.length).toEqual(0);
+    });
+
+    it('should transform swagger server url', async () => {
+        const endpoint = '/enabler/api/v1';
+        const service = {
+            serviceId: 'testservice',
+            title: 'Spring Boot Enabler Service',
+            description: 'Dummy Service for enabling others',
+            status: 'UP',
+            secured: false,
+            homePageUrl: 'http://localhost:10013/enabler/',
+            basePath: '/enabler/api/v1',
+            apiDoc: JSON.stringify({
+                openapi: "3.0.0",
+                servers: [{url: 'https://bad.com' + endpoint}],
+            }),
+            apiId: {
+                default: 'enabler'
+            }
+        };
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        await act(async () => render(<SwaggerUI selectedService={service}/>, container));
+        expect(container.textContent).toContain('Servershttp://localhost' + endpoint);
     });
 });


### PR DESCRIPTION
# Description

Fixes the transformation for swagger server URLs to be the location of the current browser location.

Linked to #1882 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
