### PR TITLE
feat: Enhance x509 authentication scheme to support client certificates (part 1)

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/auth/Authentication.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/auth/Authentication.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.auth;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import lombok.*;
 
 /**
@@ -22,7 +23,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Authentication {
+public class Authentication implements Serializable {
+    private static final long serialVersionUID = -4971506571102951057L;
 
     private AuthenticationScheme scheme;
     private String applid;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.netflix.zuul.util.ZuulRuntimeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
+import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.gateway.security.service.ServiceAuthenticationServiceImpl;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
@@ -61,8 +62,9 @@ public class ServiceAuthenticationFilter extends PreZuulFilter {
 
         final String serviceId = (String) context.get(SERVICE_ID_KEY);
         try {
-            Optional<AuthSource> authSource = authSourceService.getAuthSourceFromRequest();
-            cmd = serviceAuthenticationService.getAuthenticationCommand(serviceId, authSource.orElse(null));
+            Authentication authentication = serviceAuthenticationService.getAuthentication(serviceId);
+            Optional<AuthSource> authSource = serviceAuthenticationService.getAuthSourceByAuthentication(authentication);
+            cmd = serviceAuthenticationService.getAuthenticationCommand(serviceId, authentication, authSource.orElse(null));
 
             // Verify authentication source validity if it is required for the schema
             if (authSource.isPresent() && !isSourceValidForCommand(authSource.get(), cmd)) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecorator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecorator.java
@@ -55,7 +55,7 @@ public class ServiceAuthenticationDecorator {
             AuthenticationCommand cmd;
 
             try {
-                final Optional<AuthSource> authSource = authSourceService.getAuthSourceFromRequest();
+                final Optional<AuthSource> authSource = serviceAuthenticationService.getAuthSourceByAuthentication(authentication);
                 cmd = serviceAuthenticationService.getAuthenticationCommand(authentication, authSource.orElse(null));
 
                 if (cmd == null) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AbstractAuthenticationScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AbstractAuthenticationScheme.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.gateway.security.service.schema;
 
+import java.util.Optional;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
@@ -31,9 +32,17 @@ public interface AbstractAuthenticationScheme {
      * This method decorate the request for target service
      *
      * @param authentication DTO describing details about authentication
-     * @param authSource User's parsed authentication source (Zowe's JWT token, client certificate, etc.), evaluated only, if needed
+     * @param authSource User's authentication source (Zowe's JWT token, client certificate, etc.)
      */
     AuthenticationCommand createCommand(Authentication authentication, AuthSource authSource);
+
+    /**
+     * Returns authentication source according to the logic of the scheme. By default, authentication source is empty.
+     * @return Optional of user's authentication source (Zowe's JWT token, client certificate, etc.) or empty Optional.
+     */
+    default Optional<AuthSource> getAuthSource() {
+        return Optional.empty();
+    }
 
     /**
      * Define implementation, which will be use in case no scheme is defined.

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -11,6 +11,7 @@ package org.zowe.apiml.gateway.security.service.schema;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.zuul.context.RequestContext;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.apache.http.Header;
@@ -87,6 +88,11 @@ public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
             parsedAuthSource.getExpiration().getTime());
 
         return new PassTicketCommand(value, cookieName, expiredAt);
+    }
+
+    @Override
+    public Optional<AuthSource> getAuthSource() {
+        return authSourceService.getAuthSourceFromRequest();
     }
 
     @Value

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -14,6 +14,7 @@ import com.netflix.zuul.context.RequestContext;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.time.DateUtils;
@@ -109,6 +110,11 @@ public class SafIdtScheme implements AbstractAuthenticationScheme {
         } catch (TokenNotValidException | TokenExpireException e) {
             throw new SafIdtException("Unable to parse Identity Token", e);
         }
+    }
+
+    @Override
+    public Optional<AuthSource> getAuthSource() {
+        return authSourceService.getAuthSourceFromRequest();
     }
 
     @RequiredArgsConstructor

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ServiceAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ServiceAuthenticationService.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.gateway.security.service.schema;
 
 import com.netflix.appinfo.InstanceInfo;
+import java.util.Optional;
 import org.zowe.apiml.gateway.security.service.ServiceCacheEvict;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
@@ -52,4 +53,5 @@ public interface ServiceAuthenticationService extends ServiceCacheEvict {
      */
     Authentication getAuthentication(String serviceId);
 
