### PR TITLE
chore: Reduce ci duplication when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
                   npm version ${{ github.event.inputs.scope || env.DEFAULT_SCOPE }}
                   npm publish --access public
                   git add package.json
-                  git commit -m "Update version"
+                  git commit -m "[skip ci] Update version"
                   git push
                   cd ..
               env:

--- a/.github/workflows/specific-release.yml
+++ b/.github/workflows/specific-release.yml
@@ -47,7 +47,7 @@ jobs:
                   npm version ${{ github.event.inputs.release_version }}
                   npm publish --access public
                   git add package.json
-                  git commit -m "Update version"
+                  git commit -m "[skip ci] Update version"
                   git push
                   cd ..
               env:

--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ release {
     failOnUpdateNeeded = true
     revertOnFail = true
     preCommitText = '[Gradle Release plugin]'
-    preTagCommitMessage = 'Before tag commit'
+    preTagCommitMessage = '[skip ci] Before tag commit'
     tagCommitMessage = 'Release:'
     tagTemplate = 'v${version}'
     newVersionCommitMessage = 'Create new version:'


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

When the specific and automated release workflows are ran, they commit to master 3 times, triggering 3 snapshot releases. These 3 commits are 1) updating `onboarding-enabler-nodejs/package.json` version 2) setting `gradle.properties` version to the appropriate version for release, and 3) incrementing `gradle.properties` version to the next snapshot tag. We don't need a snapshot build for each of these commits, so with this PR only the 3rd commit (incrementing to snapshot tag) will trigger a snapshot build.

Linked to #1952

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
