### PR TITLE
chore: Update permissions after HA run

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,6 +24,7 @@ runs:
         -   name: Grant execute permission for gradlew
             run: chmod +x gradlew
             shell: bash
+            
         -   name: Cache Gradle packages
             uses: actions/cache@v2
             with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -463,16 +463,11 @@ jobs:
 
             -   uses: ./.github/actions/setup
 
-            -   name: List Permisions
-                run: |
-                    ls -all
             -   name: Build with Gradle
                 run: >
                     ./gradlew :integration-tests:runCachingServiceTests --info -Denvironment.config=-docker -Denvironment.offPlatform=true
                     -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
-            -   name: List Permisions 2
-                run: |
-                    ls -all
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -540,10 +535,6 @@ jobs:
 
             -   uses: ./.github/actions/setup
 
-            -   name: List Permisions
-                run: |
-                    ls -all
-
             -   name: Run HA Tests
                 run: >
                     ./gradlew runHATests --info --scan -Denvironment.config=-ha -Denvironment.offPlatform=true
@@ -552,10 +543,10 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-            -   name: List Permisions2
+            -   name: Correct Permisions
                 run: |
                     chmod 755 -R .gradle
-                    ls -all
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -647,6 +638,9 @@ jobs:
                 run: |
                     docker ps -a
                     docker ps -q | xargs -L 1 docker logs
+            -   name: Correct Permisions
+                run: |
+                    chmod 755 -R .gradle                    
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -713,6 +707,10 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
+            -   name: Correct Permisions
+                run: |
+                    chmod 755 -R .gradle
+                    
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -779,6 +777,10 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
+            -   name: Correct Permisions
+                run: |
+                    chmod 755 -R .gradle
+                    
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -849,6 +851,10 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
+            -   name: Correct Permisions
+                run: |
+                    chmod 755 -R .gradle
+                    
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -919,6 +925,10 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
+            -   name: Correct Permisions
+                run: |
+                    chmod 755 -R .gradle
+                    
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -543,6 +543,7 @@ jobs:
             -   name: List Permisions
                 run: |
                     ls -all
+
             -   name: Run HA Tests
                 run: >
                     ./gradlew runHATests --info --scan -Denvironment.config=-ha -Denvironment.offPlatform=true
@@ -553,6 +554,7 @@ jobs:
 
             -   name: List Permisions2
                 run: |
+                    chmod 755 -R .gradle
                     ls -all
             -   name: Store results
                 uses: actions/upload-artifact@v2

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -465,14 +465,14 @@ jobs:
 
             -   name: List Permisions
                 run: |
-                    ls -l
+                    ls -all
             -   name: Build with Gradle
                 run: >
                     ./gradlew :integration-tests:runCachingServiceTests --info -Denvironment.config=-docker -Denvironment.offPlatform=true
                     -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
             -   name: List Permisions 2
                 run: |
-                    ls -l
+                    ls -all
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -542,7 +542,7 @@ jobs:
 
             -   name: List Permisions
                 run: |
-                    ls -l
+                    ls -all
             -   name: Run HA Tests
                 run: >
                     ./gradlew runHATests --info --scan -Denvironment.config=-ha -Denvironment.offPlatform=true
@@ -553,7 +553,7 @@ jobs:
 
             -   name: List Permisions2
                 run: |
-                    ls -l
+                    ls -all
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -463,10 +463,16 @@ jobs:
 
             -   uses: ./.github/actions/setup
 
+            -   name: List Permisions
+                run: |
+                    ls -l
             -   name: Build with Gradle
                 run: >
                     ./gradlew :integration-tests:runCachingServiceTests --info -Denvironment.config=-docker -Denvironment.offPlatform=true
                     -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
+            -   name: List Permisions 2
+                run: |
+                    ls -l
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
@@ -534,6 +540,9 @@ jobs:
 
             -   uses: ./.github/actions/setup
 
+            -   name: List Permisions
+                run: |
+                    ls -l
             -   name: Run HA Tests
                 run: >
                     ./gradlew runHATests --info --scan -Denvironment.config=-ha -Denvironment.offPlatform=true
@@ -542,6 +551,9 @@ jobs:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
+            -   name: List Permisions2
+                run: |
+                    ls -l
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.net>

# Description

Within the HA runs permissions on .gradle are changed to 700. For the cache to work properly the permissions need to be 755.

Linked to #2160 

## Type of change

- [x] (chore) Chore, repository cleanup, updates the dependencies.