### PR TITLE
feat: Service ID prefix replacer

### DIFF
--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -136,6 +136,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java -Xms32m -Xmx256m ${QUI
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
     -Dapiml.service.port=${ZWE_configs_port:-7553} \
     -Dapiml.discovery.staticApiDefinitionsDirectories=${ZWE_STATIC_DEFINITIONS_DIR} \
+    -Dapiml.discovery.serviceIdPrefixReplacer=${APIML_SERVICE_PREFIX_REPLACER} \
     -Dapiml.security.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \
     -Dapiml.security.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
     -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true} \

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
@@ -16,9 +16,11 @@ import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.registry.AbstractInstanceRegistry;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
 import com.netflix.eureka.resources.ServerCodecs;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.netflix.eureka.server.InstanceRegistry;
 import org.springframework.cloud.netflix.eureka.server.InstanceRegistryProperties;
 import org.springframework.context.ApplicationContext;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -37,6 +39,7 @@ import java.lang.reflect.Method;
  * #2659 Race condition with registration events in Eureka server
  * https://github.com/spring-cloud/spring-cloud-netflix/issues/2659
  */
+@Slf4j
 public class ApimlInstanceRegistry extends InstanceRegistry {
 
     private static final String EXCEPTION_MESSAGE = "Implementation of InstanceRegistry changed, please verify fix of order sending events";
@@ -143,6 +146,10 @@ public class ApimlInstanceRegistry extends InstanceRegistry {
 
     @Override
     public void register(InstanceInfo info, int leaseDuration, boolean isReplication) {
+        String regex = System.getProperty("apiml.discovery.serviceIdPrefixReplacer");
+        if (StringUtils.isNotEmpty(regex) && isValidRegex(regex)) {
+            info = changeServiceId(info, regex);
+        }
         try {
             register3ArgsMethodHandle.invokeWithArguments(this, info, leaseDuration, isReplication);
             handleRegistrationMethod.invokeWithArguments(this, info, leaseDuration, isReplication);
@@ -156,7 +163,11 @@ public class ApimlInstanceRegistry extends InstanceRegistry {
     }
 
     @Override
-    public void register(final InstanceInfo info, final boolean isReplication) {
+    public void register(InstanceInfo info, final boolean isReplication) {
+        String regex = System.getProperty("apiml.discovery.serviceIdPrefixReplacer");
+        if (StringUtils.isNotEmpty(regex) && isValidRegex(regex)) {
+            info = changeServiceId(info, regex);
+        }
         try {
             register2ArgsMethodHandle.invokeWithArguments(this, info, isReplication);
             handleRegistrationMethod.invokeWithArguments(this, info, resolveInstanceLeaseDurationRewritten(info), isReplication);
@@ -189,5 +200,41 @@ public class ApimlInstanceRegistry extends InstanceRegistry {
         boolean isUpdated = super.statusUpdate(appName, instanceId, newStatus, lastDirtyTimestamp, isReplication);
         this.appCntx.publishEvent(new EurekaStatusUpdateEvent(this, appName, instanceId));
         return isUpdated;
+    }
+
+    /**
+     * Change the service ID prefix according to the regex before the service registers to Eureka.
+     * @param info the instance info
+     * @param regex the regex
+     * @return instance info with the modified service ID
+     */
+    protected InstanceInfo changeServiceId(final InstanceInfo info, String regex) {
+        String servicePrefix = regex.split(",")[0];
+        String targetValue = regex.split(",")[1];
+        String instanceId = info.getInstanceId();
+        if (instanceId.contains(servicePrefix)) {
+            String appName = info.getAppName();
+            instanceId = instanceId.replace(servicePrefix, targetValue);
+            appName = appName.replace(servicePrefix.toUpperCase(), targetValue.toUpperCase());
+            log.debug("The instance ID of {} service has been changed to {}.", info.getAppName(), instanceId);
+            return new InstanceInfo.Builder(info)
+                .setInstanceId(instanceId)
+                .setAppGroupName(appName)
+                .setAppName(appName)
+                .setVIPAddress(appName)
+                .build();
+        }
+        return info;
+    }
+
+    private boolean isValidRegex(String regex) {
+        String servicePrefix = regex.split(",")[0];
+        String targetValue = regex.split(",")[1];
+        if (StringUtils.isNotEmpty(servicePrefix) &&
+            StringUtils.isNotEmpty(targetValue) &&
+            !servicePrefix.equals(targetValue)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
@@ -1,0 +1,103 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.discovery;
+
+import com.netflix.appinfo.*;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.eureka.*;
+import com.netflix.eureka.resources.ServerCodecs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.Nested;
+
+import org.springframework.cloud.netflix.eureka.server.InstanceRegistryProperties;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApimlInstanceRegistryTest {
+    private ApimlInstanceRegistry apimlInstanceRegistry;
+
+    private EurekaServerConfig serverConfig;
+    private EurekaClientConfig clientConfig;
+    private ServerCodecs serverCodecs;
+    private EurekaClient eurekaClient;
+    private InstanceRegistryProperties instanceRegistryProperties;
+    private ApplicationContext appCntx;
+
+    @BeforeEach
+    void setUp() {
+        serverConfig = new DefaultEurekaServerConfig();
+        clientConfig = mock(EurekaClientConfig.class);
+        serverCodecs = mock(ServerCodecs.class);
+        eurekaClient = mock(DiscoveryClient.class);
+        instanceRegistryProperties = mock(InstanceRegistryProperties.class);
+        appCntx = mock(ApplicationContext.class);
+        apimlInstanceRegistry = new ApimlInstanceRegistry(
+            serverConfig,
+            clientConfig,
+            serverCodecs,
+            eurekaClient,
+            instanceRegistryProperties,
+            appCntx);
+    }
+
+    @Nested
+    class GivenRegexReplacer {
+        @Nested
+        class WhenChangeServiceId {
+            @Test
+            void thenChangeServicePrefix() {
+                String regex = "service,hello";
+                InstanceInfo info = apimlInstanceRegistry.changeServiceId(getStandardInstance(), regex);
+                assertEquals("hello", info.getInstanceId());
+                assertEquals("HELLO", info.getAppName());
+                assertEquals("HELLO", info.getVIPAddress());
+                assertEquals("HELLO", info.getAppGroupName());
+                assertEquals("192.168.0.1", info.getIPAddr());
+                assertEquals("localhost", info.getHostName());
+                assertEquals(9090, info.getSecurePort());
+                assertEquals("localhost", info.getSecureVipAddress());
+            }
+        }
+
+        @Nested
+        class WhenInstanceIdIsDifferentFromRegex {
+            @Test
+            void thenDontChangeServicePrefix() {
+                String regex = "differentService,hello";
+                InstanceInfo info = apimlInstanceRegistry.changeServiceId(getStandardInstance(), regex);
+                assertEquals("service", info.getInstanceId());
+                assertEquals("SERVICE", info.getAppName());
+                assertEquals("SERVICE", info.getVIPAddress());
+                assertEquals("SERVICE", info.getAppGroupName());
+            }
+        }
+    }
+
+    private InstanceInfo getStandardInstance() {
+
+        return InstanceInfo.Builder.newBuilder()
+            .setInstanceId("service")
+            .setAppName("SERVICE")
+            .setAppGroupName("SERVICE")
+            .setIPAddr("192.168.0.1")
+            .enablePort(InstanceInfo.PortType.SECURE, true)
+            .setSecurePort(9090)
+            .setHostName("localhost")
+            .setSecureVIPAddress("localhost")
+            .setVIPAddress("SERVICE")
+            .setStatus(InstanceInfo.InstanceStatus.UP)
+            .build();
+    }
+}

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListenerTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/EurekaInstanceCanceledListenerTest.java
@@ -1,4 +1,4 @@
-package org.zowe.apiml.discovery;/*
+/*
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
@@ -7,6 +7,7 @@ package org.zowe.apiml.discovery;/*
  *
  * Copyright Contributors to the Zowe Project.
  */
+package org.zowe.apiml.discovery;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceCanceledEvent;


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

Add mechanism in Eureka to replace the service ID prefix (based on Zowe configuration) before the service registers to the Discovery Service. This will allow to maintain the compatibility with Zowe v2.

The user will specify a tuple in the Zowe configuration
i.e APIML_DISCOVERY_SERVICEIDPREFIXREPLACER=caservice,bcmservice
and the occurrences in the service metadata (instance id, appname, vipAddress) will be changed based on this mapping, to allow the user to convert to the new service id and be able to use it with API ML (gw routes will be automatically mapped as well).

Linked to https://github.com/zowe/api-layer/issues/1999

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