+    Optional<AuthSource> getAuthSourceByAuthentication(Authentication authentication);
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ServiceAuthenticationService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ServiceAuthenticationService.java
@@ -32,10 +32,11 @@ public interface ServiceAuthenticationService extends ServiceCacheEvict {
     /**
      * Get or create command to service's authentication using serviceId and jwtToken of current user
      * @param serviceId ID of service to call
+     * @param authentication Object describing authentication to the service
      * @param authSource authentication source of user (authentication can depends on user privilege)
      * @return authentication command to update request in ZUUL (or lazy command to be updated in load balancer)
      */
-    AuthenticationCommand getAuthenticationCommand(String serviceId, AuthSource authSource);
+    AuthenticationCommand getAuthenticationCommand(String serviceId, Authentication authentication, AuthSource authSource);
 
     /**
      * Get authentication for given InstanceInfo
@@ -43,5 +44,12 @@ public interface ServiceAuthenticationService extends ServiceCacheEvict {
      * @return Authentication object representing instance's authentication schema
      */
     Authentication getAuthentication(InstanceInfo instanceInfo);
+
+    /**
+     * Get authentication for given Service ID
+     * @param serviceId InstanceInfo object of service instance, containing the security metadata
+     * @return Authentication object representing instance's authentication schema
+     */
+    Authentication getAuthentication(String serviceId);
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -61,6 +61,11 @@ public class ZosmfScheme implements AbstractAuthenticationScheme {
         return new ZosmfCommand(expirationTime);
     }
 
+    @Override
+    public Optional<AuthSource> getAuthSource() {
+        return authSourceService.getAuthSourceFromRequest();
+    }
+
     @lombok.Value
     @EqualsAndHashCode(callSuper = false)
     public class ZosmfCommand extends AuthenticationCommand {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
@@ -61,7 +61,7 @@ class ServiceAuthenticationDecoratorTest {
         decorator.process(request);
 
         verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(Authentication.class), any());
-        verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(String.class), any());
+        verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(String.class), any(Authentication.class), any());
     }
 
     @ParameterizedTest
@@ -74,7 +74,7 @@ class ServiceAuthenticationDecoratorTest {
         decorator.process(request);
 
         verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(Authentication.class), any());
