### PR TITLE
fix: Use tr instead of upper_case

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -90,7 +90,7 @@ fi
 # fi
 
 # how to verifyCertificates
-verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | upper_case)
+verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower:]' '[:upper:]')
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=false

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -69,7 +69,7 @@ then
 fi
 
 # how to verifyCertificates
-verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | upper_case)
+verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower:]' '[:upper:]')
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=false

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -83,7 +83,7 @@ fi
 # fi
 
 # how to verifyCertificates
-verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | upper_case)
+verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower:]' '[:upper:]')
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=false

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -105,7 +105,7 @@ fi
 # fi
 
 # how to verifyCertificates
-verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | upper_case)
+verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower:]' '[:upper:]')
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=false

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -57,7 +57,7 @@ then
 fi
 
 # how to verifyCertificates
-verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | upper_case)
+verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower:]' '[:upper:]')
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=false


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Use `tr` instead of `upper_case` in start script so zowe-launch-scripts isn't required.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
