### PR TITLE
docs: Update v2 container readme to use v2 config

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -9,14 +9,15 @@ Each image supports both `amd64` and `s390x` CPU architectures.
 
 ## Gateway Service Image
 
-Image `zowe-docker-release.jfrog.io/ompzowe/gateway-service:latest` should be able to run with minimal environment variables:
+Image `zowe-docker-release.jfrog.io/ompzowe/gateway-service:2` should be able to run with minimal environment variables:
 
-- `KEYSTORE`: path to keystore.
-- `KEY_ALIAS`: certificate alias stored in keystore.
-- `KEYSTORE_PASSWORD`: password of your keystore and truststore.
-- `TRUSTSTORE`: path to truststore.
+- `ZWE_configs_certificate_keystore_file`: path to keystore.
+- `ZWE_configs_certificate_keystore_alias`: certificate alias stored in keystore.
+- `ZWE_configs_certificate_keystore_password`: password of your keystore.
+- `ZWE_configs_certificate_truststore_file`: path to truststore.
+- `ZWE_configs_certificate_truststore_password`: password of your truststore.
 - `CMMN_LB`: set to `apiml-common-lib/bin/api-layer-lite-lib-all.jar`
-- `WORKSPACE_DIR`: set to `/component`
+- `ZWE_zowe_workspaceDirectory`: set to `/component`
 
 Review the [Gateway package start script](../gateway-package/src/main/resources/bin/start.sh) to see other environment variables that can be set.
 
@@ -24,29 +25,31 @@ Example commands:
 
 ```
 # pull image
-docker pull zowe-docker-release.jfrog.io/ompzowe/gateway-service:latest
+docker pull zowe-docker-release.jfrog.io/ompzowe/gateway-service:2
 # start container
 docker run -it --rm -p 7554:7554 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -e KEYSTORE=/home/zowe/keystore/localhost/localhost.keystore.p12 \
-    -e KEY_ALIAS=localhost \
-    -e KEYSTORE_PASSWORD=password \
-    -e TRUSTSTORE=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
+    -e ZWE_configs_certificate_keystore_alias=localhost \
+    -e ZWE_configs_certificate_keystore_password=password \
+    -e ZWE_configs_certificate_truststore_file=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_truststore_password=password \
     -e CMMN_LB=apiml-common-lib/bin/api-layer-lite-lib-all.jar \
-    -e WORKSPACE_DIR=/component \
-    zowe-docker-release.jfrog.io/ompzowe/gateway-service:latest
+    -e ZWE_zowe_workspaceDirectory=/component \
+    zowe-docker-release.jfrog.io/ompzowe/gateway-service:2
 ```
 
 ## Discovery Service Image
 
-Image `zowe-docker-release.jfrog.io/ompzowe/discovery-service:latest` should be able to run with minimal environment variables:
+Image `zowe-docker-release.jfrog.io/ompzowe/discovery-service:2` should be able to run with minimal environment variables:
 
-- `KEYSTORE`: path to keystore.
-- `KEY_ALIAS`: certificate alias stored in keystore.
-- `KEYSTORE_PASSWORD`: password of your keystore and truststore.
-- `TRUSTSTORE`: path to truststore.
+- `ZWE_configs_certificate_keystore_file`: path to keystore.
+- `ZWE_configs_certificate_keystore_alias`: certificate alias stored in keystore.
+- `ZWE_configs_certificate_keystore_password`: password of your keystore.
+- `ZWE_configs_certificate_truststore_file`: path to truststore.
+- `ZWE_configs_certificate_truststore_password`: password of your truststore.
 - `CMMN_LB`: set to `apiml-common-lib/bin/api-layer-lite-lib-all.jar`
-- `WORKSPACE_DIR`: set to `/component`
+- `ZWE_zowe_workspaceDirectory`: set to `/component`
 
 Review the [Discovery package start script](../discovery-package/src/main/resources/bin/start.sh) to see other environment variables that can be set.
 
@@ -54,30 +57,33 @@ Example commands:
 
 ```
 # pull image
-docker pull zowe-docker-release.jfrog.io/ompzowe/discovery-service:latest
+docker pull zowe-docker-release.jfrog.io/ompzowe/discovery-service:2
 # start container
 docker run -it --rm -p 7553:7553 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -e KEYSTORE=/home/zowe/keystore/localhost/localhost.keystore.p12 \
-    -e KEY_ALIAS=localhost \
-    -e KEYSTORE_PASSWORD=password \
-    -e TRUSTSTORE=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -v $(pwd)/keystore:/home/zowe/keystore \
+    -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
+    -e ZWE_configs_certificate_keystore_alias=localhost \
+    -e ZWE_configs_certificate_keystore_password=password \
+    -e ZWE_configs_certificate_truststore_file=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_truststore_password=password \
     -e CMMN_LB=apiml-common-lib/bin/api-layer-lite-lib-all.jar \
-    -e WORKSPACE_DIR=/component \
-    zowe-docker-release.jfrog.io/ompzowe/discovery-service:latest
+    -e ZWE_zowe_workspaceDirectory=/component \
+    zowe-docker-release.jfrog.io/ompzowe/discovery-service:2
 ```
 
 ## API Catalog Image
 
