### PR TITLE
fix: do not require keyAlias

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -23,7 +23,6 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.ssl.PrivateKeyDetails;
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
@@ -39,7 +38,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.*;
 import java.security.cert.CertificateException;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -196,14 +196,7 @@ public class HttpsFactory {
     private PrivateKeyStrategy getPrivateKeyStrategy() {
         return config.getKeyAlias() != null ?
             (aliases, socket) -> config.getKeyAlias() :
-            ((aliases, socket) -> {
-                String alias = "";
-                for (Map.Entry<String, PrivateKeyDetails> entry : aliases.entrySet()) {
-                    log.error("Alias from keyring: " + entry.getValue().toString());
-                    alias = entry.getKey();
-                }
-                return alias;
-            });
+            null;
     }
 
     private void loadKeyringMaterial(SSLContextBuilder sslContextBuilder) throws UnrecoverableKeyException,
@@ -274,7 +267,6 @@ public class HttpsFactory {
         setSystemProperty("javax.net.ssl.keyStorePassword",
             config.getKeyStorePassword() == null ? null : String.valueOf(config.getKeyStorePassword()));
         setSystemProperty("javax.net.ssl.keyStoreType", config.getKeyStoreType());
-
         setSystemProperty("javax.net.ssl.trustStore", SecurityUtils.replaceFourSlashes(config.getTrustStore()));
         setSystemProperty("javax.net.ssl.trustStorePassword",
             config.getTrustStorePassword() == null ? null : String.valueOf(config.getTrustStorePassword()));

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -23,6 +23,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.PrivateKeyDetails;
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
@@ -38,6 +39,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.*;
 import java.security.cert.CertificateException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 
@@ -192,7 +194,16 @@ public class HttpsFactory {
     }
 
     private PrivateKeyStrategy getPrivateKeyStrategy() {
-        return config.getKeyAlias() != null ? (aliases, socket) -> config.getKeyAlias() : null;
+        return config.getKeyAlias() != null ?
+            (aliases, socket) -> config.getKeyAlias() :
+            ((aliases, socket) -> {
+                String alias = "";
+                for (Map.Entry<String, PrivateKeyDetails> entry : aliases.entrySet()) {
+                    log.error("Alias from keyring: " + entry.getValue().toString());
+                    alias = entry.getKey();
+                }
+                return alias;
+            });
     }
 
     private void loadKeyringMaterial(SSLContextBuilder sslContextBuilder) throws UnrecoverableKeyException,

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -192,9 +192,7 @@ public class HttpsFactory {
     }
 
     private PrivateKeyStrategy getPrivateKeyStrategy() {
-        return config.getKeyAlias() != null ?
-            (aliases, socket) -> config.getKeyAlias() :
-            null;
+        return config.getKeyAlias() != null ? (aliases, socket) -> config.getKeyAlias() : null;
     }
 
     private void loadKeyringMaterial(SSLContextBuilder sslContextBuilder) throws UnrecoverableKeyException,
@@ -265,6 +263,7 @@ public class HttpsFactory {
         setSystemProperty("javax.net.ssl.keyStorePassword",
             config.getKeyStorePassword() == null ? null : String.valueOf(config.getKeyStorePassword()));
         setSystemProperty("javax.net.ssl.keyStoreType", config.getKeyStoreType());
+
         setSystemProperty("javax.net.ssl.trustStore", SecurityUtils.replaceFourSlashes(config.getTrustStore()));
         setSystemProperty("javax.net.ssl.trustStorePassword",
             config.getTrustStorePassword() == null ? null : String.valueOf(config.getTrustStorePassword()));

--- a/common-service-core/src/main/java/org/zowe/apiml/security/SecurityUtils.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/SecurityUtils.java
@@ -206,9 +206,9 @@ public class SecurityUtils {
      * @throws MalformedURLException throws in case of incorrect key ring format
      */
     public static URL keyRingUrl(String uri, String trustStore) throws MalformedURLException {
-        if (!uri.startsWith(SAFKEYRING + ":////")) {
+        if (!uri.startsWith(SAFKEYRING + "://")) {
             throw new MalformedURLException("Incorrect key ring format: " + trustStore
-                + ". Make sure you use format safkeyring:////userId/keyRing");
+                + ". Make sure you use format safkeyring://userId/keyRing");
         }
         return new URL(replaceFourSlashes(uri));
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/SecurityUtils.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/SecurityUtils.java
@@ -208,7 +208,7 @@ public class SecurityUtils {
     public static URL keyRingUrl(String uri, String trustStore) throws MalformedURLException {
         if (!uri.startsWith(SAFKEYRING + "://")) {
             throw new MalformedURLException("Incorrect key ring format: " + trustStore
-                + ". Make sure you use format safkeyring://userId/keyRing");
+                + ". Make sure you use format safkeyring:////userId/keyRing");
         }
         return new URL(replaceFourSlashes(uri));
     }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/model/DiscoverableClientConfig.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/model/DiscoverableClientConfig.java
@@ -48,7 +48,7 @@ public class DiscoverableClientConfig {
     @Value("${server.ssl.trustStoreType}")
     private String trustStoreType;
 
-    @Value("${server.ssl.keyAlias}")
+    @Value("${server.ssl.keyAlias:#{null}}")
     private String keyAlias;
 
     @Value("${server.ssl.keyPassword}")

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
@@ -87,7 +87,7 @@ public class EurekaInstanceConfigValidator {
             addParameterToProblemsList("keyStore", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyAlias())) {
-            addParameterToProblemsList("keyAlias", missingSslParameters);
+            log.warn("Key alias is missing in the SSL configuration");
         }
         if (isInvalid(ssl.getKeyStoreType())) {
             addParameterToProblemsList("keyStoreType", missingSslParameters);

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidatorTest.java
@@ -55,7 +55,7 @@ class EurekaInstanceConfigValidatorTest {
     @CsvSource(value = {
         "bad-ssl-configuration.yml|SSL configuration was not provided. Try add apiml.service.ssl section.",
         "wrong-routes-service-configuration.yml|Routes parameters  ** gatewayUrl, serviceUrl ** are missing or were not replaced by the system properties.",
-        "missing-ssl-configuration.yml|SSL parameters ** protocol, trustStore, keyStore, keyAlias, keyStoreType, trustStoreType, enabled, trustStorePassword, keyStorePassword, keyPassword ** are missing or were not replaced by the system properties."
+        "missing-ssl-configuration.yml|SSL parameters ** protocol, trustStore, keyStore, keyStoreType, trustStoreType, enabled, trustStorePassword, keyStorePassword, keyPassword ** are missing or were not replaced by the system properties."
     }, delimiter = '|')
     void givenConfigurationWithInvalidSsl_whenValidate_thenThrowException(String cfgFile, String expectedMsg) throws ServiceDefinitionException {
         ApiMediationServiceConfig testConfig = configReader.loadConfiguration(cfgFile);

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -128,7 +128,7 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
     }
 
     private InputStream getCorrectInputStream(String uri) throws IOException {
-        if (uri.startsWith(SAFKEYRING + ":////")) {
+        if (uri.startsWith(SAFKEYRING + "://")) {
             URL url = new URL(replaceFourSlashes(uri));
             return url.openStream();
         }


### PR DESCRIPTION
# Description

Users will not be required to pass keyAlias. This PR will also make it possible to use two slashes in keyring configuration. It is still preferable to use 4 slashes.

Linked to #2034 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
