### PR TITLE
Fix: Add log masking class for sensitive logs

### DIFF
--- a/apiml-common/src/main/resources/logback.xml
+++ b/apiml-common/src/main/resources/logback.xml
@@ -21,8 +21,10 @@
     </if>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 
@@ -39,8 +41,10 @@
             <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
         </triggeringPolicy>
 
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
@@ -21,7 +21,7 @@ public class MaskingLogPatternLayout extends PatternLayout {
         return maskMessage(super.doLayout(event));
     }
 
-    private String maskMessage(String message) {
+    protected String maskMessage(String message) {
         StringBuilder sb = new StringBuilder(message);
         Matcher matcher = maskPatterns.matcher(sb);
         while (matcher.find()) {
@@ -34,7 +34,7 @@ public class MaskingLogPatternLayout extends PatternLayout {
         return sb.toString();
     }
 
-    private static class MaskPatternBuilder {
+    public static class MaskPatternBuilder {
         private final List<String> maskPatterns = new ArrayList<>();
 
         public MaskPatternBuilder add(String prefix, String capture) {

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
@@ -12,8 +12,8 @@ import java.util.stream.IntStream;
 public class MaskingLogPatternLayout extends PatternLayout {
     private static final String MASK_VALUE = "***";
     private static final Pattern maskPatterns = new MaskPatternBuilder()
-        .add("\\\"password\\\"\\s*:\\s*", "\\\".*?\\\"")
-        .add("\\\"newPassword\\\"\\s*:\\s*", "\\\".*?\\\"")
+        .addJsonValue("password")
+        .addJsonValue("newPassword")
         .build();
 
     @Override
@@ -35,6 +35,7 @@ public class MaskingLogPatternLayout extends PatternLayout {
     }
 
     private static class MaskPatternBuilder {
+        private static final String JSON_VALUE = "\\\".*?\\\"";
         private final List<String> maskPatterns = new ArrayList<>();
 
         public MaskPatternBuilder add(String prefix, String capture) {
@@ -43,6 +44,15 @@ public class MaskingLogPatternLayout extends PatternLayout {
 
         public MaskPatternBuilder add(String prefix, String capture, String postfix) {
             maskPatterns.add(prefix + "(" + capture + ")" + postfix);
+            return this;
+        }
+
+        public MaskPatternBuilder addJsonValue(String jsonKey, String... keys) {
+            // add \" around key and value
+            add("\\\"" + jsonKey + "\\\"s*:\\s*", JSON_VALUE);
+            for (String k : keys) {
+                add(k, JSON_VALUE);
+            }
             return this;
         }
 

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
@@ -1,0 +1,42 @@
+package org.zowe.apiml.product.logging;
+
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+
+public class MaskingLogPatternLayout extends PatternLayout {
+    private Pattern multilinePattern;
+    private final List<String> maskPatterns = new ArrayList<>();
+
+    public void addMaskPattern(String maskPattern) {
+        maskPatterns.add(maskPattern);
+        multilinePattern = Pattern.compile(String.join("|", maskPatterns), Pattern.MULTILINE);
+    }
+
+    @Override
+    public String doLayout(ILoggingEvent event) {
+        return maskMessage(super.doLayout(event));
+    }
+
+    private String maskMessage(String message) {
+        if (multilinePattern == null) {
+            return message;
+        }
+        StringBuilder sb = new StringBuilder(message);
+        Matcher matcher = multilinePattern.matcher(sb);
+        while (matcher.find()) {
+            IntStream.rangeClosed(1, matcher.groupCount()).forEach(group -> {
+                if (matcher.group(group) != null) {
+                    sb.replace(matcher.start(group), matcher.end(group), "***");
+                    //IntStream.range(matcher.start(group), matcher.end(group)).forEach(i -> sb.setCharAt(i, '*'));
+                }
+            });
+        }
+        return sb.toString();
+    }
+}

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
@@ -35,7 +35,6 @@ public class MaskingLogPatternLayout extends PatternLayout {
     }
 
     private static class MaskPatternBuilder {
-        private static final String JSON_VALUE = "\\\".*?\\\"";
         private final List<String> maskPatterns = new ArrayList<>();
 
         public MaskPatternBuilder add(String prefix, String capture) {
@@ -48,10 +47,10 @@ public class MaskingLogPatternLayout extends PatternLayout {
         }
 
         public MaskPatternBuilder addJsonValue(String jsonKey, String... keys) {
-            // add \" around key and value
-            add("\\\"" + jsonKey + "\\\"s*:\\s*", JSON_VALUE);
+            // pattern to get \"KEY\":\"VALUE\" with optional white space separating them
+            add("\\\"" + jsonKey + "\\\"\\s*:\\s*", "\\\".*?\\\"");
             for (String k : keys) {
-                add(k, JSON_VALUE);
+                add("\\\"" + k + "\\\"\\s*:\\s*", "\\\".*?\\\"");
             }
             return this;
         }

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/MaskingLogPatternLayout.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package org.zowe.apiml.product.logging;
 
 import ch.qos.logback.classic.PatternLayout;

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/MaskingLogPatternLayoutTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/MaskingLogPatternLayoutTest.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package org.zowe.apiml.product.logging;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/MaskingLogPatternLayoutTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/MaskingLogPatternLayoutTest.java
@@ -1,0 +1,58 @@
+package org.zowe.apiml.product.logging;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MaskingLogPatternLayoutTest {
+    @Nested
+    class WhenBuildMask {
+        private MaskingLogPatternLayout.MaskPatternBuilder underTest;
+
+        @BeforeEach
+        void setup() {
+            underTest = new MaskingLogPatternLayout.MaskPatternBuilder();
+        }
+
+        @Test
+        void givenMultiplePatterns_thenReturnMaskRegexForBoth() {
+            String expectedRegex = "one(cap1)|two(cap2)post";
+            underTest.add("one", "cap1").add("two", "cap2", "post");
+
+            assertEquals(expectedRegex, underTest.build().pattern());
+        }
+
+        @Test
+        void givenJsons_thenMaskRegexWithJsonFormat() {
+            String expectedRegex = "\\\"key1\\\"\\s*:\\s*(\\\".*?\\\")|\\\"key2\\\"\\s*:\\s*(\\\".*?\\\")";
+            underTest.addJsonValue("key1", "key2");
+
+            assertEquals(expectedRegex, underTest.build().pattern());
+        }
+    }
+
+    @Nested
+    class WhenMaskMessage {
+        private MaskingLogPatternLayout underTest;
+
+        @BeforeEach
+        void setup() {
+            underTest = new MaskingLogPatternLayout();
+        }
+
+        @Test
+        void givenNothingToMask_thenNoMask() {
+            String message = "expected log";
+            String actual = underTest.maskMessage(message);
+            assertEquals(message, actual);
+        }
+
+        @Test
+        void givenSensitiveData_thenMaskData() {
+            String actual = underTest.maskMessage("\"password\":\"mypassword\"");
+            assertEquals("\"password\":***", actual);
+        }
+    }
+}

--- a/caching-service/src/main/resources/logback.xml
+++ b/caching-service/src/main/resources/logback.xml
@@ -15,8 +15,10 @@
     </turboFilter>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 
@@ -33,8 +35,10 @@
             <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
         </triggeringPolicy>
 
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 

--- a/metrics-service/src/main/resources/logback.xml
+++ b/metrics-service/src/main/resources/logback.xml
@@ -15,8 +15,10 @@
     </turboFilter>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 
@@ -33,8 +35,10 @@
             <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
         </triggeringPolicy>
 
-        <encoder>
-            <pattern>${apimlLogPattern}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.zowe.apiml.product.logging.MaskingLogPatternLayout">
+                <pattern>${apimlLogPattern}</pattern>
+            </layout>
         </encoder>
     </appender>
 


### PR DESCRIPTION
# Description

Adds a log masker that can be configured to mask sensitive information in logs. Currently masks `password` and `newPassword` in request bodies.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
