### PR TITLE
Fix: Updated URL for api catalog desktop app

### DIFF
--- a/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
+++ b/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
@@ -1,11 +1,11 @@
 {
   "identifier": "org.zowe.api.catalog",
   "apiVersion": "1.0.0",
-  "pluginVersion": "1.0.0",
+  "pluginVersion": "2.0.0",
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",
-    "destination": "https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT}/ui/v1/apicatalog",
+    "destination": "https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT}/apicatalog/ui/v1",
     "launchDefinition": {
       "pluginShortNameKey": "API Catalog",
       "pluginShortNameDefault": "API Catalog",


### PR DESCRIPTION
I hope I'm targeting the right v2 branch. 

# Description

Currently, the api catalog app in the desktop does not work in the v2 previews I've seen, due to the iframe pointer URL ending with apicatalog rather than beginning with it. I've marked the plugin version as 2.0.0 to correspond to this change.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not a realistic breaking change, but if someone were to install this on a very old (like, 1.2?) version of zowe then the url may not work there, so just marking v2 to be safe.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Testing:
I'm working off of a build https://github.com/zowe/zowe-install-packaging/pull/2568 to confirm if I can/cant load api-catalog. When I make these edits locally, the catalog works!