### PR TITLE
fix: cross platform support for npm lint

### DIFF
--- a/api-catalog-ui/frontend/package.json
+++ b/api-catalog-ui/frontend/package.json
@@ -41,7 +41,7 @@
         "uuid": "3.3.2"
     },
     "scripts": {
-        "lint": "eslint 'src/**/*.{js,jsx}'",
+        "lint": "eslint \"src/**/*.{js,jsx}\"",
         "build": "react-scripts build",
         "postbuild": "rimraf build/**/*.map",
         "test": "react-scripts test --silent --watchAll=false --env=jsdom components/* reducers/* epics/* actions/* selectors/* ErrorBoundary/* --reporters=default --reporters=jest-html-reporter --coverage",

--- a/metrics-service-ui/frontend/package.json
+++ b/metrics-service-ui/frontend/package.json
@@ -48,7 +48,7 @@
         "prettier": "2.3.0"
     },
     "scripts": {
-        "lint": "eslint 'src/**/*.{js,jsx}'",
+        "lint": "eslint \"src/**/*.{js,jsx}\"",
         "build": "react-scripts build",
         "test": "react-scripts test --watchAll=false --env=jsdom --reporters=default --reporters=jest-html-reporter --coverage --silent",
         "start": "react-scripts start",


### PR DESCRIPTION
# Description

When attempting build on some Windows systems, the npm lint script in the metrics-service and api-catalog ui gives a error saying that the file matching the pattern are not found. Replacing the single quote with an escaped double quote fixes this issue and allows the build to proceed.

Linked to # (issue)

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

