### PR TITLE
fix: API Catalog heading changed #1555

### DIFF
--- a/api-catalog-ui/frontend/src/components/Header/Header.jsx
+++ b/api-catalog-ui/frontend/src/components/Header/Header.jsx
@@ -31,7 +31,7 @@ export default class Header extends Component {
                         </div>
                     </Link>
                     <Link href={dashboard}>
-                        <Text element="h3" color="#ffffff">
+                        <Text as="h3" color="#ffffff">
                             API Catalog
                         </Text>
                     </Link>


### PR DESCRIPTION
Signed-off-by: Boris Petkov <boris.petkov@broadcom.com>

# Description
Fixes the heading API Catalog text link to be rendered as an `h3`

Linked to #1555 

## Type of change

Please delete options that are not relevant.
- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] The java tests in the area I was working on leverage @Nested annotations
- [n/a] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
