### PR TITLE
fix: specify jgit dependency for gradle plugin

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/metrics-service/build.gradle
+++ b/metrics-service/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 

--- a/mock-zosmf/build.gradle
+++ b/mock-zosmf/build.gradle
@@ -3,6 +3,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:${gradleGitPropertiesVersion}")
+        classpath ("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r") {
+            force = true
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

The new version of jgit(v6) is not compatible with Java 8. It is a transitive dependency in gradle-git-properties plugin. This PR will lock jgit on version 5.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
