### PR TITLE
Support of expired password in ZAAS client

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/exception/ZaasClientErrorCodes.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/exception/ZaasClientErrorCodes.java
@@ -9,22 +9,35 @@
  */
 package org.zowe.apiml.zaasclient.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum ZaasClientErrorCodes {
+
     EXPIRED_JWT_EXCEPTION("ZWEAS100E", "Token is expired for URL", 401),
     INVALID_AUTHENTICATION("ZWEAS120E", "Invalid username or password", 401),
     EMPTY_NULL_USERNAME_PASSWORD("ZWEAS121E", "Empty or null username or password values provided", 400),
-    INVALID_JWT_TOKEN("ZWEAS130E", "Invalid token provided", 400),
     EMPTY_NULL_AUTHORIZATION_HEADER("ZWEAS122E", "Empty or null authorization header provided", 400),
+    INVALID_JWT_TOKEN("ZWEAS130E", "Invalid token provided", 400),
     GENERIC_EXCEPTION("ZWEAS170E", "An exception occurred while trying to get the token", 400),
     BAD_REQUEST("ZWEAS400E", "Unable to generate PassTicket. Verify that the secured signon (PassTicket) function " +
         "and application ID is configured properly by referring to  Using PassTickets in the guide for your security provider", 400),
     TOKEN_NOT_PROVIDED("ZWEAS401E", "Token is not provided", 401),
     SERVICE_UNAVAILABLE("ZWEAS404E", "Gateway service is unavailable", 404),
+    EXPIRED_PASSWORD("ZWEAT412E", "The specified password is expired", 401),
     APPLICATION_NAME_NOT_FOUND("ZWEAS417E", "The application name wasn't found", 404);
 
     private final String id;
     private final String message;
     private final int returnCode;
+
+    private static final Map<String, ZaasClientErrorCodes> errorNumberToEnum = new HashMap<>();
+
+    static {
+        for (ZaasClientErrorCodes value : values()) {
+            errorNumberToEnum.put(value.id, value);
+        }
+    }
 
     ZaasClientErrorCodes(String id, String message, int returnCode) {
         this.id = id;
@@ -44,6 +57,10 @@ public enum ZaasClientErrorCodes {
         return returnCode;
     }
 
+    public static ZaasClientErrorCodes byErrorNumber(String errorNumber) {
+        return errorNumberToEnum.get(errorNumber);
+    }
+
     @Override
     public String toString() {
         return "ZaasClientErrorCodes{" +
@@ -52,4 +69,5 @@ public enum ZaasClientErrorCodes {
             ", returnCode=" + returnCode +
             '}';
     }
+
 }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtServiceTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtServiceTest.java
@@ -51,6 +51,18 @@ class ZaasJwtServiceTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
+    private static final String EXPIRED_PASSWORD_RESPONSE =
+        "{\n" +
+        "    \"messages\": [\n" +
+        "        {\n" +
+        "            \"messageType\": \"ERROR\",\n" +
+        "            \"messageNumber\": \"ZWEAT412E\",\n" +
+        "            \"messageContent\": \"The password for the specified identity has expired\",\n" +
+        "            \"messageKey\": \"org.zowe.apiml.security.platform.errno.EMVSEXPIRE\"\n" +
+        "        }\n" +
+        "    ]\n" +
+        "}";
+
     @Mock
     private CloseableHttpClient closeableHttpClient;
 
@@ -172,6 +184,20 @@ class ZaasJwtServiceTest {
         mockRequest.addHeader(HttpHeaders.AUTHORIZATION, "");
 
         zaasClientTestAssertThrows(ZaasClientErrorCodes.TOKEN_NOT_PROVIDED, "No token provided", () -> zaasJwtService.query(mockRequest));
+    }
+
+    @Test
+    void givenExpiredPassword_whenLogin_thenThrowException() throws IOException {
+        mockHttpClient(401, EXPIRED_PASSWORD_RESPONSE);
+        zaasClientTestAssertThrows(ZaasClientErrorCodes.EXPIRED_PASSWORD, "The specified password is expired",
+            () -> zaasJwtService.login("user", "password"));
+    }
+
+    @Test
+    void givenExpiredPassword_whenQuery_thenThrowException() throws IOException {
+        mockHttpClient(401, EXPIRED_PASSWORD_RESPONSE);
+        zaasClientTestAssertThrows(ZaasClientErrorCodes.EXPIRED_PASSWORD, "The specified password is expired",
+                () -> zaasJwtService.query("jwt"));
     }
 
     private void mockHttpClient(int statusCode) throws IOException {


### PR DESCRIPTION
# Description

The ZAAS client does not detect the reason of 401 (on method login and query). In case the reason is expired password, the exception should contain the information.

Linked to #2396

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [x] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
