### PR TITLE
fix: Normalize swagger paths

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocService.java
@@ -12,11 +12,14 @@ package org.zowe.apiml.apicatalog.swagger.api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.client.utils.URIBuilder;
 import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
 import org.zowe.apiml.config.ApiInfo;
 import org.zowe.apiml.product.gateway.GatewayClient;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.ServiceType;
+
+import java.net.URISyntaxException;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -66,11 +69,16 @@ public abstract class AbstractApiDocService<T, N> {
      * @return endpoint
      */
     protected String getEndPoint(String swaggerBasePath, String originalEndpoint) {
-        String endPoint = originalEndpoint;
         if (swaggerBasePath != null && !swaggerBasePath.equals(OpenApiUtil.SEPARATOR)) {
-            endPoint = swaggerBasePath + endPoint;
+            try {
+                return new URIBuilder().setPath(swaggerBasePath + originalEndpoint).build().normalize().toString();
+            } catch (URISyntaxException e) {
+                log.error("Error trying to normalize '{}{}'. Returning original endpoint '{}'. Error: {}",
+                    swaggerBasePath, originalEndpoint, originalEndpoint, e.getMessage());
+                return originalEndpoint;
+            }
         }
-        return endPoint;
+        return originalEndpoint;
     }
 
     /**

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
@@ -7,9 +7,9 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-
 package org.zowe.apiml.apicatalog.swagger.api;
 
+import org.junit.jupiter.api.Nested;
 import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
 import org.zowe.apiml.apicatalog.swagger.api.dummy.DummyApiDocService;
 import org.zowe.apiml.config.ApiInfo;
@@ -54,19 +54,34 @@ class AbstractApiDocServiceTest {
     }
 
     @Test
-    void shouldGetShortEndpoint() {
+    void givenRoutedUrlAndEndpoint_whenGetShortEndpoint_thenReturnEndpoint() {
         String shortEndpoint = abstractApiDocService.getShortEndPoint("/apicatalog/api/v1", "/apicatalog");
         assertEquals("/apicatalog", shortEndpoint);
     }
 
-    @Test
-    void shouldGetEndpoint() {
-        String endpoint = abstractApiDocService.getEndPoint("/api/v1/api-doc", "/apicatalog");
-        assertEquals("/api/v1/api-doc/apicatalog", endpoint);
+    @Nested
+    class WhenGetEndpoint {
+        @Test
+        void givenPathAndEndpoint_thenReturnThem() {
+            String endpoint = abstractApiDocService.getEndPoint("/api/v1/api-doc", "/apicatalog");
+            assertEquals("/api/v1/api-doc/apicatalog", endpoint);
+        }
+
+        @Test
+        void givenBasePathAndEndpointThatWillResultInMalformedUrl_thenReturnNormalizedEndpoint() {
+            String endpoint = abstractApiDocService.getEndPoint("/api/v1/api-doc/", "/apicatalog");
+            assertEquals("/api/v1/api-doc/apicatalog", endpoint);
+        }
+
+        @Test
+        void givenBasePathAndEndpointThatWillCauseUriException_thenReturnOriginalEndpoint() {
+            String endpoint = abstractApiDocService.getEndPoint(null, null);
+            assertNull(endpoint);
+        }
     }
 
     @Test
-    void shouldGetEndpointPairs() {
+    void givenRoutedEndpoint_whenGetEndpointPairs_thenReturnRoutedPair() {
         RoutedService routedService = new RoutedService("api_v1", "api/v1", "/apicatalog/api/v1");
         Pair endpointPairs = abstractApiDocService.getEndPointPairs("/apicatalog", "apicatalog", routedService);
         ImmutablePair expectedPairs = new ImmutablePair("/apicatalog", "/apicatalog/api/v1/apicatalog");
@@ -74,13 +89,13 @@ class AbstractApiDocServiceTest {
     }
 
     @Test
-    void shouldReturnNull_whenGetRoutedServiceByApiInfo_IfApiInfoIsNull() {
+    void givenNullApiInfo_whenGetRoutedServiceByApiInfo_thenReturnNull() {
         ApiDocInfo apiDocInfo = new ApiDocInfo(null, null, null);
         assertNull(abstractApiDocService.getRoutedServiceByApiInfo(apiDocInfo, "/"));
     }
 
     @Test
-    void preparePath() {
+    void givenSwaggerDoc_whenPreparePaths_thenSetpathsInSwaggerDoc() {
         List<Server> servers = new ArrayList<>();
         servers.add(0, new Server().url("/apicatalog"));
         ApiDocPath<PathItem> apiDocPath = new ApiDocPath<>();

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/AbstractApiDocServiceTest.java
@@ -9,14 +9,6 @@
  */
 package org.zowe.apiml.apicatalog.swagger.api;
 
-import org.junit.jupiter.api.Nested;
-import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
-import org.zowe.apiml.apicatalog.swagger.api.dummy.DummyApiDocService;
-import org.zowe.apiml.config.ApiInfo;
-import org.zowe.apiml.product.gateway.GatewayClient;
-import org.zowe.apiml.product.gateway.GatewayConfigProperties;
-import org.zowe.apiml.product.routing.RoutedService;
-import org.zowe.apiml.product.routing.RoutedServices;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -28,16 +20,22 @@ import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.zowe.apiml.apicatalog.services.cached.model.ApiDocInfo;
+import org.zowe.apiml.apicatalog.swagger.api.dummy.DummyApiDocService;
+import org.zowe.apiml.config.ApiInfo;
+import org.zowe.apiml.product.gateway.GatewayClient;
+import org.zowe.apiml.product.gateway.GatewayConfigProperties;
+import org.zowe.apiml.product.routing.RoutedService;
+import org.zowe.apiml.product.routing.RoutedServices;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 class AbstractApiDocServiceTest {


### PR DESCRIPTION
# Description

Normalize swagger paths so base paths ending with a `/` and paths starting with a `/` don't create a malformed url with `//`.

Linked to #2218 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
