### PR TITLE
fix: Add server side logging for swagger handling code

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocService.java
@@ -75,7 +75,7 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             //if there's not apiDoc in cache
-            String logMessage = String.format("Exception updating API doc in cache for %s %s", serviceId, apiVersion);
+            String logMessage = String.format("Exception updating API doc in cache for '%s %s'", serviceId, apiVersion);
             if (apiDoc == null) {
                 log.error("No API doc available for '{} {}': {}", serviceId, apiVersion, logMessage, e);
                 throw new ApiDocNotFoundException(exceptionMessage.apply(serviceId));
@@ -121,7 +121,7 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             //if there's not apiDoc in cache
-            String logMessage = String.format("Exception updating default API doc in cache for %s.", serviceId);
+            String logMessage = String.format("Exception updating default API doc in cache for '%s'.", serviceId);
             if (apiDoc == null) {
                 log.error("No default API doc available for service '{}': {}", serviceId, logMessage, e);
                 throw new ApiDocNotFoundException(exceptionMessage.apply(serviceId));
@@ -160,12 +160,12 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             // if no versions in cache
-            String logMessage = String.format("Exception updating API versions in cache for %s: %s", serviceId, e);
+            String logMessage = String.format("Exception updating API versions in cache for '%s'", serviceId);
             if (apiVersions == null) {
-                log.error("No API versions available for service '{}': {}", serviceId, logMessage);
+                log.error("No API versions available for service '{}': {}", serviceId, logMessage, e);
                 throw new ApiVersionNotFoundException("No API versions were retrieved for the service " + serviceId + ".");
             }
-            log.debug(logMessage);
+            log.debug(logMessage, e);
         }
         return apiVersions;
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocService.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.services.cached;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.zowe.apiml.apicatalog.services.cached.model.ApiDocCacheKey;
@@ -30,6 +31,7 @@ import java.util.function.UnaryOperator;
  */
 
 @Service
+@Slf4j
 public class CachedApiDocService {
     private static final String DEFAULT_API_KEY = "default";
 
@@ -73,9 +75,12 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             //if there's not apiDoc in cache
+            String logMessage = String.format("Exception updating API doc in cache for %s %s", serviceId, apiVersion);
             if (apiDoc == null) {
+                log.error("No API doc available for '{} {}': {}", serviceId, apiVersion, logMessage, e);
                 throw new ApiDocNotFoundException(exceptionMessage.apply(serviceId));
             }
+            log.debug(logMessage, e);
         }
         return apiDoc;
     }
@@ -116,9 +121,12 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             //if there's not apiDoc in cache
+            String logMessage = String.format("Exception updating default API doc in cache for %s.", serviceId);
             if (apiDoc == null) {
+                log.error("No default API doc available for service '{}': {}", serviceId, logMessage, e);
                 throw new ApiDocNotFoundException(exceptionMessage.apply(serviceId));
             }
+            log.debug(logMessage,e);
         }
         return apiDoc;
     }
@@ -152,9 +160,12 @@ public class CachedApiDocService {
             }
         } catch (Exception e) {
             // if no versions in cache
+            String logMessage = String.format("Exception updating API versions in cache for %s: %s", serviceId, e);
             if (apiVersions == null) {
+                log.error("No API versions available for service '{}': {}", serviceId, logMessage);
                 throw new ApiVersionNotFoundException("No API versions were retrieved for the service " + serviceId + ".");
             }
+            log.debug(logMessage);
         }
         return apiVersions;
     }
