### PR TITLE
fix: documentation for apidoc endpoints

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -51,7 +51,7 @@ public class CatalogApiDocController {
      */
     @GetMapping(value = "/{serviceId}/{apiId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves the API documentation for a specific service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and version {apiVersion}. When " +
+        notes = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",
         authorizations = {
             @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -138,7 +138,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
             assertNull(paths.get("/status/updates"), apiCatalogSwagger);
             assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
             assertNotNull(paths.get("/containers"), apiCatalogSwagger);
-            assertNotNull(paths.get("/apidoc/{serviceId}/{apiVersion}"), apiCatalogSwagger);
+            assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
             assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
             assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
             assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Fixes documentation and generated swagger for the API Catalog apidoc endpoints.
Note: the example uses the API Catalog service, including a v2.0.0 for the API Catalog. This does not exist, so the provided example values will return a 404. There are no core services within the APIML that have two API versions.

Linked to #2300

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
