### PR TITLE
fix: API Catalog icon links to dashboard

### DIFF
--- a/api-catalog-ui/frontend/src/components/Header/Header.jsx
+++ b/api-catalog-ui/frontend/src/components/Header/Header.jsx
@@ -70,7 +70,7 @@ const Header = (props) => {
     };
 
     const s = <PersonIcon id="profileIcon" style={{ color: 'white' }} />;
-    const dashboard = 'ui/v1/apicatalog/#/dashboard';
+    const dashboard = '#/dashboard';
     const username = localStorage.getItem('username');
     return (
         <div className="header">

--- a/api-catalog-ui/frontend/src/components/Header/Header.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Header/Header.test.jsx
@@ -20,7 +20,7 @@ describe('>>> Header component tests', () => {
 
     it('should have link href to itself', () => {
         const sample = enzyme.shallow(<Header />);
-        expect(sample.find('[data-testid="link"]').props().href).toEqual('ui/v1/apicatalog/#/dashboard');
+        expect(sample.find('[data-testid="link"]').props().href).toEqual('#/dashboard');
     });
 
     it('should handle a Logout button click', () => {


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Fixes link for API Catalog icon in the header.

Linked to #2089 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
