### PR TITLE
feat: Create endpoint to retrieve default API doc for service

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.springframework.http.HttpStatus;
 import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,8 +46,8 @@ public class CatalogApiDocController {
     /**
      * Retrieve the api-doc info for this service
      *
-     * @param serviceId  the eureka id
-     * @param apiId the version of the api
+     * @param serviceId the eureka id
+     * @param apiId     the version of the api
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}/{apiId}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -70,16 +71,13 @@ public class CatalogApiDocController {
         @PathVariable(value = "serviceId") String serviceId,
         @ApiParam(name = "apiId", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
         @PathVariable(value = "apiId") String apiId) {
-        try {
-            return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, apiId);
-        } catch (ApiDocNotFoundException e) {
-            return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, null);
-        }
+        return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, apiId);
     }
+
     /**
      * Retrieve the api-doc info for this service's default API
      *
-     * @param serviceId  the eureka id
+     * @param serviceId the eureka id
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -10,8 +10,6 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import org.springframework.http.HttpStatus;
-import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -20,7 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.zowe.apiml.apicatalog.services.status.model.ApiDocNotFoundException;
+import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
 
 /**
  * Main API for handling requests from the API Catalog UI, routed through the gateway

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -82,7 +82,7 @@ public class CatalogApiDocController {
      */
     @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieves the API documentation for the default service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and it's default version.",
+        notes = "Returns the API documentation for a specific service {serviceId} and its default version.",
         authorizations = {
             @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
         },

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -76,6 +76,32 @@ public class CatalogApiDocController {
             return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, null);
         }
     }