-        verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(String.class), any());
+        verify(serviceAuthenticationService, never()).getAuthenticationCommand(any(String.class), any(Authentication.class), any());
     }
 
     @ParameterizedTest

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/http/ServiceAuthenticationDecoratorTest.java
@@ -141,7 +141,7 @@ class ServiceAuthenticationDecoratorTest {
     private void prepareContext(AuthenticationCommand command, AuthSource authSource) {
         RequestContext.getCurrentContext().set(AUTHENTICATION_COMMAND_KEY, command);
         RequestContext.getCurrentContext().set(LOADBALANCED_INSTANCE_INFO_KEY, info);
-        doReturn(Optional.of(authSource)).when(authSourceService).getAuthSourceFromRequest();
+        doReturn(Optional.of(authSource)).when(serviceAuthenticationService).getAuthSourceByAuthentication(any());
         Authentication authentication = mock(Authentication.class);
 
         when(serviceAuthenticationService.getAuthentication(info)).thenReturn(authentication);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,6 +42,7 @@ import org.zowe.apiml.config.service.security.MockedSecurityContext;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
 import org.zowe.apiml.gateway.cache.RetryIfExpiredAspect;
 import org.zowe.apiml.gateway.config.CacheConfig;
+import org.zowe.apiml.gateway.security.service.ServiceAuthenticationServiceImpl.LoadBalancerAuthentication;
 import org.zowe.apiml.gateway.security.service.schema.*;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource.Origin;
@@ -99,7 +101,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
     @BeforeEach
     void init() {
         lockAndClearRequestContext();
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         RequestContext.testSetCurrentContext(null);
         serviceAuthenticationService.evictCacheAllService();
 
@@ -183,7 +185,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
     }
 
     @Test
-    void testGetAuthentication() {
+    void testGetAuthenticationFromInstanceInfo() {
         InstanceInfo ii;
 
         ii = createInstanceInfo("instance1", "bypass", "applid");
@@ -197,6 +199,101 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
 
         ii = createInstanceInfo("instance2", (AuthenticationScheme) null, null);
         assertEquals(new Authentication(), serviceAuthenticationServiceImpl.getAuthentication(ii));
+    }
+
+    @Nested
+    class GivenServiceId {
+        Application application;
+        ServiceAuthenticationService sas;
+
+        @BeforeEach
+        void setup() {
+            sas = spy(serviceAuthenticationServiceImpl);
+        }
+
+        @Nested
+        class WhenNoApplicationsDiscovered {
+            @Test
+            void thenReturnNull() {
+                when(discoveryClient.getApplication("svr01")).thenReturn(null);
+                assertNull(sas.getAuthentication("svr01"));
+            }
+        }
+
+        @Nested
+        class WhenNoInstancesDiscovered {
+            @Test
+            void thenReturnNull() {
+                application = createApplication();
+                when(discoveryClient.getApplication("svr01")).thenReturn(null);
+                assertNull(sas.getAuthentication("svr01"));
+            }
+        }
+
+        @Nested
+        class WhenApplicationDiscovered {
+            Authentication a1 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid01");
+            Authentication a2 = new Authentication(AuthenticationScheme.ZOWE_JWT, null);
+            Authentication a3 = new Authentication(AuthenticationScheme.ZOWE_JWT, "applid01");
+            Authentication a4 = new Authentication(null, null);
+
+            InstanceInfo ii1 = createInstanceInfo("inst01", a1);
+            InstanceInfo ii2 = createInstanceInfo("inst01", a2);
+            InstanceInfo ii3 = createInstanceInfo("inst01", a3);
+            InstanceInfo ii4 = createInstanceInfo("inst02", a4);
+            InstanceInfo ii5 = createInstanceInfo("inst02", null);
+
+            Authentication lba = new LoadBalancerAuthentication();
+
+            @Nested
+            class AndHaveMultipleInstances {
+                @Test
+                void andAllInstancesHasSameAuthentication_thenReturnAuthentication() {
+                    application = createApplication(ii1, ii1, ii1);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(a1, sas.getAuthentication("svr01"));
+                }
+
+                @Test
+                void andInstancesHaveDifferentAuthentication_thenReturnLoadBalancerAuthentication() {
+                    application = createApplication(ii1, ii2, ii3);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(lba, sas.getAuthentication("svr01"));
+                }
+
+                @Test
+                void andInstancesHaveEmptyAuthentication_thenReturnNull() {
+                    application = createApplication(ii4, ii4);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(a4, sas.getAuthentication("svr01"));
+                }
+
+                @Test
+                void andInstancesHaveNullAuthentication_thenReturnNull() {
+                    application = createApplication(ii5, ii5);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(a4, sas.getAuthentication("svr01"));
+                }
+            }
+
+            @Nested
+            class AndHaveOneInstance {
+                @Test
+                void foundAuthenticationIsNull_thenReturnNull() {
+                    application = createApplication(ii5);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(a4, sas.getAuthentication("svr01"));
+                }
+
+                @Test
+                void foundAuthenticationIsEmpty_thenReturnNull() {
+                    application = createApplication(ii4);
+                    when(discoveryClient.getApplication("svr01")).thenReturn(application);
+                    assertEquals(a4, sas.getAuthentication("svr01"));
+                }
+            }
+        }
+
     }
 
     @ParameterizedTest
@@ -251,99 +348,56 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
     @ParameterizedTest
     @MethodSource("provideAuthSourcesList")
     void testGetAuthenticationCommandByServiceId(List<AuthSource> authSourceTriplet) {
-        AuthSource authSource1 = authSourceTriplet.get(0);
-        AuthSource authSource2 = authSourceTriplet.get(1);
-        AuthSource authSource3 = authSourceTriplet.get(2);
+        AuthSource authSource = authSourceTriplet.get(0);
         AuthenticationCommand ok = new AuthenticationCommandTest(false);
         Authentication a1 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid01");
-        Authentication a2 = new Authentication(AuthenticationScheme.ZOWE_JWT, null);
-        Authentication a3 = new Authentication(AuthenticationScheme.ZOWE_JWT, "applid01");
-        Authentication a4 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid02");
-        Authentication a5 = new Authentication(null, null);
-
-        InstanceInfo ii1 = createInstanceInfo("inst01", a1);
-        InstanceInfo ii2 = createInstanceInfo("inst01", a2);
-        InstanceInfo ii3 = createInstanceInfo("inst01", a3);
-        InstanceInfo ii4 = createInstanceInfo("inst01", a4);
-        InstanceInfo ii5 = createInstanceInfo("inst02", a5);
-
-        Application application;
+        Authentication ea = new Authentication(null, null);
+        Authentication lba = new LoadBalancerAuthentication();
 
         ServiceAuthenticationService sas = spy(serviceAuthenticationServiceImpl);
 
         AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
-        doAnswer(invocation -> {
-            return ok;
-        }).when(scheme).createCommand(any(), any());
+        doAnswer(invocation -> ok).when(scheme).createCommand(any(), any());
         when(authenticationSchemeFactory.getSchema(any())).thenReturn(scheme);
 
-        // just one instance
-        application = createApplication(ii1);
-        when(discoveryClient.getApplication("svr01")).thenReturn(application);
-        assertSame(ok, sas.getAuthenticationCommand("svr01", authSource1));
+        // normal authentication as parameter (just one instance or multiple instances with same authentication)
+        assertSame(ok, sas.getAuthenticationCommand("svr01", a1, authSource));
 
-        // multiple same instances
-        application = createApplication(ii1, ii1, ii1);
-        when(discoveryClient.getApplication("svr02")).thenReturn(application);
-        assertSame(ok, sas.getAuthenticationCommand("svr02", authSource2));
+        // loadBalanceAuthentication as parameter (multiple different instances)
+        assertTrue(sas.getAuthenticationCommand("svr02", lba, authSource) instanceof ServiceAuthenticationServiceImpl.LoadBalancerAuthenticationCommand);
 
-        // multiple different instances
-        reset(discoveryClient);
-        application = createApplication(ii1, ii2);
-        when(discoveryClient.getApplication("svr03")).thenReturn(application);
-        assertTrue(sas.getAuthenticationCommand("svr03", authSource3) instanceof ServiceAuthenticationServiceImpl.LoadBalancerAuthenticationCommand);
+        // empty authentication
+        assertSame(AuthenticationCommand.EMPTY, sas.getAuthenticationCommand("svr03", ea, authSource));
 
-        reset(discoveryClient);
-        application = createApplication(ii1, ii3);
-        when(discoveryClient.getApplication("svr03")).thenReturn(application);
-        assertTrue(sas.getAuthenticationCommand("svr03", authSource3) instanceof ServiceAuthenticationServiceImpl.LoadBalancerAuthenticationCommand);
-
-        reset(discoveryClient);
-        application = createApplication(ii1, ii4);
-        when(discoveryClient.getApplication("svr03")).thenReturn(application);
-        assertTrue(sas.getAuthenticationCommand("svr03", authSource3) instanceof ServiceAuthenticationServiceImpl.LoadBalancerAuthenticationCommand);
-
-        reset(discoveryClient);
-        application = createApplication(ii1, ii2, ii3, ii4);
-        when(discoveryClient.getApplication("svr03")).thenReturn(application);
-        assertTrue(sas.getAuthenticationCommand("svr03", authSource3) instanceof ServiceAuthenticationServiceImpl.LoadBalancerAuthenticationCommand);
-
-        reset(discoveryClient);
-        when(discoveryClient.getInstancesById("svr03")).thenReturn(Collections.singletonList(ii5));
-        assertSame(AuthenticationCommand.EMPTY, sas.getAuthenticationCommand("svr03", authSource3));
-
-        when(discoveryClient.getInstancesById("svr04")).thenReturn(Collections.emptyList());
-        assertSame(AuthenticationCommand.EMPTY, sas.getAuthenticationCommand("svr04", authSource3));
+        // null authentication
+        assertSame(AuthenticationCommand.EMPTY, sas.getAuthenticationCommand("svr04", null, authSource));
     }
 
     @ParameterizedTest
     @MethodSource("provideAuthSources")
     void testGetAuthenticationCommandByServiceIdCache(AuthSource authSource) {
-        InstanceInfo ii1 = createInstanceInfo("i1", AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1");
         AuthenticationCommand ac1 = new AuthenticationCommandTest(true);
         AuthenticationCommand ac2 = new AuthenticationCommandTest(false);
-        AbstractAuthenticationScheme aas1 = mock(AbstractAuthenticationScheme.class);
-        when(aas1.getScheme()).thenReturn(AuthenticationScheme.HTTP_BASIC_PASSTICKET);
-        reset(discoveryClient);
+        AbstractAuthenticationScheme schemeBeanMock = mock(AbstractAuthenticationScheme.class);
+        Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1");
 
-        Application application = createApplication(ii1);
-        when(discoveryClient.getApplication("s1")).thenReturn(application);
-        when(authenticationSchemeFactory.getSchema(AuthenticationScheme.HTTP_BASIC_PASSTICKET)).thenReturn(aas1);
-        when(aas1.createCommand(eq(new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1")), any()))
-            .thenReturn(ac1);
+        when(authenticationSchemeFactory.getSchema(AuthenticationScheme.HTTP_BASIC_PASSTICKET)).thenReturn(schemeBeanMock);
+        when(schemeBeanMock.createCommand(eq(authentication), any())).thenReturn(ac1);
 
-        assertSame(ac1, serviceAuthenticationService.getAuthenticationCommand("s1", authSource));
-        verify(discoveryClient, times(2)).getApplication("s1");
+        assertSame(ac1, serviceAuthenticationService.getAuthenticationCommand("s1", authentication, authSource));
+        verify(schemeBeanMock, times(2)).createCommand(authentication, authSource);
 
         serviceAuthenticationService.evictCacheAllService();
-        Mockito.reset(aas1);
-        when(aas1.getScheme()).thenReturn(AuthenticationScheme.HTTP_BASIC_PASSTICKET);
-        when(aas1.createCommand(eq(new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1")), any()))
-            .thenReturn(ac2);
-        assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", authSource));
-        verify(discoveryClient, times(3)).getApplication("s1");
-        assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", authSource));
-        verify(discoveryClient, times(3)).getApplication("s1");
+        Mockito.reset(schemeBeanMock);
+        when(schemeBeanMock.getScheme()).thenReturn(AuthenticationScheme.HTTP_BASIC_PASSTICKET);
+
+        when(schemeBeanMock.createCommand(eq(authentication), any())).thenReturn(ac2);
+
+        assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", authentication, authSource));
+        verify(schemeBeanMock, times(1)).createCommand(authentication, authSource);
+
+        assertSame(ac2, serviceAuthenticationService.getAuthenticationCommand("s1", authentication, authSource));
+        verify(schemeBeanMock, times(1)).createCommand(authentication, authSource);
     }
 
     @ParameterizedTest
@@ -395,49 +449,54 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         AuthSource authSource1 = authSourceList.get(0);
         AuthSource authSource2 = authSourceList.get(1);
         AuthenticationCommand command = AuthenticationCommand.EMPTY;
-        reset(discoveryClient);
+        AbstractAuthenticationScheme schemeBeanMock = mock(ByPassScheme.class);
 
-        Authentication auth = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applicationId0001");
-        doReturn(Collections.singletonList(createInstanceInfo("instance0001", auth))).when(discoveryClient).getInstancesById("service0001");
-        doReturn(Collections.singletonList(createInstanceInfo("instance0002", auth))).when(discoveryClient).getInstancesById("service0002");
-        doReturn(new ByPassScheme()).when(authenticationSchemeFactory).getSchema(auth.getScheme());
+        Authentication auth1 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applicationId0001");
+        Authentication auth2 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applicationId0002");
+        doReturn(schemeBeanMock).when(authenticationSchemeFactory).getSchema(auth1.getScheme());
+        doReturn(schemeBeanMock).when(authenticationSchemeFactory).getSchema(auth2.getScheme());
+        when(schemeBeanMock.createCommand(eq(auth1), any())).thenReturn(command);
+        when(schemeBeanMock.createCommand(eq(auth2), any())).thenReturn(command);
 
-        verify(discoveryClient, never()).getInstancesById("service0001");
-        verify(discoveryClient, never()).getInstancesById("service0002");
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource1));
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource1));
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth2, authSource1));
+        verify(schemeBeanMock, times(1)).createCommand(auth1, authSource1);
+        verify(schemeBeanMock, times(1)).createCommand(auth2, authSource1);
 
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource1));
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource1));
-        verify(discoveryClient, times(1)).getApplication("service0001");
-        verify(discoveryClient, never()).getApplication("service0002");
-
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource2));
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", authSource1));
-        verify(discoveryClient, times(2)).getApplication("service0001");
-        verify(discoveryClient, times(1)).getApplication("service0002");
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource2));
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", auth1, authSource1));
+        verify(schemeBeanMock, times(2)).createCommand(auth1, authSource1);
+        verify(schemeBeanMock, times(1)).createCommand(auth1, authSource2);
 
         serviceAuthenticationService.evictCacheService("service0001");
