### PR TITLE
chore: rename AbstractAuthenticationScheme interface

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImpl.java
@@ -27,7 +27,7 @@ import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
 import org.zowe.apiml.gateway.cache.RetryIfExpired;
 import org.zowe.apiml.gateway.config.CacheConfig;
-import org.zowe.apiml.gateway.security.service.schema.AbstractAuthenticationScheme;
+import org.zowe.apiml.gateway.security.service.schema.IAuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationSchemeFactory;
 import org.zowe.apiml.gateway.security.service.schema.ServiceAuthenticationService;
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  * This bean is responsible for "translating" security to specific service. It decorate request with security data for
  * specific service. Implementation of security updates are defined with beans extending
- * {@link AbstractAuthenticationScheme}.
+ * {@link IAuthenticationScheme}.
  * <p>
  * The main idea of this bean is to create command
  * {@link AuthenticationCommand}. Command is object which update the
@@ -112,7 +112,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
     @CacheEvict(value = CACHE_BY_AUTHENTICATION, condition = "#result != null && #result.isExpired()")
     @Cacheable(CACHE_BY_AUTHENTICATION)
     public AuthenticationCommand getAuthenticationCommand(Authentication authentication, AuthSource authSource) {
-        final AbstractAuthenticationScheme scheme = authenticationSchemeFactory.getSchema(authentication.getScheme());
+        final IAuthenticationScheme scheme = authenticationSchemeFactory.getSchema(authentication.getScheme());
         return scheme.createCommand(authentication, authSource);
     }
 
@@ -137,7 +137,7 @@ public class ServiceAuthenticationServiceImpl implements ServiceAuthenticationSe
         if (authentication == null || authentication.isEmpty() || authentication instanceof LoadBalancerAuthentication) {
             return Optional.empty();
         }
