### PR TITLE
fix: publish images to appropriate Artifactory location

### DIFF
--- a/.github/actions/image-publish-setup/action.yml
+++ b/.github/actions/image-publish-setup/action.yml
@@ -2,10 +2,14 @@ name: "Setup for image publishing action"
 description: "Prepares for image publishing"
 
 inputs:
-    imageVersion:
-        description: "Image version to be published"
+    versionOverride:
+        description: "Value to override existing version with. If empty no override is done."
         required: false
         default: ""
+outputs:
+    imageVersion:
+        description: "Image version to be published"
+        value: ${{ steps.output-version.outputs.version }}
 
 runs:
     using: "composite"
@@ -18,5 +22,11 @@ runs:
             if: ${{ inputs.imageVersion != '' }}
             shell: bash
             run: sed -i 's/version=.*/version=${{ inputs.imageVersion }}/g' gradle.properties
+
+        -   id: output-version
+            shell: bash
+            run: |
+                version=$(cat gradle.properties | awk '/version=/' | awk -F= '{print$2;}')
+                echo "::set-output name=version::$version"
 
         -   uses: zowe-actions/shared-actions/prepare-workflow@main

--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -3,8 +3,9 @@ name: Reusable workflow to create Zowe conformant images
 on:
     workflow_call:
         inputs:
-            release:
+            forceNoRelease:
                 type: boolean
+                description: 'If this is set to true, images will be published to the snapshot location. If false, the publish location will be determined from the version.'
                 default: false
                 required: false
             service:
@@ -65,7 +66,7 @@ jobs:
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ inputs.release }}
+                    release: ${{ !inputs.forceNoRelease }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -109,7 +110,7 @@ jobs:
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ inputs.release }}
+                    release: ${{ !inputs.forceNoRelease }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -158,7 +159,7 @@ jobs:
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ inputs.release }}
+                    release: ${{ !inputs.forceNoRelease }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -197,7 +198,7 @@ jobs:
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ inputs.release }}
+                    release: ${{ !inputs.forceNoRelease }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ inputs.service }}
                     image-name: ${{ inputs.service }}
                     linux-distro: ${{ matrix.os }}
@@ -253,7 +254,7 @@ jobs:
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ inputs.release }}
+                    release: ${{ !inputs.forceNoRelease }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ inputs.service }}
                     image-name: ${{ inputs.service }}
                     linux-distro: ${{ matrix.os }}

--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -38,6 +38,7 @@ on:
 
 env:
     IMAGE_BASE_DIR: ./containers
+    SNAPSHOT_POSTFIX: "-SNAPSHOT"
 
 jobs:
 
@@ -59,14 +60,15 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   uses: ./.github/actions/image-publish-setup
+                id: setup
                 with:
-                    imageVersion: ${{ inputs.version }}
+                    versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ !inputs.forceNoRelease }}
+                    release: ${{ !inputs.forceNoRelease && !endsWith(steps.setup.outputs.imageVersion, env.SNAPSHOT_POSTFIX) }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -103,14 +105,15 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   uses: ./.github/actions/image-publish-setup
+                id: setup
                 with:
-                    imageVersion: ${{ inputs.version }}
+                    versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ !inputs.forceNoRelease }}
+                    release: ${{ !inputs.forceNoRelease && !endsWith(steps.setup.outputs.imageVersion, env.SNAPSHOT_POSTFIX) }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -152,14 +155,15 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   uses: ./.github/actions/image-publish-setup
+                id: setup
                 with:
-                    imageVersion: ${{ inputs.version }}
+                    versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ !inputs.forceNoRelease }}
+                    release: ${{ !inputs.forceNoRelease && !endsWith(steps.setup.outputs.imageVersion, env.SNAPSHOT_POSTFIX) }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ matrix.service }}
                     image-name: ${{ matrix.service }}
                     linux-distro: ${{ matrix.os }}
@@ -191,14 +195,15 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   uses: ./.github/actions/image-publish-setup
+                id: setup
                 with:
