### PR TITLE
accept homepage without context path

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
@@ -78,7 +78,12 @@ public class RoutedServices {
                 RoutedService value = serviceEntry.getValue();
                 int size = value.getServiceUrl().length();
                 //Remove last slash for service url
-                String routeServiceUrl = UrlUtils.removeLastSlash(value.getServiceUrl().toLowerCase());
+                String routeServiceUrl;
+                if ("/".equals(value.getServiceUrl())) {
+                    routeServiceUrl = value.getServiceUrl();
+                } else {
+                    routeServiceUrl = UrlUtils.removeLastSlash(value.getServiceUrl().toLowerCase());
+                }
                 if (size > maxSize && isMatchingApiRoute(serviceUrl, routeServiceUrl)) {
                     result = value;
                     maxSize = size;

--- a/common-service-core/src/test/java/org/zowe/apiml/product/routing/RoutedServicesTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/product/routing/RoutedServicesTest.java
@@ -107,6 +107,7 @@ class RoutedServicesTest {
 
         RoutedService routedService1 = new RoutedService("api_v2", "api/v2", "/test2/api/v2");
         RoutedService routedService2 = new RoutedService("ui_v2", "ui/v2", "/test2/ui/v2");
+
         routedServices.addRoutedService(routedService1);
         routedServices.addRoutedService(routedService2);
 
@@ -115,5 +116,16 @@ class RoutedServicesTest {
         assertEquals("api_v2", routedService.getSubServiceId());
         assertEquals("api/v2", routedService.getGatewayUrl());
         assertEquals("/test2/api/v2", routedService.getServiceUrl());
+
+
+    }
+
+    @Test
+    void givenServiceWithoutContextPath_thenReturnCorrectPath() {
+        RoutedService routedService3 = new RoutedService("api_v3", "api/v2", "/");
+        RoutedServices routedServ = new RoutedServices();
+        routedServ.addRoutedService(routedService3);
+        RoutedService routedService = routedServ.getBestMatchingApiUrl("/");
+        assertEquals("/", routedService.getServiceUrl());
     }
 }


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

API catalog transforming homepage URL doesn't count with the possibility of missing context path or prefix.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