-Image `zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:latest` should be able to run with minimal environment variables:
+Image `zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:2` should be able to run with minimal environment variables:
 
-- `KEYSTORE`: path to keystore.
-- `KEY_ALIAS`: certificate alias stored in keystore.
-- `KEYSTORE_PASSWORD`: password of your keystore and truststore.
-- `TRUSTSTORE`: path to truststore.
+- `ZWE_configs_certificate_keystore_file`: path to keystore.
+- `ZWE_configs_certificate_keystore_alias`: certificate alias stored in keystore.
+- `ZWE_configs_certificate_keystore_password`: password of your keystore.
+- `ZWE_configs_certificate_truststore_file`: path to truststore.
+- `ZWE_configs_certificate_truststore_password`: password of your truststore.
 - `CMMN_LB`: set to `apiml-common-lib/bin/api-layer-lite-lib-all.jar`
-- `WORKSPACE_DIR`: set to `/component`
-- `GATEAY_HOST`: the host of the API Gateway
+- `ZWE_zowe_workspaceDirectory`: set to `/component`
+- `ZWE_GATEWAY_HOST`: the host of the API Gateway
 
 Review the [API Catalog package start script](../api-catalog-package/src/main/resources/bin/start.sh) to see other environment variables that can be set.
 
@@ -85,29 +91,32 @@ Example commands:
 
 ```
 # pull image
-docker pull zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:latest
+docker pull zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:2
 # start container
 docker run -it --rm -p 7552:7552 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -e KEYSTORE=/home/zowe/keystore/localhost/localhost.keystore.p12 \
-    -e KEY_ALIAS=localhost \
-    -e KEYSTORE_PASSWORD=password \
-    -e TRUSTSTORE=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -v $(pwd)/keystore:/home/zowe/keystore \
+    -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
+    -e ZWE_configs_certificate_keystore_alias=localhost \
+    -e ZWE_configs_certificate_keystore_password=password \
+    -e ZWE_configs_certificate_truststore_file=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_truststore_password=password \
     -e CMMN_LB=apiml-common-lib/bin/api-layer-lite-lib-all.jar \
-    -e WORKSPACE_DIR=/component \
-    -e GATEWAY_HOST=gateway.com \
-    zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:latest
+    -e ZWE_zowe_workspaceDirectory=/component \
+    -e ZWE_GATEWAY_HOST=gateway.com \
+    zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:2
 ```
 
 ## Caching Service Image
 
-Image `zowe-docker-release.jfrog.io/ompzowe/caching-service:latest` should be able to run with minimal environment variables:
+Image `zowe-docker-release.jfrog.io/ompzowe/caching-service:2` should be able to run with minimal environment variables:
 
-- `KEYSTORE`: path to keystore.
-- `KEY_ALIAS`: certificate alias stored in keystore.
-- `KEYSTORE_PASSWORD`: password of your keystore and truststore.
-- `TRUSTSTORE`: path to truststore.
-- `WORKSPACE_DIR`: set to `/component`
+- `ZWE_configs_certificate_keystore_file`: path to keystore.
+- `ZWE_configs_certificate_keystore_alias`: certificate alias stored in keystore.
+- `ZWE_configs_certificate_keystore_password`: password of your keystore.
+- `ZWE_configs_certificate_truststore_file`: path to truststore.
+- `ZWE_configs_certificate_truststore_password`: password of your truststore.
+- `ZWE_zowe_workspaceDirectory`: set to `/component`
 
 Review the [Caching service package start script](../caching-service-package/src/main/resources/bin/start.sh) to see other environment variables that can be set.
 
@@ -115,29 +124,31 @@ Example commands:
 
 ```
 # pull image
-docker pull zowe-docker-release.jfrog.io/ompzowe/caching-service:latest
+docker pull zowe-docker-release.jfrog.io/ompzowe/caching-service:2
 # start container
 docker run -it --rm -p 7555:7555 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -e KEYSTORE=/home/zowe/keystore/localhost/localhost.keystore.p12 \
-    -e KEY_ALIAS=localhost \
-    -e KEYSTORE_PASSWORD=password \
-    -e TRUSTSTORE=/home/zowe/keystore/localhost/localhost.truststore.p12 \
-    -e WORKSPACE_DIR=/component \
-    zowe-docker-release.jfrog.io/ompzowe/caching-service:latest
+    -v $(pwd)/keystore:/home/zowe/keystore \
+    -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
+    -e ZWE_configs_certificate_keystore_alias=localhost \
+    -e ZWE_configs_certificate_keystore_password=password \
+    -e ZWE_configs_certificate_truststore_file=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_truststore_password=password \
+    -e ZWE_zowe_workspaceDirectory=/component \
+    zowe-docker-release.jfrog.io/ompzowe/caching-service:2
 ```
 
 ## Metrics Service Image
 
