### PR TITLE
chore: Replace springfox with springdoc for API Catalog

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -74,9 +74,6 @@ dependencies {
     implementation libraries.gson
     implementation libraries.spring_cloud_starter_hystrix
     implementation libraries.spring_retry
-    implementation libraries.swagger_core
-    implementation libraries.swagger3_core
-    implementation libraries.swagger3_parser
     implementation libraries.jackson_annotations
     implementation libraries.jackson_core
     implementation libraries.jackson_databind
@@ -114,12 +111,11 @@ dependencies {
     implementation libraries.spring_webflux
     implementation libraries.spring_webmvc
     implementation libraries.spring_websocket
+    implementation libraries.spring_doc
     implementation libraries.thymeleaf
     implementation libraries.thymeleafSpring
     implementation libraries.logback_core
     implementation libraries.logback_classic
-
-    implementation libraries.springFox
 
     testCompile libraries.rest_assured
     testCompile libraries.spring_mock_mvc

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -75,7 +75,7 @@ public class ApiCatalogController {
     @Operation(summary = "Lists catalog dashboard tiles",
         description = "Returns a list of tiles including status and tile description",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         }
     )
     @ApiResponses(value = {
@@ -112,7 +112,7 @@ public class ApiCatalogController {
     @Operation(summary = "Retrieves a specific dashboard tile information",
         description = "Returns information for a specific tile {id} including status and tile description",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         }
     )
     @ApiResponses(value = {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -10,9 +10,11 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -41,7 +43,7 @@ import java.util.stream.StreamSupport;
 @Slf4j
 @RestController
 @RequestMapping("/")
-@Api(tags = {"API Catalog"})
+@Tag(name = "API Catalog")
 public class ApiCatalogController {
 
     private final CachedProductFamilyService cachedProductFamilyService;
@@ -70,12 +72,19 @@ public class ApiCatalogController {
      * @return a list of all containers
      */
     @GetMapping(value = "/containers", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Lists catalog dashboard tiles",
-        notes = "Returns a list of tiles including status and tile description",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
+    @Operation(summary = "Lists catalog dashboard tiles",
+        description = "Returns a list of tiles including status and tile description",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
         }
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
+    })
     @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAllAPIContainers() throws ContainerStatusRetrievalThrowable {
         try {
@@ -100,12 +109,19 @@ public class ApiCatalogController {
      * @return a containers by id
      */
     @GetMapping(value = "/containers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves a specific dashboard tile information",
-        notes = "Returns information for a specific tile {id} including status and tile description",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
+    @Operation(summary = "Retrieves a specific dashboard tile information",
+        description = "Returns information for a specific tile {id} including status and tile description",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
         }
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
+    })
     @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAPIContainerById(@PathVariable(value = "id") String id) throws ContainerStatusRetrievalThrowable {
         try {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -58,7 +58,7 @@ public class CatalogApiDocController {
         description = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -86,7 +86,7 @@ public class CatalogApiDocController {
     @Operation(summary = "Retrieves the API documentation for the default service version",
         description = "Returns the API documentation for a specific service {serviceId} and its default version.",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -106,7 +106,7 @@ public class CatalogApiDocController {
     @Operation(summary = "Retrieve diff of two api versions for a specific service",
         description = "Returns an HTML document which details the difference between two versions of a API service",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -10,7 +10,12 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +30,7 @@ import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
  */
 @RestController
 @RequestMapping("/apidoc")
-@Api(tags = {"API Documentation"})
+@Tag(name = "API Documentation")
 public class CatalogApiDocController {
 
     private final APIServiceStatusService apiServiceStatusService;
@@ -49,25 +54,24 @@ public class CatalogApiDocController {
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}/{apiId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves the API documentation for a specific service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
+    @Operation(summary = "Retrieves the API documentation for a specific service version",
+        description = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred"),
     })
     @HystrixCommand
     public ResponseEntity<String> getApiDocInfo(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,
-        @ApiParam(name = "apiId", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
+        @Parameter(name = "apiId", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
         @PathVariable(value = "apiId") String apiId) {
         return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, apiId);
     }
@@ -79,47 +83,45 @@ public class CatalogApiDocController {
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves the API documentation for the default service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and its default version.",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+    @Operation(summary = "Retrieves the API documentation for the default service version",
+        description = "Returns the API documentation for a specific service {serviceId} and its default version.",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred"),
     })
     @HystrixCommand
     public ResponseEntity<String> getDefaultApiDocInfo(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId) {
         return this.apiServiceStatusService.getServiceCachedDefaultApiDocInfo(serviceId);
     }
 
     @GetMapping(value = "/{serviceId}/{apiId1}/{apiId2}", produces = MediaType.TEXT_HTML_VALUE)
-    @ApiOperation(value = "Retrieve diff of two api versions for a specific service",
-        notes = "Returns an HTML document which details the difference between two versions of a API service",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+    @Operation(summary = "Retrieve diff of two api versions for a specific service",
+        description = "Returns an HTML document which details the difference between two versions of a API service",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
     })
     @HystrixCommand
     public ResponseEntity<String> getApiDiff(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,
-        @ApiParam(name = "apiId1", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
+        @Parameter(name = "apiId1", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
         @PathVariable(value = "apiId1") String apiId1,
-        @ApiParam(name = "apiId2", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v2.0.0")
+        @Parameter(name = "apiId2", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v2.0.0")
         @PathVariable(value = "apiId2") String apiId2) {
         return this.apiServiceStatusService.getApiDiffInfo(serviceId, apiId1, apiId2);
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIContainer.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIContainer.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.apicatalog.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,22 +27,22 @@ public class APIContainer implements Serializable {
 
     private static final long serialVersionUID = 1905122041950251207L;
 
-    @ApiModelProperty(notes = "The version of the API container")
+    @Schema(description = "The version of the API container")
     private String version;
 
-    @ApiModelProperty(notes = "The API Container Id")
+    @Schema(description = "The API Container Id")
     private String id;
 
-    @ApiModelProperty(notes = "The API Container title")
+    @Schema(description = "The API Container title")
     private String title;
 
-    @ApiModelProperty(notes = "The Status of the container")
+    @Schema(description = "The Status of the container")
     private String status;
 
-    @ApiModelProperty(notes = "The description of the API")
+    @Schema(description = "The description of the API")
     private String description;
 
-    @ApiModelProperty(notes = "A collection of services which are registered with this API")
+    @Schema(description = "A collection of services which are registered with this API")
     private Set<APIService> services;
 
     private Integer totalServices;
@@ -55,7 +55,7 @@ public class APIContainer implements Serializable {
     // used to determine if container is new
     private Calendar createdTimestamp;
 
-    @ApiModelProperty(notes = "The SSO support of all services and instances in the container")
+    @Schema(description = "The SSO support of all services and instances in the container")
     private boolean sso;
 
     public APIContainer() {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
@@ -9,7 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -24,49 +24,49 @@ public class APIService implements Serializable {
 
     private static final long serialVersionUID = 5119572678327579985L;
 
-    @ApiModelProperty(notes = "The service id")
+    @Schema(description = "The service id")
     private String serviceId;
 
-    @ApiModelProperty(notes = "The API service name")
+    @Schema(description = "The API service name")
     private String title;
 
-    @ApiModelProperty(notes = "The description of the API service")
+    @Schema(description = "The description of the API service")
     private String description;
 
-    @ApiModelProperty(notes = "The status of the API service")
+    @Schema(description = "The status of the API service")
     private String status;
 
-    @ApiModelProperty(notes = "The security status of the API service")
+    @Schema(description = "The security status of the API service")
     private boolean secured;
 
-    @ApiModelProperty(notes = "The instance home URL")
+    @Schema(description = "The instance home URL")
     private String baseUrl;
 
-    @ApiModelProperty(notes = "The service home page of the API service")
+    @Schema(description = "The service home page of the API service")
     private String homePageUrl;
 
-    @ApiModelProperty(notes = "The service API base path of the API service")
+    @Schema(description = "The service API base path of the API service")
     private String basePath;
 
-    @ApiModelProperty(notes = "The API documentation for this service")
+    @Schema(description = "The API documentation for this service")
     private String apiDoc;
 
-    @ApiModelProperty(notes = "The default API version for this service")
+    @Schema(description = "The default API version for this service")
     private String defaultApiVersion = "v1";
 
-    @ApiModelProperty(notes = "The available API versions for this service")
+    @Schema(description = "The available API versions for this service")
     private List<String> apiVersions;
 
-    @ApiModelProperty(notes = "The SSO support for this instance")
+    @Schema(description = "The SSO support for this instance")
     private boolean sso;
 
-    @ApiModelProperty(notes = "The SSO support for all instances")
+    @Schema(description = "The SSO support for all instances")
     private boolean ssoAllInstances;
 
-    @ApiModelProperty(notes = "The API ID for this service")
+    @Schema(description = "The API ID for this service")
     private Map<String, String> apiId;
 
-    @ApiModelProperty(notes = "The Gateway URLs used within this service")
+    @Schema(description = "The Gateway URLs used within this service")
     private Map<String, String> gatewayUrls;
 
     private List<String> instances = new ArrayList<>();
@@ -75,6 +75,7 @@ public class APIService implements Serializable {
         this.serviceId = serviceId;
         this.status = "UP";
     }
+
     public static class Builder {
         private APIService apiService;
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
@@ -9,23 +9,15 @@
  */
 package org.zowe.apiml.apicatalog.swagger;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.BasicAuth;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Value("${apiml.service.apiDoc.title}")
@@ -38,31 +30,16 @@ public class SwaggerConfiguration {
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("org.zowe.apiml.apicatalog.controllers.api"))
-            .paths(
-                PathSelectors.any()
+    public OpenAPI openApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title(apiTitle)
+                .description(apiDescription)
+                .version(apiVersion)
             )
-            .build()
-            .securitySchemes(
-                Arrays.asList(
-                    new BasicAuth("LoginBasicAuth"),
-                    new ApiKey("CookieAuth", "apimlAuthenticationToken", "header")
-                )
-            )
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
+            .components(new Components()
+                .addSecuritySchemes("LoginBasicAuth", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
+                .addSecuritySchemes("CookieAuth", new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("apimlAuthenticationToken"))
             );
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
@@ -38,7 +38,7 @@ public class SwaggerConfiguration {
                 .version(apiVersion)
             )
             .components(new Components()
-                .addSecuritySchemes("LoginBasicAuth", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
+                .addSecuritySchemes("Basic authorization", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
                 .addSecuritySchemes("CookieAuth", new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("apimlAuthenticationToken"))
             );
     }

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-springdoc:
-    api-docs.path: /v2/api-docs
-    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
-
 spring:
     config:
         useLegacyProcessing: true
@@ -20,6 +16,9 @@ spring:
             enabled: detect
     main:
         banner-mode: ${apiml.banner:"off"}
+
+springdoc:
+    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
 
 logging:
     level:
@@ -145,7 +144,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 
                 service:
                     title: API Catalog
@@ -238,7 +237,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 apiml:
     service:
         scheme: http

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+springdoc:
+    api-docs.path: /v2/api-docs
+    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
 
 spring:
     config:
@@ -23,6 +26,7 @@ logging:
         ROOT: INFO
         org.zowe.apiml: INFO
         org.springframework: WARN
+        org.springdoc: WARN
         com.netflix: WARN
         com.netflix.discovery: ERROR
         com.netflix.config: ERROR

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -37,7 +37,6 @@ logging:
         # New Config
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
-        springfox: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
 
 ##############################################################################################
@@ -194,7 +193,6 @@ logging:
         org.apache: INFO
         org.apache.http: DEBUG
         com.netflix: INFO
-        springfox: INFO
         net.sf.ehcache: INFO
 
 ---

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -176,7 +176,7 @@ class ApiDocV3ServiceTest {
                 Exception exception = assertThrows(UnexpectedTypeException.class, () -> {
                     apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo);
                 });
-                assertEquals("[No swagger supplied]", exception.getMessage());
+                assertEquals("[Null or empty definition]", exception.getMessage());
             }
 
             @Test

--- a/api-catalog-services/src/test/resources/application.yml
+++ b/api-catalog-services/src/test/resources/application.yml
@@ -34,7 +34,6 @@ logging:
         # New Config
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
-        springfox: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
 
 ##############################################################################################
@@ -189,7 +188,6 @@ logging:
         org.apache: INFO
         org.apache.http: DEBUG
         com.netflix: INFO
-        springfox: INFO
         net.sf.ehcache: INFO
 
 ---

--- a/api-catalog-services/src/test/resources/application.yml
+++ b/api-catalog-services/src/test/resources/application.yml
@@ -141,7 +141,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 
                 service:
                     title: API Catalog
@@ -232,7 +232,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 apiml:
     service:
         scheme: http

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
@@ -50,7 +50,7 @@ describe('>>> Detail page test', () => {
 
         const baseUrl = `${Cypress.env('catalogHomePage')}`;
 
-        cy.get('#swaggerContainer > div > div:nth-child(2) > div.information-container.wrapper > section > div > div > hgroup > pre')
+        cy.get('#swaggerContainer > div > div:nth-child(2) > div.scheme-container > section > div:nth-child(1) > div > label > select > option')
             .should('exist')
             .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}\/apicatalog\/api\/v1`);
 

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/swagger-try-out-and-code-snippets.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/swagger-try-out-and-code-snippets.test.js
@@ -72,11 +72,11 @@ describe('>>> Swagger Try Out and Code Snippets Test', () => {
         cy.get('button.execute').click();
         // check the first tab of the code snippet panel. The order should be always the same
         cy.get(
-            '#operations-API_Catalog-getAllAPIContainersUsingGET > div.no-margin > div > div.responses-wrapper > div.responses-inner > div > div > div:nth-child(1) > div:nth-child(1)'
+            '#operations-API_Catalog-getAllAPIContainers > div.no-margin > div > div.responses-wrapper > div.responses-inner > div > div > div:nth-child(1) > div:nth-child(1)'
         ).should('exist');
         cy.get('div.curl-command > div:nth-child(1) > div:nth-child(1) > h4').should('contain', 'cURL (CMD)');
         cy.get(
-            '#operations-API_Catalog-getAllAPIContainersUsingGET > div.no-margin > div > div.responses-wrapper > div.responses-inner > div > div > div:nth-child(1) > div.curl-command > div:nth-child(3) > pre'
+            '#operations-API_Catalog-getAllAPIContainers > div.no-margin > div > div.responses-wrapper > div.responses-inner > div > div > div:nth-child(1) > div.curl-command > div:nth-child(3) > pre'
         ).should('exist');
         cy.get('div.curl-command > div:nth-child(1) > div:nth-child(2)').click();
         cy.get('div.curl-command > div:nth-child(3) > pre').should('exist');

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -60,6 +60,7 @@ ext {
     slf4jVersion = '1.7.31'
     snakeyamlVersion = '1.27'
     springFoxVersion = '2.9.2'
+    springDocVersion = '1.6.9'
     spring4Version = '4.3.7.RELEASE' // Used within PJE in tests
     swagger3CoreVersion = '2.0.0'
     swagger3ParserVersion = '2.0.17'
@@ -210,6 +211,7 @@ ext {
         spring4Mvc                         : "org.springframework:spring-webmvc:${spring4Version}",
         spring4Test                        : "org.springframework:spring-test:${spring4Version}",
         springFox                          : "io.springfox:springfox-swagger2:${springFoxVersion}",
+        spring_doc                         : "org.springdoc:springdoc-openapi-ui:${springDocVersion}",
         spring_mock_mvc                    : "io.rest-assured:spring-mock-mvc:${restAssuredVersion}",
         swagger_core                       : "io.swagger:swagger-core:${swaggerCoreVersion}",
         swagger3_core                      : "io.swagger.core.v3:swagger-core:${swagger3CoreVersion}",

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -146,7 +146,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
-                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("Basic authorization"), apiCatalogSwagger);
                 assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
 
@@ -179,7 +179,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
-                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("Basic authorization"), apiCatalogSwagger);
                 assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
         }

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -131,23 +131,23 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                     "\n**************************\n";
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-                String swaggerHost = jsonContext.read("$.host");
-                String swaggerBasePath = jsonContext.read("$.basePath");
+                String swaggerServer = jsonContext.read("$.servers[0].url");
                 LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.definitions");
+                LinkedHashMap componentSchemas = jsonContext.read("$.components.schemas");
+                LinkedHashMap securitySchemes = jsonContext.read("$.components.securitySchemes");
 
                 // Then
                 assertFalse(paths.isEmpty(), apiCatalogSwagger);
-                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertFalse(componentSchemas.isEmpty(), apiCatalogSwagger);
+                assertEquals("https://" + baseHost + "/apicatalog/api/v1", swaggerServer, apiCatalogSwagger);
                 assertNull(paths.get("/status/updates"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers"), apiCatalogSwagger);
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
 
             @Test
@@ -164,23 +164,23 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                     "\n**************************\n";
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-                String swaggerHost = jsonContext.read("$.host");
-                String swaggerBasePath = jsonContext.read("$.basePath");
+                String swaggerServer = jsonContext.read("$.servers[0].url");
                 LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.definitions");
+                LinkedHashMap componentSchemas = jsonContext.read("$.components.schemas");
+                LinkedHashMap securitySchemes = jsonContext.read("$.components.securitySchemes");
 
                 // Then
                 assertFalse(paths.isEmpty(), apiCatalogSwagger);
-                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertFalse(componentSchemas.isEmpty(), apiCatalogSwagger);
+                assertEquals("https://" + baseHost + "/apicatalog/api/v1", swaggerServer, apiCatalogSwagger);
                 assertNull(paths.get("/status/updates"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers"), apiCatalogSwagger);
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
         }
 


### PR DESCRIPTION
# Description

Replaces the use of springfox with springdoc for `api-catalog-services`.

Linked to #1971 

## Type of change

Please delete options that are not relevant.

- [x] (chore) Chore, repository cleanup, updates the dependencies.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
