### PR TITLE
Support expired password by Dummy SAF provider

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/saf/MockPlatformUser.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/saf/MockPlatformUser.java
@@ -13,19 +13,24 @@ import org.zowe.apiml.security.common.auth.saf.PlatformReturned;
 import org.zowe.apiml.security.common.error.PlatformPwdErrno;
 
 public class MockPlatformUser implements PlatformUser {
+
     public static final String VALID_USERID = "USER";
     public static final String VALID_PASSWORD = "validPassword";
+    public static final String EXPIRED_PASSWORD = "expiredPassword";
     public static final String INVALID_USERID = "notuser";
     public static final String INVALID_PASSWORD = "notuser"; //NOSONAR
 
     @Override
     public PlatformReturned authenticate(String userid, String password) {
-        if (userid.equalsIgnoreCase(VALID_USERID) && password.equalsIgnoreCase(VALID_PASSWORD)) {
-            return null;
+        if (userid.equalsIgnoreCase(VALID_USERID)) {
+            if (password.equalsIgnoreCase(VALID_PASSWORD)) {
+                return null;
+            }
+            if (password.equalsIgnoreCase(EXPIRED_PASSWORD)) {
+                return PlatformReturned.builder().success(false).errno(PlatformPwdErrno.EMVSEXPIRE.errno).build();
+            }
         }
-        else {
-            return PlatformReturned.builder().success(false).errno(PlatformPwdErrno.EACCES.errno).build();
-        }
+        return PlatformReturned.builder().success(false).errno(PlatformPwdErrno.EACCES.errno).build();
     }
 
     @Override
@@ -36,4 +41,5 @@ public class MockPlatformUser implements PlatformUser {
             return PlatformReturned.builder().success(false).errno(PlatformPwdErrno.EMVSPASSWORD.errno).build();
         }
     }
+
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/saf/MockPlatformUserTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/saf/MockPlatformUserTest.java
@@ -10,12 +10,13 @@
 
 package org.zowe.apiml.gateway.security.login.saf;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.zowe.apiml.security.common.auth.saf.PlatformReturned;
 import org.zowe.apiml.security.common.error.PlatformPwdErrno;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MockPlatformUserTest {
 
@@ -31,7 +32,7 @@ class MockPlatformUserTest {
         class Success {
             @Test
             void givenValidCredentials_whenAuthenticate_thenReturnNull() {
-                assertEquals(null, mockPlatformUser.authenticate("USER", "validPassword"));
+                assertNull(mockPlatformUser.authenticate("USER", "validPassword"));
             }
         }
 
@@ -41,6 +42,13 @@ class MockPlatformUserTest {
             void givenInValidCredentials_whenAuthenticate_thenReturnPlatformReturnedSuccessFalse() {
                 PlatformReturned platformReturned = PlatformReturned.builder().success(false).errno(PlatformPwdErrno.EACCES.errno).build();
                 assertEquals(platformReturned, mockPlatformUser.authenticate("USER", "invalidPassword"));
+            }
+
+            @Test
+            void givenExpiredPassword_whenAuthenticate_thenReturnEmvsExpire() {
+                PlatformReturned platformReturned = mockPlatformUser.authenticate("USER", "expiredPassword");
+                assertFalse(platformReturned.success);
+                assertEquals(PlatformPwdErrno.EMVSEXPIRE.errno, platformReturned.errno);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>

# Description

This PR adds support to expired passwords. If credentials will be `USER:expiredPassword` the response will simulate expired password.

Linked to #2418

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