-Image `zowe-docker-release.jfrog.io/ompzowe/metrics-service:latest` should be able to run with minimal environment variables:
+Image `zowe-docker-release.jfrog.io/ompzowe/metrics-service:2` should be able to run with minimal environment variables:
 
-- `KEYSTORE`: path to keystore.
-- `KEY_ALIAS`: certificate alias stored in keystore.
-- `KEYSTORE_PASSWORD`: password of your keystore and truststore.
-- `TRUSTSTORE`: path to truststore.
-- `CMMN_LB`: set to `apiml-common-lib/bin/api-layer-lite-lib-all.jar`.
-- `WORKSPACE_DIR`: set to `/component`.
-- `APIML_METRICS_ENBALED` set to `true`.
+- `ZWE_configs_certificate_keystore_file`: path to keystore.
+- `ZWE_configs_certificate_keystore_alias`: certificate alias stored in keystore.
+- `ZWE_configs_certificate_keystore_password`: password of your keystore.
+- `ZWE_configs_certificate_truststore_file`: path to truststore.
+- `ZWE_configs_certificate_truststore_password`: password of your truststore.
+- `CMMN_LB`: set to `apiml-common-lib/bin/api-layer-lite-lib-all.jar`
+- `ZWE_zowe_workspaceDirectory`: set to `/component`
 
 Review the [Metrics Service package start script](../metrics-service-package/src/main/resources/bin/start.sh) to see other environment variables that can be set.
 
@@ -145,16 +156,17 @@ Example commands:
 
 ```
 # pull image
-docker pull zowe-docker-release.jfrog.io/ompzowe/metrics-service:latest
+docker pull zowe-docker-release.jfrog.io/ompzowe/metrics-service:2
 # start container
 docker run -it --rm -p 7551:7551 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -e KEYSTORE=/home/zowe/keystore/localhost/localhost.keystore.p12 \
-    -e KEY_ALIAS=localhost \
-    -e KEYSTORE_PASSWORD=password \
-    -e TRUSTSTORE=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -v $(pwd)/keystore:/home/zowe/keystore \
+    -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
+    -e ZWE_configs_certificate_keystore_alias=localhost \
+    -e ZWE_configs_certificate_keystore_password=password \
+    -e ZWE_configs_certificate_truststore_file=/home/zowe/keystore/localhost/localhost.truststore.p12 \
+    -e ZWE_configs_certificate_truststore_password=password \
     -e CMMN_LB=apiml-common-lib/bin/api-layer-lite-lib-all.jar \
-    -e WORKSPACE_DIR=/component \
-    -e APIML_METRICS_ENABLED=true \
-    zowe-docker-release.jfrog.io/ompzowe/metrics-service:latest
+    -e ZWE_zowe_workspaceDirectory=/component \
+    zowe-docker-release.jfrog.io/ompzowe/metrics-service:2
 ```

--- a/containers/README.md
+++ b/containers/README.md
@@ -61,7 +61,6 @@ docker pull zowe-docker-release.jfrog.io/ompzowe/discovery-service:2
 # start container
 docker run -it --rm -p 7553:7553 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -v $(pwd)/keystore:/home/zowe/keystore \
     -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
     -e ZWE_configs_certificate_keystore_alias=localhost \
     -e ZWE_configs_certificate_keystore_password=password \
@@ -95,7 +94,6 @@ docker pull zowe-docker-release.jfrog.io/ompzowe/api-catalog-services:2
 # start container
 docker run -it --rm -p 7552:7552 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -v $(pwd)/keystore:/home/zowe/keystore \
     -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
     -e ZWE_configs_certificate_keystore_alias=localhost \
     -e ZWE_configs_certificate_keystore_password=password \
@@ -128,7 +126,6 @@ docker pull zowe-docker-release.jfrog.io/ompzowe/caching-service:2
 # start container
 docker run -it --rm -p 7555:7555 \
     -v $(pwd)/keystore:/home/zowe/keystore \
-    -v $(pwd)/keystore:/home/zowe/keystore \
     -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
     -e ZWE_configs_certificate_keystore_alias=localhost \
     -e ZWE_configs_certificate_keystore_password=password \
@@ -159,7 +156,6 @@ Example commands:
 docker pull zowe-docker-release.jfrog.io/ompzowe/metrics-service:2
 # start container
 docker run -it --rm -p 7551:7551 \
-    -v $(pwd)/keystore:/home/zowe/keystore \
     -v $(pwd)/keystore:/home/zowe/keystore \
     -e ZWE_configs_certificate_keystore_file=/home/zowe/keystore/localhost/localhost.keystore.p12 \
     -e ZWE_configs_certificate_keystore_alias=localhost \


### PR DESCRIPTION
# Description

Update config for containers readme to use v2 values.

Linked to #2179 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [x] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
