### PR TITLE
chore: Migrate springfox to springdoc

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -74,9 +74,6 @@ dependencies {
     implementation libraries.gson
     implementation libraries.spring_cloud_starter_hystrix
     implementation libraries.spring_retry
-    implementation libraries.swagger_core
-    implementation libraries.swagger3_core
-    implementation libraries.swagger3_parser
     implementation libraries.jackson_annotations
     implementation libraries.jackson_core
     implementation libraries.jackson_databind
@@ -113,12 +110,11 @@ dependencies {
     implementation libraries.spring_webflux
     implementation libraries.spring_webmvc
     implementation libraries.spring_websocket
+    implementation libraries.spring_doc
     implementation libraries.thymeleaf
     implementation libraries.thymeleafSpring
     implementation libraries.logback_core
     implementation libraries.logback_classic
-
-    implementation libraries.springFox
 
     testCompile libraries.rest_assured
     testCompile libraries.spring_mock_mvc

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -75,7 +75,7 @@ public class ApiCatalogController {
     @Operation(summary = "Lists catalog dashboard tiles",
         description = "Returns a list of tiles including status and tile description",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         }
     )
     @ApiResponses(value = {
@@ -112,7 +112,7 @@ public class ApiCatalogController {
     @Operation(summary = "Retrieves a specific dashboard tile information",
         description = "Returns information for a specific tile {id} including status and tile description",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         }
     )
     @ApiResponses(value = {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -10,9 +10,11 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -41,7 +43,7 @@ import java.util.stream.StreamSupport;
 @Slf4j
 @RestController
 @RequestMapping("/")
-@Api(tags = {"API Catalog"})
+@Tag(name = "API Catalog")
 public class ApiCatalogController {
 
     private final CachedProductFamilyService cachedProductFamilyService;
@@ -70,12 +72,19 @@ public class ApiCatalogController {
      * @return a list of all containers
      */
     @GetMapping(value = "/containers", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Lists catalog dashboard tiles",
-        notes = "Returns a list of tiles including status and tile description",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
+    @Operation(summary = "Lists catalog dashboard tiles",
+        description = "Returns a list of tiles including status and tile description",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
         }
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
+    })
     @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAllAPIContainers() throws ContainerStatusRetrievalThrowable {
         try {
@@ -100,12 +109,19 @@ public class ApiCatalogController {
      * @return a containers by id
      */
     @GetMapping(value = "/containers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves a specific dashboard tile information",
-        notes = "Returns information for a specific tile {id} including status and tile description",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
+    @Operation(summary = "Retrieves a specific dashboard tile information",
+        description = "Returns information for a specific tile {id} including status and tile description",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
         }
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
+    })
     @HystrixCommand
     public ResponseEntity<List<APIContainer>> getAPIContainerById(@PathVariable(value = "id") String id) throws ContainerStatusRetrievalThrowable {
         try {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -58,7 +58,7 @@ public class CatalogApiDocController {
         description = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -86,7 +86,7 @@ public class CatalogApiDocController {
     @Operation(summary = "Retrieves the API documentation for the default service version",
         description = "Returns the API documentation for a specific service {serviceId} and its default version.",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -106,7 +106,7 @@ public class CatalogApiDocController {
     @Operation(summary = "Retrieve diff of two api versions for a specific service",
         description = "Returns an HTML document which details the difference between two versions of a API service",
         security = {
-            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+            @SecurityRequirement(name = "Basic authorization"), @SecurityRequirement(name = "CookieAuth")
         })
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/CatalogApiDocController.java
@@ -10,7 +10,12 @@
 package org.zowe.apiml.apicatalog.controllers.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +30,7 @@ import org.zowe.apiml.apicatalog.services.status.APIServiceStatusService;
  */
 @RestController
 @RequestMapping("/apidoc")
-@Api(tags = {"API Documentation"})
+@Tag(name = "API Documentation")
 public class CatalogApiDocController {
 
     private final APIServiceStatusService apiServiceStatusService;
@@ -49,25 +54,24 @@ public class CatalogApiDocController {
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}/{apiId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves the API documentation for a specific service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
+    @Operation(summary = "Retrieves the API documentation for a specific service version",
+        description = "Returns the API documentation for a specific service {serviceId} and version {apiId}. When " +
             " the API documentation for the specified version is not found, the first discovered version will be used.",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred"),
     })
     @HystrixCommand
     public ResponseEntity<String> getApiDocInfo(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,
-        @ApiParam(name = "apiId", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
+        @Parameter(name = "apiId", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
         @PathVariable(value = "apiId") String apiId) {
         return this.apiServiceStatusService.getServiceCachedApiDocInfo(serviceId, apiId);
     }
@@ -79,47 +83,45 @@ public class CatalogApiDocController {
      * @return api-doc info (as JSON)
      */
     @GetMapping(value = "/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves the API documentation for the default service version",
-        notes = "Returns the API documentation for a specific service {serviceId} and its default version.",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+    @Operation(summary = "Retrieves the API documentation for the default service version",
+        description = "Returns the API documentation for a specific service {serviceId} and its default version.",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred"),
     })
     @HystrixCommand
     public ResponseEntity<String> getDefaultApiDocInfo(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId) {
         return this.apiServiceStatusService.getServiceCachedDefaultApiDocInfo(serviceId);
     }
 
     @GetMapping(value = "/{serviceId}/{apiId1}/{apiId2}", produces = MediaType.TEXT_HTML_VALUE)
-    @ApiOperation(value = "Retrieve diff of two api versions for a specific service",
-        notes = "Returns an HTML document which details the difference between two versions of a API service",
-        authorizations = {
-            @Authorization("LoginBasicAuth"), @Authorization("CookieAuth")
-        },
-        response = String.class)
+    @Operation(summary = "Retrieve diff of two api versions for a specific service",
+        description = "Returns an HTML document which details the difference between two versions of a API service",
+        security = {
+            @SecurityRequirement(name = "LoginBasicAuth"), @SecurityRequirement(name = "CookieAuth")
+        })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "An unexpected condition occurred"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "An unexpected condition occurred")
     })
     @HystrixCommand
     public ResponseEntity<String> getApiDiff(
-        @ApiParam(name = "serviceId", value = "The unique identifier of the registered service", required = true, example = "apicatalog")
+        @Parameter(name = "serviceId", description = "The unique identifier of the registered service", required = true, example = "apicatalog")
         @PathVariable(value = "serviceId") String serviceId,
-        @ApiParam(name = "apiId1", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
+        @Parameter(name = "apiId1", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v1.0.0")
         @PathVariable(value = "apiId1") String apiId1,
-        @ApiParam(name = "apiId2", value = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v2.0.0")
+        @Parameter(name = "apiId2", description = "The API ID and version, separated by a space, of the API documentation", required = true, example = "zowe.apiml.apicatalog v2.0.0")
         @PathVariable(value = "apiId2") String apiId2) {
         return this.apiServiceStatusService.getApiDiffInfo(serviceId, apiId1, apiId2);
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIContainer.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIContainer.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.apicatalog.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,22 +27,22 @@ public class APIContainer implements Serializable {
 
     private static final long serialVersionUID = 1905122041950251207L;
 
-    @ApiModelProperty(notes = "The version of the API container")
+    @Schema(description = "The version of the API container")
     private String version;
 
-    @ApiModelProperty(notes = "The API Container Id")
+    @Schema(description = "The API Container Id")
     private String id;
 
-    @ApiModelProperty(notes = "The API Container title")
+    @Schema(description = "The API Container title")
     private String title;
 
-    @ApiModelProperty(notes = "The Status of the container")
+    @Schema(description = "The Status of the container")
     private String status;
 
-    @ApiModelProperty(notes = "The description of the API")
+    @Schema(description = "The description of the API")
     private String description;
 
-    @ApiModelProperty(notes = "A collection of services which are registered with this API")
+    @Schema(description = "A collection of services which are registered with this API")
     private Set<APIService> services;
 
     private Integer totalServices;
@@ -55,7 +55,7 @@ public class APIContainer implements Serializable {
     // used to determine if container is new
     private Calendar createdTimestamp;
 
-    @ApiModelProperty(notes = "The SSO support of all services and instances in the container")
+    @Schema(description = "The SSO support of all services and instances in the container")
     private boolean sso;
 
     public APIContainer() {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
@@ -9,7 +9,7 @@
  */
 package org.zowe.apiml.apicatalog.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -24,49 +24,49 @@ public class APIService implements Serializable {
 
     private static final long serialVersionUID = 5119572678327579985L;
 
-    @ApiModelProperty(notes = "The service id")
+    @Schema(description = "The service id")
     private String serviceId;
 
-    @ApiModelProperty(notes = "The API service name")
+    @Schema(description = "The API service name")
     private String title;
 
-    @ApiModelProperty(notes = "The description of the API service")
+    @Schema(description = "The description of the API service")
     private String description;
 
-    @ApiModelProperty(notes = "The status of the API service")
+    @Schema(description = "The status of the API service")
     private String status;
 
-    @ApiModelProperty(notes = "The security status of the API service")
+    @Schema(description = "The security status of the API service")
     private boolean secured;
 
-    @ApiModelProperty(notes = "The instance home URL")
+    @Schema(description = "The instance home URL")
     private String baseUrl;
 
-    @ApiModelProperty(notes = "The service home page of the API service")
+    @Schema(description = "The service home page of the API service")
     private String homePageUrl;
 
-    @ApiModelProperty(notes = "The service API base path of the API service")
+    @Schema(description = "The service API base path of the API service")
     private String basePath;
 
-    @ApiModelProperty(notes = "The API documentation for this service")
+    @Schema(description = "The API documentation for this service")
     private String apiDoc;
 
-    @ApiModelProperty(notes = "The default API version for this service")
+    @Schema(description = "The default API version for this service")
     private String defaultApiVersion = "v1";
 
-    @ApiModelProperty(notes = "The available API versions for this service")
+    @Schema(description = "The available API versions for this service")
     private List<String> apiVersions;
 
-    @ApiModelProperty(notes = "The SSO support for this instance")
+    @Schema(description = "The SSO support for this instance")
     private boolean sso;
 
-    @ApiModelProperty(notes = "The SSO support for all instances")
+    @Schema(description = "The SSO support for all instances")
     private boolean ssoAllInstances;
 
-    @ApiModelProperty(notes = "The API ID for this service")
+    @Schema(description = "The API ID for this service")
     private Map<String, String> apiId;
 
-    @ApiModelProperty(notes = "The Gateway URLs used within this service")
+    @Schema(description = "The Gateway URLs used within this service")
     private Map<String, String> gatewayUrls;
 
     private List<String> instances = new ArrayList<>();
@@ -75,6 +75,7 @@ public class APIService implements Serializable {
         this.serviceId = serviceId;
         this.status = "UP";
     }
+
     public static class Builder {
         private APIService apiService;
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
@@ -9,23 +9,15 @@
  */
 package org.zowe.apiml.apicatalog.swagger;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.BasicAuth;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Value("${apiml.service.apiDoc.title}")
@@ -38,31 +30,16 @@ public class SwaggerConfiguration {
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("org.zowe.apiml.apicatalog.controllers.api"))
-            .paths(
-                PathSelectors.any()
+    public OpenAPI openApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title(apiTitle)
+                .description(apiDescription)
+                .version(apiVersion)
             )
-            .build()
-            .securitySchemes(
-                Arrays.asList(
-                    new BasicAuth("LoginBasicAuth"),
-                    new ApiKey("CookieAuth", "apimlAuthenticationToken", "header")
-                )
-            )
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
+            .components(new Components()
+                .addSecuritySchemes("LoginBasicAuth", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
+                .addSecuritySchemes("CookieAuth", new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("apimlAuthenticationToken"))
             );
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/SwaggerConfiguration.java
@@ -38,7 +38,7 @@ public class SwaggerConfiguration {
                 .version(apiVersion)
             )
             .components(new Components()
-                .addSecuritySchemes("LoginBasicAuth", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
+                .addSecuritySchemes("Basic authorization", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic"))
                 .addSecuritySchemes("CookieAuth", new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("apimlAuthenticationToken"))
             );
     }

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-springdoc:
-    api-docs.path: /v2/api-docs
-    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
-
 spring:
     config:
         useLegacyProcessing: true
@@ -20,6 +16,9 @@ spring:
             enabled: detect
     main:
         banner-mode: ${apiml.banner:"off"}
+
+springdoc:
+    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
 
 logging:
     level:
@@ -145,7 +144,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 
                 service:
                     title: API Catalog
@@ -238,7 +237,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 apiml:
     service:
         scheme: http

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+springdoc:
+    api-docs.path: /v2/api-docs
+    packagesToScan: org.zowe.apiml.apicatalog.controllers.api
 
 spring:
     config:
@@ -23,6 +26,7 @@ logging:
         ROOT: INFO
         org.zowe.apiml: INFO
         org.springframework: WARN
+        org.springdoc: WARN
         com.netflix: WARN
         com.netflix.discovery: ERROR
         com.netflix.config: ERROR

--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -37,7 +37,6 @@ logging:
         # New Config
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
-        springfox: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
 
 ##############################################################################################
@@ -194,7 +193,6 @@ logging:
         org.apache: INFO
         org.apache.http: DEBUG
         com.netflix: INFO
-        springfox: INFO
         net.sf.ehcache: INFO
 
 ---

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -176,7 +176,7 @@ class ApiDocV3ServiceTest {
                 Exception exception = assertThrows(UnexpectedTypeException.class, () -> {
                     apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo);
                 });
-                assertEquals("[No swagger supplied]", exception.getMessage());
+                assertEquals("[Null or empty definition]", exception.getMessage());
             }
 
             @Test

--- a/api-catalog-services/src/test/resources/application.yml
+++ b/api-catalog-services/src/test/resources/application.yml
@@ -34,7 +34,6 @@ logging:
         # New Config
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
-        springfox: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
 
 ##############################################################################################
@@ -189,7 +188,6 @@ logging:
         org.apache: INFO
         org.apache.http: DEBUG
         com.netflix: INFO
-        springfox: INFO
         net.sf.ehcache: INFO
 
 ---

--- a/api-catalog-services/src/test/resources/application.yml
+++ b/api-catalog-services/src/test/resources/application.yml
@@ -141,7 +141,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: https://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 
                 service:
                     title: API Catalog
@@ -232,7 +232,7 @@ eureka:
                     - apiId: zowe.apiml.apicatalog
                       version: 1.0.0
                       gatewayUrl: api/v1
-                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                      swaggerUrl: http://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
 apiml:
     service:
         scheme: http

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
@@ -48,7 +48,7 @@ describe('>>> Detail page test', () => {
         ];
         const regex = new RegExp(`${values.join('|')}`, 'g');
 
-        cy.get('pre.base-url')
+        cy.get('pre.servers')
             .should('exist')
             .then(element => {
                 const text = element.text();

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/detail-page.test.js
@@ -48,7 +48,7 @@ describe('>>> Detail page test', () => {
         ];
         const regex = new RegExp(`${values.join('|')}`, 'g');
 
-        cy.get('pre.servers')
+        cy.get('#swaggerContainer > div > div:nth-child(2) > div.scheme-container > section > div:nth-child(1) > div > label > select > option')
             .should('exist')
             .then(element => {
                 const text = element.text();

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/service-version-switch.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/service-version-switch.test.js
@@ -37,7 +37,7 @@ describe('>>> Service version change Test', () => {
 
     it('Should pre select default version', () => {
         cy.get('.version-text').should('exist');
-        cy.get('.base-url').should('contain.text', '/discoverableclient/api/v1');
+        cy.get('.servers').should('contain.text', '/discoverableclient/api/v1');
     });
 
     it('Should change version when clicking version 2', () => {
@@ -47,6 +47,6 @@ describe('>>> Service version change Test', () => {
         cy.get('.nav-tab')
             .eq(2)
             .click();
-        cy.get('.base-url', { timeout: 10000 }).should('contain.text', '/discoverableclient/api/v2');
+        cy.get('#servers', { timeout: 10000 }).should('contain.text', '/discoverableclient/api/v2');
     });
 });

--- a/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/service-version-switch.test.js
+++ b/api-catalog-ui/frontend/cypress/integration/e2e/detail-page/service-version-switch.test.js
@@ -47,6 +47,6 @@ describe('>>> Service version change Test', () => {
         cy.get('.nav-tab')
             .eq(2)
             .click();
-        cy.get('#servers', { timeout: 10000 }).should('contain.text', '/discoverableclient/api/v2');
+        cy.get('.servers', { timeout: 10000 }).should('contain.text', '/discoverableclient/api/v2');
     });
 });

--- a/apiml-sample-extension/build.gradle
+++ b/apiml-sample-extension/build.gradle
@@ -22,11 +22,9 @@ gitProperties {
 }
 
 dependencies {
-
-    implementation libraries.springFox
+    implementation libraries.spring_doc
     implementation libraries.spring_webmvc
     implementation libraries.guava
-
 }
 
 jar {

--- a/apiml-sample-extension/src/main/java/org/zowe/apiml/gateway/api/GreetingController.java
+++ b/apiml-sample-extension/src/main/java/org/zowe/apiml/gateway/api/GreetingController.java
@@ -9,14 +9,16 @@
  */
 package org.zowe.apiml.gateway.api;
 
-import io.swagger.annotations.Api;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controller that returns greetings.
  */
 @RestController
-@Api(tags = {"Other Operations"})
+@Tag(name = "Other Operations")
 @RequestMapping("/api/v1")
 public class GreetingController {
     private static final String GREETING = "Hello, I'm a sample extension!";

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation libraries.infinispan_core
     implementation libraries.infinispan_jboss_marshalling
 
-    implementation libraries.springFox
+    implementation libraries.spring_doc
     implementation libraries.spring_boot_starter
     implementation libraries.spring_boot_starter_actuator
     implementation libraries.spring_boot_starter_web

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -10,7 +10,7 @@
 package org.zowe.apiml.caching.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
@@ -36,8 +36,8 @@ public class CachingController {
 
 
     @GetMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves all values in the cache",
-        notes = "Values returned for the calling service")
+    @Operation(summary = "Retrieves all values in the cache",
+        description = "Values returned for the calling service")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> getAllValues(HttpServletRequest request) {
@@ -53,8 +53,8 @@ public class CachingController {
     }
 
     @DeleteMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Delete all values for service from the cache",
-        notes = "Will delete all key-value pairs for specific service")
+    @Operation(summary = "Delete all values for service from the cache",
+        description = "Will delete all key-value pairs for specific service")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> deleteAllValues(HttpServletRequest request) {
@@ -77,8 +77,8 @@ public class CachingController {
     }
 
     @GetMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Retrieves a specific value in the cache",
-        notes = "Value returned is for the provided {key}")
+    @Operation(summary = "Retrieves a specific value in the cache",
+        description = "Value returned is for the provided {key}")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> getValue(@PathVariable String key, HttpServletRequest request) {
@@ -87,8 +87,8 @@ public class CachingController {
     }
 
     @DeleteMapping(value = "/cache/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Delete key from the cache",
-        notes = "Will delete key-value pair for the provided {key}")
+    @Operation(summary = "Delete key from the cache",
+        description = "Will delete key-value pair for the provided {key}")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> delete(@PathVariable String key, HttpServletRequest request) {
@@ -97,8 +97,8 @@ public class CachingController {
     }
 
     @PostMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Create a new key in the cache",
-        notes = "A new key-value pair will be added to the cache")
+    @Operation(summary = "Create a new key in the cache",
+        description = "A new key-value pair will be added to the cache")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> createKey(@RequestBody KeyValue keyValue, HttpServletRequest request) {
@@ -107,8 +107,8 @@ public class CachingController {
     }
 
     @PutMapping(value = "/cache", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Update key in the cache",
-        notes = "Value at the key in the provided key-value pair will be updated to the provided value")
+    @Operation(summary = "Update key in the cache",
+        description = "Value at the key in the provided key-value pair will be updated to the provided value")
     @ResponseBody
     @HystrixCommand
     public ResponseEntity<Object> update(@RequestBody KeyValue keyValue, HttpServletRequest request) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
@@ -46,7 +46,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
         String[] noSecurityAntMatchers = {
             "/application/health",
             "/application/info",
-            "/v2/api-docs"
+            "/v3/api-docs"
         };
         web.ignoring().antMatchers(noSecurityAntMatchers);
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/config/SwaggerConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/config/SwaggerConfig.java
@@ -9,20 +9,13 @@
  */
 package org.zowe.apiml.caching.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
 
     @Value("${apiml.service.title}")
@@ -35,23 +28,11 @@ public class SwaggerConfig {
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/api/v1/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
-            );
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(new Info()
+            .title(apiTitle)
+            .description(apiDescription)
+            .version(apiVersion)
+        );
     }
 }

--- a/caching-service/src/main/resources/application.yml
+++ b/caching-service/src/main/resources/application.yml
@@ -26,6 +26,7 @@ logging:
         org.zowe.apiml: INFO
         org.zowe.apiml.enable: WARN
         org.zowe.apiml.caching: WARN
+        org.springdoc: WARN
         org.springframework: WARN
         org.springframework.boot: OFF
         com.netflix: WARN
@@ -70,7 +71,7 @@ apiml:
             -   apiId: zowe.apiml.cachingservice
                 version: 1.0.0
                 gatewayUrl: api/v1
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
                 documentationUrl: https://www.zowe.org
         catalog:
             tile:
@@ -110,6 +111,9 @@ spring:
         pathmatch:
             matchingStrategy: ant-path-matcher # used to resolve spring fox path matching issue
     output.ansi.enabled: always
+
+springdoc:
+    pathsToMatch: /api/v1/**
 
 server:
     port: ${apiml.service.port}

--- a/caching-service/src/test/resources/application.yml
+++ b/caching-service/src/test/resources/application.yml
@@ -45,7 +45,7 @@ apiml:
             -   apiId: zowe.apiml.cachingservice
                 version: 1.0.0
                 gatewayUrl: api/v1
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v1/api-docs
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
                 documentationUrl: https://www.zowe.org
         catalog:
             tile:

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -50,7 +50,7 @@ gitProperties {
 dependencies {
     implementation project(':onboarding-enabler-spring')
     implementation project(':zaas-client')
-    implementation libraries.springFox
+    implementation libraries.spring_doc
     implementation libraries.spring_boot_starter
     implementation libraries.spring_boot_starter_actuator
     implementation libraries.spring_boot_starter_web

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ApiMediationClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ApiMediationClientTestController.java
@@ -10,8 +10,8 @@
 package org.zowe.apiml.client.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.client.model.Registered;
@@ -20,9 +20,9 @@ import org.zowe.apiml.exception.ServiceDefinitionException;
 
 @RestController
 @RequestMapping("/api/v1/apiMediationClient")
-@Api(
-    value = "/api/v1/apiMediationClient",
-    tags = {"API Mediation Client test call"}
+@Tag(
+    description = "/api/v1/apiMediationClient",
+    name = "API Mediation Client test call"
 )
 public class ApiMediationClientTestController {
     private final ApiMediationClientService apiMediationClientService;
@@ -32,7 +32,7 @@ public class ApiMediationClientTestController {
     }
 
     @PostMapping
-    @ApiOperation(value = "Forward registration to discovery service via API mediation client")
+    @Operation(summary = "Forward registration to discovery service via API mediation client")
     @HystrixCommand
     public ResponseEntity<String> forwardRegistration() {
         try {
@@ -44,7 +44,7 @@ public class ApiMediationClientTestController {
     }
 
     @DeleteMapping
-    @ApiOperation(value = "Forward un-registration to discovery service via API mediation client")
+    @Operation(summary = "Forward un-registration to discovery service via API mediation client")
     @HystrixCommand
     public ResponseEntity<String> forwardUnRegistration() {
         apiMediationClientService.unregister();
@@ -52,7 +52,7 @@ public class ApiMediationClientTestController {
     }
 
     @GetMapping
-    @ApiOperation(value = "Indicate if registration with discovery service via API mediation client was successful")
+    @Operation(summary = "Indicate if registration with discovery service via API mediation client was successful")
     public Registered isRegistered() {
         boolean isRegistered = apiMediationClientService.isRegistered();
         return new Registered(isRegistered);

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/FileController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/FileController.java
@@ -8,26 +8,31 @@
  * Copyright Contributors to the Zowe Project.
  */
 package org.zowe.apiml.client.api;
-import io.swagger.annotations.Api;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+
 import javax.servlet.ServletContext;
 import java.io.InputStream;
+
 /**
  * Version 1 of the controller that returns a zip file.
  */
 @RestController
-@Api(tags = {"Other Operations"})
+@Tag(name = "Other Operations")
 public class FileController {
     private final ServletContext servletContext;
+
     public FileController(ServletContext servletContext) {
         this.servletContext = servletContext;
     }
+
     @GetMapping(value = "/api/v1/get-file", produces = "image/png")
     @HystrixCommand()
     public ResponseEntity<InputStreamResource> downloadImage() {

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingController.java
@@ -9,13 +9,11 @@
  */
 package org.zowe.apiml.client.api;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.SwaggerDefinition;
-import io.swagger.annotations.Tag;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.client.model.Greeting;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 import java.util.Date;
 
@@ -24,9 +22,7 @@ import java.util.Date;
  * Version 1 of the controller that returns greetings.
  */
 @RestController
-@Api(tags = {"Other Operations"})
-@SwaggerDefinition(tags = {
-    @Tag(name = "Other Operations", description = "General Operations")})
+@Tag(name = "Other Operations", description = "General Operations")
 @RequestMapping("/api/v1")
 public class GreetingController {
     private static final String TEMPLATE = "Hello, %s!";
@@ -35,8 +31,7 @@ public class GreetingController {
      * Gets a greeting for anyone.
      */
     @GetMapping(value = "/greeting")
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Other Operations"})
+    @Operation(summary = "Get a greeting", tags = {"Other Operations"})
     @HystrixCommand()
     public Greeting greeting(@RequestParam(value = "name", defaultValue = "world") String name,
                              @RequestParam(value = "delayMs", defaultValue = "0", required = false) Integer delayMs) {
@@ -54,8 +49,7 @@ public class GreetingController {
      * Gets a custom greeting.
      */
     @GetMapping(value = {"/{yourName}/greeting"})
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Other Operations"})
+    @Operation(summary = "Get a greeting", tags = {"Other Operations"})
     @HystrixCommand()
     public Greeting customGreeting(@PathVariable(value = "yourName") String yourName) {
         return new Greeting(new Date(), String.format(TEMPLATE, yourName));

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingGraphController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingGraphController.java
@@ -9,11 +9,12 @@
  */
 package org.zowe.apiml.client.api;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.SwaggerDefinition;
-import io.swagger.annotations.Tag;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.zowe.apiml.client.model.Greeting;
 
 import java.util.Date;
@@ -22,9 +23,7 @@ import java.util.Date;
  * Version WS of the controller that returns greetings.
  */
 @RestController
-@Api(tags = {"Other Operations"})
-@SwaggerDefinition(tags = {
-    @Tag(name = "Other Operations", description = "General Operations")})
+@Tag(name = "Other Operations", description = "General Operations")
 @RequestMapping("/graphql/v1")
 public class GreetingGraphController {
     private static final String TEMPLATE = "Hi, %s!";
@@ -33,8 +32,7 @@ public class GreetingGraphController {
      * Gets a greeting for anyone.
      */
     @GetMapping(value = "/greeting")
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Other Operations"})
+    @Operation(summary = "Get a greeting", tags = {"Other Operations"})
     public Greeting greeting(@RequestParam(value = "name", defaultValue = "user") String name,
                              @RequestParam(value = "delayMs", defaultValue = "0", required = false) Integer delayMs) {
         if (delayMs > 0) {

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingV2Controller.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/GreetingV2Controller.java
@@ -9,10 +9,8 @@
  */
 package org.zowe.apiml.client.api;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.SwaggerDefinition;
-import io.swagger.annotations.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.client.model.Greeting;
 
@@ -22,9 +20,7 @@ import java.util.Date;
  * Version 2 of the controller that returns greetings.
  */
 @RestController
-@Api(tags = {"Other Operations"})
-@SwaggerDefinition(tags = {
-    @Tag(name = "Other Operations", description = "General Operations")})
+@Tag(name = "Other Operations", description = "General Operations")
 @RequestMapping("/api/v2")
 public class GreetingV2Controller {
     private static final String TEMPLATE = "Hi, %s!";
@@ -33,8 +29,7 @@ public class GreetingV2Controller {
      * Gets a greeting for anyone.
      */
     @GetMapping(value = "/greeting")
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Other Operations"})
+    @Operation(summary = "Get a greeting", tags = {"Other Operations"})
     public Greeting greeting(@RequestParam(value = "name", defaultValue = "user") String name,
                              @RequestParam(value = "delayMs", defaultValue = "0", required = false) Integer delayMs) {
         if (delayMs > 0) {
@@ -51,8 +46,7 @@ public class GreetingV2Controller {
      * Gets a custom greeting.
      */
     @GetMapping(value = {"/greeting/{yourName}"})
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Other Operations"})
+    @Operation(summary = "Get a greeting", tags = {"Other Operations"})
     public Greeting customGreeting(@PathVariable(value = "yourName") String yourName) {
         return new Greeting(new Date(), String.format(TEMPLATE, yourName));
     }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PageRedirectionController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PageRedirectionController.java
@@ -9,15 +9,19 @@
  */
 package org.zowe.apiml.client.api;
 
-import org.zowe.apiml.client.model.RedirectLocation;
-import io.swagger.annotations.*;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.zowe.apiml.client.model.RedirectLocation;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -29,7 +33,7 @@ import static org.springframework.http.HttpHeaders.LOCATION;
  * Response Header and returns status code 307
  */
 @RestController
-@Api(tags = {"Other Operations"})
+@Tag(name = "Other Operations")
 public class PageRedirectionController {
 
     /**
@@ -45,14 +49,14 @@ public class PageRedirectionController {
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.TEMPORARY_REDIRECT)
-    @ApiOperation(
-        value = "/redirect",
-        notes = "Redirect to location")
+    @Operation(
+        summary = "/redirect",
+        description = "Redirect to location")
     @ApiResponses(value = {
-        @ApiResponse(code = 307, message = "Redirect to specified location", response = String.class)
+        @ApiResponse(responseCode = "307", description = "Redirect to specified location")
     })
     @HystrixCommand
-    public RedirectLocation redirectPage(@ApiParam(value = "Location that need to be redirected to", required = true, example = "https://host:port/context/path")
+    public RedirectLocation redirectPage(@Parameter(description = "Location that need to be redirected to", required = true, example = "https://host:port/context/path")
                                          @RequestBody RedirectLocation redirectLocation,
                                          HttpServletResponse response) {
         response.setHeader(LOCATION, redirectLocation.getLocation());

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PassTicketTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PassTicketTestController.java
@@ -9,16 +9,16 @@
  */
 package org.zowe.apiml.client.api;
 
-import org.zowe.apiml.passticket.IRRPassTicketEvaluationException;
-import org.zowe.apiml.passticket.PassTicketService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.zowe.apiml.passticket.IRRPassTicketEvaluationException;
+import org.zowe.apiml.passticket.PassTicketService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -27,7 +27,7 @@ import java.util.Base64;
  * Controller for testing PassTickets.
  */
 @RestController
-@Api(tags = { "Test Operations" })
+@Tag(name = "Test Operations")
 public class PassTicketTestController {
 
     @Value("${apiml.service.applId:ZOWEAPPL}")
@@ -43,11 +43,11 @@ public class PassTicketTestController {
      * Validates the PassTicket in authorization header.
      */
     @GetMapping(value = "/api/v1/passticketTest")
-    @ApiOperation(value = "Validate that the PassTicket in Authorization header is valid", tags = { "Test Operations" })
+    @Operation(summary = "Validate that the PassTicket in Authorization header is valid", tags = {"Test Operations"})
     @HystrixCommand()
     public void passticketTest(@RequestHeader("authorization") String authorization,
-        @RequestHeader(value = "X-Zowe-Auth-Failure", required = false) String zoweAuthFailure,
-        @RequestParam(value = "applId", defaultValue = "", required = false) String applId)
+                               @RequestHeader(value = "X-Zowe-Auth-Failure", required = false) String zoweAuthFailure,
+                               @RequestParam(value = "applId", defaultValue = "", required = false) String applId)
         throws IRRPassTicketEvaluationException {
         if (authorization != null && authorization.toLowerCase().startsWith("basic")) {
             if (zoweAuthFailure != null) {

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/PetController.java
@@ -9,20 +9,24 @@
  */
 package org.zowe.apiml.client.api;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import org.zowe.apiml.client.exception.PetIdMismatchException;
 import org.zowe.apiml.client.exception.PetNotFoundException;
 import org.zowe.apiml.client.model.Pet;
 import org.zowe.apiml.client.model.state.Existing;
 import org.zowe.apiml.client.model.state.New;
 import org.zowe.apiml.client.service.PetService;
-import org.zowe.apiml.message.api.ApiMessageView;
-import io.swagger.annotations.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,15 +37,15 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/v1")
-@Api(
-    value = "/api/v1/pets",
-    consumes = "application/json",
-    tags = {"The pet API"})
+@Tag(
+    description = "/api/v1/pets",
+    name = "The pet API")
 public class PetController {
     private final PetService petService;
 
     /**
      * Constructor for {@link PetController}.
+     *
      * @param petService service for working with {@link Pet} objects.
      */
     @Autowired
@@ -58,11 +62,11 @@ public class PetController {
         value = "/pets",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ApiOperation(
-        value = "List all existing pets",
-        notes = "Returns information about all existing pets")
-    @ApiResponses( value = {
-        @ApiResponse(code = 200, message = "List of pets", response = Pet.class, responseContainer = "List")
+    @Operation(
+        summary = "List all existing pets",
+        description = "Returns information about all existing pets")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "List of pets")
     })
     @HystrixCommand()
     public List<Pet> getAllPets() {
@@ -85,21 +89,21 @@ public class PetController {
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(
-        value = "Add a new pet",
-        notes = "Creates a new pet",
-        authorizations = {
-            @Authorization(
-                value = "ESM token"
+    @Operation(
+        summary = "Add a new pet",
+        description = "Creates a new pet",
+        security = {
+            @SecurityRequirement(
+                name = "ESM token"
             )
         })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "New created pet", response = Pet.class),
-        @ApiResponse(code = 401, message = "Authentication is required", response = ApiMessageView.class),
-        @ApiResponse(code = 400, message = "Request object is not valid", response = ApiMessageView.class)
+        @ApiResponse(responseCode = "200", description = "New created pet"),
+        @ApiResponse(responseCode = "401", description = "Authentication is required"),
+        @ApiResponse(responseCode = "400", description = "Request object is not valid")
     })
     @HystrixCommand()
-    public Pet addPet(@ApiParam(value = "Pet object that needs to be added", required = true)
+    public Pet addPet(@Parameter(description = "Pet object that needs to be added", required = true)
                       @Validated(value = {New.class})
                       @RequestBody Pet pet) {
         return petService.save(pet);
@@ -115,19 +119,19 @@ public class PetController {
         value = "/pets/{id}",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ApiOperation(value = "Find pet by id", notes = "Returns a single pet",
-        authorizations = {
-            @Authorization(
-                value = "ESM token"
+    @Operation(summary = "Find pet by id", description = "Returns a single pet",
+        security = {
+            @SecurityRequirement(
+                name = "ESM token"
             )
         })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK", response = Pet.class),
-        @ApiResponse(code = 401, message = "Authentication is required", response = ApiMessageView.class),
-        @ApiResponse(code = 404, message = "The pet with id is not found.", response = ApiMessageView.class)
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "401", description = "Authentication is required"),
+        @ApiResponse(responseCode = "404", description = "The pet with id is not found.")
     })
     @HystrixCommand()
-    public Pet getPetById(@ApiParam(value = "Pet id to return", required = true, example = "1")
+    public Pet getPetById(@Parameter(description = "Pet id to return", required = true, example = "1")
                           @PathVariable("id") Long id) {
         Pet pet = petService.getById(id);
         if (pet == null) {
@@ -149,21 +153,21 @@ public class PetController {
         consumes = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "Update an existing pet", notes = "Change information for an existing pet",
-        authorizations = {
-            @Authorization(
-                value = "ESM token"
+    @Operation(summary = "Update an existing pet", description = "Change information for an existing pet",
+        security = {
+            @SecurityRequirement(
+                name = "ESM token"
             )
         })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Pet updated", response = Pet.class),
-        @ApiResponse(code = 401, message = "Authentication is required", response = ApiMessageView.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = ApiMessageView.class)
+        @ApiResponse(responseCode = "200", description = "Pet updated"),
+        @ApiResponse(responseCode = "401", description = "Authentication is required"),
+        @ApiResponse(responseCode = "404", description = "Pet not found")
     })
     @HystrixCommand()
-    public Pet updatePetById(@ApiParam(value = "Pet id to update", required = true, example = "1")
+    public Pet updatePetById(@Parameter(description = "Pet id to update", required = true, example = "1")
                              @PathVariable("id") Long id,
-                             @ApiParam(value = "Pet object that needs to be updated", required = true)
+                             @Parameter(description = "Pet object that needs to be updated", required = true)
                              @Validated(value = {Existing.class})
                              @RequestBody Pet pet) {
         if (!id.equals(pet.getId())) {
@@ -186,20 +190,20 @@ public class PetController {
         produces = MediaType.APPLICATION_JSON_VALUE
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @ApiOperation(value = "Delete a pet", notes = "Removes an existing pet",
-        authorizations = {
-            @Authorization(
-                value = "ESM token"
+    @Operation(summary = "Delete a pet", description = "Removes an existing pet",
+        security = {
+            @SecurityRequirement(
+                name = "ESM token"
             )
         })
     @ApiResponses(value = {
-        @ApiResponse(code = 204, message = "Pet updated", response = Pet.class),
-        @ApiResponse(code = 401, message = "Authentication is required", response = ApiMessageView.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = ApiMessageView.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = ApiMessageView.class)
+        @ApiResponse(responseCode = "204", description = "Pet updated"),
+        @ApiResponse(responseCode = "401", description = "Authentication is required"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "Pet not found")
     })
     @HystrixCommand()
-    public void deletePetById(@ApiParam(value = "Pet id to delete", required = true, example = "1")
+    public void deletePetById(@Parameter(description = "Pet id to delete", required = true, example = "1")
                               @PathVariable("id") Long id) {
         petService.deleteById(id);
     }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/RequestInfoController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/RequestInfoController.java
@@ -10,7 +10,12 @@
 package org.zowe.apiml.client.api;
 
 import com.google.common.io.CharStreams;
-import io.swagger.annotations.*;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.Value;
 import org.springframework.http.MediaType;
@@ -18,7 +23,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -36,22 +40,21 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/v1/request")
-@Api(
-    value = "/api/v1/request",
-    consumes = "application/json",
-    tags = {"The request info API"})
+@Tag(
+    description = "/api/v1/request",
+    name = "The request info API")
 public class RequestInfoController {
 
     @GetMapping(
         value = "",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ApiOperation(
-        value = "Returns all base information about request",
-        notes = "Data contains sign information, headers and content")
-    @ApiResponses( value = {
-        @ApiResponse(code = 200, message = "Information from request", response = RequestInfo.class),
-        @ApiResponse(code = 500, message = "Error in parsing of request ")
+    @Operation(
+        summary = "Returns all base information about request",
+        description = "Data contains sign information, headers and content")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Information from request"),
+        @ApiResponse(responseCode = "500", description = "Error in parsing of request ")
     })
     @ResponseBody
     @HystrixCommand
@@ -102,28 +105,28 @@ public class RequestInfoController {
         requestInfo.content = CharStreams.toString(httpServletRequest.getReader());
     }
 
-    @ApiModel(description = "Request info detail")
+    @Schema(description = "Request info detail")
     @Getter
     public class RequestInfo {
 
-        @ApiModelProperty(value = "Any certificate sign the request")
+        @Schema(description = "Any certificate sign the request")
         private boolean signed;
 
-        @ApiModelProperty(value = "Certificates used to sign the request")
+        @Schema(description = "Certificates used to sign the request")
         private Certificate[] certs;
 
-        @ApiModelProperty(value = "Requests header in the original request")
+        @Schema(description = "Requests header in the original request")
         private Map<String, String> headers = new HashMap<>();
 
-        @ApiModelProperty(value = "Requests cookie in the original request")
+        @Schema(description = "Requests cookie in the original request")
         private Map<String, String> cookies = new HashMap<>();
 
-        @ApiModelProperty(value = "Text content in the original request")
+        @Schema(description = "Text content in the original request")
         private String content;
 
     }
 
-    @ApiModel(description = "Certificate info detail")
+    @Schema(description = "Certificate info detail")
     @Value
     public class Certificate {
 

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/StatusCodeController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/StatusCodeController.java
@@ -9,14 +9,14 @@
  */
 package org.zowe.apiml.client.api;
 
-import io.swagger.annotations.ApiOperation;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 @RestController
 @Slf4j
@@ -24,19 +24,19 @@ public class StatusCodeController {
 
 
     @GetMapping(value = "/api/v1/status-code")
-    @ApiOperation(value = "Parametrized status code",
+    @Operation(summary = "Parametrized status code",
         tags = {"Other Operations"})
     public ResponseEntity<String> returnStatusCodeForGET(@RequestParam(value = "code", defaultValue = "200") int statusCode) {
-        log.info("Calling GET from gateway, status code: {}",statusCode);
+        log.info("Calling GET from gateway, status code: {}", statusCode);
         return ResponseEntity.status(statusCode).body("status code: " + statusCode);
     }
 
     @PostMapping(value = "/api/v1/status-code")
-    @ApiOperation(value = "Parametrized status code",
+    @Operation(summary = "Parametrized status code",
         tags = {"Other Operations"})
     @HystrixCommand
     public ResponseEntity<String> returnStatusCodeForPOST(@RequestParam(value = "code", defaultValue = "200") int statusCode) {
-        log.info("Calling POST from gateway, status code: {}",statusCode);
+        log.info("Calling POST from gateway, status code: {}", statusCode);
         return ResponseEntity.status(statusCode).body("status code: " + statusCode);
     }
 }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/WebServiceController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/WebServiceController.java
@@ -10,10 +10,8 @@
 package org.zowe.apiml.client.api;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.SwaggerDefinition;
-import io.swagger.annotations.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,9 +20,7 @@ import org.zowe.apiml.client.model.Greeting;
 import java.util.Date;
 
 @RestController
-@Api(tags = {"Web Service"})
-@SwaggerDefinition(tags = {
-    @Tag(name = "Web Service", description = "Test handling of URL containing \"ws\"")})
+@Tag(name = "Web Service", description = "Test handling of URL containing \"ws\"")
 @RequestMapping("/api/v1")
 public class WebServiceController {
 
@@ -34,8 +30,7 @@ public class WebServiceController {
      * Gets a custom greeting from Web Service.
      */
     @GetMapping(value = {"/ws", "/sse"})
-    @ApiOperation(value = "Get a greeting", response = Greeting.class,
-        tags = {"Web Service"})
+    @Operation(summary = "Get a greeting", tags = {"Web Service"})
     @HystrixCommand()
     public Greeting weServiceGreet() {
 

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ZaasClientTestController.java
@@ -9,8 +9,9 @@
  */
 package org.zowe.apiml.client.api;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,14 +24,12 @@ import org.zowe.apiml.zaasclient.config.DefaultZaasClientConfiguration;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 @RestController
 @RequestMapping("/api/v1/zaasClient")
-@Api(
-    value = "/api/v1/zaasClient",
-    consumes = "application/json",
-    tags = {"Zaas client test call"})
+@Tag(
+    description = "/api/v1/zaasClient",
+    name = "Zaas client test call")
 @Import(DefaultZaasClientConfiguration.class)
 public class ZaasClientTestController {
 
@@ -41,7 +40,7 @@ public class ZaasClientTestController {
     }
 
     @PostMapping(value = "/login")
-    @ApiOperation(value = "Forward login to gateway service via zaas client")
+    @Operation(summary = "Forward login to gateway service via zaas client")
     @HystrixCommand
     public ResponseEntity<String> forwardLogin(@RequestBody LoginRequest loginRequest) {
         try {
@@ -54,7 +53,7 @@ public class ZaasClientTestController {
     }
 
     @PostMapping(value = "/logout")
-    @ApiOperation(value = "Forward logout to gateway service via zaas client")
+    @Operation(summary = "Forward logout to gateway service via zaas client")
     @HystrixCommand
     public ResponseEntity<String> forwardLogout(
         @CookieValue(value = "apimlAuthenticationToken", required = false) String cookieToken,

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SwaggerConfiguration.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SwaggerConfiguration.java
@@ -28,7 +28,7 @@ public class SwaggerConfiguration {
     private String apiVersionRest1;
 
     @Value("${apiml.service.apiInfo[1].version}")
-    private String apiVersionGraphql;
+    private String graphqlVersion;
 
     @Value("${apiml.service.apiInfo[2].version}")
     private String apiVersionRest2;
@@ -41,8 +41,7 @@ public class SwaggerConfiguration {
         return new OpenAPI()
             .info(new Info()
                 .title(apiTitle)
-                .description(apiDescription)
-                .version(apiVersionRest1)) // TODO
+                .description(apiDescription))
             .components(new Components().addSecuritySchemes("ESM token",
                 new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("esmToken"))
             );
@@ -53,6 +52,7 @@ public class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("apiv1")
             .pathsToMatch("/api/v1/**")
+            .addOpenApiCustomiser(openApi -> openApi.setInfo(openApi.getInfo().version(apiVersionRest1)))
             .build();
     }
 
@@ -61,6 +61,7 @@ public class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("apiv2")
             .pathsToMatch("/api/v2/**")
+            .addOpenApiCustomiser(openApi -> openApi.setInfo(openApi.getInfo().version(apiVersionRest2)))
             .build();
     }
 
@@ -69,6 +70,7 @@ public class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("graphv1")
             .pathsToMatch("/graphql/v1/**")
+            .addOpenApiCustomiser(openApi -> openApi.setInfo(openApi.getInfo().version(graphqlVersion)))
             .build();
     }
 }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SwaggerConfiguration.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SwaggerConfiguration.java
@@ -9,96 +9,66 @@
  */
 package org.zowe.apiml.client.configuration;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Value("${apiml.service.title}")
     private String apiTitle;
 
     @Value("${apiml.service.apiInfo[0].version}")
-    private String apiVersion;
+    private String apiVersionRest1;
+
+    @Value("${apiml.service.apiInfo[1].version}")
+    private String apiVersionGraphql;
+
+    @Value("${apiml.service.apiInfo[2].version}")
+    private String apiVersionRest2;
 
     @Value("${apiml.service.description}")
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/api/v1/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
-            );
-    }
-
-    @Value("${apiml.service.apiInfo[1].version}")
-    private String apiVersion2;
-
-    @Bean
-    public Docket apiv2() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .groupName("apiv2")
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/api/v2/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion2,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title(apiTitle)
+                .description(apiDescription)
+                .version(apiVersionRest1)) // TODO
+            .components(new Components().addSecuritySchemes("ESM token",
+                new SecurityScheme().type(SecurityScheme.Type.APIKEY).in(SecurityScheme.In.HEADER).name("esmToken"))
             );
     }
 
     @Bean
-    public Docket graphv1() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .groupName("graphv1")
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/graphql/v1/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion2,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
-            );
+    public GroupedOpenApi apiV1() {
+        return GroupedOpenApi.builder()
+            .group("apiv1")
+            .pathsToMatch("/api/v1/**")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi apiV2() {
+        return GroupedOpenApi.builder()
+            .group("apiv2")
+            .pathsToMatch("/api/v2/**")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi graphV1() {
+        return GroupedOpenApi.builder()
+            .group("graphv1")
+            .pathsToMatch("/graphql/v1/**")
+            .build();
     }
 }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/model/Pet.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/model/Pet.java
@@ -9,35 +9,34 @@
  */
 package org.zowe.apiml.client.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.zowe.apiml.client.model.state.Existing;
 import org.zowe.apiml.client.model.state.New;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
-
 import java.util.Objects;
 
 /**
  * This is an example of a model class.
  */
-@ApiModel(description = "A Pet Object")
+@Schema(description = "A Pet Object")
 public class Pet {
     @Null(groups = New.class, message = "Id should be null for pet creation")
     @NotNull(groups = Existing.class, message = "Id should be not null for pet update")
-    @ApiModelProperty(value = "The id is of the pet", example = "1")
+    @Schema(description = "The id is of the pet", example = "1")
     private Long id;
 
-    @NotEmpty(groups = { New.class, Existing.class }, message = "Name should not be empty string")
-    @ApiModelProperty(value = "The name of the pet", example = "Falco")
+    @NotEmpty(groups = {New.class, Existing.class}, message = "Name should not be empty string")
+    @Schema(description = "The name of the pet", example = "Falco")
     private String name;
 
     /**
      * Pet object
-     * @param id Pet ID
+     *
+     * @param id   Pet ID
      * @param name Pet name
      */
     public Pet(@JsonProperty("id") Long id,
@@ -48,6 +47,7 @@ public class Pet {
 
     /**
      * Gets Pet ID
+     *
      * @return Pet ID
      */
     public Long getId() {
@@ -56,6 +56,7 @@ public class Pet {
 
     /**
      * Gets Pet name
+     *
      * @return Pet name
      */
     public String getName() {
@@ -64,6 +65,7 @@ public class Pet {
 
     /**
      * Sets Pet ID
+     *
      * @param id Pet ID
      */
     public void setId(Long id) {
@@ -72,6 +74,7 @@ public class Pet {
 
     /**
      * Sets Pet name
+     *
      * @param name Pet name
      */
     public void setName(String name) {

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/model/RedirectLocation.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/model/RedirectLocation.java
@@ -9,11 +9,10 @@
  */
 package org.zowe.apiml.client.model;
 
-import org.zowe.apiml.client.model.state.New;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.zowe.apiml.client.model.state.New;
 
 import javax.validation.constraints.NotNull;
 
@@ -21,12 +20,12 @@ import javax.validation.constraints.NotNull;
  * This model is used for integration test of PageRedirectionFilter.java
  * It wraps Location url
  */
-@ApiModel
+@Schema
 @Data
 public class RedirectLocation {
 
     @NotNull(groups = New.class, message = "Location should not be null")
-    @ApiModelProperty(value = "Redirect location", example = "https://hostA:8080/some/path")
+    @Schema(description = "Redirect location", example = "https://hostA:8080/some/path")
     private String location;
 
     public RedirectLocation(@JsonProperty("location") String location) {

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -23,8 +23,6 @@ spring:
         name: ${apiml.service.serviceId}
     mvc:
         throw-exception-if-no-handler-found: true
-        pathmatch:
-            matchingStrategy: ant-path-matcher # used to resolve spring fox path matching issue
     output:
         ansi:
             enabled: detect

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -3,6 +3,7 @@ logging:
         ROOT: INFO
         org.zowe.apiml: INFO
         org.springframework: WARN
+        org.springdoc: WARN
         org.apache.catalina: WARN
         com.netflix: WARN
         com.netflix.discovery: ERROR
@@ -73,18 +74,18 @@ apiml:
             -   apiId: zowe.apiml.discoverableclient.rest
                 version: 1.0.0
                 gatewayUrl: api/v1
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs/apiv1
                 documentationUrl: https://www.zowe.org
                 defaultApi: true
             -   apiId: zowe.apiml.discoverableclient.ws
                 version: 1.0.0
                 gatewayUrl: graphql/v1
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs?group=graphv1
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs/graphv1
                 documentationUrl: https://www.zowe.org
             -   apiId: zowe.apiml.discoverableclient.rest
                 version: 2.0.0
                 gatewayUrl: api/v2
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs?group=apiv2
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs/apiv2
                 documentationUrl: https://www.zowe.org
         catalog:
             tile:

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -73,7 +73,6 @@ dependencies {
     implementation libraries.xstream
     implementation libraries.json_smart
 
-    implementation libraries.swagger3_core
     implementation libraries.swagger3_parser
     implementation libraries.jackson_annotations
     implementation libraries.jackson_core
@@ -153,7 +152,6 @@ dependencies {
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok
 
-    implementation libraries.springFox
     testCompile libraries.mockito_core
     testCompile libraries.spring_mock_mvc
     testCompile libraries.spring_boot_starter_test

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -60,6 +60,7 @@ ext {
     slf4jVersion = '1.7.31'
     snakeyamlVersion = '1.27'
     springFoxVersion = '2.9.2'
+    springDocVersion = '1.6.9'
     spring4Version = '4.3.7.RELEASE' // Used within PJE in tests
     swagger3CoreVersion = '2.0.0'
     swagger3ParserVersion = '2.0.17'
@@ -210,6 +211,7 @@ ext {
         spring4Mvc                         : "org.springframework:spring-webmvc:${spring4Version}",
         spring4Test                        : "org.springframework:spring-test:${spring4Version}",
         springFox                          : "io.springfox:springfox-swagger2:${springFoxVersion}",
+        spring_doc                         : "org.springdoc:springdoc-openapi-ui:${springDocVersion}",
         spring_mock_mvc                    : "io.rest-assured:spring-mock-mvc:${restAssuredVersion}",
         swagger_core                       : "io.swagger:swagger-core:${swaggerCoreVersion}",
         swagger3_core                      : "io.swagger.core.v3:swagger-core:${swagger3CoreVersion}",

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -146,7 +146,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
-                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("Basic authorization"), apiCatalogSwagger);
                 assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
 
@@ -179,7 +179,7 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
                 assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
-                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("Basic authorization"), apiCatalogSwagger);
                 assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
         }

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogEndpointIntegrationTest.java
@@ -131,23 +131,23 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                     "\n**************************\n";
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-                String swaggerHost = jsonContext.read("$.host");
-                String swaggerBasePath = jsonContext.read("$.basePath");
+                String swaggerServer = jsonContext.read("$.servers[0].url");
                 LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.definitions");
+                LinkedHashMap componentSchemas = jsonContext.read("$.components.schemas");
+                LinkedHashMap securitySchemes = jsonContext.read("$.components.securitySchemes");
 
                 // Then
                 assertFalse(paths.isEmpty(), apiCatalogSwagger);
-                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertFalse(componentSchemas.isEmpty(), apiCatalogSwagger);
+                assertEquals("https://" + baseHost + "/apicatalog/api/v1", swaggerServer, apiCatalogSwagger);
                 assertNull(paths.get("/status/updates"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers"), apiCatalogSwagger);
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
 
             @Test
@@ -164,23 +164,23 @@ class ApiCatalogEndpointIntegrationTest implements TestWithStartedInstances {
                     "\n**************************\n";
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-                String swaggerHost = jsonContext.read("$.host");
-                String swaggerBasePath = jsonContext.read("$.basePath");
+                String swaggerServer = jsonContext.read("$.servers[0].url");
                 LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.definitions");
+                LinkedHashMap componentSchemas = jsonContext.read("$.components.schemas");
+                LinkedHashMap securitySchemes = jsonContext.read("$.components.securitySchemes");
 
                 // Then
                 assertFalse(paths.isEmpty(), apiCatalogSwagger);
-                assertFalse(definitions.isEmpty(), apiCatalogSwagger);
-                assertEquals(baseHost, swaggerHost, apiCatalogSwagger);
-                assertEquals("/apicatalog/api/v1", swaggerBasePath, apiCatalogSwagger);
+                assertFalse(componentSchemas.isEmpty(), apiCatalogSwagger);
+                assertEquals("https://" + baseHost + "/apicatalog/api/v1", swaggerServer, apiCatalogSwagger);
                 assertNull(paths.get("/status/updates"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers/{id}"), apiCatalogSwagger);
                 assertNotNull(paths.get("/containers"), apiCatalogSwagger);
                 assertNotNull(paths.get("/apidoc/{serviceId}/{apiId}"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIContainer"), apiCatalogSwagger);
-                assertNotNull(definitions.get("APIService"), apiCatalogSwagger);
-                assertNotNull(definitions.get("TimeZone"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIContainer"), apiCatalogSwagger);
+                assertNotNull(componentSchemas.get("APIService"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("LoginBasicAuth"), apiCatalogSwagger);
+                assertNotNull(securitySchemes.get("CookieAuth"), apiCatalogSwagger);
             }
         }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/caching/CachingAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/caching/CachingAuthenticationTest.java
@@ -38,7 +38,7 @@ class CachingAuthenticationTest implements TestWithStartedInstances {
     private static final String CACHING_PATH = "/cachingservice/api/v1/cache";
     private static final String HEALTH_PATH = "/cachingservice/application/health";
     private static final String INFO_PATH = "/cachingservice/application/info";
-    private static final String APIDOC_PATH = "/cachingservice/v2/api-docs";
+    private static final String APIDOC_PATH = "/cachingservice/v3/api-docs";
 
     private String caching_url = ConfigReader.environmentConfiguration().getCachingServiceConfiguration().getUrl();
     private static final String CERT_HEADER_NAME = "X-Certificate-DistinguishedName";

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/ApiCatalogDiscoverableClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/ApiCatalogDiscoverableClientIntegrationTest.java
@@ -27,8 +27,7 @@ import org.zowe.apiml.util.http.HttpSecurityUtils;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
@@ -75,13 +74,13 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
                 LinkedHashMap swaggerInfo = jsonContext.read("$.info");
-                String swaggerBasePath = jsonContext.read("$.basePath");
+                String swaggerServer = jsonContext.read("$.servers[0].url");
                 LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.definitions");
+                LinkedHashMap definitions = jsonContext.read("$.components.schemas");
                 LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
 
                 assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);
-                assertEquals("/discoverableclient/api/v2", swaggerBasePath, apiCatalogSwagger);
+                assertThat(swaggerServer, endsWith(""));
                 assertEquals("External documentation", externalDoc.get("description"), apiCatalogSwagger);
 
                 assertFalse(paths.isEmpty(), apiCatalogSwagger);
@@ -169,14 +168,14 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
         // When
         LinkedHashMap swaggerInfo = jsonContext.read("$.info");
-        String swaggerBasePath = jsonContext.read("$.basePath");
+        String swaggerServer = jsonContext.read("$.servers[0].url");
         LinkedHashMap paths = jsonContext.read("$.paths");
-        LinkedHashMap definitions = jsonContext.read("$.definitions");
+        LinkedHashMap definitions = jsonContext.read("$.components.schemas");
         LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
 
         // Then
         assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);
-        assertEquals("/discoverableclient/api/v1", swaggerBasePath, apiCatalogSwagger);
+        assertThat(swaggerServer, endsWith("/discoverableclient/api/v1"));
         assertEquals("External documentation", externalDoc.get("description"), apiCatalogSwagger);
 
         assertFalse(paths.isEmpty(), apiCatalogSwagger);
@@ -184,8 +183,6 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
         assertFalse(definitions.isEmpty(), apiCatalogSwagger);
 
-        assertNotNull(definitions.get("ApiMessage"), apiCatalogSwagger);
-        assertNotNull(definitions.get("ApiMessageView"), apiCatalogSwagger);
         assertNotNull(definitions.get("Greeting"), apiCatalogSwagger);
         assertNotNull(definitions.get("Pet"), apiCatalogSwagger);
         assertNotNull(definitions.get("RedirectLocation"), apiCatalogSwagger);

--- a/metrics-service/build.gradle
+++ b/metrics-service/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation libraries.jetty_http
     implementation libraries.jetty_io
     implementation libraries.jetty_util
-    implementation libraries.springFox
+    implementation libraries.spring_doc
     implementation libraries.spring_boot_starter_actuator
     implementation(libraries.spring_cloud_starter_eureka){
         exclude group: "com.google.code.gson", module: "gson"

--- a/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SwaggerConfiguration.java
+++ b/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SwaggerConfiguration.java
@@ -9,20 +9,13 @@
  */
 package org.zowe.apiml.metrics.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Value("${apiml.service.title}")
@@ -35,23 +28,11 @@ public class SwaggerConfiguration {
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/api/v1/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
-            );
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(new Info()
+            .title(apiTitle)
+            .description(apiDescription)
+            .version(apiVersion)
+        );
     }
 }

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -5,6 +5,7 @@ logging:
         org.zowe.apiml.enable: WARN
         org.springframework: WARN
         org.springframework.boot: WARN
+        org.springdoc: WARN
         com.netflix: WARN
         com.netflix.discovery: ERROR
         com.netflix.config: ERROR
@@ -55,7 +56,7 @@ apiml:
             -   apiId: zowe.apiml.metricsservice
                 version: 1.0.0
                 gatewayUrl: api/v1
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v2/api-docs
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs
                 documentationUrl: https://www.zowe.org
         catalog:
             tile:
@@ -92,6 +93,9 @@ spring:
     application:
         name: Metrics Service
     output.ansi.enabled: always
+
+springdoc:
+    pathsToMatch: /api/v1/**
 
 server:
     port: ${apiml.service.port}

--- a/mock-services/build.gradle
+++ b/mock-services/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation libraries.apache_commons_lang3
     implementation libraries.nimbusJoseJwt
 
-    implementation libraries.springFox
     implementation libraries.spring_boot_starter
     implementation libraries.spring_boot_starter_actuator
     implementation libraries.spring_boot_starter_web
@@ -63,7 +62,7 @@ dependencies {
     implementation libraries.tomcat_embed_core
     implementation libraries.tomcat_embed_websocket
     implementation libraries.logback_classic
-    
+
     implementation libraries.spring_aop
     implementation libraries.spring_beans
     implementation libraries.spring_context

--- a/onboarding-enabler-spring-sample-app/build.gradle
+++ b/onboarding-enabler-spring-sample-app/build.gradle
@@ -35,8 +35,7 @@ repositories {
 dependencies {
     implementation(project(':onboarding-enabler-spring'))
     implementation libraries.spring_boot_starter_actuator
-    implementation "io.springfox:springfox-swagger2:2.9.2"
-    implementation "io.springfox:springfox-spring-web:2.9.2"
+    implementation libraries.spring_doc
 
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok

--- a/onboarding-enabler-spring-sample-app/src/main/java/org/zowe/apiml/sample/enable/config/SwaggerConfiguration.java
+++ b/onboarding-enabler-spring-sample-app/src/main/java/org/zowe/apiml/sample/enable/config/SwaggerConfiguration.java
@@ -9,20 +9,13 @@
  */
 package org.zowe.apiml.sample.enable.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Collections;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Value("${apiml.service.title}")
@@ -35,23 +28,11 @@ public class SwaggerConfiguration {
     private String apiDescription;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.any())
-            .paths(PathSelectors.ant("/api/v1/**"))
-            .build()
-            .apiInfo(
-                new ApiInfo(
-                    apiTitle,
-                    apiDescription,
-                    apiVersion,
-                    null,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyList()
-                )
-            );
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(new Info()
+            .title(apiTitle)
+            .description(apiDescription)
+            .version(apiVersion)
+        );
     }
 }

--- a/onboarding-enabler-spring-sample-app/src/main/java/org/zowe/apiml/sample/enable/controller/SampleController.java
+++ b/onboarding-enabler-spring-sample-app/src/main/java/org/zowe/apiml/sample/enable/controller/SampleController.java
@@ -9,7 +9,10 @@
  */
 package org.zowe.apiml.sample.enable.controller;
 
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,18 +27,16 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1")
-@Api(tags = {"V1EnablerSampleApp"})
+@Tag(name = "V1EnablerSampleApp")
 public class SampleController {
 
     @GetMapping(value = "/samples", produces = "application/json")
-    @ApiOperation(value = "Retrieve all samples",
-        notes = "Simple method to demonstrate how to expose an API endpoint with Open API information",
-        responseContainer = "List",
-        response = Sample.class)
+    @Operation(summary = "Retrieve all samples",
+        description = "Simple method to demonstrate how to expose an API endpoint with Open API information")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "URI not found"),
-        @ApiResponse(code = 500, message = "Internal Error"),
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "404", description = "URI not found"),
+        @ApiResponse(responseCode = "500", description = "Internal Error"),
     })
     public ResponseEntity<List<Sample>> list() {
         List<Sample> samples;

--- a/onboarding-enabler-spring-sample-app/src/main/resources/application.yml
+++ b/onboarding-enabler-spring-sample-app/src/main/resources/application.yml
@@ -11,6 +11,7 @@ logging:
     level:
         ROOT: INFO
         org.springframework: INFO
+        org.springdoc: WARN
         org.apache: DEBUG
         org.zowe.apiml: DEBUG
 
@@ -94,3 +95,6 @@ server:
         keyStorePassword: password
         trustStore: keystore/localhost/localhost.truststore.p12
         trustStorePassword: password
+
+springdoc:
+    pathsToMatch: /api/v1/**


### PR DESCRIPTION
# Description

Migrates v1 branch to use springdoc instead of springfox. Cherry picks commits from #2430, #2427, #2424, with a few tweaks for v1 specific code.

Linked to #1971

## Type of change

Please delete options that are not relevant.

- [x] (chore) Chore, repository cleanup, updates the dependencies.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
