### PR TITLE
docs: update IntelliJ setup to include all services that need to be run

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -41,7 +41,12 @@ For each of the available services:
     * For the Discovery service add Environment variable `spring.profiles.active` and it's value `https`
 5. Run the service Run -> Run... (Alt + Shift + F10 or Ctrl + Option + R)
 
-Repeat the above for the following application main classes and their service names as written above.    
+Repeat the above for the following application main classes and their service names as written above:
+- gateway-service
+- discovery-service
+- mock-services
+- api-catalog-services
+- discoverable-client
 
 ## Visual Studio Code setup
 


### PR DESCRIPTION
# Description

Line in ide-setup.md where it mentions "repeat the above.." is missing the 5 modules that include the application main classes and their service names. The below are now included:

- gateway-service
- discovery-service
- mock-services
- api-catalog-services
- discoverable-client


Linked to # ([2122](https://github.com/zowe/api-layer/pull/2122))

## Type of change

Please delete options that are not relevant.

- [x] (docs) Change in a documentation


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
