### PR TITLE
fix: zaas client supports v2 compatibility with both gateway endpoint base Url paths

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
@@ -13,6 +13,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.Tolerate;
 
+import java.util.Objects;
+
 @Data
 @Builder
 public class ConfigProperties {
@@ -28,6 +30,8 @@ public class ConfigProperties {
     private char[] trustStorePassword;
     private boolean httpOnly;
     private boolean nonStrictVerifySslCertificatesOfServices;
+
+    private static final String GATEWAY_SERVICE_ID = "gateway";
 
     @Tolerate
     public ConfigProperties() {
@@ -45,6 +49,30 @@ public class ConfigProperties {
             .httpOnly(httpOnly)
             .nonStrictVerifySslCertificatesOfServices(nonStrictVerifySslCertificatesOfServices)
             .build();
+    }
+
+    public void setApimlBaseUrl(String baseUrl) {
+        if (baseUrl == null) { // default path
+            apimlBaseUrl = "/gateway/api/v1/auth";
+        }
+        else if (baseUrl.contains("/") && baseUrl.contains(GATEWAY_SERVICE_ID)) {
+            String[] baseUrlParts = baseUrl.split("/");
+            if (Objects.equals(baseUrlParts[2], GATEWAY_SERVICE_ID)) {
+                apimlBaseUrl = "/gateway/" + baseUrlParts[0] + "/" + baseUrlParts[1] + "/auth";
+            }
+            else if (Objects.equals(baseUrlParts[3], GATEWAY_SERVICE_ID)) {
+                apimlBaseUrl = "/gateway/" + baseUrlParts[1] + "/" + baseUrlParts[2] + "/auth";
+            }
+            else if (!baseUrl.startsWith("/")) { // starts with gateway/..
+                apimlBaseUrl = "/" + baseUrl;
+            }
+            else {
+                apimlBaseUrl = baseUrl;
+            }
+        }
+        else {
+            apimlBaseUrl = baseUrl;
+        }
     }
 
 }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/DefaultZaasClientConfiguration.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/DefaultZaasClientConfiguration.java
@@ -52,6 +52,7 @@ public class DefaultZaasClientConfiguration {
         ConfigProperties configProperties = new ConfigProperties();
         configProperties.setApimlHost(host);
         configProperties.setApimlPort(port);
+        configProperties.setApimlBaseUrl(baseUrl);
         configProperties.setKeyStorePath(keyStorePath);
         configProperties.setKeyStorePassword(keyStorePassword);
         configProperties.setKeyStoreType(keyStoreType);
@@ -59,15 +60,6 @@ public class DefaultZaasClientConfiguration {
         configProperties.setTrustStorePassword(trustStorePassword);
         configProperties.setTrustStoreType(trustStoreType);
         configProperties.setNonStrictVerifySslCertificatesOfServices(nonStrictVerifySslCertificatesOfServices);
-
-        String updatedBaseUrl;
-        if (!baseUrl.startsWith("/gateway")) {
-            // rearrange path to match new base url format - {service id}/{type}/{api version} - both paths supported until March 2023
-            updatedBaseUrl = "/gateway" + baseUrl.substring(0, baseUrl.indexOf("/gateway")) + "/auth";
-        } else {
-            updatedBaseUrl = baseUrl;
-        }
-        configProperties.setApimlBaseUrl(updatedBaseUrl);
         return configProperties;
     }
 

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/DefaultZaasClientConfiguration.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/DefaultZaasClientConfiguration.java
@@ -52,7 +52,6 @@ public class DefaultZaasClientConfiguration {
         ConfigProperties configProperties = new ConfigProperties();
         configProperties.setApimlHost(host);
         configProperties.setApimlPort(port);
-        configProperties.setApimlBaseUrl(baseUrl);
         configProperties.setKeyStorePath(keyStorePath);
         configProperties.setKeyStorePassword(keyStorePassword);
         configProperties.setKeyStoreType(keyStoreType);
@@ -60,6 +59,15 @@ public class DefaultZaasClientConfiguration {
         configProperties.setTrustStorePassword(trustStorePassword);
         configProperties.setTrustStoreType(trustStoreType);
         configProperties.setNonStrictVerifySslCertificatesOfServices(nonStrictVerifySslCertificatesOfServices);
+
+        String updatedBaseUrl;
+        if (!baseUrl.startsWith("/gateway")) {
+            // rearrange path to match new base url format - {service id}/{type}/{api version} - both paths supported until March 2023
+            updatedBaseUrl = "/gateway" + baseUrl.substring(0, baseUrl.indexOf("/gateway")) + "/auth";
+        } else {
+            updatedBaseUrl = baseUrl;
+        }
+        configProperties.setApimlBaseUrl(updatedBaseUrl);
         return configProperties;
     }
 

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientApimlBaseUrlTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientApimlBaseUrlTest.java
@@ -1,0 +1,47 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.zaasclient.service.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ZaasClientApimlBaseUrlTest {
+
+    private static final String ZOWE_V2_BASE_URL = "/gateway/api/v1/auth";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/v1/gateway/auth", "api/v1/gateway/auth", "/gateway/api/v1/auth", "gateway/api/v1/auth"})
+    void givenBaseUrl_thenTransformToOrDontChangeZoweV2BaseUrl(String baseUrl) {
+        ConfigProperties configProperties = new ConfigProperties();
+        configProperties.setApimlBaseUrl(baseUrl);
+        assertThat(configProperties.getApimlBaseUrl(), is(ZOWE_V2_BASE_URL));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/v1/zaasClient/auth", "api.v1.zaasClient.auth"})
+    void givenBaseUrl_thenDontChangeBaseUrl(String baseUrl) {
+        ConfigProperties configProperties = new ConfigProperties();
+        configProperties.setApimlBaseUrl(baseUrl);
+        assertThat(configProperties.getApimlBaseUrl(), is(baseUrl));
+    }
+
+    @Test
+    void givenBaseUrlIsNull_thenTransformToZoweV2BaseUrl() {
+        ConfigProperties configProperties = new ConfigProperties();
+        configProperties.setApimlBaseUrl(null);
+        assertThat(configProperties.getApimlBaseUrl(), is(ZOWE_V2_BASE_URL));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Amanda D'Errico <amanda.derrico@ibm.com>

# Description

Users can now have both paths `api/v1/gateway/auth` and `gateway/api/v1/auth` be compatible with Zowe v2.x.x. If the old `api/v1/gateway/auth` is provided for apiml.gatewayAuthEndpoint, update that to `gateway/api/v1/auth` before initializing the ZaasClientImpl constructor.

Linked to # ([2182](https://github.com/zowe/api-layer/issues/2182))

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
