### PR TITLE
chore: Use common spring boot version for spring enabler sample app

### DIFF
--- a/onboarding-enabler-spring-sample-app/build.gradle
+++ b/onboarding-enabler-spring-sample-app/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext {
-        springBootVersion = "2.3.9.RELEASE"
-    }
     repositories {
         mavenCentral()
         maven { url "http://repo.spring.io/libs-milestone" }
@@ -36,16 +33,16 @@ repositories {
 }
 
 dependencies {
-    compile(project(':onboarding-enabler-spring'))
-    compile "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
-    compile "io.springfox:springfox-swagger2:2.9.2"
-    compile "io.springfox:springfox-spring-web:2.9.2"
+    implementation(project(':onboarding-enabler-spring'))
+    implementation libraries.spring_boot_starter_actuator
+    implementation "io.springfox:springfox-swagger2:2.9.2"
+    implementation "io.springfox:springfox-spring-web:2.9.2"
 
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok
 
-    testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
-    testCompile libraries.json_smart
+    testImplementation libraries.spring_boot_starter_test
+    testImplementation libraries.json_smart
 }
 
 


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Use versions.gradle for spring onboarding enabler sample app instead of custom dependency versions.

Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