-
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource1));
-        verify(discoveryClient, times(3)).getApplication("service0001");
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource2));
-        verify(discoveryClient, times(4)).getApplication("service0001");
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", authSource1));
-        verify(discoveryClient, times(1)).getApplication("service0002");
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource1));
+        verify(schemeBeanMock, times(3)).createCommand(auth1, authSource1);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource2));
+        verify(schemeBeanMock, times(2)).createCommand(auth1, authSource2);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth2, authSource1));
+        verify(schemeBeanMock, times(2)).createCommand(auth2, authSource1);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", auth1, authSource1));
+        verify(schemeBeanMock, times(3)).createCommand(auth1, authSource1);
 
         serviceAuthenticationService.evictCacheAllService();
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource1));
-        verify(discoveryClient, times(5)).getApplication("service0001");
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", authSource2));
-        verify(discoveryClient, times(6)).getApplication("service0001");
-        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", authSource1));
-        verify(discoveryClient, times(2)).getApplication("service0002");
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource1));
+        verify(schemeBeanMock, times(4)).createCommand(auth1, authSource1);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth1, authSource2));
+        verify(schemeBeanMock, times(3)).createCommand(auth1, authSource2);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0001", auth2, authSource2));
+        verify(schemeBeanMock, times(1)).createCommand(auth2, authSource2);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", auth1, authSource1));
+        verify(schemeBeanMock, times(5)).createCommand(auth1, authSource1);
+        assertSame(command, serviceAuthenticationService.getAuthenticationCommand("service0002", auth2, authSource1));
+        verify(schemeBeanMock, times(3)).createCommand(auth2, authSource1);
     }
 
     @ParameterizedTest
     @MethodSource("provideAuthSources")
     void testNoApplication(AuthSource authSource) {
         when(discoveryClient.getApplication(any())).thenReturn(null);
-        assertSame(AuthenticationCommand.EMPTY, serviceAuthenticationServiceImpl.getAuthenticationCommand("unknown", authSource));
+        assertSame(AuthenticationCommand.EMPTY, serviceAuthenticationServiceImpl.getAuthenticationCommand("unknown", null, authSource));
     }
 
     @Test
