### PR TITLE
refactor: add validation of auth. source to AuthenticationCommand

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
@@ -99,7 +99,7 @@ public class ServiceAuthenticationFilter extends ZuulFilter {
     }
 
     private boolean isSourceValidForCommand(AuthSource authSource, AuthenticationCommand cmd) {
-        return !cmd.isRequiredValidSource() || authSourceService.isValid(authSource);
+        return !cmd.isRequiredValidSource() || cmd.isValidSource(authSource);
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecorator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecorator.java
@@ -75,7 +75,7 @@ public class ServiceAuthenticationDecorator {
     }
 
     private boolean isSourceValidForCommand(AuthSource authSource, AuthenticationCommand cmd) {
-        return !cmd.isRequiredValidSource() || (authSource != null && authSourceService.isValid(authSource));
+        return !cmd.isRequiredValidSource() || (authSource != null && cmd.isValidSource(authSource));
     }
 }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -161,7 +161,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
 
                 // if authentication schema required valid authentication source, check it
                 if (cmd.isRequiredValidSource()) {
-                    rejected = (!authSource.isPresent()) || !authSourceService.isValid(authSource.get());
+                    rejected = (!authSource.isPresent()) || !cmd.isValidSource(authSource.get());
                 }
 
             } catch (AuthenticationException ae) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommand.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommand.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpRequest;
 import org.zowe.apiml.cache.EntryExpiration;
 
 import java.io.Serializable;
