### PR TITLE
feat: use default expiration time in Zosmf scheme

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/ZosmfScheme.java
@@ -111,8 +111,8 @@ public class ZosmfScheme implements IAuthenticationScheme {
 
         final long defaultExpirationTime = System.currentTimeMillis() + authConfigurationProperties.getTokenProperties().getExpirationInSeconds() * 1000L;
         final Date expiration = parsedAuthSource == null ? null : parsedAuthSource.getExpiration();
-        final Long expirationTime = expiration != null ? expiration.getTime() : null;
-        final Long expireAt = expirationTime != null ? Math.min(defaultExpirationTime, expirationTime) : null;
+        final long expirationTime = expiration != null ? expiration.getTime() : defaultExpirationTime;
+        final Long expireAt = Math.min(defaultExpirationTime, expirationTime);
         final AuthSource.Origin origin = parsedAuthSource != null ? parsedAuthSource.getOrigin() : null;
 
         return new ZosmfCommand(expireAt, origin, cookieValue, error);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/ZosmfSchemeTest.java
@@ -321,11 +321,14 @@ class ZosmfSchemeTest extends CleanCurrentRequestContextTest {
 
         @Test
         void givenAuthSourceWithoutExpiration_thenCommandIsNotExpired() {
+            long defaultExpiration = System.currentTimeMillis() + authConfigurationProperties.getTokenProperties().getExpirationInSeconds() * 1000L;
             when(authSourceService.parse(new JwtAuthSource("jwtToken"))).thenReturn(new JwtAuthSource.Parsed("user", null, null, Origin.ZOWE));
 
             AuthenticationCommand command = zosmfScheme.createCommand(null, new JwtAuthSource("jwtToken"));
 
-            assertNull(ReflectionTestUtils.getField(command, "expireAt"));
+            Long expiration = (Long) ReflectionTestUtils.getField(command, "expireAt");
+            assertNotNull(expiration);
+            assertTrue(expiration >= defaultExpiration);
             assertFalse(command.isExpired());
         }
 


### PR DESCRIPTION
Signed-off-by: Yelyzaveta Chebanova <yelyzaveta.chebanova@broadcom.com>

# Description

use default expiration time in Zosmf scheme for auth. source without expiration

Linked to #2246 

## Type of change

Please delete options that are not relevant.

- [x] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