-                    imageVersion: ${{ inputs.version }}
+                    versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ !inputs.forceNoRelease }}
+                    release: ${{ !inputs.forceNoRelease && !endsWith(steps.setup.outputs.imageVersion, env.SNAPSHOT_POSTFIX) }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ inputs.service }}
                     image-name: ${{ inputs.service }}
                     linux-distro: ${{ matrix.os }}
@@ -247,14 +252,15 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   uses: ./.github/actions/image-publish-setup
+                id: setup
                 with:
-                    imageVersion: ${{ inputs.version }}
+                    versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
-                    release: ${{ !inputs.forceNoRelease }}
+                    release: ${{ !inputs.forceNoRelease && !endsWith(steps.setup.outputs.imageVersion, env.SNAPSHOT_POSTFIX) }}
                     base-directory: ${{ env.IMAGE_BASE_DIR }}/${{ inputs.service }}
                     image-name: ${{ inputs.service }}
                     linux-distro: ${{ matrix.os }}

--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -242,7 +242,6 @@ jobs:
             - create-image-one-service
         strategy:
             matrix:
-                service: [ gateway-service, discovery-service, api-catalog-services, caching-service, metrics-service ]
                 os: [ ubuntu, ubi ]
         runs-on: ubuntu-latest
         if: ${{ inputs.service != 'all' }}

--- a/.github/workflows/create-image-without-release.yml
+++ b/.github/workflows/create-image-without-release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
             service: ${{ github.event.inputs.service }}
-            release: false
+            forceNoRelease: true
         secrets:
             registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
             registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}

--- a/.github/workflows/create-image-without-release.yml
+++ b/.github/workflows/create-image-without-release.yml
@@ -39,7 +39,7 @@ jobs:
             -   uses: ./.github/actions/teardown
 
 
-    build-images:
+    publish-images:
         needs:
             - build-services
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
                   version=$(cat onboarding-enabler-nodejs/package.json | awk '/"version":/' | awk -F: '{print$2;}' | awk -F\" '{print$2;}')
                   echo "::set-output name=imageVersion::$version"
 
-    release-images:
+    publish-images:
         needs:
             - get-image-version
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,6 @@ jobs:
             - get-image-version
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
-            release: true
             version: ${{ needs.get-image-version.outputs.imageVersion }}
         secrets:
             registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -26,7 +26,7 @@ jobs:
 
             - uses: ./.github/actions/teardown
 
-    release-images:
+    publish-images:
         needs:
             - release # Ensure services can build and binary released successfully
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -31,7 +31,7 @@ jobs:
             - release # Ensure services can build and binary released successfully
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
-            release: true
+            forceNoRelease: true
         secrets:
             registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
             registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}

--- a/.github/workflows/specific-release.yml
+++ b/.github/workflows/specific-release.yml
@@ -69,8 +69,8 @@ jobs:
             - release # Ensure services can build and binary released successfully
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
-            release: true
-            version: ${{ inputs.release_version }}
+            release: ${{ !endsWith(github.event.inputs.release_version, '-SNAPSHOT') }}
+            version: ${{ github.event.inputs.release_version }}
         secrets:
             registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
             registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}

--- a/.github/workflows/specific-release.yml
+++ b/.github/workflows/specific-release.yml
@@ -69,7 +69,6 @@ jobs:
             - release # Ensure services can build and binary released successfully
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
-            release: ${{ !endsWith(github.event.inputs.release_version, '-SNAPSHOT') }}
             version: ${{ github.event.inputs.release_version }}
         secrets:
             registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}

--- a/.github/workflows/specific-release.yml
+++ b/.github/workflows/specific-release.yml
@@ -64,7 +64,7 @@ jobs:
 
             - uses: ./.github/actions/teardown
 
-    release-images:
+    publish-images:
         needs:
             - release # Ensure services can build and binary released successfully
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master


### PR DESCRIPTION
# Description

Publish images to appropriate location of `docker-snapshot` or `docker-release` based on workflow and version tag.

Linked to #2048

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
