### PR TITLE
fix: use unique artifacts for gha

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [ master, v2.x.x ]
 
+env:
+    JOB_ID: ${{ github.run_id }}-${{ github.run_number }}
+
 jobs:
     BuildAndTest:
         runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITests
+                    name: CITests-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [ master, v2.x.x ]
 
+env:
+    JOB_ID: ${{ github.run_id }}-${{ github.run_number }}
+
 jobs:
     PublishJibContainers:
         runs-on: ubuntu-latest
@@ -65,7 +68,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITests
+                    name: ContainerCITests-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -110,7 +113,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsRegistration
+                    name: ContainerCITestsRegistration-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -157,7 +160,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsZosmfRsu2012
+                    name: ContainerCITestsZosmfRsu2012-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -204,7 +207,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsZosmfPH34201
+                    name: CITestsZosmfPH34201-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -251,7 +254,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsZosmfWithoutJwt
+                    name: ContainerCITestsZosmfWithoutJwt-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -299,7 +302,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsZosmfWithoutJwtWithAuthenticateEndpoint
+                    name: ContainerCITestsZosmfWithoutJwtWithAuthenticateEndpoint-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -346,7 +349,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsInternalPort
+                    name: ContainerCITestsInternalPort-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -406,7 +409,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsWithRedis
+                    name: ContainerCITestsWithRedis-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -472,7 +475,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: ContainerCITestsWithRedisWithoutSslVerification
+                    name: ContainerCITestsWithRedisWithoutSslVerification-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -551,7 +554,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsHA
+                    name: CITestsHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -640,12 +643,12 @@ jobs:
                     docker ps -q | xargs -L 1 docker logs
             -   name: Correct Permisions
                 run: |
-                    chmod 755 -R .gradle                    
+                    chmod 755 -R .gradle
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: LbHaTests
+                    name: LbHaTests-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -710,12 +713,12 @@ jobs:
             -   name: Correct Permisions
                 run: |
                     chmod 755 -R .gradle
-                    
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsDiscoveryChaoticHA
+                    name: CITestsDiscoveryChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -780,12 +783,12 @@ jobs:
             -   name: Correct Permisions
                 run: |
                     chmod 755 -R .gradle
-                    
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsGatewayChaoticHA
+                    name: CITestsGatewayChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -854,12 +857,12 @@ jobs:
             -   name: Correct Permisions
                 run: |
                     chmod 755 -R .gradle
-                    
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsDicoverableClientChaoticHA
+                    name: CITestsDicoverableClientChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -928,12 +931,12 @@ jobs:
             -   name: Correct Permisions
                 run: |
                     chmod 755 -R .gradle
-                    
+
             -   name: Store results
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsWebSocketChaoticHA
+                    name: CITestsWebSocketChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -1002,7 +1005,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsWithInfinispan
+                    name: CITestsWithInfinispan-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
         # * is a special character in YAML so you have to quote this string
         - cron:  '0 0 * * 5'
 
+env:
+    JOB_ID: ${{ github.run_id }}-${{ github.run_number }}
+
 jobs:
     analyze:
         name: Identify and generate changes in the Error messages
@@ -39,7 +42,7 @@ jobs:
             - name: Store results
               uses: actions/upload-artifact@v2
               with:
-                  name: ErrorMessage
+                  name: ErrorMessage-${{ env.JOB_ID }}
                   path: |
                       docs/docgen/ErrorMessagesDocumentation.md
 


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Using the same artifact name can result in artifact collision and conflicts/corruption: https://github.com/actions/upload-artifact#uploading-to-the-same-artifact
This PR makes each artifact name unique.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
