### PR TITLE
chore: Add password change to mock zosmf

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -268,7 +268,7 @@ public class ZosmfService extends AbstractZosmfService {
                 new HttpEntity<>(new ChangePasswordRequest((LoginRequest) authentication.getCredentials()), headers), String.class);
         } catch (RuntimeException re) {
             log.warn("The change password endpoint has failed, ensure that the PTF for APAR PH34912 " +
-                "(https://www.ibm.com/support/pages/apar/PH34912) has been installed and that the user ID and old password you provide is correct.");
+                "(https://www.ibm.com/support/pages/apar/PH34912) has been installed and that the user ID and old password you provide are correct.");
             throw handleExceptionOnCall(url, re);
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -267,8 +267,8 @@ public class ZosmfService extends AbstractZosmfService {
                 httpMethod,
                 new HttpEntity<>(new ChangePasswordRequest((LoginRequest) authentication.getCredentials()), headers), String.class);
         } catch (RuntimeException re) {
-            log.warn("The check of z/OSMF JWT authentication endpoint has failed, ensure that the PTF for APAR PH34912 " +
-                "(https://www.ibm.com/support/pages/apar/PH34912) has been installed. ");
+            log.warn("The change password endpoint has failed, ensure that the PTF for APAR PH34912 " +
+                "(https://www.ibm.com/support/pages/apar/PH34912) has been installed and that the user ID and old password you provide is correct.");
             throw handleExceptionOnCall(url, re);
         }
     }

--- a/mock-services/README.md
+++ b/mock-services/README.md
@@ -28,6 +28,7 @@ The supported APARs are:
 * PH28507
 * PH28532
 * RSU2012
+* PH34912 - which mocks the password change functionality
 
 Multiple APARs can be set in `zosmf.appliedApars`. Conflicting functionality will result in only one functionality mocked, but it is not guaranteed which will be mocked. 
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/api/AuthenticationController.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/api/AuthenticationController.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.client.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.zowe.apiml.client.model.LoginBody;
 import org.zowe.apiml.client.services.AparBasedService;
 
 import javax.servlet.http.HttpServletResponse;
@@ -37,6 +38,15 @@ public class AuthenticationController {
         @RequestHeader Map<String, String> headers
     ) {
         return authentication.process(AUTHENTICATION_SERVICE, "create", response, headers);
+    }
+
+    @PutMapping(value = "/zosmf/services/authenticate", produces = "application/json; charset=utf-8")
+    public ResponseEntity<?> changePassword(
+        @RequestBody LoginBody loginBody,
+        HttpServletResponse response,
+        @RequestHeader Map<String, String> headers
+    ) {
+        return authentication.process(AUTHENTICATION_SERVICE, "update", response, headers, loginBody);
     }
 
     @GetMapping(value = "/zosmf/notifications/inbox", produces = "application/json; charset=utf-8")

--- a/mock-services/src/main/java/org/zowe/apiml/client/model/LoginBody.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/model/LoginBody.java
@@ -1,0 +1,19 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.model;
+
+import lombok.Data;
+
+@Data
+public class LoginBody {
+    private String username;
+    private String password;
+    private String newPassword;
+}

