### PR TITLE
feat: Discovery service health check

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicator.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicator.java
@@ -29,9 +29,9 @@ public class DiscoveryServiceHealthIndicator extends AbstractHealthIndicator {
     @Override
     protected void doHealthCheck(Health.Builder builder) {
         String gatewayServiceId = CoreService.GATEWAY.getServiceId();
-        Status gatewayStatus = this.discoveryClient.getInstances(gatewayServiceId).isEmpty() ? Status.DOWN : Status.UP;
+        boolean gatewayDown = this.discoveryClient.getInstances(gatewayServiceId).isEmpty();
         builder
-            .up()
-            .withDetail(gatewayServiceId, gatewayStatus.getCode());
+            .status(gatewayDown ? new Status("PARTIAL", "Authenticated endpoints not available.") : Status.UP)
+            .withDetail(gatewayServiceId, gatewayDown ? Status.DOWN : Status.UP);
     }
 }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicator.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicator.java
@@ -1,0 +1,37 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.discovery.health;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.stereotype.Component;
+import org.zowe.apiml.product.constants.CoreService;
+
+/**
+ * Discovery service health information (/application/health)
+ */
+@Component
+@RequiredArgsConstructor
+public class DiscoveryServiceHealthIndicator extends AbstractHealthIndicator {
+
+    private final DiscoveryClient discoveryClient;
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) {
+        String gatewayServiceId = CoreService.GATEWAY.getServiceId();
+        Status gatewayStatus = this.discoveryClient.getInstances(gatewayServiceId).isEmpty() ? Status.DOWN : Status.UP;
+        builder
+            .up()
+            .withDetail(gatewayServiceId, gatewayStatus.getCode());
+    }
+}

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -87,6 +87,8 @@ management:
     endpoint:
         shutdown:
             enabled: true
+        health:
+            show-details: always
 
 hystrix.command.default.execution.timeout.enabled: false
 ---

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicatorTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicatorTest.java
@@ -37,16 +37,17 @@ class DiscoveryServiceHealthIndicatorTest {
         discoverServiceHealthIndicator.doHealthCheck(builder);
 
         Assertions.assertEquals(Status.UP, builder.build().getStatus());
-        Assertions.assertEquals("UP", builder.build().getDetails().get("gateway"));
+        Assertions.assertEquals(Status.UP, builder.build().getDetails().get("gateway"));
     }
 
     @Test
-    void testStatusIsUpWhenGatewayIsNotAvailable() {
+    void testStatusIsPartialWhenGatewayIsNotAvailable() {
         when(discoveryClient.getInstances(CoreService.GATEWAY.getServiceId())).thenReturn(Collections.emptyList());
 
         discoverServiceHealthIndicator.doHealthCheck(builder);
 
-        Assertions.assertEquals(Status.UP, builder.build().getStatus());
-        Assertions.assertEquals("DOWN", builder.build().getDetails().get("gateway"));
+        Assertions.assertEquals(new Status("PARTIAL"), builder.build().getStatus());
+        Assertions.assertEquals("Authenticated endpoints not available.", builder.build().getStatus().getDescription());
+        Assertions.assertEquals(Status.DOWN, builder.build().getDetails().get("gateway"));
     }
 }

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicatorTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/health/DiscoveryServiceHealthIndicatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.discovery.health;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.zowe.apiml.product.constants.CoreService;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DiscoveryServiceHealthIndicatorTest {
+
+    private final DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+    private final DiscoveryServiceHealthIndicator discoverServiceHealthIndicator = new DiscoveryServiceHealthIndicator(discoveryClient);
+    private final Health.Builder builder = new Health.Builder();
+
+    @Test
+    void testStatusIsUpWhenGatewayIsAvailable() {
+        when(discoveryClient.getInstances(CoreService.GATEWAY.getServiceId())).thenReturn(
+            Collections.singletonList(
+                new DefaultServiceInstance(null, CoreService.GATEWAY.getServiceId(), "host", 10010, true)));
+
+        discoverServiceHealthIndicator.doHealthCheck(builder);
+
+        Assertions.assertEquals(Status.UP, builder.build().getStatus());
+        Assertions.assertEquals("UP", builder.build().getDetails().get("gateway"));
+    }
+
+    @Test
+    void testStatusIsUpWhenGatewayIsNotAvailable() {
+        when(discoveryClient.getInstances(CoreService.GATEWAY.getServiceId())).thenReturn(Collections.emptyList());
+
+        discoverServiceHealthIndicator.doHealthCheck(builder);
+
+        Assertions.assertEquals(Status.UP, builder.build().getStatus());
+        Assertions.assertEquals("DOWN", builder.build().getDetails().get("gateway"));
+    }
+}

--- a/discovery-service/src/test/resources/application.yml
+++ b/discovery-service/src/test/resources/application.yml
@@ -49,6 +49,11 @@ management:
             enabled: false
     endpoint:
         health:
+            status:
+                order: "DOWN,PARTIAL,UP"
+                http-mapping:
+                  DOWN: 503
+                  PARTIAL: 200
             show-details: always
 ---
 spring:

--- a/discovery-service/src/test/resources/application.yml
+++ b/discovery-service/src/test/resources/application.yml
@@ -47,6 +47,9 @@ management:
     health:
         defaults:
             enabled: false
+    endpoint:
+        health:
+            show-details: always
 ---
 spring:
     profiles: https


### PR DESCRIPTION
# Description
This change enables the discovery service health endpoint to return details even when not authenticated. Those details contain the status of the gateway service. The status of the gateway service does not influence the discovery service status, i.e. it remains UP even when the gateway is DOWN.

Sample status:
```
{"status":"UP","components":{"discoveryService":{"status":"UP","details":{"gateway":"DOWN"}}}}
```

Linked to #1549 

## Type of change

Please delete options that are not relevant.
- [x] (feat) New feature (non-breaking change which adds functionality)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [n/a] Any dependent changes have been merged and published in downstream modules
