### PR TITLE
feat: Extend API operation filter in the Swagger UI

### DIFF
--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -14,6 +14,7 @@ import './Swagger.css';
 import InstanceInfo from '../ServiceTab/InstanceInfo';
 import getBaseUrl from '../../helpers/urls';
 import { BasicSnippedGenerator } from '../../utils/generateSnippets';
+import { AdvancedFilterPlugin } from '../../utils/filterApis';
 
 function transformSwaggerToCurrentHost(swagger) {
     swagger.host = window.location.host;
@@ -101,7 +102,7 @@ export default class SwaggerUI extends Component {
                     spec: swagger,
                     presets: [SwaggerUi.presets.apis],
                     requestSnippetsEnabled: true,
-                    plugins: [this.customPlugins, BasicSnippedGenerator],
+                    plugins: [this.customPlugins, BasicSnippedGenerator, AdvancedFilterPlugin],
                     filter: true,
                 });
             }
@@ -113,7 +114,7 @@ export default class SwaggerUI extends Component {
                     url,
                     presets: [SwaggerUi.presets.apis],
                     requestSnippetsEnabled: true,
-                    plugins: [this.customPlugins, BasicSnippedGenerator],
+                    plugins: [this.customPlugins, BasicSnippedGenerator, AdvancedFilterPlugin],
                     filter: true,
                     responseInterceptor: (res) => {
                         // response.text field is used to render the swagger

--- a/api-catalog-ui/frontend/src/utils/filterApis.js
+++ b/api-catalog-ui/frontend/src/utils/filterApis.js
@@ -1,0 +1,47 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+/**
+ * Custom Plugin which extends the SwaggerUI filter functionality to filter APIs by tag, summary and description
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const AdvancedFilterPlugin = function (system) {
+    return {
+        fn: {
+            opsFilter: (taggedOps, phrase) => {
+                // eslint-disable-next-line no-param-reassign
+                phrase = phrase.toLowerCase();
+                const normalTaggedOps = JSON.parse(JSON.stringify(taggedOps));
+                Object.keys(normalTaggedOps).forEach((tagObj) => {
+                    const { operations } = normalTaggedOps[tagObj];
+                    let i = operations.length;
+                    // eslint-disable-next-line no-plusplus
+                    while (i--) {
+                        const { operation } = operations[i];
+                        if (
+                            operations[i].path.toLowerCase().indexOf(phrase) === -1 &&
+                            operation.summary !== undefined &&
+                            operation.description !== undefined &&
+                            operation.summary.toLowerCase().indexOf(phrase) === -1 &&
+                            operation.description.toLowerCase().indexOf(phrase) === -1
+                        ) {
+                            operations.splice(i, 1);
+                        }
+                    }
+                    if (operations.length === 0) {
+                        delete normalTaggedOps[tagObj];
+                    } else {
+                        normalTaggedOps[tagObj].operations = operations;
+                    }
+                });
+                return system.Im.fromJS(normalTaggedOps);
+            },
+        },
+    };
+};

--- a/api-catalog-ui/frontend/src/utils/filterApis.js
+++ b/api-catalog-ui/frontend/src/utils/filterApis.js
@@ -7,6 +7,44 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
+/**
+ * Extend the filter by allowing to search not only by tags, but also by description and summary.
+ * The filter is also case-insensitive.
+ * @param phrase the search input
+ * @param taggedOps the API doc
+ * @param system the system
+ * @returns {*} the filtered API operation
+ */
+export function extendFilter(phrase, taggedOps, system) {
+    // eslint-disable-next-line no-param-reassign
+    phrase = phrase.toLowerCase();
+    const normalTaggedOps = JSON.parse(JSON.stringify(taggedOps));
+    Object.keys(normalTaggedOps).forEach((tagObj) => {
+        const { operations } = normalTaggedOps[tagObj];
+        let i = operations.length;
+        // eslint-disable-next-line no-plusplus
+        while (i--) {
+            const { operation } = operations[i];
+            if (
+                operations[i].path.toLowerCase().indexOf(phrase) === -1 &&
+                operation.summary !== undefined &&
+                operation.description !== undefined &&
+                operation.summary.toLowerCase().indexOf(phrase) === -1 &&
+                operation.description.toLowerCase().indexOf(phrase) === -1
+            ) {
+                operations.splice(i, 1);
+            }
+        }
+        if (operations.length === 0) {
+            delete normalTaggedOps[tagObj];
+        } else {
+            normalTaggedOps[tagObj].operations = operations;
+        }
+    });
+    return system.Im.fromJS(normalTaggedOps);
+}
+
 /**
  * Custom Plugin which extends the SwaggerUI filter functionality to filter APIs by tag, summary and description
  */
@@ -14,34 +52,7 @@
 export const AdvancedFilterPlugin = function (system) {
     return {
         fn: {
-            opsFilter: (taggedOps, phrase) => {
-                // eslint-disable-next-line no-param-reassign
-                phrase = phrase.toLowerCase();
-                const normalTaggedOps = JSON.parse(JSON.stringify(taggedOps));
-                Object.keys(normalTaggedOps).forEach((tagObj) => {
-                    const { operations } = normalTaggedOps[tagObj];
-                    let i = operations.length;
-                    // eslint-disable-next-line no-plusplus
-                    while (i--) {
-                        const { operation } = operations[i];
-                        if (
-                            operations[i].path.toLowerCase().indexOf(phrase) === -1 &&
-                            operation.summary !== undefined &&
-                            operation.description !== undefined &&
-                            operation.summary.toLowerCase().indexOf(phrase) === -1 &&
-                            operation.description.toLowerCase().indexOf(phrase) === -1
-                        ) {
-                            operations.splice(i, 1);
-                        }
-                    }
-                    if (operations.length === 0) {
-                        delete normalTaggedOps[tagObj];
-                    } else {
-                        normalTaggedOps[tagObj].operations = operations;
-                    }
-                });
-                return system.Im.fromJS(normalTaggedOps);
-            },
+            opsFilter: (taggedOps, phrase) => extendFilter(phrase, taggedOps, system),
         },
     };
 };

--- a/api-catalog-ui/frontend/src/utils/filterApis.test.js
+++ b/api-catalog-ui/frontend/src/utils/filterApis.test.js
@@ -1,0 +1,84 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+import { extendFilter } from './filterApis';
+
+describe('>>> Filter APIs', () => {
+    it('should filter the operation', () => {
+        const system = {
+            Im: {
+                fromJS: (obj) => obj,
+            },
+        };
+        const spec = {
+            'API Catalog': {
+                tagDetails: {
+                    name: 'API Catalog',
+                    description: 'Api Catalog Controller',
+                },
+                operations: [
+                    {
+                        path: '/containers',
+                        method: 'get',
+                        operation: {
+                            tags: ['API Catalog'],
+                            summary: 'Lists catalog dashboard tiles',
+                            description: 'Returns a list of tiles including status and tile description',
+                            operationId: 'getAllAPIContainersUsingGET',
+                            produces: ['application/json'],
+                            parameters: [],
+                            responses: {
+                                200: {
+                                    description: 'OK',
+                                    schema: {
+                                        type: 'array',
+                                        items: {
+                                            $ref: '#/definitions/APIContainer',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        id: 'get-/containers',
+                    },
+                    {
+                        path: '/containers/{id}',
+                        method: 'get',
+                        operation: {
+                            tags: ['API Catalog'],
+                            summary: 'Retrieves a specific dashboard tile information',
+                            description:
+                                'Returns information for a specific tile {id} including status and tile description',
+                            operationId: 'getAPIContainerByIdUsingGET',
+                            parameters: [
+                                {
+                                    name: 'id',
+                                },
+                            ],
+                            responses: {
+                                200: {
+                                    description: 'OK',
+                                    schema: {
+                                        type: 'array',
+                                        items: {
+                                            $ref: '#/definitions/APIContainer',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        id: 'get-/containers/{id}',
+                    },
+                ],
+            },
+        };
+        const filteredApi = extendFilter('Lists catalog', spec, system);
+        expect(filteredApi['API Catalog'].operations[0].operation.summary).toEqual('Lists catalog dashboard tiles');
+    });
+});


### PR DESCRIPTION
# Description

Customize via plugin the APIs filtering. By default, the `filter` feature allows to search APIs by tag. 
These changes will extend the filtering mechanism to search also by description and summary.
It addresses one of the possible acceptance criteria of #2253 


## Type of change

Please delete options that are not relevant.

- [x] (feat) New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