--- a/mock-services/src/main/java/org/zowe/apiml/client/model/LoginBody.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/model/LoginBody.java
@@ -9,11 +9,13 @@
  */
 package org.zowe.apiml.client.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class LoginBody {
-    private String username;
-    private String password;
-    private String newPassword;
+    private String userID;
+    private String oldPwd;
+    private String newPwd;
 }

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/AparBasedService.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/AparBasedService.java
@@ -46,12 +46,17 @@ public class AparBasedService {
     public ResponseEntity<?> process(String calledService, String calledMethods, HttpServletResponse response, Map<String, String> headers, Object ... parameters) {
         try {
             List<Apar> applied = versions.fullSetOfApplied(baseVersion, appliedApars);
-            LoginBody body = (LoginBody) parameters[0];
             log.info("calledService: {}, calledMethods, {}", calledService, calledMethods);
             Optional<ResponseEntity<?>> result = Optional.empty();
             for (Apar apar : applied) {
                 log.info("applying: {}", apar);
-                result = apar.apply(calledService, calledMethods, result, response, headers, body);
+                if (parameters.length > 0) {
+                    LoginBody body = (LoginBody) parameters[0];
+                    result = apar.apply(calledService, calledMethods, result, response, headers, body);
+                }
+                else {
+                    result = apar.apply(calledService, calledMethods, result, response, headers);
+                }
                 log.info("result: {}", result);
             }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/AparBasedService.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/AparBasedService.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.zowe.apiml.client.model.LoginBody;
 import org.zowe.apiml.client.services.apars.Apar;
 import org.zowe.apiml.client.services.versions.Versions;
 
@@ -42,15 +43,15 @@ public class AparBasedService {
         log.info("fullSetOfApplied: {}", versions.fullSetOfApplied(baseVersion, appliedApars));
     }
 
-    public ResponseEntity<?> process(String calledService, String calledMethods, HttpServletResponse response, Map<String, String> headers) {
+    public ResponseEntity<?> process(String calledService, String calledMethods, HttpServletResponse response, Map<String, String> headers, Object ... parameters) {
         try {
             List<Apar> applied = versions.fullSetOfApplied(baseVersion, appliedApars);
-
+            LoginBody body = (LoginBody) parameters[0];
             log.info("calledService: {}, calledMethods, {}", calledService, calledMethods);
             Optional<ResponseEntity<?>> result = Optional.empty();
             for (Apar apar : applied) {
                 log.info("applying: {}", apar);
-                result = apar.apply(calledService, calledMethods, result, response, headers);
+                result = apar.apply(calledService, calledMethods, result, response, headers, body);
                 log.info("result: {}", result);
             }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -51,7 +51,6 @@ public class FunctionalApar implements Apar {
         Optional<ResponseEntity<?>> originalResult = (Optional<ResponseEntity<?>>) parameters[2];
         HttpServletResponse response = (HttpServletResponse) parameters[3];
         Map<String, String> headers = (Map<String, String>) parameters[4];
-        LoginBody body = (LoginBody) parameters[5];
         ResponseEntity<?> result = null;
         String token = jwtTokenService.extractToken(headers);
 
@@ -64,7 +63,10 @@ public class FunctionalApar implements Apar {
                     result = handleAuthenticationVerify(headers, response);
                     break;
                 case "update":
-                    result = handleAuthenticationUpdate(headers, body);
+                    if (parameters.length > 4) {
+                        LoginBody body = (LoginBody) parameters[5];
+                        result = handleAuthenticationUpdate(headers, body);
+                    }
                     break;
                 case "delete":
                     result = handleAuthenticationDelete(headers);

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.client.services.apars;
 
-import lombok.Data;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 
 @SuppressWarnings({"squid:S1452", "squid:S1172"})
-@Data
 public class FunctionalApar implements Apar {
     private static final String COOKIE_HEADER = "cookie";
     private static final String JWT_TOKEN_NAME = "jwtToken";
@@ -33,7 +31,7 @@ public class FunctionalApar implements Apar {
     protected static final String AUTHORIZATION_HEADER = "authorization";
 
     private final List<String> usernames;
-    private List<String> passwords;
+    protected List<String> passwords;
     private JwtTokenService jwtTokenService;
 
     protected FunctionalApar(List<String> usernames, List<String> passwords) {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.client.services.apars;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.model.LoginBody;
 import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.Cookie;
@@ -50,6 +51,7 @@ public class FunctionalApar implements Apar {
         Optional<ResponseEntity<?>> originalResult = (Optional<ResponseEntity<?>>) parameters[2];
         HttpServletResponse response = (HttpServletResponse) parameters[3];
         Map<String, String> headers = (Map<String, String>) parameters[4];
+        LoginBody body = (LoginBody) parameters[5];
         ResponseEntity<?> result = null;
         String token = jwtTokenService.extractToken(headers);
 
@@ -60,6 +62,9 @@ public class FunctionalApar implements Apar {
                     break;
                 case "verify":
                     result = handleAuthenticationVerify(headers, response);
+                    break;
+                case "update":
+                    result = handleAuthenticationUpdate(headers, body);
                     break;
                 case "delete":
                     result = handleAuthenticationDelete(headers);
@@ -106,6 +111,14 @@ public class FunctionalApar implements Apar {
      * for the authentication service is called with proper authorization.
      */
     protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
+        return null;
+    }
+
+    /**
+     * Override to provide a response entity, or set fields (like cookies) in the HTTP response when the update method
+     * for the authentication service is called with proper authorization.
+     */
+    protected ResponseEntity<?> handleAuthenticationUpdate(Map<String, String> headers, LoginBody loginBody) {
         return null;
     }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.client.services.apars;
 
+import lombok.Data;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @SuppressWarnings({"squid:S1452", "squid:S1172"})
+@Data
 public class FunctionalApar implements Apar {
     private static final String COOKIE_HEADER = "cookie";
     private static final String JWT_TOKEN_NAME = "jwtToken";
@@ -31,7 +33,7 @@ public class FunctionalApar implements Apar {
     protected static final String AUTHORIZATION_HEADER = "authorization";
 
     private final List<String> usernames;
-    private final List<String> passwords;
+    private List<String> passwords;
     private JwtTokenService jwtTokenService;
 
     protected FunctionalApar(List<String> usernames, List<String> passwords) {
@@ -65,7 +67,7 @@ public class FunctionalApar implements Apar {
                 case "update":
                     if (parameters.length > 4) {
                         LoginBody body = (LoginBody) parameters[5];
-                        result = handleAuthenticationUpdate(headers, body);
+                        result = handleChangePassword(body);
                     }
                     break;
                 case "delete":
@@ -117,14 +119,6 @@ public class FunctionalApar implements Apar {
     }
 
     /**
-     * Override to provide a response entity, or set fields (like cookies) in the HTTP response when the update method
-     * for the authentication service is called with proper authorization.
-     */
-    protected ResponseEntity<?> handleAuthenticationUpdate(Map<String, String> headers, LoginBody loginBody) {
-        return null;
-    }
-
-    /**
      * Override to provide a response entity when the delete method for the authentication service is called
      * with proper authorization.
      */
@@ -137,6 +131,14 @@ public class FunctionalApar implements Apar {
      * is not explicitly handled.
      */
     protected ResponseEntity<?> handleAuthenticationDefault(Map<String, String> headers) {
+        return null;
+    }
+
+    /**
+     * Override to provide a response entity when the update method for the authentication service is called
+     * with proper authorization.
+     */
+    protected ResponseEntity<?> handleChangePassword(LoginBody body) {
         return null;
     }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
@@ -1,0 +1,90 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.model.LoginBody;
+import org.zowe.apiml.client.services.JwtTokenService;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@SuppressWarnings("squid:S1452")
+public class PH34912 extends FunctionalApar {
+    private final String keystorePath;
+
+    public PH34912(List<String> usernames, List<String> passwords, String keystorePath, Integer timeout) {
+        super(usernames, passwords, new JwtTokenService(timeout));
+        this.keystorePath = keystorePath;
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
+        log.error("SONO LA");
+        if (isUnauthorized(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        if (noAuthentication(headers)) {
+            log.error("SONO QUA");
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        String[] credentials = getPiecesOfCredentials(headers);
+        return validJwtResponse(response, credentials[0], keystorePath);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationVerify(Map<String, String> headers, HttpServletResponse response) {
+        return handleAuthenticationCreate(headers, response);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationDelete(Map<String, String> headers) {
+        if (noAuthentication(headers)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        if (isUnauthorized(headers)) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleJwtKeys() {
+        return new ResponseEntity<>("{\n" +
+            "  \"keys\": [\n" +
+            "    {\n" +
+            "      \"kty\": \"RSA\",\n" +
+            "      \"e\": \"AQAB\",\n" +
+            "      \"use\": \"sig\",\n" +
+            "      \"kid\": \"ozG_ySMHRsVQFmN1mVBeS-WtCupY1r-K7ewben09IBg\",\n" +
+            "      \"alg\": \"RS256\",\n" +
+            "      \"n\": \"wRdwksGIAR2A4cHsoOsYcGp5AmQl5ZjF5xIPXeyjkaLHmNTMvjixdWso1ecVlVeg_6pIXzMRhmOvmjXjz1PLfI2GD3drmeqsStjISWdDfH_rIQCYc9wYbWIZ3bQ0wFRDaVpZ6iOZ2iNcIevvZQKNw9frJthKSMM52JtsgwrgN--Ub2cKWioU_d52SC2SfDzOdnChqlU7xkqXwKXSUqcGM92A35dJJXkwbZhAHnDy5FST1HqYq27MOLzBkChw1bJQHZtlSqkxcHPxphnnbFKQmwRVUvyC5kfBemX-7Mzp1wDogt5lGvBAf3Eq8rFxaevAke327rM7q2KqO_LDMN2J-Q\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}", HttpStatus.OK);
+    }
+
+    private boolean isUnauthorized(Map<String, String> headers) {
+        return containsInvalidOrNoUser(headers) && noLtpaCookie(headers);
+    }
+
+    @Override
+    protected ResponseEntity<?> handleAuthenticationUpdate(Map<String, String> headers, LoginBody loginBody) {
+        if (loginBody == null) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
@@ -16,8 +16,6 @@ import org.zowe.apiml.client.model.LoginBody;
 import org.zowe.apiml.client.services.JwtTokenService;
 
 import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -99,9 +97,7 @@ public class PH34912 extends FunctionalApar {
         } else if (isBadRequest(body)) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         } else {
-            List<String> passwords = new <String>ArrayList(Arrays.asList(getPasswords()));
-            passwords.add(body.getNewPwd());
-            setPasswords(passwords);
+            getPasswords().add(body.getNewPwd());
             return new ResponseEntity<>(HttpStatus.OK);
         }
     }

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
@@ -84,6 +84,7 @@ public class PH34912 extends FunctionalApar {
 
     private boolean isBadRequest(LoginBody body) {
         return body == null ||
+            (!passwords.contains(body.getOldPwd())) ||
             StringUtils.isEmpty(body.getUserID()) ||
             StringUtils.isEmpty(body.getOldPwd()) ||
             StringUtils.isEmpty(body.getNewPwd()) ||
@@ -97,7 +98,7 @@ public class PH34912 extends FunctionalApar {
         } else if (isBadRequest(body)) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         } else {
-            getPasswords().add(body.getNewPwd());
+            passwords.add(body.getNewPwd());
             return new ResponseEntity<>(HttpStatus.OK);
         }
     }

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
@@ -9,7 +9,6 @@
  */
 package org.zowe.apiml.client.services.apars;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.zowe.apiml.client.model.LoginBody;
@@ -19,7 +18,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
 @SuppressWarnings("squid:S1452")
 public class PH34912 extends FunctionalApar {
     private final String keystorePath;
@@ -31,12 +29,10 @@ public class PH34912 extends FunctionalApar {
 
     @Override
     protected ResponseEntity<?> handleAuthenticationCreate(Map<String, String> headers, HttpServletResponse response) {
-        log.error("SONO LA");
         if (isUnauthorized(headers)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
         if (noAuthentication(headers)) {
-            log.error("SONO QUA");
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PH34912.java
@@ -76,10 +76,28 @@ public class PH34912 extends FunctionalApar {
         return containsInvalidOrNoUser(headers) && noLtpaCookie(headers);
     }
 
+    private boolean isInternalError(LoginBody body) {
+        return body == null ||
+            body.getOldPwd().equals(body.getNewPwd());
+    }
+
+    private boolean isBadRequest(LoginBody body) {
+        return body == null ||
+            body.getUserID().isEmpty() ||
+            body.getOldPwd().isEmpty() ||
+            body.getNewPwd().isEmpty() ||
+            body.getOldPwd().equals(body.getNewPwd());
+    }
+
     @Override
-    protected ResponseEntity<?> handleAuthenticationUpdate(Map<String, String> headers, LoginBody loginBody) {
-        if (loginBody == null) {
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+    protected ResponseEntity<?> handleChangePassword(LoginBody body) {
+        List<String> passwords = getPasswords();
+        passwords.add(body.getNewPwd());
+        setPasswords(passwords);
+        if (isInternalError(body)) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        } else if (isBadRequest(body)) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/versions/AvailableApars.java
@@ -25,6 +25,7 @@ public class AvailableApars {
         implementedApars.put("PH28507", new NoApar());
         implementedApars.put("PH28532", new NoApar());
         implementedApars.put("PH34201", new PH34201(usernames, passwords, jwtKeystorePath, timeout));
+        implementedApars.put("PH34912", new PH34912(usernames, passwords, jwtKeystorePath, timeout));
         implementedApars.put("RSU2012", new RSU2012(usernames, passwords, jwtKeystorePath, timeout));
         implementedApars.put("JwtKeys", new JwtKeys(usernames, passwords));
         implementedApars.put("AuthenticateApar", new AuthenticateApar(usernames, passwords, timeout));

--- a/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PH34912Test.java
+++ b/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PH34912Test.java
@@ -41,8 +41,8 @@ class PH34912Test {
     @BeforeEach
     void setUp() {
         List<String> usernames = Collections.singletonList(USERNAME);
-        List<String> passwords = Collections.singletonList(PASSWORD);
-
+        List<String> passwords = new ArrayList<>();
+        passwords.add(PASSWORD);
         underTest = new PH34912(usernames, passwords, "../keystore/localhost/localhost.keystore.p12", 60);
         mockResponse = mock(HttpServletResponse.class);
         headers = new HashMap<>();

--- a/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PH34912Test.java
+++ b/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PH34912Test.java
@@ -1,0 +1,246 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.client.services.apars;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.zowe.apiml.client.model.LoginBody;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+class PH34912Test {
+    private static final String SERVICE = "authentication";
+    private static final String USERNAME = "USER";
+    private static final String PASSWORD = "validPassword";
+    private static final String NEW_PASSWORD = "newPassword";
+
+    private PH34912 underTest;
+    private HttpServletResponse mockResponse;
+    private Map<String, String> headers;
+
+    @BeforeEach
+    void setUp() {
+        List<String> usernames = Collections.singletonList(USERNAME);
+        List<String> passwords = Collections.singletonList(PASSWORD);
+
+        underTest = new PH34912(usernames, passwords, "../keystore/localhost/localhost.keystore.p12", 60);
+        mockResponse = mock(HttpServletResponse.class);
+        headers = new HashMap<>();
+    }
+
+    @Nested
+    class whenAuthenticating {
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify", "delete"})
+        void givenNoAuthorization_thenReturnInternalServerError(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+
+            assertThat(result, is(expected));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify", "delete"})
+        void givenEmptyAuthorization_thenReturnInternalServerError(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+            headers.put("authorization", "");
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+
+            assertThat(result, is(expected));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify", "delete"})
+        void givenNoCredentials_thenReturnUnauthorized(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+
+            headers.put("authorization", getBasicAuthorizationHeader(null, null));
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+
+            assertThat(result, is(expected));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify", "delete"})
+        void givenInvalidUsername_thenReturnUnauthorized(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+
+            headers.put("authorization", getBasicAuthorizationHeader("baduser", PASSWORD));
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+
+            assertThat(result, is(expected));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify", "delete"})
+        void givenInvalidPassword_thenReturnUnauthorized(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+
+            headers.put("authorization", getBasicAuthorizationHeader(USERNAME, "badpassword"));
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+
+            assertThat(result, is(expected));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify"})
+        void givenValidUserAndPassword_thenReturnJwtAndLtpa(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>("{}", HttpStatus.OK));
+
+            headers.put("authorization", getBasicAuthorizationHeader(USERNAME, PASSWORD));
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+            assertThat(result, is(expected));
+
+            ArgumentCaptor<Cookie> called = ArgumentCaptor.forClass(Cookie.class);
+            verify(mockResponse, times(2)).addCookie(called.capture());
+            List<Cookie> cookies = called.getAllValues();
+
+            Cookie jwt = cookies.get(0);
+            assertThat(jwt.getName(), is("jwtToken"));
+
+            Cookie ltpa = cookies.get(1);
+            assertThat(ltpa.getName(), is("LtpaToken2"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify"})
+        void givenValidUserAndPassticket_thenReturnJwtAndLtpa(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>("{}", HttpStatus.OK));
+
+            headers.put("authorization", getBasicAuthorizationHeader(USERNAME, "PASS_TICKET"));
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+            assertThat(result, is(expected));
+
+            ArgumentCaptor<Cookie> called = ArgumentCaptor.forClass(Cookie.class);
+            verify(mockResponse, times(2)).addCookie(called.capture());
+
+            List<Cookie> cookies = called.getAllValues();
+            Cookie jwt = cookies.get(0);
+            assertThat(jwt.getName(), is("jwtToken"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"create", "verify"})
+        void givenValidLtpaCookie_thenReturnJwtAndLtpa(String method) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>("{}", HttpStatus.OK));
+
+            headers.put("cookie", getLtpaCookieHeader());
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, method, Optional.empty(), mockResponse, headers);
+            assertThat(result, is(expected));
+
+            ArgumentCaptor<Cookie> called = ArgumentCaptor.forClass(Cookie.class);
+            verify(mockResponse, times(2)).addCookie(called.capture());
+
+            List<Cookie> cookies = called.getAllValues();
+            Cookie jwt = cookies.get(0);
+            assertThat(jwt.getName(), is("jwtToken"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {PASSWORD, "PASS_TICKET"})
+        void givenValidCredentials_whenDelete_thenReturnNoContent(String password) {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+            headers.put("authorization", getBasicAuthorizationHeader(USERNAME, password));
+
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "delete", Optional.empty(), mockResponse, headers);
+            assertThat(result, is(expected));
+        }
+
+        @Test
+        void givenValidLtpaCookie_whenDelete_thenReturnNoContent() {
+            Optional<ResponseEntity<?>> expected = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+            headers.put("cookie", getLtpaCookieHeader());
+
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "delete", Optional.empty(), mockResponse, headers);
+            assertThat(result, is(expected));
+        }
+    }
+
+    @Nested
+    class whenApplyApar {
+        @Test
+        void givenAuthenticationMethodNotHandled_thenReturnOriginalResult() {
+            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+            Optional<ResponseEntity<?>> result = underTest.apply("authentication", "default", previousResult, mockResponse, headers);
+            assertThat(result, is(previousResult));
+        }
+
+        @Test
+        void givenServiceNotHandled_thenReturnOriginalResult() {
+            Optional<ResponseEntity<?>> previousResult = Optional.of(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+            Optional<ResponseEntity<?>> result = underTest.apply("badservice", "", previousResult, mockResponse, headers);
+            assertThat(result, is(previousResult));
+        }
+    }
+
+    @Nested
+    class whenRetrieveJwtKeys {
+        @Test
+        void thenOkIsReturned() {
+            Optional<ResponseEntity<?>> result = underTest.apply("jwtKeys", "get", null, null, null);
+
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+        }
+    }
+
+    @Nested
+    class WhenChangePassword {
+        @Test
+        void givenValidBody_thenChangePassword() {
+            LoginBody loginBody = new LoginBody(USERNAME, PASSWORD, NEW_PASSWORD);
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "update", Optional.empty(), mockResponse, headers, loginBody);
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+        }
+
+        @Test
+        void givenEmptyBody_thenReturnInternalError() {
+            LoginBody loginBody = new LoginBody(USERNAME, PASSWORD, PASSWORD);
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "update", Optional.empty(), mockResponse, headers, loginBody);
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        }
+
+        @Test
+        void givenEmptyBody_thenReturnBadRequest() {
+            LoginBody loginBody = new LoginBody(USERNAME, null, null);
+            Optional<ResponseEntity<?>> result = underTest.apply(SERVICE, "update", Optional.empty(), mockResponse, headers, loginBody);
+            assertThat(result.isPresent(), is(true));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        }
+    }
+
+    private String getBasicAuthorizationHeader(String user, String password) {
+        return "Basic " + Base64.encodeBase64String((user + ":" + password).getBytes());
+    }
+
+    private String getLtpaCookieHeader() {
+        return "LtpaToken2=token";
+    }
+
+}


### PR DESCRIPTION
# Description

Implement the change password support to mock zosmf

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
