### PR TITLE
improve shell if checks

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -45,7 +45,7 @@
 # - ZWE_haInstance_hostname
 # - ZWE_zowe_certificate_keystore_type - The default keystore type to use for SSL certificates
 # - ZWE_zowe_verifyCertificates - if we accept only verified certificates
-if [ ${LAUNCH_COMPONENT} ]
+if [ -n "${LAUNCH_COMPONENT}" ]
 then
     JAR_FILE="${LAUNCH_COMPONENT}/api-catalog-services-lite.jar"
 else
@@ -54,21 +54,21 @@ fi
 echo "jar file: "${JAR_FILE}
 # script assumes it's in the catalog component directory and common_lib needs to be relative path
 
-if [[ -z ${CMMN_LB} ]]
+if [ -z "${CMMN_LB}" ]
 then
     COMMON_LIB="../apiml-common-lib/bin/api-layer-lite-lib-all.jar"
 else
     COMMON_LIB=${CMMN_LB}
 fi
 
-if [[ -z ${LIBRARY_PATH} ]]
+if [ -z "${LIBRARY_PATH}" ]
 then
     LIBRARY_PATH="../common-java-lib/bin/"
 fi
 # API Mediation Layer Debug Mode
 export LOG_LEVEL=
 
-if [[ ! -z ${ZWE_configs_debug} && ${ZWE_configs_debug} == true ]]
+if [ "${ZWE_configs_debug}" = "true" ]
 then
   export LOG_LEVEL="debug"
 fi
@@ -103,7 +103,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ `uname` = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]; then
     QUICK_START=-Xquickstart
 fi
 LIBPATH="$LIBPATH":"/lib"

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -103,7 +103,8 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]
+then
     QUICK_START=-Xquickstart
 fi
 LIBPATH="$LIBPATH":"/lib"

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -82,7 +82,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
 fi

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -42,7 +42,7 @@
 # - ZWE_haInstance_hostname
 # - ZWE_zowe_certificate_keystore_type - The default keystore type to use for SSL certificates
 # - ZWE_zowe_verifyCertificates - if we accept only verified certificates
-if [ ${LAUNCH_COMPONENT} ]
+if [ -n "${LAUNCH_COMPONENT}" ]
 then
     JAR_FILE="${LAUNCH_COMPONENT}/caching-service.jar"
 else
@@ -53,17 +53,17 @@ echo "jar file: "${JAR_FILE}
 # API Mediation Layer Debug Mode
 export LOG_LEVEL=
 
-if [[ ! -z ${ZWE_configs_debug} && ${ZWE_configs_debug} == true ]]
+if [ "${ZWE_configs_debug}" = "true" ]
 then
   export LOG_LEVEL="debug"
 fi
 
-if [[ -z ${LIBRARY_PATH} ]]
+if [ -z "${LIBRARY_PATH}" ]
 then
     LIBRARY_PATH="../common-java-lib/bin/"
 fi
 
-if [ ! -z ${ZWE_configs_storage_vsam_name} ]
+if [ -n "${ZWE_configs_storage_vsam_name}" ]
 then
     VSAM_FILE_NAME=//\'${ZWE_configs_storage_vsam_name}\'
 fi
@@ -82,7 +82,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ `uname` = "OS/390" ]
+if [ "$(uname)" = "OS/390" ]; then
 then
     QUICK_START=-Xquickstart
 fi

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -39,7 +39,7 @@
 # - ZWE_zowe_certificate_keystore_type - The default keystore type to use for SSL certificates
 # - ZWE_zowe_verifyCertificates - if we accept only verified certificates
 # - ZWE_configs_apiml_discovery_serviceIdPrefixReplacer - The service ID prefix replacer to be V2 conformant
-if [ ${LAUNCH_COMPONENT} ]
+if [ -n "${LAUNCH_COMPONENT}" ]
 then
     JAR_FILE="${LAUNCH_COMPONENT}/discovery-service-lite.jar"
 else
@@ -48,21 +48,21 @@ fi
 
 echo "jar file: "${JAR_FILE}
 # script assumes it's in the discovery component directory and common_lib needs to be relative path
-if [[ -z ${CMMN_LB} ]]
+if [ -z "${CMMN_LB}" ]
 then
     COMMON_LIB="../apiml-common-lib/bin/api-layer-lite-lib-all.jar"
 else
     COMMON_LIB=${CMMN_LB}
 fi
 
-if [[ -z ${LIBRARY_PATH} ]]
+if [ -z "${LIBRARY_PATH}" ]
 then
     LIBRARY_PATH="../common-java-lib/bin/"
 fi
 # API Mediation Layer Debug Mode
 export LOG_LEVEL=
 
-if [[ ! -z ${ZWE_configs_debug} && ${ZWE_configs_debug} == true ]]
+if [ "${ZWE_configs_debug}" = "true" ]
 then
   export LOG_LEVEL="debug"
 fi
@@ -97,13 +97,13 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ `uname` = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]; then
     QUICK_START=-Xquickstart
 fi
 
 DISCOVERY_LOADER_PATH=${COMMON_LIB}
 
-if [[ ! -z ${ZWE_DISCOVERY_SHARED_LIBS} ]]
+if [ -n "${ZWE_GATEWAY_SHARED_LIBS}" ]
 then
     DISCOVERY_LOADER_PATH=${ZWE_DISCOVERY_SHARED_LIBS},${DISCOVERY_LOADER_PATH}
 fi

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -97,7 +97,8 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]
+then
     QUICK_START=-Xquickstart
 fi
 

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -128,7 +128,8 @@ then
     APIML_GATEWAY_CATALOG_ID=""
 fi
 
-if [ "$(uname)" = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]
+then
     QUICK_START=-Xquickstart
     GATEWAY_LOADER_PATH=${COMMON_LIB},/usr/include/java_classes/IRRRacf.jar
 else

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -67,7 +67,7 @@
 # - ZWE_zowe_certificate_keystore_type - The default keystore type to use for SSL certificates
 # - ZWE_zowe_verifyCertificates - if we accept only verified certificates
 
-if [ ${LAUNCH_COMPONENT} ]
+if [ -n "${LAUNCH_COMPONENT}" ]
 then
     JAR_FILE="${LAUNCH_COMPONENT}/gateway-service-lite.jar"
 else
@@ -76,14 +76,14 @@ fi
 echo "jar file: "${JAR_FILE}
 # script assumes it's in the gateway component directory and common_lib needs to be relative path
 
-if [[ -z ${CMMN_LB} ]]
+if [ -z "${CMMN_LB}" ]
 then
     COMMON_LIB="../apiml-common-lib/bin/api-layer-lite-lib-all.jar"
 else
     COMMON_LIB=${CMMN_LB}
 fi
 
-if [[ -z ${LIBRARY_PATH} ]]
+if [ -z "${LIBRARY_PATH}" ]
 then
     LIBRARY_PATH="../common-java-lib/bin/"
 fi
@@ -91,7 +91,7 @@ fi
 # API Mediation Layer Debug Mode
 export LOG_LEVEL=
 
-if [[ ! -z ${ZWE_configs_debug} && ${ZWE_configs_debug} == true ]]
+if [ "${ZWE_configs_debug}" = "true" ]
 then
   export LOG_LEVEL="debug"
 fi
@@ -118,17 +118,17 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [[ -z ${ZWE_configs_apiml_catalog_serviceId} ]]
+if [ -z "${ZWE_configs_apiml_catalog_serviceId}" ]
 then
     APIML_GATEWAY_CATALOG_ID="apicatalog"
 fi
 
-if [ ${ZWE_configs_apiml_catalog_serviceId} = "none" ]
+if [ "${ZWE_configs_apiml_catalog_serviceId}" = "none" ]
 then
     APIML_GATEWAY_CATALOG_ID=""
 fi
 
-if [ `uname` = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ]; then
     QUICK_START=-Xquickstart
     GATEWAY_LOADER_PATH=${COMMON_LIB},/usr/include/java_classes/IRRRacf.jar
 else
@@ -136,7 +136,7 @@ else
 fi
 
 # Check if the directory containing the Gateway shared JARs was set and append it to the GW loader path
-if [[ ! -z ${ZWE_GATEWAY_SHARED_LIBS} ]]
+if [ -n "${ZWE_GATEWAY_SHARED_LIBS}" ]
 then
     GATEWAY_LOADER_PATH=${ZWE_GATEWAY_SHARED_LIBS},${GATEWAY_LOADER_PATH}
 fi
@@ -153,7 +153,7 @@ LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/default
 LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/j9vm
 LIBPATH="$LIBPATH":"${LIBRARY_PATH}"
 
-if [[ ! -z ${ZWE_GATEWAY_LIBRARY_PATH} ]]
+if [ -n "${ZWE_GATEWAY_LIBRARY_PATH}" ]
 then
     LIBPATH="$LIBPATH":"${ZWE_GATEWAY_LIBRARY_PATH}"
 fi

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -70,7 +70,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ]; then
+if [ "$(uname)" = "OS/390" ];
 then
     QUICK_START=-Xquickstart
 fi

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -70,7 +70,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ];
+if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
 fi

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -41,7 +41,7 @@
 
 JAR_FILE="$(pwd)/bin/metrics-service-lite.jar"
 # script assumes it's in the metrics component directory and common_lib needs to be relative path
-if [[ -z ${CMMN_LB} ]]
+if [ -z "${CMMN_LB}" ]
 then
     COMMON_LIB="../apiml-common-lib/bin/api-layer-lite-lib-all.jar"
 else
@@ -51,7 +51,7 @@ fi
 # API Mediation Layer Debug Mode
 export LOG_LEVEL=
 
-if [[ ! -z ${ZWE_configs_debug} && ${ZWE_configs_debug} == true ]]
+if [ "${ZWE_configs_debug}" = "true" ]
 then
   export LOG_LEVEL="debug"
 fi
@@ -70,7 +70,7 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ `uname` = "OS/390" ]
+if [ "$(uname)" = "OS/390" ]; then
 then
     QUICK_START=-Xquickstart
 fi


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

# Description

This should completely fix potential errors in lifecycle scripts. Reported in slack zowe-user channel:

in the server startup log, I see this line:
```
[: FSUM6807 expression syntax error
```

The exact line causes this error is gateway start.sh:

```
if [ ${ZWE_configs_apiml_catalog_serviceId} = "none" ]
then
    APIML_GATEWAY_CATALOG_ID=""
fi
```

This issue should also exist in v1 since there is similar code https://github.com/zowe/api-layer/blob/master/gateway-package/src/main/resources/bin/start.sh#L67.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