+    /**
+     * Retrieve the api-doc info for this service's default API
+     *
+     * @param serviceId  the eureka id
+     * @return api-doc info (as JSON)
+     */
+    @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Retrieves the API documentation for the default service version",
+        notes = "Returns the API documentation for a specific service {serviceId} and it's default version.",
+        authorizations = {
+            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
+        },
+        response = String.class)
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "URI not found"),
+        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+    })
+    @HystrixCommand
+    public ResponseEntity<String> getDefaultApiDocInfo(
+        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @PathVariable(value = "serviceId") String serviceId) {
+        return this.apiServiceStatusService.getServiceCachedDefaultApiDocInfo(serviceId);
+    }
 
     @GetMapping(value = "/{serviceId}/{apiVersion1}/{apiVersion2}", produces = MediaType.TEXT_HTML_VALUE)
     @ApiOperation(value = "Retrieve diff of two api versions for a specific service",

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/CatalogApiDocControllerExceptionHandler.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/CatalogApiDocControllerExceptionHandler.java
@@ -40,7 +40,7 @@ public class CatalogApiDocControllerExceptionHandler {
         Message message = messageService.createMessage("org.zowe.apiml.apicatalog.apiDocNotFound", exception.getMessage());
 
         return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .status(HttpStatus.NOT_FOUND)
             .body(message.mapToView());
     }
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
@@ -89,6 +89,16 @@ public class APIServiceStatusService {
     }
 
     /**
+     * Return the cached default API doc for a service
+     *
+     * @param serviceId  the unique service id
+     * @return the default version of an API Doc
+     */
+    public ResponseEntity<String> getServiceCachedDefaultApiDocInfo(@NonNull String serviceId) {
+        return new ResponseEntity<>(cachedApiDocService.getDefaultApiDocForService(serviceId), createHeaders(), HttpStatus.OK);
+    }
+
+    /**
      * Return the diff of two api versions
      * @param serviceId the unique service id
      * @param apiVersion1 the old version of the api

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocControllerApiDocNotFoundTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocControllerApiDocNotFoundTest.java
@@ -40,7 +40,7 @@ class CatalogApiDocControllerApiDocNotFoundTest {
     @Test
     void getApiDocAndFailThenThrowApiDocNotFoundException() throws Exception {
         this.mockMvc.perform(get("/apidoc/service2/v1"))
-            .andExpect(status().isInternalServerError())
+            .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.messages[?(@.messageNumber == 'ZWEAC103E')].messageContent",
                 hasItem("API Documentation not retrieved, Really bad stuff happened")));
     }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocControllerTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocControllerTest.java
@@ -52,14 +52,9 @@ class CatalogApiDocControllerTest {
             }
 
             @Test
-            void givenNoApiDoc_thenReturnFirst() {
-                ResponseEntity<String> response = new ResponseEntity<>("First API Doc", HttpStatus.OK);
+            void givenNoApiDoc_thenThrowException() {
                 when(mockApiServiceStatusService.getServiceCachedApiDocInfo("service", "1.0.0")).thenThrow(new ApiDocNotFoundException("error"));
-                when(mockApiServiceStatusService.getServiceCachedApiDocInfo("service", null)).thenReturn(response);
-
-                ResponseEntity<String> res = underTest.getApiDocInfo("service", "1.0.0");
-                assertNotNull(res);
-                assertEquals("First API Doc", res.getBody());
+                assertThrows(ApiDocNotFoundException.class, () -> underTest.getApiDocInfo("service", "1.0.0"));
             }
         }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/ApiServiceStatusServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/ApiServiceStatusServiceTest.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.services.status;
 
+import org.junit.jupiter.api.Nested;
 import org.zowe.apiml.apicatalog.model.APIContainer;
 import org.zowe.apiml.apicatalog.model.APIService;
 import org.zowe.apiml.apicatalog.services.cached.CachedApiDocService;
@@ -100,26 +101,43 @@ class ApiServiceStatusServiceTest {
         }
     }
 
-    @Test
-    void givenApiDoc_whenGetCachedApiDocForService_thenSuccessfulResponse() {
-        String apiDoc = "this is the api doc";
-        when(cachedApiDocService.getApiDocForService(anyString(), anyString())).thenReturn(apiDoc);
-        ResponseEntity<String> expectedResponse = new ResponseEntity<>(apiDoc, HttpStatus.OK);
-        ResponseEntity<String> actualResponse = apiServiceStatusService.getServiceCachedApiDocInfo("aaa", "v1");
-        assertEquals(expectedResponse.getStatusCode(), actualResponse.getStatusCode());
-        assertEquals(expectedResponse.getBody(), actualResponse.getBody());
-    }
+    @Nested
+    class GivenCachedApiDoc {
+        @Test
+        void whenGetApiDocForService_thenSuccessfulResponse() {
+            String apiDoc = "this is the api doc";
+            when(cachedApiDocService.getApiDocForService(anyString(), anyString())).thenReturn(apiDoc);
 
-    @Test
-    void givenCachedApiDoc_whenGetApiDiff_thenReturnsApiDiff() {
-        String apiDoc = "{}";
-        when(cachedApiDocService.getApiDocForService(anyString(), anyString())).thenReturn(apiDoc);
-        OpenApiCompareProducer actualProducer = new OpenApiCompareProducer();
-        when(openApiCompareProducer.fromContents(anyString(), anyString())).thenReturn(actualProducer.fromContents(apiDoc, apiDoc));
-        ResponseEntity<String> actualResponse = apiServiceStatusService.getApiDiffInfo("service", "v1", "v2");
-        assertNotNull(actualResponse.getBody());
-        assertTrue(actualResponse.getBody().contains("Api Change Log"));
-        assertEquals(HttpStatus.OK, actualResponse.getStatusCode());
+            ResponseEntity<String> expectedResponse = new ResponseEntity<>(apiDoc, HttpStatus.OK);
+            ResponseEntity<String> actualResponse = apiServiceStatusService.getServiceCachedApiDocInfo("aaa", "v1");
+
+            assertEquals(expectedResponse.getStatusCode(), actualResponse.getStatusCode());
+            assertEquals(expectedResponse.getBody(), actualResponse.getBody());
+        }
+
+        @Test
+        void whenGetDefaultApiDocForService_thenSuccessfulResponse() {
+            String apiDoc = "this is the api doc";
+            when(cachedApiDocService.getDefaultApiDocForService(anyString())).thenReturn(apiDoc);
+
+            ResponseEntity<String> expectedResponse = new ResponseEntity<>(apiDoc, HttpStatus.OK);
+            ResponseEntity<String> actualResponse = apiServiceStatusService.getServiceCachedDefaultApiDocInfo("aaa");
+
+            assertEquals(expectedResponse.getStatusCode(), actualResponse.getStatusCode());
+            assertEquals(expectedResponse.getBody(), actualResponse.getBody());
+        }
+
+        @Test
+        void whenGetApiDiff_thenReturnsApiDiff() {
+            String apiDoc = "{}";
+            when(cachedApiDocService.getApiDocForService(anyString(), anyString())).thenReturn(apiDoc);
+            OpenApiCompareProducer actualProducer = new OpenApiCompareProducer();
+            when(openApiCompareProducer.fromContents(anyString(), anyString())).thenReturn(actualProducer.fromContents(apiDoc, apiDoc));
+            ResponseEntity<String> actualResponse = apiServiceStatusService.getApiDiffInfo("service", "v1", "v2");
+            assertNotNull(actualResponse.getBody());
+            assertTrue(actualResponse.getBody().contains("Api Change Log"));
+            assertEquals(HttpStatus.OK, actualResponse.getStatusCode());
+        }
     }
 
     @Test

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
@@ -49,7 +49,7 @@ class ApiCatalogAuthenticationTest {
     private static final String CATALOG_SERVICE_ID_PATH = "/" + CATALOG_SERVICE_ID;
     private static final String CATALOG_PREFIX = "/api/v1";
 
-    private static final String CATALOG_APIDOC_ENDPOINT = "/apidoc/discoverableclient/v1";
+    private static final String CATALOG_APIDOC_ENDPOINT = "/apidoc/discoverableclient/zowe.apiml.discoverableclient.rest v1.0.0";
     private static final String CATALOG_STATIC_REFRESH_ENDPOINT = "/static-api/refresh";
     private static final String CATALOG_ACTUATOR_ENDPOINT = "/application";
 

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
@@ -14,6 +14,7 @@ import io.restassured.config.SSLConfig;
 import io.restassured.response.Validatable;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -30,6 +31,7 @@ import org.zowe.apiml.util.config.ItSslConfigFactory;
 import org.zowe.apiml.util.config.SslContext;
 import org.zowe.apiml.util.service.DiscoveryUtils;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -67,7 +69,10 @@ class ApiCatalogAuthenticationTest {
 
     static Stream<Arguments> requestsToTest() {
         return Stream.of(
-            Arguments.of(CATALOG_APIDOC_ENDPOINT, (Request) (when, endpoint) -> when.get(getUriFromGateway(CATALOG_SERVICE_ID_PATH + CATALOG_PREFIX + endpoint))),
+            Arguments.of(CATALOG_APIDOC_ENDPOINT, (Request) (when, endpoint) ->
+                when.urlEncodingEnabled(false) // space in URL gets encoded by getUriFromGateway
+                    .get(getUriFromGateway(CATALOG_SERVICE_ID_PATH + CATALOG_PREFIX + endpoint))
+            ),
             Arguments.of(CATALOG_STATIC_REFRESH_ENDPOINT, (Request) (when, endpoint) -> when.post(getUriFromGateway(CATALOG_SERVICE_ID_PATH + CATALOG_PREFIX + endpoint))),
             Arguments.of(CATALOG_ACTUATOR_ENDPOINT, (Request) (when, endpoint) -> when.get(getUriFromGateway(CATALOG_SERVICE_ID_PATH + CATALOG_PREFIX + endpoint)))
         );
@@ -149,8 +154,8 @@ class ApiCatalogAuthenticationTest {
         class ReturnUnauthorized {
             @ParameterizedTest(name = "givenNoAuthentication {index} {0}")
             @MethodSource("org.zowe.apiml.functional.apicatalog.ApiCatalogAuthenticationTest#requestsToTest")
-            void givenNoAuthentication(String endpoint, Request request) {
-                String expectedMessage = "Authentication is required for URL '" + CATALOG_SERVICE_ID_PATH + endpoint + "'";
+            void givenNoAuthentication(String endpoint, Request request) throws URISyntaxException {
+                String expectedMessage = "Authentication is required for URL '" + CATALOG_SERVICE_ID_PATH + new URIBuilder().setPath(endpoint).build() + "'";
 
                 request.execute(
                         given()
@@ -168,8 +173,8 @@ class ApiCatalogAuthenticationTest {
 
             @ParameterizedTest(name = "givenInvalidBasicAuthentication {index} {0}")
             @MethodSource("org.zowe.apiml.functional.apicatalog.ApiCatalogAuthenticationTest#requestsToTest")
-            void givenInvalidBasicAuthentication(String endpoint, Request request) {
-                String expectedMessage = "Invalid username or password for URL '" + CATALOG_SERVICE_ID_PATH + endpoint + "'";
+            void givenInvalidBasicAuthentication(String endpoint, Request request) throws URISyntaxException {
+                String expectedMessage = "Invalid username or password for URL '" + CATALOG_SERVICE_ID_PATH + new URIBuilder().setPath(endpoint).build() + "'";
 
                 request.execute(
                         given()
@@ -185,8 +190,8 @@ class ApiCatalogAuthenticationTest {
 
             @ParameterizedTest(name = "givenInvalidBearerAuthentication {index} {0}")
             @MethodSource("org.zowe.apiml.functional.apicatalog.ApiCatalogAuthenticationTest#requestsToTest")
-            void givenInvalidBearerAuthentication(String endpoint, Request request) {
-                String expectedMessage = "Token is not valid for URL '" + CATALOG_SERVICE_ID_PATH + endpoint + "'";
+            void givenInvalidBearerAuthentication(String endpoint, Request request) throws URISyntaxException {
+                String expectedMessage = "Token is not valid for URL '" + CATALOG_SERVICE_ID_PATH + new URIBuilder().setPath(endpoint).build() + "'";
 
                 request.execute(
                         given()
@@ -202,8 +207,8 @@ class ApiCatalogAuthenticationTest {
 
             @ParameterizedTest(name = "givenInvalidTokenInCookie {index} {0}")
             @MethodSource("org.zowe.apiml.functional.apicatalog.ApiCatalogAuthenticationTest#requestsToTest")
-            void givenInvalidTokenInCookie(String endpoint, Request request) {
-                String expectedMessage = "Token is not valid for URL '" + CATALOG_SERVICE_ID_PATH + endpoint + "'";
+            void givenInvalidTokenInCookie(String endpoint, Request request) throws URISyntaxException {
+                String expectedMessage = "Token is not valid for URL '" + CATALOG_SERVICE_ID_PATH + new URIBuilder().setPath(endpoint).build() + "'";
                 String invalidToken = "nonsense";
 
                 request.execute(

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -52,6 +52,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
     private static final String GET_ALL_CONTAINERS_ENDPOINT = "/apicatalog/api/v1/containers";
     private static final String GET_CONTAINER_BY_ID_ENDPOINT = "/apicatalog/api/v1/containers/apimediationlayer";
     private static final String GET_CONTAINER_BY_INVALID_ID_ENDPOINT = "/apicatalog/api/v1/containers/bad";
+    private static final String GET_API_CATALOG_API_DOC_DEFAULT_ENDPOINT = "/apicatalog/api/v1/apidoc/apicatalog";
     private static final String GET_API_CATALOG_API_DOC_ENDPOINT = "/apicatalog/api/v1/apidoc/apicatalog/zowe.apiml.apicatalog v1.0.0";
     private static final String INVALID_API_CATALOG_API_DOC_ENDPOINT = "/apicatalog/api/v1/apidoc/apicatalog/zowe.apiml.apicatalog v18.0.0";
 
@@ -112,8 +113,41 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
     class ApiDoc {
         @Test
             // Functional
-        void whenCatalogApiDoc_thenResponseOK() throws Exception {
+        void whenSpecificCatalogApiDoc_thenResponseOK() throws Exception {
             final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_ENDPOINT, HttpStatus.SC_OK);
+
+            // When
+            final String jsonResponse = EntityUtils.toString(response.getEntity());
+
+            String apiCatalogSwagger = "\n**************************\n" +
+                "Integration Test: API Catalog Swagger" +
+                "\n**************************\n" +
+                jsonResponse +
+                "\n**************************\n";
+            DocumentContext jsonContext = JsonPath.parse(jsonResponse);
+
+            String swaggerHost = jsonContext.read("$.host");
+            String swaggerBasePath = jsonContext.read("$.basePath");
+            LinkedHashMap paths = jsonContext.read("$.paths");
+            LinkedHashMap definitions = jsonContext.read("$.definitions");
+
+            // Then
+            assertFalse(paths.isEmpty(), apiCatalogSwagger);
+            assertFalse(definitions.isEmpty(), apiCatalogSwagger);
+            assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+            assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+            assertNull(paths.get("/status/updates"), apiCatalogSwagger);
+            assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
+            assertNotNull(paths.get("/containers"), apiCatalogSwagger);
+            assertNotNull(paths.get("/apidoc/{serviceId}/{apiVersion}"), apiCatalogSwagger);
+            assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
+            assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
+            assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+        }
+
+        @Test
+        void whenDefaultCatalogApiDoc_thenResponseOK() throws Exception {
+            final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_DEFAULT_ENDPOINT, HttpStatus.SC_OK);
 
             // When
             final String jsonResponse = EntityUtils.toString(response.getEntity());

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -114,71 +114,74 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
 
     @Nested
     class ApiDoc {
-        @Test
-            // Functional
-        void whenSpecificCatalogApiDoc_thenResponseOK() throws Exception {
-            final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_ENDPOINT, HttpStatus.SC_OK);
+        @Nested
+        class ThenResponseOk {
+            @Test
+                // Functional
+            void whenSpecificCatalogApiDoc() throws Exception {
+                final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_ENDPOINT, HttpStatus.SC_OK);
 
-            // When
-            final String jsonResponse = EntityUtils.toString(response.getEntity());
+                // When
+                final String jsonResponse = EntityUtils.toString(response.getEntity());
 
-            String apiCatalogSwagger = "\n**************************\n" +
-                "Integration Test: API Catalog Swagger" +
-                "\n**************************\n" +
-                jsonResponse +
-                "\n**************************\n";
-            DocumentContext jsonContext = JsonPath.parse(jsonResponse);
+                String apiCatalogSwagger = "\n**************************\n" +
+                    "Integration Test: API Catalog Swagger" +
+                    "\n**************************\n" +
+                    jsonResponse +
+                    "\n**************************\n";
+                DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-            String swaggerHost = jsonContext.read("$.host");
-            String swaggerBasePath = jsonContext.read("$.basePath");
-            LinkedHashMap paths = jsonContext.read("$.paths");
-            LinkedHashMap definitions = jsonContext.read("$.definitions");
+                String swaggerHost = jsonContext.read("$.host");
+                String swaggerBasePath = jsonContext.read("$.basePath");
+                LinkedHashMap paths = jsonContext.read("$.paths");
+                LinkedHashMap definitions = jsonContext.read("$.definitions");
 
-            // Then
-            assertFalse(paths.isEmpty(), apiCatalogSwagger);
-            assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-            assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-            assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
-            assertNull(paths.get("/status/updates"), apiCatalogSwagger);
-            assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
-            assertNotNull(paths.get("/containers"), apiCatalogSwagger);
-            assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
-            assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-            assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-            assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
-        }
+                // Then
+                assertFalse(paths.isEmpty(), apiCatalogSwagger);
+                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
+                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertNull(paths.get("/status/updates"), apiCatalogSwagger);
+                assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
+                assertNotNull(paths.get("/containers"), apiCatalogSwagger);
+                assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
+                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
+                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+            }
 
-        @Test
-        void whenDefaultCatalogApiDoc_thenResponseOK() throws Exception {
-            final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_DEFAULT_ENDPOINT, HttpStatus.SC_OK);
+            @Test
+            void whenDefaultCatalogApiDoc() throws Exception {
+                final HttpResponse response = getResponse(GET_API_CATALOG_API_DOC_DEFAULT_ENDPOINT, HttpStatus.SC_OK);
 
-            // When
-            final String jsonResponse = EntityUtils.toString(response.getEntity());
+                // When
+                final String jsonResponse = EntityUtils.toString(response.getEntity());
 
-            String apiCatalogSwagger = "\n**************************\n" +
-                "Integration Test: API Catalog Swagger" +
-                "\n**************************\n" +
-                jsonResponse +
-                "\n**************************\n";
-            DocumentContext jsonContext = JsonPath.parse(jsonResponse);
+                String apiCatalogSwagger = "\n**************************\n" +
+                    "Integration Test: API Catalog Swagger" +
+                    "\n**************************\n" +
+                    jsonResponse +
+                    "\n**************************\n";
+                DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-            String swaggerHost = jsonContext.read("$.host");
-            String swaggerBasePath = jsonContext.read("$.basePath");
-            LinkedHashMap paths = jsonContext.read("$.paths");
-            LinkedHashMap definitions = jsonContext.read("$.definitions");
+                String swaggerHost = jsonContext.read("$.host");
+                String swaggerBasePath = jsonContext.read("$.basePath");
+                LinkedHashMap paths = jsonContext.read("$.paths");
+                LinkedHashMap definitions = jsonContext.read("$.definitions");
 
-            // Then
-            assertFalse(paths.isEmpty(), apiCatalogSwagger);
-            assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-            assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-            assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
-            assertNull(paths.get("/status/updates"), apiCatalogSwagger);
-            assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
-            assertNotNull(paths.get("/containers"), apiCatalogSwagger);
-            assertNotNull(paths.get("/apidoc/{serviceId}/{apiVersion}"), apiCatalogSwagger);
-            assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-            assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-            assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+                // Then
+                assertFalse(paths.isEmpty(), apiCatalogSwagger);
+                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
+                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
+                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertNull(paths.get("/status/updates"), apiCatalogSwagger);
+                assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
+                assertNotNull(paths.get("/containers"), apiCatalogSwagger);
+                assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
+                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
+                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+            }
         }
 
         @Test

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -88,24 +88,27 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
             assertTrue(containerStatus.contains("UP"));
         }
 
-        @Test
-        @Disabled("The test is flaky, update needed.")
-        void givenApiCatalog_whenGetContainerById_thenResponseOk() throws IOException {
-            final HttpResponse response = getResponse(GET_CONTAINER_BY_ID_ENDPOINT, HttpStatus.SC_OK);
+        @Nested
+        class GivenApiCatalog_thenResponseOk {
+            @Test
+            @Disabled("The test is flaky, update needed.")
+            void whenGetContainerById() throws IOException {
+                final HttpResponse response = getResponse(GET_CONTAINER_BY_ID_ENDPOINT, HttpStatus.SC_OK);
 
-            final String jsonResponse = EntityUtils.toString(response.getEntity());
-            DocumentContext jsonContext = JsonPath.parse(jsonResponse);
-            JSONArray containerTitles = jsonContext.read("$.[*].title");
-            JSONArray containerStatus = jsonContext.read("$.[*].status");
+                final String jsonResponse = EntityUtils.toString(response.getEntity());
+                DocumentContext jsonContext = JsonPath.parse(jsonResponse);
+                JSONArray containerTitles = jsonContext.read("$.[*].title");
+                JSONArray containerStatus = jsonContext.read("$.[*].status");
 
-            assertTrue(containerTitles.contains("API Mediation Layer API"), "Tile title did not match: API Mediation Layer API");
-            assertTrue(containerStatus.contains("UP"));
-        }
+                assertTrue(containerTitles.contains("API Mediation Layer API"), "Tile title did not match: API Mediation Layer API");
+                assertTrue(containerStatus.contains("UP"));
+            }
 
-        @Test
-        void givenApiCatalog_whenGetContainerByInvalidId_thenResponseOk() throws IOException {
-            final HttpResponse response = getResponse(GET_CONTAINER_BY_INVALID_ID_ENDPOINT, HttpStatus.SC_OK);
-            assertEquals("[]", EntityUtils.toString(response.getEntity()));
+            @Test
+            void whenGetContainerByInvalidId() throws IOException {
+                final HttpResponse response = getResponse(GET_CONTAINER_BY_INVALID_ID_ENDPOINT, HttpStatus.SC_OK);
+                assertEquals("[]", EntityUtils.toString(response.getEntity()));
+            }
         }
     }
 
@@ -179,14 +182,8 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
         }
 
         @Test
-        void whenInvalidApiDocVersion_thenReturnFirstDoc() throws Exception {
-            final HttpResponse response = getResponse(INVALID_API_CATALOG_API_DOC_ENDPOINT, HttpStatus.SC_OK);
-
-            // When
-            final String jsonResponse = EntityUtils.toString(response.getEntity());
-            String swaggerBasePath = JsonPath.parse(jsonResponse).read("$.basePath");
-
-            assertEquals("/apicatalog/api/v1", swaggerBasePath);
+        void whenInvalidApiDocVersion_thenReturn404() throws Exception {
+            getResponse(INVALID_API_CATALOG_API_DOC_ENDPOINT, HttpStatus.SC_NOT_FOUND);
         }
     }
 


### PR DESCRIPTION
# Description

- Create endpoint `/apidoc/{serviceId}` that will return the default swagger doc for the given service. The default swagger doc functionality was already made, this endpoint just exposes it directly. The default doc is the `apiInfo` marked with `defaultApi: true`, and if none are marked as default then the highest major version is used. If there is no swagger doc then 404 is returned.
- Change behaviour for the specific version apidoc endpoint `/apidoc/{serviceId}/{apiId}` to return 404 if there is no matching swagger, instead of returning the "first" swagger.

Linked to #2320

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
