### PR TITLE
fix: choose correct key by alias

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -184,14 +184,17 @@ public class HttpsFactory {
         }
         log.info("Loading key store file: " + config.getKeyStore());
         File keyStoreFile = new File(config.getKeyStore());
-        sslContextBuilder.loadKeyMaterial(keyStoreFile, config.getKeyStorePassword(), config.getKeyPassword());
+        sslContextBuilder.loadKeyMaterial(
+            keyStoreFile, config.getKeyStorePassword(), config.getKeyPassword(),
+            (aliases, socket) -> config.getKeyAlias()
+        );
     }
 
     private void loadKeyringMaterial(SSLContextBuilder sslContextBuilder) throws UnrecoverableKeyException,
         NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
         log.info("Loading trust key ring: " + config.getKeyStore());
         sslContextBuilder.loadKeyMaterial(keyRingUrl(config.getKeyStore()), config.getKeyStorePassword(),
-            config.getKeyPassword(), null);
+            config.getKeyPassword(), (aliases, socket) -> config.getKeyAlias());
     }
 
     private synchronized SSLContext createSecureSslContext() {

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -23,6 +23,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.zowe.apiml.message.log.ApimlLogger;
@@ -186,15 +187,19 @@ public class HttpsFactory {
         File keyStoreFile = new File(config.getKeyStore());
         sslContextBuilder.loadKeyMaterial(
             keyStoreFile, config.getKeyStorePassword(), config.getKeyPassword(),
-            (aliases, socket) -> config.getKeyAlias()
+            getPrivateKeyStrategy()
         );
+    }
+
+    private PrivateKeyStrategy getPrivateKeyStrategy() {
+        return config.getKeyAlias() != null ? (aliases, socket) -> config.getKeyAlias() : null;
     }
 
     private void loadKeyringMaterial(SSLContextBuilder sslContextBuilder) throws UnrecoverableKeyException,
         NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
         log.info("Loading trust key ring: " + config.getKeyStore());
         sslContextBuilder.loadKeyMaterial(keyRingUrl(config.getKeyStore()), config.getKeyStorePassword(),
-            config.getKeyPassword(), (aliases, socket) -> config.getKeyAlias());
+            config.getKeyPassword(), getPrivateKeyStrategy());
     }
 
     private synchronized SSLContext createSecureSslContext() {

--- a/common-service-core/src/test/java/org/zowe/apiml/security/SecurityTestUtils.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/SecurityTestUtils.java
@@ -29,7 +29,7 @@ public class SecurityTestUtils {
     public static HttpsConfig.HttpsConfigBuilder correctHttpsKeyStoreSettings() {
         return HttpsConfig.builder().protocol("TLSv1.2")
             .keyStore(SecurityTestUtils.pathFromRepository("keystore/localhost/localhost.keystore.p12"))
-            .keyStorePassword(STORE_PASSWORD).keyPassword(STORE_PASSWORD).keyAlias("localhost");
+            .keyStorePassword(STORE_PASSWORD).keyPassword(STORE_PASSWORD);
     }
 
     public static String pathFromRepository(String path) {

--- a/common-service-core/src/test/java/org/zowe/apiml/security/SecurityTestUtils.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/SecurityTestUtils.java
@@ -22,14 +22,14 @@ public class SecurityTestUtils {
 
     public static HttpsConfig.HttpsConfigBuilder correctHttpsSettings() {
         return SecurityTestUtils.correctHttpsKeyStoreSettings()
-                .trustStore(pathFromRepository("keystore/localhost/localhost.truststore.p12"))
-                .trustStorePassword(STORE_PASSWORD);
+            .trustStore(pathFromRepository("keystore/localhost/localhost.truststore.p12"))
+            .trustStorePassword(STORE_PASSWORD);
     }
 
     public static HttpsConfig.HttpsConfigBuilder correctHttpsKeyStoreSettings() {
         return HttpsConfig.builder().protocol("TLSv1.2")
-                .keyStore(SecurityTestUtils.pathFromRepository("keystore/localhost/localhost.keystore.p12"))
-                .keyStorePassword(STORE_PASSWORD).keyPassword(STORE_PASSWORD);
+            .keyStore(SecurityTestUtils.pathFromRepository("keystore/localhost/localhost.keystore.p12"))
+            .keyStorePassword(STORE_PASSWORD).keyPassword(STORE_PASSWORD).keyAlias("localhost");
     }
 
     public static String pathFromRepository(String path) {


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

HTTP client is choosing the first key certificate pair returned from the keyring. In some cases, this could lead to the use of the wrong key certificate pair.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