@@ -184,6 +195,7 @@ public class CachedApiDocService {
                 defaultVersion = version;
             }
         } catch (Exception e) {
+            log.error("No default API version available for service '{}'", serviceId, e);
             throw new ApiVersionNotFoundException("Error trying to find default API version");
         }
         return defaultVersion;

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
@@ -140,7 +140,7 @@ public class APIDocRetrievalService {
         String apiDocUrl = getApiDocUrl(apiInfo, instanceInfo, routes);
 
         if (apiDocUrl == null) {
-            log.warn("No api doc URL for {} {} {}", serviceId, apiInfo.getApiId(), apiInfo.getVersion());
+            log.warn("No api doc URL for '{} {} {}'", serviceId, apiInfo.getApiId(), apiInfo.getVersion());
             return getApiDocInfoBySubstituteSwagger(instanceInfo, routes, apiInfo);
         }
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIServiceStatusService.java
@@ -106,8 +106,8 @@ public class APIServiceStatusService {
             result = result.replace("<link rel=\"stylesheet\" href=\"http://deepoove.com/swagger-diff/stylesheets/demo.css\">", "");
             return new ResponseEntity<>(result, createHeaders(), HttpStatus.OK);
         } catch (Exception e) {
-            String errorMessage = String.format("Error retrieving API diff for %s and versions %s and %s", serviceId, apiVersion1, apiVersion2);
-            log.debug("{}. Cause: {}", errorMessage, e.getMessage());
+            String errorMessage = String.format("Error retrieving API diff for '%s' with versions '%s' and '%s'", serviceId, apiVersion1, apiVersion2);
+            log.error(errorMessage, e);
             throw new ApiDiffNotAvailableException(errorMessage);
         }
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGenerator.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SubstituteSwaggerGenerator.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.swagger;
 
+import lombok.extern.slf4j.Slf4j;
 import org.zowe.apiml.config.ApiInfo;
 import com.netflix.appinfo.InstanceInfo;
 import org.apache.velocity.Template;
@@ -22,6 +23,7 @@ import java.io.StringWriter;
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_DESCRIPTION;
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_TITLE;
 
+@Slf4j
 public class SubstituteSwaggerGenerator {
     private final VelocityEngine ve = new VelocityEngine();
 
@@ -34,6 +36,7 @@ public class SubstituteSwaggerGenerator {
     public String generateSubstituteSwaggerForService(InstanceInfo service,
                                                       ApiInfo api,
                                                       String gatewayScheme, String gatewayHost) {
+        log.warn("Generating substitute swagger for service instance '{}' API '{} {}'", service.getInstanceId(), api.getApiId(), api.getVersion());
         String title = service.getMetadata().get(SERVICE_TITLE);
         String description = service.getMetadata().get(SERVICE_DESCRIPTION);
         String basePath = (api.getGatewayUrl().startsWith("/") ? "" : "/") + service.getAppName().toLowerCase()

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -71,7 +71,7 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
         try {
             return initializeObjectMapper().writeValueAsString(openAPI);
         } catch (JsonProcessingException e) {
-            log.debug("Could not convert Swagger to JSON", e);
+            log.debug("Could not convert OpenAPI to JSON", e);
             throw new ApiDocTransformationException("Could not convert Swagger to JSON");
         }
     }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
@@ -10,6 +10,7 @@
 package org.zowe.apiml.apicatalog.services.cached;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,58 +49,61 @@ class CachedApiDocServiceTest {
         cachedApiDocService.resetCache();
     }
 
-    @Test
-    void givenValidApiDoc_whenRetrieving_thenReturnIt() {
-        String serviceId = "Service";
-        String version = "v1";
-        String expectedApiDoc = "This is some api doc";
+    @Nested
+    class GivenValidApiDoc_thenReturnIt {
+        @Test
+        void whenRetrieving() {
+            String serviceId = "Service";
+            String version = "v1";
+            String expectedApiDoc = "This is some api doc";
 
-        ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
+            ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
 
-        when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
-            .thenReturn(apiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
-            .thenReturn(expectedApiDoc);
+            when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
+                .thenReturn(apiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
+                .thenReturn(expectedApiDoc);
 
-        String apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
+            String apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
 
-        assertNotNull(apiDoc);
-        assertEquals(expectedApiDoc, apiDoc);
-    }
+            assertNotNull(apiDoc);
+            assertEquals(expectedApiDoc, apiDoc);
+        }
 
-    @Test
-    void givenValidApiDoc_whenUpdating_thenRetrieve() {
-        String serviceId = "Service";
-        String version = "v1";
-        String expectedApiDoc = "This is some api doc";
-        String updatedApiDoc = "This is some updated API Doc";
+        @Test
+        void whenUpdating() {
+            String serviceId = "Service";
+            String version = "v1";
+            String expectedApiDoc = "This is some api doc";
+            String updatedApiDoc = "This is some updated API Doc";
 
 
-        ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
+            ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
 
-        when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
-            .thenReturn(apiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
-            .thenReturn(expectedApiDoc);
+            when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
+                .thenReturn(apiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
+                .thenReturn(expectedApiDoc);
 
-        String apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
+            String apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
 
-        assertNotNull(apiDoc);
-        assertEquals(expectedApiDoc, apiDoc);
+            assertNotNull(apiDoc);
+            assertEquals(expectedApiDoc, apiDoc);
 
-        cachedApiDocService.updateApiDocForService(serviceId, version, updatedApiDoc);
+            cachedApiDocService.updateApiDocForService(serviceId, version, updatedApiDoc);
 
-        apiDocInfo = new ApiDocInfo(null, updatedApiDoc, null);
+            apiDocInfo = new ApiDocInfo(null, updatedApiDoc, null);
 
-        when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
-            .thenReturn(apiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
-            .thenReturn(updatedApiDoc);
+            when(apiDocRetrievalService.retrieveApiDoc(serviceId, version))
+                .thenReturn(apiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo))
+                .thenReturn(updatedApiDoc);
 
-        apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
+            apiDoc = cachedApiDocService.getApiDocForService(serviceId, version);
 
-        assertNotNull(apiDoc);
-        assertEquals(updatedApiDoc, apiDoc);
+            assertNotNull(apiDoc);
+            assertEquals(updatedApiDoc, apiDoc);
+        }
     }
 
     @Test
@@ -113,34 +117,37 @@ class CachedApiDocServiceTest {
         assertEquals("No API Documentation was retrieved for the service Service.", exception.getMessage());
     }
 
-    @Test
-    void givenValidApiVersions_whenRetrieving_thenReturnIt() {
-        String serviceId = "service";
-        List<String> expectedVersions = Arrays.asList("1.0.0", "2.0.0");
+    @Nested
+    class GivenValidApiVersions_thenReturnThem {
+        @Test
+        void whenRetrieving() {
+            String serviceId = "service";
+            List<String> expectedVersions = Arrays.asList("1.0.0", "2.0.0");
 
-        when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(expectedVersions);
+            when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(expectedVersions);
 
-        List<String> versions = cachedApiDocService.getApiVersionsForService(serviceId);
-        assertEquals(expectedVersions, versions);
-    }
+            List<String> versions = cachedApiDocService.getApiVersionsForService(serviceId);
+            assertEquals(expectedVersions, versions);
+        }
 
-    @Test
-    void givenValidApiVersions_whenUpdating_thenRetrieve() {
-        String serviceId = "service";
-        List<String> initialVersions = Arrays.asList("1.0.0", "2.0.0");
-        List<String> updatedVersions = Arrays.asList("1.0.0", "2.0.0", "3.0.0");
+        @Test
+        void whenUpdating() {
+            String serviceId = "service";
+            List<String> initialVersions = Arrays.asList("1.0.0", "2.0.0");
+            List<String> updatedVersions = Arrays.asList("1.0.0", "2.0.0", "3.0.0");
 
-        when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(initialVersions);
+            when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(initialVersions);
 
-        List<String> versions = cachedApiDocService.getApiVersionsForService(serviceId);
-        assertEquals(initialVersions, versions);
+            List<String> versions = cachedApiDocService.getApiVersionsForService(serviceId);
+            assertEquals(initialVersions, versions);
 
-        cachedApiDocService.updateApiVersionsForService(serviceId, updatedVersions);
+            cachedApiDocService.updateApiVersionsForService(serviceId, updatedVersions);
 
-        when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(updatedVersions);
+            when(apiDocRetrievalService.retrieveApiVersions(serviceId)).thenReturn(updatedVersions);
 
-        versions = cachedApiDocService.getApiVersionsForService(serviceId);
-        assertEquals(updatedVersions, versions);
+            versions = cachedApiDocService.getApiVersionsForService(serviceId);
+            assertEquals(updatedVersions, versions);
+        }
     }
 
     @Test
@@ -154,40 +161,43 @@ class CachedApiDocServiceTest {
         assertEquals("No API versions were retrieved for the service service.", exception.getMessage());
     }
 
-    @Test
-    void givenValidApiDocs_whenRetrievingDefault_thenReturnLatestApi() {
-        String serviceId = "service";
-        String expectedApiDoc = "This is some api doc";
-        ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
+    @Nested
+    class GivenValidApiDocs {
+        @Test
+        void whenRetrievingDefault_thenReturnLatestApi() {
+            String serviceId = "service";
+            String expectedApiDoc = "This is some api doc";
+            ApiDocInfo apiDocInfo = new ApiDocInfo(null, expectedApiDoc, null);
 
-        when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(apiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo)).thenReturn(expectedApiDoc);
+            when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(apiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, apiDocInfo)).thenReturn(expectedApiDoc);
 
-        String apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
-        assertEquals(expectedApiDoc, apiDoc);
-    }
+            String apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
+            assertEquals(expectedApiDoc, apiDoc);
+        }
 
-    @Test
-    void givenValidApiDocs_whenUpdatingDefault_thenRetrieveDefault() {
-        String serviceId = "service";
-        String initialApiDoc = "This is some api doc";
-        String updatedApiDoc = "This is some updated api doc";
-        ApiDocInfo initialApiDocInfo = new ApiDocInfo(null, initialApiDoc, null);
-        ApiDocInfo updatedApiDocInfo = new ApiDocInfo(null, updatedApiDoc, null);
+        @Test
+        void whenUpdatingDefault_thenRetrieveDefault() {
+            String serviceId = "service";
+            String initialApiDoc = "This is some api doc";
+            String updatedApiDoc = "This is some updated api doc";
+            ApiDocInfo initialApiDocInfo = new ApiDocInfo(null, initialApiDoc, null);
+            ApiDocInfo updatedApiDocInfo = new ApiDocInfo(null, updatedApiDoc, null);
 
-        when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(initialApiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, initialApiDocInfo)).thenReturn(initialApiDoc);
+            when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(initialApiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, initialApiDocInfo)).thenReturn(initialApiDoc);
 
-        String apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
-        assertEquals(initialApiDoc, apiDoc);
+            String apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
+            assertEquals(initialApiDoc, apiDoc);
 
-        cachedApiDocService.updateDefaultApiDocForService(serviceId, updatedApiDoc);
+            cachedApiDocService.updateDefaultApiDocForService(serviceId, updatedApiDoc);
 
-        when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(updatedApiDocInfo);
-        when(transformApiDocService.transformApiDoc(serviceId, updatedApiDocInfo)).thenReturn(updatedApiDoc);
+            when(apiDocRetrievalService.retrieveDefaultApiDoc(serviceId)).thenReturn(updatedApiDocInfo);
+            when(transformApiDocService.transformApiDoc(serviceId, updatedApiDocInfo)).thenReturn(updatedApiDoc);
 
-        apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
-        assertEquals(updatedApiDoc, apiDoc);
+            apiDoc = cachedApiDocService.getDefaultApiDocForService(serviceId);
+            assertEquals(updatedApiDoc, apiDoc);
+        }
     }
 
     @Test
@@ -200,31 +210,34 @@ class CachedApiDocServiceTest {
         assertEquals("No API Documentation was retrieved for the service service.", exception.getMessage());
     }
 
-    @Test
-    void givenDefaultApiVersion_whenRetrieveDefaultVersion_thenReturnIt() {
-        String serviceId = "service";
-        String expected = "v1";
-        when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(expected);
+    @Nested
+    class GivenDefaultApiVersion_thenReturnIt {
+        @Test
+        void whenRetrieveDefaultVersion() {
+            String serviceId = "service";
+            String expected = "v1";
+            when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(expected);
 
-        String actual = cachedApiDocService.getDefaultApiVersionForService(serviceId);
-        assertEquals(expected, actual);
-    }
+            String actual = cachedApiDocService.getDefaultApiVersionForService(serviceId);
+            assertEquals(expected, actual);
+        }
 
-    @Test
-    void givenDefaultApiVersion_whenUpdateDefaultVersion_thenRetrieveDefault() {
-        String serviceId = "service";
-        String initialVersion = "v1";
-        String updatedVersion = "v2";
+        @Test
+        void whenUpdateDefaultVersion() {
+            String serviceId = "service";
+            String initialVersion = "v1";
+            String updatedVersion = "v2";
 
-        when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(initialVersion);
-        String version = cachedApiDocService.getDefaultApiVersionForService(serviceId);
-        assertEquals(initialVersion, version);
+            when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(initialVersion);
+            String version = cachedApiDocService.getDefaultApiVersionForService(serviceId);
+            assertEquals(initialVersion, version);
 
-        cachedApiDocService.updateDefaultApiVersionForService(serviceId, updatedVersion);
+            cachedApiDocService.updateDefaultApiVersionForService(serviceId, updatedVersion);
 
-        when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(null);
-        version = cachedApiDocService.getDefaultApiVersionForService(serviceId);
-        assertEquals(updatedVersion, version);
+            when(apiDocRetrievalService.retrieveDefaultApiVersion(serviceId)).thenReturn(null);
+            version = cachedApiDocService.getDefaultApiVersionForService(serviceId);
+            assertEquals(updatedVersion, version);
+        }
     }
 
     @Test

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/ApiServiceStatusServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/status/ApiServiceStatusServiceTest.java
@@ -146,7 +146,7 @@ class ApiServiceStatusServiceTest {
         Exception ex = assertThrows(ApiDiffNotAvailableException.class, () ->
             apiServiceStatusService.getApiDiffInfo("service", "v1", "v2")
         );
-        assertEquals("Error retrieving API diff for service and versions v1 and v2", ex.getMessage());
+        assertEquals("Error retrieving API diff for 'service' with versions 'v1' and 'v2'", ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
# Description

Add better logging for server side code in  API Catalog that handles swagger, errors and warnings are logged and more debug information is logged. This will greatly help with debugging why a swagger document isn't rendered in the Catalog.

Linked to #2315

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
