### PR TITLE
fix: Add missing fields in error response

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
@@ -36,11 +36,12 @@ public class ApiMessage {
     private String messageSource;
 
 
-    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent) {
+    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent, String messageAction) {
         this.messageKey = messageKey;
         this.messageType = messageType;
         this.messageNumber = messageNumber;
         this.messageContent = messageContent;
+        this.messageAction = messageAction;
     }
 
     /**

--- a/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
@@ -36,12 +36,13 @@ public class ApiMessage {
     private String messageSource;
 
 
-    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent, String messageAction) {
+    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent, String messageReason, String messageAction) {
         this.messageKey = messageKey;
         this.messageType = messageType;
         this.messageNumber = messageNumber;
         this.messageContent = messageContent;
         this.messageAction = messageAction;
+        this.messageReason = messageReason;
     }
 
     /**

--- a/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/api/ApiMessage.java
@@ -36,7 +36,7 @@ public class ApiMessage {
     private String messageSource;
 
 
-    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent, String messageReason, String messageAction) {
+    public ApiMessage(String messageKey, MessageType messageType, String messageNumber, String messageContent, String messageAction, String messageReason) {
         this.messageKey = messageKey;
         this.messageType = messageType;
         this.messageNumber = messageNumber;

--- a/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
@@ -131,8 +131,8 @@ public final class Message {
             messageTemplate.getType(),
             messageTemplate.getNumber() + messageTemplate.getType().toChar(),
             getConvertedText(),
-            messageTemplate.getReason(),
-            messageTemplate.getAction());
+            messageTemplate.getAction(),
+            messageTemplate.getReason());
     }
 
     /**

--- a/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
@@ -130,7 +130,8 @@ public final class Message {
             requestedKey,
             messageTemplate.getType(),
             messageTemplate.getNumber() + messageTemplate.getType().toChar(),
-            getConvertedText());
+            getConvertedText(),
+            messageTemplate.getAction());
     }
 
     /**

--- a/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/core/Message.java
@@ -131,6 +131,7 @@ public final class Message {
             messageTemplate.getType(),
             messageTemplate.getNumber() + messageTemplate.getType().toChar(),
             getConvertedText(),
+            messageTemplate.getReason(),
             messageTemplate.getAction());
     }
 

--- a/common-service-core/src/test/java/org/zowe/apiml/message/core/MessageTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/core/MessageTest.java
@@ -108,7 +108,7 @@ class MessageTest {
 
         String expectedReadableText = "No response received within the allowed time: 3000";
         ApiMessageView expectedApiMessageView = new ApiMessageView(Collections.singletonList(
-            new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, "action")));
+            new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, null, null)));
 
         assertEquals(expectedApiMessageView, actualApiMessageView, "ApiMessageView is different");
     }
@@ -119,7 +119,7 @@ class MessageTest {
         ApiMessage actualApiMessage = message.mapToApiMessage();
 
         String expectedReadableText = "No response received within the allowed time: 3000";
-        ApiMessage expectedApiMessage = new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, "action");
+        ApiMessage expectedApiMessage = new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, null, null);
 
         assertEquals(expectedApiMessage, actualApiMessage, "ApiMessage is different");
     }

--- a/common-service-core/src/test/java/org/zowe/apiml/message/core/MessageTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/core/MessageTest.java
@@ -108,8 +108,7 @@ class MessageTest {
 
         String expectedReadableText = "No response received within the allowed time: 3000";
         ApiMessageView expectedApiMessageView = new ApiMessageView(Collections.singletonList(
-            new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText)
-        ));
+            new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, "action")));
 
         assertEquals(expectedApiMessageView, actualApiMessageView, "ApiMessageView is different");
     }
@@ -120,7 +119,7 @@ class MessageTest {
         ApiMessage actualApiMessage = message.mapToApiMessage();
 
         String expectedReadableText = "No response received within the allowed time: 3000";
-        ApiMessage expectedApiMessage = new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText);
+        ApiMessage expectedApiMessage = new ApiMessage("org.zowe.apiml.common.serviceTimeout", MessageType.ERROR, "ZWEAM700E", expectedReadableText, "action");
 
         assertEquals(expectedApiMessage, actualApiMessage, "ApiMessage is different");
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
@@ -73,7 +73,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse);
         assertEquals(HttpStatus.UNAUTHORIZED, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired", "The JWT token has expired.", "Obtain new token by performing an authentication request.")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired","Obtain new token by performing an authentication request.", "The JWT token has expired.")));
     }
 
     @Test
@@ -93,7 +93,7 @@ class SecurityErrorCheckTest {
 
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid", "The JWT token is not valid.", "Provide a valid token.")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid", "Provide a valid token.", "The JWT token is not valid.")));
     }
 
     @Test
@@ -114,7 +114,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.security.login.invalidCredentials",
-            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'", "The username and/or password are invalid.", "Provide a valid username and password.")));
+            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'", "Provide a valid username and password.", "The username and/or password are invalid.")));
     }
 }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
@@ -73,7 +73,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse);
         assertEquals(HttpStatus.UNAUTHORIZED, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired", "action")));
     }
 
     @Test
@@ -93,7 +93,7 @@ class SecurityErrorCheckTest {
 
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid", "action")));
     }
 
     @Test
@@ -114,7 +114,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.security.login.invalidCredentials",
-            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'")));
+            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'", "action")));
     }
 }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/SecurityErrorCheckTest.java
@@ -73,7 +73,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse);
         assertEquals(HttpStatus.UNAUTHORIZED, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired", "action")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.expiredToken", MessageType.ERROR, "ZWEAG103E", "The token has expired", "The JWT token has expired.", "Obtain new token by performing an authentication request.")));
     }
 
     @Test
@@ -93,7 +93,7 @@ class SecurityErrorCheckTest {
 
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
-        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid", "action")));
+        assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.security.invalidToken", MessageType.ERROR, "ZWEAG102E", "Token is not valid", "The JWT token is not valid.", "Provide a valid token.")));
     }
 
     @Test
@@ -114,7 +114,7 @@ class SecurityErrorCheckTest {
         assertNotNull(actualResponse.getBody());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.security.login.invalidCredentials",
-            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'", "action")));
+            MessageType.ERROR, "ZWEAG120E", "Invalid username or password for URL 'null'", "The username and/or password are invalid.", "Provide a valid username and password.")));
     }
 }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
@@ -62,7 +62,7 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.common.endPointNotFound",
-            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located")));
+            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located", "action")));
     }
 
     @Test
@@ -77,6 +77,6 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.serviceUnavailable",
-            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'")));
+            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'", "action")));
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
@@ -62,7 +62,7 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.common.endPointNotFound",
-            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located", "The endpoint you are looking for could not be located.", "Verify that the URL of the endpoint you are trying to reach is correct.")));
+            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located", "Verify that the URL of the endpoint you are trying to reach is correct.", "The endpoint you are looking for could not be located.")));
     }
 
     @Test
@@ -77,6 +77,6 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.serviceUnavailable",
-            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'", "The service is not available.", "Make sure that the service is running and is accessible by the URL provided in the message.")));
+            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'", "Make sure that the service is running and is accessible by the URL provided in the message.", "The service is not available.")));
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/error/check/ServiceErrorCheckTest.java
@@ -62,7 +62,7 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.common.endPointNotFound",
-            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located", "action")));
+            MessageType.ERROR, "ZWEAM104E", "The endpoint you are looking for 'serviceId' could not be located", "The endpoint you are looking for could not be located.", "Verify that the URL of the endpoint you are trying to reach is correct.")));
     }
 
     @Test
@@ -77,6 +77,6 @@ class ServiceErrorCheckTest {
         assertEquals(HttpStatus.NOT_FOUND, actualResponse.getStatusCode());
         List<ApiMessage> actualMessageList = actualResponse.getBody().getMessages();
         assertThat(actualMessageList, hasItem(new ApiMessage("org.zowe.apiml.gateway.serviceUnavailable",
-            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'", "action")));
+            MessageType.ERROR, "ZWEAG709E", "Service is not available at URL 'null'. Error returned: 'null'", "The service is not available.", "Make sure that the service is running and is accessible by the URL provided in the message.")));
     }
 }


### PR DESCRIPTION
# Description

Add `messageAction` and `messageReason` fields to the REST error responses.

Fixes to #2067 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
