### PR TITLE
fix: Add support for regex

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1080,7 +1080,7 @@ jobs:
                 volumes:
                     - /api-defs:/api-defs
                 env:
-                    APIML_DISCOVERY_SERVICEIDPREFIXREPLACER: "discoverable,sample"
+                    APIML_DISCOVERY_SERVICEIDPREFIXREPLACER: "discoverable*,sample"
             gateway-service:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
             mock-services:

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
@@ -235,6 +235,9 @@ public class ApimlInstanceRegistry extends InstanceRegistry {
     protected InstanceInfo changeServiceId(final InstanceInfo info) {
         if (tuple.isValid()) {
             String servicePrefix = tuple.getOldPrefix();
+            if (!servicePrefix.contains("*")) {
+                servicePrefix = servicePrefix + "*";
+            }
             String instanceId = info.getInstanceId();
             String appName = info.getAppName();
             Pattern p = Pattern.compile("(?i)^" + servicePrefix);

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/ApimlInstanceRegistry.java
@@ -214,6 +214,9 @@ public class ApimlInstanceRegistry extends InstanceRegistry {
             String appNameRegex = "(?i)^" + tuple.getOldPrefix();
             String instanceIdRegex = "(?i):" + tuple.getOldPrefix();
             String targetValue = tuple.getNewPrefix();
+            if (targetValue.contains("*")) {
+                targetValue = targetValue.replace("*", "");
+            }
             appName = appName.replaceAll(appNameRegex, targetValue).toUpperCase();
             if (instanceId.contains(":")) {
                 instanceId = instanceId.replaceAll(instanceIdRegex, ":" + targetValue);

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
@@ -56,7 +56,7 @@ class ApimlInstanceRegistryTest {
         eurekaClient = mock(DiscoveryClient.class);
         instanceRegistryProperties = mock(InstanceRegistryProperties.class);
         appCntx = mock(ApplicationContext.class);
-        tuple = new EurekaConfig.Tuple("service,hello");
+        tuple = new EurekaConfig.Tuple("service*,hello");
         apimlInstanceRegistry = spy(new ApimlInstanceRegistry(
             serverConfig,
             clientConfig,
@@ -80,10 +80,10 @@ class ApimlInstanceRegistryTest {
             @Test
             void thenChangeServicePrefix() {
                 InstanceInfo info = apimlInstanceRegistry.changeServiceId(standardInstance);
-                assertEquals("hello", info.getInstanceId());
-                assertEquals("HELLO", info.getAppName());
-                assertEquals("HELLO", info.getVIPAddress());
-                assertEquals("HELLO", info.getAppGroupName());
+                assertEquals("helloclient", info.getInstanceId());
+                assertEquals("HELLOCLIENT", info.getAppName());
+                assertEquals("helloclient", info.getVIPAddress());
+                assertEquals("HELLOCLIENT", info.getAppGroupName());
                 assertEquals("192.168.0.1", info.getIPAddr());
                 assertEquals("localhost", info.getHostName());
                 assertEquals(9090, info.getSecurePort());
@@ -93,13 +93,13 @@ class ApimlInstanceRegistryTest {
     }
     private static Stream<Arguments> tuples() {
        return Stream.of(
-           Arguments.of("service,hello", "hello"),
-           Arguments.of("service,service", "service"),
-           Arguments.of("service", "service"),
-           Arguments.of(",service", "service"),
-           Arguments.of("service,", "service"),
-           Arguments.of(null, "service"),
-           Arguments.of("different,hello", "service")
+           Arguments.of("service*,hello", "helloclient"),
+           Arguments.of("service*,service", "serviceclient"),
+           Arguments.of("service*", "serviceclient"),
+           Arguments.of(",service", "serviceclient"),
+           Arguments.of("service,", "serviceclient"),
+           Arguments.of(null, "serviceclient"),
+           Arguments.of("different*,hello", "serviceclient")
        );
     }
 
@@ -167,7 +167,7 @@ class ApimlInstanceRegistryTest {
                     serverCodecs,
                     eurekaClient,
                     instanceRegistryProperties,
-                    appCntx,new EurekaConfig.Tuple("service,hello")));
+                    appCntx,new EurekaConfig.Tuple("service*,hello")));
                 MethodHandle methodHandle = mock(MethodHandle.class);
                 ReflectionTestUtils.setField(apimlInstanceRegistry, "register2ArgsMethodHandle", methodHandle);
                 when(methodHandle.invokeWithArguments(any(), any(), any())).thenThrow(new RuntimeException());
@@ -202,7 +202,7 @@ class ApimlInstanceRegistryTest {
                     serverCodecs,
                     eurekaClient,
                     instanceRegistryProperties,
-                    appCntx,new EurekaConfig.Tuple("service,hello")));
+                    appCntx,new EurekaConfig.Tuple("service*,hello")));
                 MethodHandle methodHandle = mock(MethodHandle.class);
                 ReflectionTestUtils.setField(apimlInstanceRegistry, "register3ArgsMethodHandle", methodHandle);
                 when(methodHandle.invokeWithArguments(any(), any(), any())).thenThrow(new RuntimeException());
@@ -213,8 +213,8 @@ class ApimlInstanceRegistryTest {
 
             private Stream<Arguments> exceptions() {
                 return Stream.of(
-                    Arguments.of("service,hello", new WrongMethodTypeException()),
-                    Arguments.of("service,hello", new Exception(new Throwable()))
+                    Arguments.of("service*,hello", new WrongMethodTypeException()),
+                    Arguments.of("service*,hello", new Exception(new Throwable()))
                 );
             }
         }
@@ -298,15 +298,15 @@ class ApimlInstanceRegistryTest {
     private InstanceInfo getStandardInstance() {
 
         return InstanceInfo.Builder.newBuilder()
-            .setInstanceId("service")
-            .setAppName("SERVICE")
-            .setAppGroupName("SERVICE")
+            .setInstanceId("serviceclient")
+            .setAppName("SERVICECLIENT")
+            .setAppGroupName("SERVICECLIENT")
             .setIPAddr("192.168.0.1")
             .enablePort(InstanceInfo.PortType.SECURE, true)
             .setSecurePort(9090)
             .setHostName("localhost")
             .setSecureVIPAddress("localhost")
-            .setVIPAddress("SERVICE")
+            .setVIPAddress("serviceclient")
             .setStatus(InstanceInfo.InstanceStatus.UP)
             .build();
     }

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
@@ -94,6 +94,7 @@ class ApimlInstanceRegistryTest {
     private static Stream<Arguments> tuples() {
        return Stream.of(
            Arguments.of("service*,hello", "helloclient"),
+           Arguments.of("service,hello", "helloclient"),
            Arguments.of("service*,hello*", "helloclient"),
            Arguments.of("service*,service", "serviceclient"),
            Arguments.of("service*", "serviceclient"),

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/ApimlInstanceRegistryTest.java
@@ -94,6 +94,7 @@ class ApimlInstanceRegistryTest {
     private static Stream<Arguments> tuples() {
        return Stream.of(
            Arguments.of("service*,hello", "helloclient"),
+           Arguments.of("service*,hello*", "helloclient"),
            Arguments.of("service*,service", "serviceclient"),
            Arguments.of("service*", "serviceclient"),
            Arguments.of(",service", "serviceclient"),


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

Add regex support for the service id prefix replacer. It supports:
1. ca*,bcm
2. ca*,bcm*
3. ca,bcm
4. ca,bcm*

Even uppercase.

Linked to #1999 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [x] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