+import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 
 /**
  * This command represented a code, which distribute right access to a service. Gateway translates requests
@@ -57,6 +58,15 @@ public abstract class AuthenticationCommand implements EntryExpiration, Serializ
     public boolean isRequiredValidSource() {
         return false;
     }
+
+    /**
+     * This method validates authentication source based on command logic.
+     * <p>
+     * Default implementation of this method returns "false".
+     * @param authSource AuthSource object which hold original source of authentication (JWT token, client certificate etc.)
+     * @return result of the validation of the authentication source, or "false" by default.
+     */
+    public boolean isValidSource(AuthSource authSource) { return false; }
 
     @Override
     public boolean isExpired() {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommandWithValidation.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommandWithValidation.java
@@ -1,0 +1,31 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.security.service.schema;
+
+import lombok.RequiredArgsConstructor;
+import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
+import org.zowe.apiml.gateway.security.service.schema.source.AuthSourceService;
+
+/**
+ * This command extends {@link AuthenticationCommand} and keeps common validation logic for authentication source. */
+@RequiredArgsConstructor
+public abstract class AuthenticationCommandWithValidation extends AuthenticationCommand {
+    private final AuthSourceService authSourceService;
+
+    @Override
+    public boolean isRequiredValidSource() {
+        return true;
+    }
+
+    @Override
+    public boolean isValidSource(AuthSource authSource) {
+        return authSourceService.isValid(authSource);
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommandWithValidation.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationCommandWithValidation.java
@@ -9,15 +9,14 @@
  */
 package org.zowe.apiml.gateway.security.service.schema;
 
-import lombok.RequiredArgsConstructor;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSourceService;
 
 /**
  * This command extends {@link AuthenticationCommand} and keeps common validation logic for authentication source. */
-@RequiredArgsConstructor
 public abstract class AuthenticationCommandWithValidation extends AuthenticationCommand {
-    private final AuthSourceService authSourceService;
+
+    public abstract AuthSourceService getAuthSourceService();
 
     @Override
     public boolean isRequiredValidSource() {
@@ -26,6 +25,6 @@ public abstract class AuthenticationCommandWithValidation extends Authentication
 
     @Override
     public boolean isValidSource(AuthSource authSource) {
-        return authSourceService.isValid(authSource);
+        return getAuthSourceService().isValid(authSource);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ByPassScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ByPassScheme.java
@@ -30,11 +30,6 @@ public class ByPassScheme implements AbstractAuthenticationScheme {
         private static final long serialVersionUID = -3351658649447418579L;
 
         @Override
-        public boolean isExpired() {
-            return false;
-        }
-
-        @Override
         public void apply(InstanceInfo instanceInfo) {
             RequestContext.getCurrentContext().put(AUTHENTICATION_SCHEME_BY_PASS_KEY, Boolean.TRUE);
         }
@@ -42,11 +37,6 @@ public class ByPassScheme implements AbstractAuthenticationScheme {
         @Override
         public void applyToRequest(HttpRequest request) {
             // do nothing
-        }
-
-        @Override
-        public boolean isRequiredValidSource() {
-            return false;
         }
     };
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -91,7 +91,7 @@ public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
 
     @Value
     @EqualsAndHashCode(callSuper = false)
-    public static class PassTicketCommand extends AuthenticationCommand {
+    public class PassTicketCommand extends AuthenticationCommand {
 
         private static final long serialVersionUID = 3941300386857998443L;
 
@@ -139,5 +139,9 @@ public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
             return true;
         }
 
+        @Override
+        public boolean isValidSource(AuthSource authSource) {
+            return authSourceService.isValid(authSource);
+        }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -43,16 +43,12 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
         final AuthSource.Parsed parsedSource = authSourceService.parse(authSource);
         final Date expiration = parsedSource == null ? null : parsedSource.getExpiration();
         final Long expirationTime = expiration == null ? null : expiration.getTime();
-        return new SafIdtCommand(expirationTime, authSourceService);
+        return new SafIdtCommand(expirationTime);
     }
 
+    @RequiredArgsConstructor
     public class SafIdtCommand extends AuthenticationCommandWithValidation {
         private final Long expireAt;
-
-        public SafIdtCommand(Long expirationTime, AuthSourceService authSourceService) {
-            super(authSourceService);
-            this.expireAt = expirationTime;
-        }
 
         @Override
         public void apply(InstanceInfo instanceInfo) {
@@ -76,6 +72,11 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
             if (expireAt == null) return false;
 
             return System.currentTimeMillis() > expireAt;
+        }
+
+        @Override
+        public AuthSourceService getAuthSourceService() {
+            return authSourceService;
         }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -43,12 +43,16 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
         final AuthSource.Parsed parsedSource = authSourceService.parse(authSource);
         final Date expiration = parsedSource == null ? null : parsedSource.getExpiration();
         final Long expirationTime = expiration == null ? null : expiration.getTime();
-        return new SafIdtCommand(expirationTime);
+        return new SafIdtCommand(expirationTime, authSourceService);
     }
 
-    @RequiredArgsConstructor
-    public class SafIdtCommand extends AuthenticationCommand {
+    public class SafIdtCommand extends AuthenticationCommandWithValidation {
         private final Long expireAt;
+
+        public SafIdtCommand(Long expirationTime, AuthSourceService authSourceService) {
+            super(authSourceService);
+            this.expireAt = expirationTime;
+        }
 
         @Override
         public void apply(InstanceInfo instanceInfo) {
@@ -72,16 +76,6 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
             if (expireAt == null) return false;
 
             return System.currentTimeMillis() > expireAt;
-        }
-
-        @Override
-        public boolean isRequiredValidSource() {
-            return true;
-        }
-
-        @Override
-        public boolean isValidSource(AuthSource authSource) {
-            return authSourceService.isValid(authSource);
         }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -78,5 +78,10 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
         public boolean isRequiredValidSource() {
             return true;
         }
+
+        @Override
+        public boolean isValidSource(AuthSource authSource) {
+            return authSourceService.isValid(authSource);
+        }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -155,6 +155,10 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
             return true;
         }
 
+        @Override
+        public boolean isValidSource(AuthSource authSource) {
+            return authSourceService.isValid(authSource);
+        }
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -50,7 +50,7 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
         final AuthSource.Parsed parsedAuthSource = authSourceService.parse(authSource);
         final Date expiration = parsedAuthSource == null ? null : parsedAuthSource.getExpiration();
         final Long expirationTime = expiration == null ? null : expiration.getTime();
-        return new ZosmfCommand(expirationTime, authSourceService);
+        return new ZosmfCommand(expirationTime);
     }
 
     @lombok.Value
@@ -63,9 +63,9 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
 
         private final Long expireAt;
 
-        public ZosmfCommand(Long expirationTime, AuthSourceService authSourceService) {
-            super(authSourceService);
-            this.expireAt = expirationTime;
+        @Override
+        public AuthSourceService getAuthSourceService() {
+            return authSourceService;
         }
 
         private void createCookie(Cookies cookies, String name, String token) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -50,18 +50,23 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
         final AuthSource.Parsed parsedAuthSource = authSourceService.parse(authSource);
         final Date expiration = parsedAuthSource == null ? null : parsedAuthSource.getExpiration();
         final Long expirationTime = expiration == null ? null : expiration.getTime();
-        return new ZosmfCommand(expirationTime);
+        return new ZosmfCommand(expirationTime, authSourceService);
     }
 
     @lombok.Value
     @EqualsAndHashCode(callSuper = false)
-    public class ZosmfCommand extends AuthenticationCommand {
+    public class ZosmfCommand extends AuthenticationCommandWithValidation {
 
         private static final long serialVersionUID = 2284037230674275720L;
 
         public static final String COOKIE_HEADER = "cookie";
 
         private final Long expireAt;
+
+        public ZosmfCommand(Long expirationTime, AuthSourceService authSourceService) {
+            super(authSourceService);
+            this.expireAt = expirationTime;
+        }
 
         private void createCookie(Cookies cookies, String name, String token) {
             HttpCookie jwtCookie = new HttpCookie(name, token);
@@ -149,16 +154,5 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
 
             return System.currentTimeMillis() > expireAt;
         }
-
-        @Override
-        public boolean isRequiredValidSource() {
-            return true;
-        }
-
-        @Override
-        public boolean isValidSource(AuthSource authSource) {
-            return authSourceService.isValid(authSource);
-        }
     }
-
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
@@ -120,7 +120,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
     void givenValidJwt_whenTokenRequired_thenCallThrought() {
         String jwtToken = "invalidJwtToken";
         AuthenticationCommand cmd = createJwtValidationCommand(jwtToken);
-        doReturn(false).when(authSourceService).isValid(any());
+        doReturn(false).when(cmd).isValidSource(any());
 
         serviceAuthenticationFilter.run();
 
@@ -133,7 +133,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
     void givenValidJwt_whenTokenRequired_thenRejected() {
         String jwtToken = "validJwtToken";
         AuthenticationCommand cmd = createJwtValidationCommand(jwtToken);
-        doReturn(true).when(authSourceService).isValid(any());
+        doReturn(true).when(cmd).isValidSource(any());
 
         serviceAuthenticationFilter.run();
 
@@ -147,7 +147,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
         String jwtToken = "validJwtToken";
         AuthenticationCommand cmd = createJwtValidationCommand(jwtToken);
         doThrow(new RuntimeException()).when(cmd).apply(null);
-        doReturn(true).when(authSourceService).isValid(any());
+        doReturn(true).when(cmd).isValidSource(any());
         CounterFactory.initialize(new CounterFactory() {
             @Override
             public void increment(String name) {
@@ -168,7 +168,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
     void givenExpiredJwt_thenCallThrought() {
         String jwtToken = "expiredJwtToken";
         AuthenticationCommand cmd = createJwtValidationCommand(jwtToken);
-        doThrow(new TokenExpireException("Token is expired.")).when(authSourceService).isValid(any());
+        doThrow(new TokenExpireException("Token is expired.")).when(cmd).isValidSource(any());
 
         serviceAuthenticationFilter.run();
 
@@ -182,7 +182,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
         String jwtToken = "unparsableJwtToken";
         AuthenticationCommand cmd = createJwtValidationCommand(jwtToken);
         AuthenticationException ae = mock(AuthenticationException.class);
-        doThrow(ae).when(authSourceService).isValid(any());
+        doThrow(ae).when(cmd).isValidSource(any());
 
         serviceAuthenticationFilter.run();
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
@@ -75,6 +75,7 @@ class ServiceAuthenticationDecoratorTest {
         AuthenticationCommand universalCmd = mock(ServiceAuthenticationServiceImpl.UniversalAuthenticationCommand.class);
         prepareContext(universalCmd);
         doReturn(true).when(authSourceService).isValid(any());
+        doReturn(true).when(universalCmd).isValidSource(any());
 
         decorator.process(request);
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
@@ -80,6 +80,7 @@ class ServiceAuthenticationDecoratorTest {
         decorator.process(request);
 
         verify(serviceAuthenticationService, atLeastOnce()).getAuthentication(info);
+        verify(universalCmd, times(1)).isValidSource(any());
         verify(universalCmd, times(1)).applyToRequest(request);
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ByPassSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ByPassSchemeTest.java
@@ -12,6 +12,7 @@ import com.netflix.zuul.context.RequestContext;
 import org.apache.http.HttpRequest;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.auth.AuthenticationScheme;
+import org.zowe.apiml.gateway.security.service.schema.source.JwtAuthSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -31,6 +32,7 @@ class ByPassSchemeTest {
         assertEquals(Boolean.TRUE, RequestContext.getCurrentContext().get("AuthenticationSchemeByPass"));
         assertFalse(cmd.isExpired());
         assertFalse(cmd.isRequiredValidSource());
+        assertFalse(cmd.isValidSource(new JwtAuthSource("token")));
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -43,7 +43,10 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 import static org.zowe.apiml.passticket.PassTicketService.DefaultPassTicketImpl.UNKNOWN_USER;
 
 class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
@@ -76,6 +79,10 @@ class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
         when(authSourceService.parse(new JwtAuthSource("token"))).thenReturn(parsedSource);
         AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, new JwtAuthSource("token"));
         assertNotNull(ac);
+
+        // test validation of the authentication source
+        ac.isValidSource(new JwtAuthSource("token"));
+        verify(authSourceService, times(1)).isValid(any());
 
         RequestContext requestContext = new RequestContext();
         HttpServletRequest request = new MockHttpServletRequest();

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -169,13 +169,16 @@ class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
         AuthSourceService authSourceService = mock(AuthSourceService.class);
         httpBasicPassTicketScheme = new HttpBasicPassTicketScheme(passTicketService, authSourceService, authConfigurationProperties);
 
+        AuthSource authSource = new JwtAuthSource("token");
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DATE, 1);
         Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
         AuthSource.Parsed parsedSource = new JwtAuthSource.Parsed("username", calendar.getTime(), calendar.getTime(), QueryResponse.Source.ZOWE);
-        when(authSourceService.parse(new JwtAuthSource("token"))).thenReturn(parsedSource);
-        AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, new JwtAuthSource("token"));
+        when(authSourceService.parse(authSource)).thenReturn(parsedSource);
+        when(authSourceService.isValid(authSource)).thenReturn(true);
+        AuthenticationCommand ac = httpBasicPassTicketScheme.createCommand(authentication, authSource);
         assertTrue(ac.isRequiredValidSource());
+        assertTrue(ac.isValidSource(authSource));
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.gateway.security.service.saf.SafRestAuthenticationService;
+import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSourceService;
 import org.zowe.apiml.gateway.security.service.schema.source.JwtAuthSource;
 import org.zowe.apiml.security.common.token.QueryResponse.Source;
@@ -27,6 +28,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SafIdtSchemeTest {
@@ -49,6 +52,13 @@ class SafIdtSchemeTest {
         void setCommandUnderTest() {
             JwtAuthSource authSource = mock(JwtAuthSource.class);
             commandUnderTest = underTest.createCommand(null, authSource);
+        }
+
+        @Test
+        void testIsValidSource() {
+            AuthSource authSource = new JwtAuthSource("token");
+            commandUnderTest.isValidSource(authSource);
+            verify(authSourceService, times(1)).isValid(authSource);
         }
 
         @Nested

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
@@ -287,4 +287,12 @@ class ZosmfSchemeTest extends CleanCurrentRequestContextTest {
         assertEquals("cookie1=1;jwtToken=jwtToken2", httpRequest.getFirstHeader("cookie").getValue());
     }
 
+    @Test
+    void testIsValidSource() {
+        AuthSource authSource = new JwtAuthSource("token");
+        AuthenticationCommand command = scheme.createCommand(null, null);
+        assertNotNull(command);
+        command.isValidSource(authSource);
+        verify(authSourceService, times(1)).isValid(authSource);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Yelyzaveta Chebanova <yelyzaveta.chebanova@broadcom.com>

# Description

Add validation of the authentication source to a AuthenticationCommand class, so that each command can implement its own validation logic.

Linked to #2062

## Type of change

- [x] (refactor) Refactor the code 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules