### PR TITLE
fix: use same key and record lengths as jcl

### DIFF
--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/config/VsamConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/config/VsamConfig.java
@@ -31,9 +31,9 @@ public class VsamConfig {
 
     @Value("${caching.storage.vsam.name:}")
     private String fileName;
-    @Value("${caching.storage.vsam.keyLength:32}")
+    @Value("${caching.storage.vsam.keyLength:128}")
     private int keyLength;
-    @Value("${caching.storage.vsam.recordLength:512}")
+    @Value("${caching.storage.vsam.recordLength:4096}")
     private int recordLength;
     @Value("${caching.storage.vsam.encoding:" + ZFileConstants.DEFAULT_EBCDIC_CODE_PAGE + "}")
     private String encoding;


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Fixes the default values of `caching.storage.vsam.keyLength` and `caching.storage.vsam.recordLength` to match those in the JCL of zowe-install-packaging.

Linked to #2203

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
