### PR TITLE
chore: separate snapshot release of images and binaries

### DIFF
--- a/.github/workflows/binary-snapshot-release.yml
+++ b/.github/workflows/binary-snapshot-release.yml
@@ -1,6 +1,6 @@
 # This workflow will release project with Gradle
 
-name: Release new version (snapshot)
+name: Release new binary version (snapshot)
 
 on:
     push:
@@ -25,19 +25,3 @@ jobs:
                   ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
             - uses: ./.github/actions/teardown
-
-    publish-images:
-        needs:
-            - release # Ensure services can build and binary released successfully
-        uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
-        with:
-            forceNoRelease: true
-        secrets:
-            registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
-            registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
-            redhat-registry-user: ${{ secrets.REDHAT_DEVELOPER_USER }}
-            redhat-registry-password: ${{ secrets.REDHAT_DEVELOPER_PASSWORD }}
-            zlinux-host: ${{ secrets.ZLINUX_HOST }}
-            zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
-            zlinux-ssh-key: ${{ secrets.ZLINUX_SSH_KEY }}
-            zlinux-ssh-passphrase: ${{ secrets.ZLINUX_SSH_PASSPHRASE }}

--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -65,6 +65,7 @@ jobs:
                     versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
+                timeout-minutes: 15
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
@@ -82,7 +83,7 @@ jobs:
                 uses: zowe-actions/shared-actions/docker-build-local@main
                 with:
                     build-arg-list: ${{ matrix.BUILD_ARG_LIST }}
-                timeout-minutes: 45
+                timeout-minutes: 60
 
             -   uses: ./.github/actions/teardown
 
@@ -110,6 +111,7 @@ jobs:
                     versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
+                timeout-minutes: 15
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
@@ -135,7 +137,7 @@ jobs:
                     redhat-registry: ${{ env.DEFAULT_REDHAT_DOCKER_REGISTRY }}
                     redhat-registry-user: ${{ secrets.redhat-registry-user }}
                     redhat-registry-password: ${{ secrets.redhat-registry-password }}
-                timeout-minutes: 45
+                timeout-minutes: 60
 
             -   uses: ./.github/actions/teardown
 
@@ -160,6 +162,7 @@ jobs:
                     versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
+                timeout-minutes: 15
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
@@ -200,6 +203,7 @@ jobs:
                     versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
+                timeout-minutes: 15
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}
@@ -218,7 +222,7 @@ jobs:
                 uses: zowe-actions/shared-actions/docker-build-local@main
                 with:
                     build-arg-list: ${{ matrix.BUILD_ARG_LIST }}
-                timeout-minutes: 45
+                timeout-minutes: 60
 
             -   name: Build s390x
                 if: matrix.arch == 's390x'
@@ -233,7 +237,7 @@ jobs:
                     redhat-registry: ${{ env.DEFAULT_REDHAT_DOCKER_REGISTRY }}
                     redhat-registry-user: ${{ secrets.redhat-registry-user }}
                     redhat-registry-password: ${{ secrets.redhat-registry-password }}
-                timeout-minutes: 45
+                timeout-minutes: 60
 
             -   uses: ./.github/actions/teardown
 
@@ -256,6 +260,7 @@ jobs:
                     versionOverride: ${{ inputs.version }}
 
             -   uses: zowe-actions/shared-actions/docker-prepare@main
+                timeout-minutes: 15
                 with:
                     registry-user: ${{ secrets.registry-user }}
                     registry-password: ${{ secrets.registry-password }}

--- a/.github/workflows/image-snapshot-release.yml
+++ b/.github/workflows/image-snapshot-release.yml
@@ -1,0 +1,20 @@
+name: Release new image version (snapshot)
+
+on:
+    push:
+        branches: [ master, v2.x.x ]
+
+jobs:
+    publish-images:
+        uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
+        with:
+            forceNoRelease: true
+        secrets:
+            registry-user: ${{ secrets.ARTIFACTORY_X_USERNAME }}
+            registry-password: ${{ secrets.ARTIFACTORY_X_PASSWORD }}
+            redhat-registry-user: ${{ secrets.REDHAT_DEVELOPER_USER }}
+            redhat-registry-password: ${{ secrets.REDHAT_DEVELOPER_PASSWORD }}
+            zlinux-host: ${{ secrets.ZLINUX_HOST }}
+            zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
+            zlinux-ssh-key: ${{ secrets.ZLINUX_SSH_KEY }}
+            zlinux-ssh-passphrase: ${{ secrets.ZLINUX_SSH_PASSPHRASE }}


### PR DESCRIPTION
# Description

Separate image and binary snapshot release so snapshot release workflow is more clear when there are failures due to our code. Also increase image jobs timeouts to reduce number of failures.

Linked to #2074 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
