### PR TITLE
fix: publish extension loader library

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -14,7 +14,8 @@ ext.javaLibraries = [
     'security-service-client-spring',
     'zaas-client',
     'apiml-sample-extension',
-    'apiml-sample-extension-package'
+    'apiml-sample-extension-package',
+    'apiml-extension-loader'
 ]
 
 ext.servicesToPublish = [


### PR DESCRIPTION
# Description

Including the Gateway Service with the extensions loader library as a dependency in gradle results in ClassNotFoundException because this library is missing.

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