@@ -539,17 +598,18 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         Application application = createApplication(
             createInstanceInfo("instanceId", AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid")
         );
+        Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
         doReturn(application).when(discoveryClient).getApplication("serviceId");
         doReturn(scheme).when(authenticationSchemeFactory).getSchema(any());
         AuthenticationCommandTest cmd = new AuthenticationCommandTest(false);
         doReturn(cmd).when(scheme).createCommand(any(), any());
 
         // first time, create and put into cache
-        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", authSource));
+        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", authentication, authSource));
         verify(scheme, times(1)).createCommand(any(), any());
 
         // second time, get from cache
-        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", authSource));
+        assertSame(cmd, serviceAuthenticationService.getAuthenticationCommand("serviceId", authentication, authSource));
         verify(scheme, times(1)).createCommand(any(), any());
 
         // command expired, take new one
@@ -557,18 +617,18 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         AuthenticationCommand cmd2 = new AuthenticationCommandTest(false);
         reset(scheme);
         doReturn(cmd2).when(scheme).createCommand(any(), any());
-        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", authSource));
+        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", authentication, authSource));
         verify(scheme, times(1)).createCommand(any(), any());
 
         // second command is cached now
-        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", authSource));
+        assertSame(cmd2, serviceAuthenticationService.getAuthenticationCommand("serviceId", authentication, authSource));
         verify(scheme, times(1)).createCommand(any(), any());
     }
 
     @Getter
     @Setter
     @AllArgsConstructor
