### PR TITLE
Update schemas to match configmgr use

### DIFF
--- a/api-catalog-package/src/main/resources/manifest.yaml
+++ b/api-catalog-package/src/main/resources/manifest.yaml
@@ -13,11 +13,6 @@ schemas:
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 commands:
   start: bin/start.sh
   validate: bin/validate.sh

--- a/apiml-common-lib-package/build.gradle
+++ b/apiml-common-lib-package/build.gradle
@@ -24,6 +24,7 @@ task packageCommonLib(type: Zip) {
 
     into('/') {
         from "$resourceDir/manifest.yaml"
+        from "../schemas/apiml-common-lib-schema.json"
     }
 
     into('bin/') {

--- a/apiml-common-lib-package/src/main/resources/manifest.yaml
+++ b/apiml-common-lib-package/src/main/resources/manifest.yaml
@@ -11,8 +11,5 @@ license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
+schemas:
+  configs: "apiml-common-lib-schema.json"

--- a/apiml-sample-extension-package/build.gradle
+++ b/apiml-sample-extension-package/build.gradle
@@ -28,6 +28,7 @@ task packageSampleExtension(type: Zip) {
 
     into('/') {
         from "$resourceDir/manifest.yaml"
+        from "../schemas/apiml-sample-extension-schema.json"
     }
 
     into('bin/') {

--- a/apiml-sample-extension-package/src/main/resources/manifest.yaml
+++ b/apiml-sample-extension-package/src/main/resources/manifest.yaml
@@ -11,13 +11,9 @@ license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 # The following block contains all the extensions directory path
 # (or file path) that will be included in the API ML
 gatewaySharedLibs:
     - bin/apiml-sample-extension.jar
-
+schemas:
+  configs: "apiml-sample-extension-schema.json"

--- a/caching-service-package/src/main/resources/manifest.yaml
+++ b/caching-service-package/src/main/resources/manifest.yaml
@@ -13,11 +13,6 @@ schemas:
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 commands:
   start: bin/start.sh
   validate: bin/validate.sh

--- a/discovery-package/src/main/resources/manifest.yaml
+++ b/discovery-package/src/main/resources/manifest.yaml
@@ -13,11 +13,6 @@ schemas:
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 commands:
   start: bin/start.sh
   validate: bin/validate.sh

--- a/gateway-package/src/main/resources/manifest.yaml
+++ b/gateway-package/src/main/resources/manifest.yaml
@@ -13,11 +13,6 @@ schemas:
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 commands:
   start: bin/start.sh
   validate: bin/validate.sh

--- a/metrics-service-package/src/main/resources/manifest.yaml
+++ b/metrics-service-package/src/main/resources/manifest.yaml
@@ -13,11 +13,6 @@ schemas:
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 commands:
   start: bin/start.sh
   validate: bin/validate.sh

--- a/schemas/apiml-common-lib-schema.json
+++ b/schemas/apiml-common-lib-schema.json
@@ -1,0 +1,22 @@
+{  
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/v2/apiml-common-lib",
+  "allOf": [
+    { "$ref": "https://zowe.org/schemas/v2/server-base" },
+    { 
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {  
+            "apiml-common-lib": {
+              "$ref": "https://zowe.org/schemas/v2/server-base#zoweComponent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+

--- a/schemas/apiml-sample-extension-schema.json
+++ b/schemas/apiml-sample-extension-schema.json
@@ -1,0 +1,22 @@
+{  
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/v2/apiml-sample-extension",
+  "allOf": [
+    { "$ref": "https://zowe.org/schemas/v2/server-base" },
+    { 
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {  
+            "apiml-sample-extension": {
+              "$ref": "https://zowe.org/schemas/v2/server-base#zoweComponent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
# Description

Upon using configmgr, it was spotted that many components do not fill in the templates on their manifest.yaml files for the `build` info section (the {{}} remain in builds from what I saw). This is not APIML exclusive though I'm sure it could be fixed in a pipeline update. For now, I was able to have manifest schema validation succeed by just removing the build info sections since they're just optional.

Also, because every component needs a schema, this includes `apiml-common-lib` and `common-java-lib`. I made a 'trivial' schema for them. Due to how components have evolved, I'm not sure if they should be/need to be components but at least adding these trivial schemas makes the validation code happy.

Linked to https://github.com/zowe/zowe-install-packaging/issues/2879
Linked to https://github.com/zowe/zowe-install-packaging/issues/2662

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
These changes wont have a meaningful effect until configmgr is merged, but they dont depend upon configmgr.