-        final AbstractAuthenticationScheme scheme = authenticationSchemeFactory.getSchema(authentication.getScheme());
+        final IAuthenticationScheme scheme = authenticationSchemeFactory.getSchema(authentication.getScheme());
         return scheme.getAuthSource();
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationSchemeFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationSchemeFactory.java
@@ -27,21 +27,21 @@ import java.util.Map;
 @Service
 public class AuthenticationSchemeFactory {
 
-    private final AbstractAuthenticationScheme defaultScheme;
-    private final Map<AuthenticationScheme, AbstractAuthenticationScheme> map;
+    private final IAuthenticationScheme defaultScheme;
+    private final Map<AuthenticationScheme, IAuthenticationScheme> map;
 
     private final AuthSourceService authSourceService;
 
-    public AuthenticationSchemeFactory(@Autowired AuthSourceService authSourceService, @Autowired List<AbstractAuthenticationScheme> schemes) {
+    public AuthenticationSchemeFactory(@Autowired AuthSourceService authSourceService, @Autowired List<IAuthenticationScheme> schemes) {
         this.authSourceService = authSourceService;
 
         map = new EnumMap<>(AuthenticationScheme.class);
 
-        AbstractAuthenticationScheme foundDefaultScheme = null;
+        IAuthenticationScheme foundDefaultScheme = null;
 
         // map beans to map, checking duplicity and find exactly one default bean, otherwise throw exception
-        for (final AbstractAuthenticationScheme aas : schemes) {
-            final AbstractAuthenticationScheme prev = map.put(aas.getScheme(), aas);
+        for (final IAuthenticationScheme aas : schemes) {
+            final IAuthenticationScheme prev = map.put(aas.getScheme(), aas);
 
             if (prev != null) {
                 throw new IllegalArgumentException("Multiple beans for scheme " + aas.getScheme() +
@@ -65,10 +65,10 @@ public class AuthenticationSchemeFactory {
         this.defaultScheme = foundDefaultScheme;
     }
 
-    public AbstractAuthenticationScheme getSchema(AuthenticationScheme scheme) {
+    public IAuthenticationScheme getSchema(AuthenticationScheme scheme) {
         if (scheme == null) return defaultScheme;
 
-        final AbstractAuthenticationScheme output = map.get(scheme);
+        final IAuthenticationScheme output = map.get(scheme);
         if (output == null) {
             throw new IllegalArgumentException("Unknown scheme : " + scheme);
         }
@@ -76,7 +76,7 @@ public class AuthenticationSchemeFactory {
     }
 
     public AuthenticationCommand getAuthenticationCommand(Authentication authentication) {
-        final AbstractAuthenticationScheme scheme;
+        final IAuthenticationScheme scheme;
         if ((authentication == null) || (authentication.getScheme() == null)) {
             scheme = defaultScheme;
         } else {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ByPassScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ByPassScheme.java
@@ -21,7 +21,7 @@ import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
  * Default scheme, just forward, don't set anything.
  */
 @Component
-public class ByPassScheme implements AbstractAuthenticationScheme {
+public class ByPassScheme implements IAuthenticationScheme {
 
     public static final String AUTHENTICATION_SCHEME_BY_PASS_KEY = "AuthenticationSchemeByPass";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -37,7 +37,7 @@ import java.util.Base64;
  * SAF and generating new authentication header in request.
  */
 @Component
-public class HttpBasicPassTicketScheme implements AbstractAuthenticationScheme {
+public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
 
     private final PassTicketService passTicketService;
     private final AuthSourceService authSourceService;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/IAuthenticationScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/IAuthenticationScheme.java
@@ -21,7 +21,7 @@ import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
  *
  * For each type of scheme should exist right one implementation.
  */
-public interface AbstractAuthenticationScheme {
+public interface IAuthenticationScheme {
 
     /**
      * @return Scheme which is supported by this component

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/SafIdtScheme.java
@@ -49,7 +49,7 @@ import static org.zowe.apiml.gateway.security.service.JwtUtils.getJwtClaims;
  */
 @Component
 @RequiredArgsConstructor
-public class SafIdtScheme implements AbstractAuthenticationScheme {
+public class SafIdtScheme implements IAuthenticationScheme {
     private final AuthConfigurationProperties authConfigurationProperties;
     private final AuthSourceService authSourceService;
     private final PassTicketService passTicketService;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/X509Scheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/X509Scheme.java
@@ -30,7 +30,7 @@ import java.util.Base64;
  */
 @Component
 @Slf4j
-public class X509Scheme implements AbstractAuthenticationScheme {
+public class X509Scheme implements IAuthenticationScheme {
 
     public static final String ALL_HEADERS = "X-Certificate-Public,X-Certificate-DistinguishedName,X-Certificate-CommonName";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  */
 @Component
 @RequiredArgsConstructor
-public class ZosmfScheme implements AbstractAuthenticationScheme {
+public class ZosmfScheme implements IAuthenticationScheme {
 
     private final AuthSourceService authSourceService;
     private final AuthConfigurationProperties authConfigurationProperties;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZoweJwtScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZoweJwtScheme.java
@@ -16,7 +16,7 @@ import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 
 
 @Component
-public class ZoweJwtScheme implements AbstractAuthenticationScheme {
+public class ZoweJwtScheme implements IAuthenticationScheme {
 
     @Override
     public AuthenticationScheme getScheme() {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/ServiceAuthenticationServiceImplTest.java
@@ -303,7 +303,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         AuthSource authSource2 = authSourcePairs.get(1).left;
         AuthSource.Parsed parsedAuthSource1 = authSourcePairs.get(0).right;
         AuthSource.Parsed parsedAuthSource2 = authSourcePairs.get(1).right;
-        AbstractAuthenticationScheme schemeBeanMock = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme schemeBeanMock = mock(IAuthenticationScheme.class);
 
         AuthenticationCommand acValid = spy(new AuthenticationCommandTest(false));
         AuthenticationCommand acExpired = spy(new AuthenticationCommandTest(true));
@@ -332,7 +332,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
 
     @Test
     void testGetAuthenticationCommand_whenNoAuthSource() {
-        AbstractAuthenticationScheme schemeBeanMock = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme schemeBeanMock = mock(IAuthenticationScheme.class);
         when(authenticationSchemeFactory.getSchema(AuthenticationScheme.HTTP_BASIC_PASSTICKET))
             .thenReturn(schemeBeanMock);
         Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid");
@@ -356,7 +356,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
 
         ServiceAuthenticationService sas = spy(serviceAuthenticationServiceImpl);
 
-        AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme scheme = mock(IAuthenticationScheme.class);
         doAnswer(invocation -> ok).when(scheme).createCommand(any(), any());
         when(authenticationSchemeFactory.getSchema(any())).thenReturn(scheme);
 
@@ -378,7 +378,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
     void testGetAuthenticationCommandByServiceIdCache(AuthSource authSource) {
         AuthenticationCommand ac1 = new AuthenticationCommandTest(true);
         AuthenticationCommand ac2 = new AuthenticationCommandTest(false);
-        AbstractAuthenticationScheme schemeBeanMock = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme schemeBeanMock = mock(IAuthenticationScheme.class);
         Authentication authentication = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid1");
 
         when(authenticationSchemeFactory.getSchema(AuthenticationScheme.HTTP_BASIC_PASSTICKET)).thenReturn(schemeBeanMock);
@@ -420,7 +420,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         when(requestContext.getRequest()).thenReturn(request);
         RequestContext.testSetCurrentContext(requestContext);
         when(authSourceService.getAuthSourceFromRequest()).thenReturn(Optional.of(authSource));
-        AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme scheme = mock(IAuthenticationScheme.class);
         when(scheme.createCommand(eq(new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid0001")), any())).thenReturn(ac);
         when(authenticationSchemeFactory.getSchema(AuthenticationScheme.HTTP_BASIC_PASSTICKET)).thenReturn(scheme);
 
@@ -449,7 +449,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
         AuthSource authSource1 = authSourceList.get(0);
         AuthSource authSource2 = authSourceList.get(1);
         AuthenticationCommand command = AuthenticationCommand.EMPTY;
-        AbstractAuthenticationScheme schemeBeanMock = mock(ByPassScheme.class);
+        IAuthenticationScheme schemeBeanMock = mock(ByPassScheme.class);
 
         Authentication auth1 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applicationId0001");
         Authentication auth2 = new Authentication(AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applicationId0002");
@@ -519,7 +519,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
 
         AuthenticationCommand ac = mock(AuthenticationCommand.class);
         AuthSource.Parsed parsedSource = mock(AuthSource.Parsed.class);
-        AbstractAuthenticationScheme schema = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme schema = mock(IAuthenticationScheme.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
         RequestContext.getCurrentContext().setRequest(request);
 
@@ -594,7 +594,7 @@ class ServiceAuthenticationServiceImplTest extends CurrentRequestContextTest {
     @ParameterizedTest
     @MethodSource("provideAuthSources")
     void givenServiceIdAndAuthSource_whenExpiringCommand_thenReturnNewOne(AuthSource authSource) {
-        AbstractAuthenticationScheme scheme = mock(AbstractAuthenticationScheme.class);
+        IAuthenticationScheme scheme = mock(IAuthenticationScheme.class);
         Application application = createApplication(
             createInstanceInfo("instanceId", AuthenticationScheme.HTTP_BASIC_PASSTICKET, "applid")
         );

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationSchemeFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/AuthenticationSchemeFactoryTest.java
@@ -29,8 +29,8 @@ class AuthenticationSchemeFactoryTest extends CleanCurrentRequestContextTest {
 
     private static final AuthenticationCommand COMMAND = mock(AuthenticationCommand.class);
 
-    private AbstractAuthenticationScheme createScheme(final AuthenticationScheme scheme, final boolean isDefault) {
-        return new AbstractAuthenticationScheme() {
+    private IAuthenticationScheme createScheme(final AuthenticationScheme scheme, final boolean isDefault) {
+        return new IAuthenticationScheme() {
             @Override
             public AuthenticationScheme getScheme() {
                 return scheme;
@@ -64,7 +64,7 @@ class AuthenticationSchemeFactoryTest extends CleanCurrentRequestContextTest {
 
     @Test
     void testInit_NoDefault() {
-        List<AbstractAuthenticationScheme> schemes = Arrays.asList(
+        List<IAuthenticationScheme> schemes = Arrays.asList(
             createScheme(AuthenticationScheme.BYPASS, false),
             createScheme(AuthenticationScheme.HTTP_BASIC_PASSTICKET, false),
             createScheme(AuthenticationScheme.ZOWE_JWT, false)
@@ -79,7 +79,7 @@ class AuthenticationSchemeFactoryTest extends CleanCurrentRequestContextTest {
 
     @Test
     void testInit_MultipleDefaults() {
-        List<AbstractAuthenticationScheme> schemes = Arrays.asList(
+        List<IAuthenticationScheme> schemes = Arrays.asList(
             createScheme(AuthenticationScheme.BYPASS, true),
             createScheme(AuthenticationScheme.HTTP_BASIC_PASSTICKET, true),
             createScheme(AuthenticationScheme.ZOWE_JWT, false)
@@ -95,7 +95,7 @@ class AuthenticationSchemeFactoryTest extends CleanCurrentRequestContextTest {
 
     @Test
     void testInit_MultipleSameScheme() {
-        List<AbstractAuthenticationScheme> schemes = Arrays.asList(
+        List<IAuthenticationScheme> schemes = Arrays.asList(
             createScheme(AuthenticationScheme.BYPASS, true),
             createScheme(AuthenticationScheme.BYPASS, false));
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -125,8 +125,8 @@ class AuthenticationSchemeFactoryTest extends CleanCurrentRequestContextTest {
 
     @Test
     void testGetAuthenticationCommand() {
-        final AbstractAuthenticationScheme byPass = spy(createScheme(AuthenticationScheme.BYPASS, true));
-        final AbstractAuthenticationScheme passTicket = spy(createScheme(AuthenticationScheme.HTTP_BASIC_PASSTICKET, false));
+        final IAuthenticationScheme byPass = spy(createScheme(AuthenticationScheme.BYPASS, true));
+        final IAuthenticationScheme passTicket = spy(createScheme(AuthenticationScheme.HTTP_BASIC_PASSTICKET, false));
 
         AuthSourceService as = mock(AuthSourceService.class);
         AuthenticationSchemeFactory asf = new AuthenticationSchemeFactory(as, Arrays.asList(byPass, passTicket));


### PR DESCRIPTION
Signed-off-by: Yelyzaveta Chebanova <yelyzaveta.chebanova@broadcom.com>

# Description

Rename interface AbstractAuthenticationScheme into IAuthenticationScheme.

Linked to #2198 

## Type of change

Please delete options that are not relevant.

- [x] (chore) Chore, repository cleanup, updates the dependencies.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