-    public class AuthenticationCommandTest extends AuthenticationCommand {
+    public static class AuthenticationCommandTest extends AuthenticationCommand {
 
         private static final long serialVersionUID = 8527412076986152763L;
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.gateway.security.service.schema;
 
 import com.netflix.zuul.context.RequestContext;
+import java.util.Optional;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpGet;
@@ -44,6 +45,8 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zowe.apiml.passticket.PassTicketService.DefaultPassTicketImpl.UNKNOWN_USER;
 
@@ -117,6 +120,18 @@ class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
         calendar.add(Calendar.SECOND, authConfigurationProperties.getPassTicket().getTimeout());
         // checking setup of expired time, JWT expired in future (more than hour), check if set date is similar to passticket timeout (5s)
         assertEquals(0.0, Math.abs(calendar.getTime().getTime() - (long) ReflectionTestUtils.getField(ac, "expireAt")), 10.0);
+    }
+
+    @Test
+    void testGetAuthSource() {
+        PassTicketService passTicketService = mock(PassTicketService.class);
+        AuthSourceService authSourceService = mock(AuthSourceService.class);
+        httpBasicPassTicketScheme = new HttpBasicPassTicketScheme(passTicketService, authSourceService, authConfigurationProperties);
+
+        doReturn(Optional.empty()).when(authSourceService).getAuthSourceFromRequest();
+
+        httpBasicPassTicketScheme.getAuthSource();
+        verify(authSourceService, times(1)).getAuthSourceFromRequest();
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
@@ -105,6 +105,14 @@ class ZosmfSchemeTest extends CleanCurrentRequestContextTest {
     }
 
     @Test
+    void testGetAuthSource() {
+        doReturn(Optional.empty()).when(authSourceService).getAuthSourceFromRequest();
+
+        zosmfScheme.getAuthSource();
+        verify(authSourceService, times(1)).getAuthSourceFromRequest();
+    }
+
+    @Test
     void givenAuthSource_whenZosmfIsNotSetAsAuthProvider_thenThrowException() {
         ZosmfScheme zosmfScheme = new ZosmfScheme(authSourceService, null);
         JwtAuthSource authSource = new JwtAuthSource("jwt");


### PR DESCRIPTION
# Description

This PR moves the logic for getting the authentication source from request into schemes.
The motivation for the change: only when specific scheme is chosen (directly or after load balancer) then we can correctly select the source of authentication in case there is more than one present in request.

Linked to #2198 

## Type of change

Please delete options that are not relevant.

- [x] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
