### PR TITLE
chore: Sync github actions changed on v2 with v1 branch

### DIFF
--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -89,7 +89,7 @@ jobs:
 
     create-image-all-services-s390x:
         strategy:
-            max-parallel: 2
+            max-parallel: 1
             matrix:
                 service: [ gateway-service, discovery-service, api-catalog-services, caching-service, metrics-service ]
                 os: [ ubuntu, ubi ]

--- a/.github/workflows/image-publish-branch.yml
+++ b/.github/workflows/image-publish-branch.yml
@@ -19,7 +19,7 @@ on:
                 default: 'all'
 
 jobs:
-    build-services:
+    build-test-services:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
 
     publish-images:
         needs:
-            - build-services
+            - build-test-services
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
             service: ${{ github.event.inputs.service }}

--- a/.github/workflows/image-snapshot-release.yml
+++ b/.github/workflows/image-snapshot-release.yml
@@ -5,7 +5,23 @@ on:
         branches: [ master, v1, v2.x.x ]
 
 jobs:
+    build-test-services:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    ref: ${{ github.head_ref }}
+
+            -   uses: ./.github/actions/setup
+
+            -   name: Build and test services
+                run: ./gradlew build
+
+            -   uses: ./.github/actions/teardown
+
     publish-images:
+        needs:
+            - build-test-services
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
             forceNoRelease: true

--- a/.github/workflows/image-specific-release.yml
+++ b/.github/workflows/image-specific-release.yml
@@ -8,7 +8,23 @@ on:
                 required: true
 
 jobs:
+    build-test-services:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    ref: ${{ github.head_ref }}
+
+            -   uses: ./.github/actions/setup
+
+            -   name: Build and test services
+                run: ./gradlew build
+
+            -   uses: ./.github/actions/teardown
+
     publish-images:
+        needs:
+            - build-test-services
         uses: zowe/api-layer/.github/workflows/build-conformant-images.yml@master
         with:
             version: ${{ github.event.inputs.release_version }}

--- a/api-catalog-ui/build.gradle
+++ b/api-catalog-ui/build.gradle
@@ -15,6 +15,10 @@ node {
     nodeProjectDir = file("${project.projectDir}/frontend")
 }
 
+if (project.hasProperty('omitDevDependencies')) {
+    npmInstall.args = ['--production', '--omit=dev'] // different args for different npm versions
+}
+
 // =================================================
 //
 //  Please manage all task dependencies in here and

--- a/containers/api-catalog-services/prepare.sh
+++ b/containers/api-catalog-services/prepare.sh
@@ -43,7 +43,7 @@ api_catalog_package="api-catalog-package"
 apiml_common_package="apiml-common-lib-package"
 
 ignoredUiTasks="$(getIgnoredUiTasks "api-catalog-ui")"
-buildPackage $api_catalog_package "packageApiCatalog ${ignoredUiTasks}"
+buildPackage $api_catalog_package "packageApiCatalog -PomitDevDependencies ${ignoredUiTasks}"
 buildApimlCommonPackage
 
 preparePackage $api_catalog_package

--- a/containers/api-catalog-services/prepare.sh
+++ b/containers/api-catalog-services/prepare.sh
@@ -42,8 +42,9 @@ cleanUpWorkingFolder
 api_catalog_package="api-catalog-package"
 apiml_common_package="apiml-common-lib-package"
 
-buildPackage $api_catalog_package "packageApiCatalog"
-buildPackage $apiml_common_package "packageCommonLib"
+ignoredUiTasks="$(getIgnoredUiTasks "api-catalog-ui")"
+buildPackage $api_catalog_package "packageApiCatalog ${ignoredUiTasks}"
+buildApimlCommonPackage
 
 preparePackage $api_catalog_package
 preparePackage $apiml_common_package "apiml-common-lib"

--- a/containers/discovery-service/prepare.sh
+++ b/containers/discovery-service/prepare.sh
@@ -43,7 +43,7 @@ discovery_package="discovery-package"
 apiml_common_package="apiml-common-lib-package"
 
 buildPackage $discovery_package "packageDiscovery"
-buildPackage $apiml_common_package "packageCommonLib"
+buildApimlCommonPackage
 
 preparePackage $discovery_package
 preparePackage $apiml_common_package "apiml-common-lib"

--- a/containers/gateway-service/prepare.sh
+++ b/containers/gateway-service/prepare.sh
@@ -43,7 +43,7 @@ gateway_package="gateway-package"
 apiml_common_package="apiml-common-lib-package"
 
 buildPackage $gateway_package "packageApiGateway"
-buildPackage $apiml_common_package "packageCommonLib"
+buildApimlCommonPackage
 
 preparePackage $gateway_package
 preparePackage $apiml_common_package "apiml-common-lib"

--- a/containers/metrics-service/prepare.sh
+++ b/containers/metrics-service/prepare.sh
@@ -43,7 +43,7 @@ metrics_package="metrics-service-package"
 apiml_common_package="apiml-common-lib-package"
 
 ignoredUiTasks="$(getIgnoredUiTasks "metrics-service-ui")"
-buildPackage $metrics_package "packageMetricsService ${ignoredUiTasks}"
+buildPackage $metrics_package "packageMetricsService -P omitDevDependencies ${ignoredUiTasks}"
 buildApimlCommonPackage
 
 preparePackage $metrics_package

--- a/containers/metrics-service/prepare.sh
+++ b/containers/metrics-service/prepare.sh
@@ -42,8 +42,9 @@ cleanUpWorkingFolder
 metrics_package="metrics-service-package"
 apiml_common_package="apiml-common-lib-package"
 
-buildPackage $metrics_package "packageMetricsService"
-buildPackage $apiml_common_package "packageCommonLib"
+ignoredUiTasks="$(getIgnoredUiTasks "metrics-service-ui")"
+buildPackage $metrics_package "packageMetricsService ${ignoredUiTasks}"
+buildApimlCommonPackage
 
 preparePackage $metrics_package
 preparePackage $apiml_common_package "apiml-common-lib"

--- a/containers/prepare-utils.sh
+++ b/containers/prepare-utils.sh
@@ -75,6 +75,10 @@ function buildPackage {
     fi
 }
 
+function buildApimlCommonPackage {
+    buildPackage "apiml-common-lib-package" "packageCommonLib -x gateway-service:test -x discovery-service:test -x api-catalog-services:test -x api-catalog-ui:test -x api-catalog-ui:npmLint"
+}
+
 function preparePackage {
     service_package=$1
     subdirectory=$2

--- a/metrics-service-ui/build.gradle
+++ b/metrics-service-ui/build.gradle
@@ -20,6 +20,10 @@ node {
     nodeProjectDir = file("${project.projectDir}/frontend")
 }
 
+if (project.hasProperty('omitDevDependencies')) {
+    npmInstall.args = ['--production', '--omit=dev'] // different args for different npm versions
+}
+
 // =================================================
 //
 //  Please manage all task dependencies in here and


### PR DESCRIPTION
# Description

Brings commits from v2.x.x branch for github actions onto v1 branch.



Linked to # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
