### PR TITLE
fix: Change homepage label to be consistent

### DIFF
--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -167,11 +167,11 @@ export default class ServiceTab extends Component {
                                         {selectedService.status === 'DOWN' && (
                                             <Tooltip
                                                 key={selectedService.serviceId}
-                                                content="API Homepage navigation is disabled as the service is not running"
+                                                content="Service Homepage navigation is disabled as the service is not running"
                                                 placement="bottom"
                                             >
                                                 <Link variant="danger">
-                                                    <strong>API Homepage</strong>
+                                                    <strong>Service Homepage</strong>
                                                 </Link>
                                             </Tooltip>
                                         )}


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

Change homepage label in case of service down to `Service Homepage` to be consistent.
Fixes #2011 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
