### PR TITLE
fix: immediately expires passticket command

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/AuthConfigurationProperties.java
@@ -57,7 +57,6 @@ public class AuthConfigurationProperties {
 
     private String provider = "zosmf";
 
-    private AuthConfigurationProperties.PassTicket passTicket;
     private AuthConfigurationProperties.X509Cert x509Cert;
 
     private AuthConfigurationProperties.Zosmf zosmf = new AuthConfigurationProperties.Zosmf();
@@ -89,11 +88,6 @@ public class AuthConfigurationProperties {
     }
 
     @Data
-    public static class PassTicket {
-        private Integer timeout = 540;
-    }
-
-    @Data
     public static class X509Cert {
         private Integer timeout = 15 * 60;
     }
@@ -108,7 +102,6 @@ public class AuthConfigurationProperties {
     public AuthConfigurationProperties() {
         this.cookieProperties = new AuthConfigurationProperties.CookieProperties();
         this.tokenProperties = new AuthConfigurationProperties.TokenProperties();
-        this.passTicket = new AuthConfigurationProperties.PassTicket();
         this.x509Cert = new AuthConfigurationProperties.X509Cert();
     }
 

--- a/config/docker/gateway-service.yml
+++ b/config/docker/gateway-service.yml
@@ -7,8 +7,6 @@ apiml:
         auth:
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/config/local-multi/gateway-service-1.yml
+++ b/config/local-multi/gateway-service-1.yml
@@ -10,8 +10,6 @@ apiml:
             provider: zosmf
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/config/local-multi/gateway-service-2.yml
+++ b/config/local-multi/gateway-service-2.yml
@@ -10,8 +10,6 @@ apiml:
             provider: zosmf
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -11,8 +11,6 @@ apiml:
             provider: zosmf
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         ssl:
             verifySslCertificatesOfServices: true
         x509:

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -65,7 +65,6 @@ public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
 
     @Override
     public AuthenticationCommand createCommand(Authentication authentication, AuthSource authSource) {
-        final long before = System.currentTimeMillis();
 
         if (authSource == null || authSource.getRawSource() == null) {
             throw new AuthSchemeException("org.zowe.apiml.gateway.security.schema.missingAuthentication");
@@ -104,11 +103,7 @@ public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
             .encodeToString((userId + ":" + passTicket).getBytes(StandardCharsets.UTF_8));
         final String value = "Basic " + encoded;
 
-        final long defaultExpirationTime = before + authConfigurationProperties.getPassTicket().getTimeout() * 1000L;
-        final long expirationTime = parsedAuthSource.getExpiration() != null ? parsedAuthSource.getExpiration().getTime() : defaultExpirationTime;
-        final Long expireAt = Math.min(defaultExpirationTime, expirationTime);
-
-        return new PassTicketCommand(value, cookieName, expireAt);
+        return new PassTicketCommand(value, cookieName, System.currentTimeMillis());
     }
 
     @Override

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketScheme.java
@@ -11,11 +11,12 @@ package org.zowe.apiml.gateway.security.service.schema;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.zuul.context.RequestContext;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.apache.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.zowe.apiml.auth.Authentication;
+import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSchemeException;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSourceService;
@@ -23,8 +24,6 @@ import org.zowe.apiml.message.core.MessageType;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.passticket.IRRPassTicketGenerationException;
 import org.zowe.apiml.passticket.PassTicketService;
-import org.zowe.apiml.auth.Authentication;
-import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 import org.zowe.apiml.security.common.token.TokenExpireException;
@@ -32,6 +31,7 @@ import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Optional;
 
 /**
  * This bean support PassTicket. Bean is responsible for getting PassTicket from
@@ -44,7 +44,6 @@ public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
 
     private final PassTicketService passTicketService;
     private final AuthSourceService authSourceService;
-    private final AuthConfigurationProperties authConfigurationProperties;
     private final String cookieName;
 
     public HttpBasicPassTicketScheme(
@@ -54,7 +53,6 @@ public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
     ) {
         this.passTicketService = passTicketService;
         this.authSourceService = authSourceService;
-        this.authConfigurationProperties = authConfigurationProperties;
         cookieName = authConfigurationProperties.getCookieProperties().getCookieName();
     }
 
@@ -102,8 +100,9 @@ public class HttpBasicPassTicketScheme implements IAuthenticationScheme {
         final String encoded = Base64.getEncoder()
             .encodeToString((userId + ":" + passTicket).getBytes(StandardCharsets.UTF_8));
         final String value = "Basic " + encoded;
-
-        return new PassTicketCommand(value, cookieName, System.currentTimeMillis());
+//        passticket is valid only once, therefore this command needs to expire immediately and each call should generate new passticket
+        long expiration = System.currentTimeMillis();
+        return new PassTicketCommand(value, cookieName, expiration);
     }
 
     @Override

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/HttpBasicPassTicketSchemeTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.security.service.schema.source.*;
@@ -133,16 +132,6 @@ class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
     class ExpirationTest {
         AuthenticationCommand ac;
 
-        @Test
-        void whenJwtExpired_thenCommandExpired() {
-            // JWT token expired one minute ago (command expired also if JWT token expired)
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.MINUTE, -1);
-            AuthSource.Parsed parsedSource = new JwtAuthSource.Parsed(USERNAME, calendar.getTime(), calendar.getTime(), AuthSource.Origin.ZOWE);
-            when(authSourceService.parse(jwtAuthSource)).thenReturn(parsedSource);
-            ac = httpBasicPassTicketScheme.createCommand(authentication, jwtAuthSource);
-            assertTrue(ac.isExpired());
-        }
 
         @Test
         void whenJwtExpireSoon_thenCommandInNotExpiredYet() {
@@ -153,20 +142,6 @@ class HttpBasicPassTicketSchemeTest extends CleanCurrentRequestContextTest {
             when(authSourceService.parse(jwtAuthSource)).thenReturn(parsedSource);
             ac = httpBasicPassTicketScheme.createCommand(authentication, jwtAuthSource);
             assertFalse(ac.isExpired());
-        }
-
-        @Test
-        void testPassticketTimeout() {
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.MINUTE, 100);
-            AuthSource.Parsed parsedSource4 = new JwtAuthSource.Parsed(USERNAME, calendar.getTime(), calendar.getTime(), AuthSource.Origin.ZOWE);
-            when(authSourceService.parse(jwtAuthSource)).thenReturn(parsedSource4);
-            ac = httpBasicPassTicketScheme.createCommand(authentication, jwtAuthSource);
-
-            calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, authConfigurationProperties.getPassTicket().getTimeout());
-            // checking setup of expired time, JWT expired in future (more than hour), check if set date is similar to passticket timeout (5s)
-            assertEquals(0.0, Math.abs(calendar.getTime().getTime() - (long) ReflectionTestUtils.getField(ac, "expireAt")), 10.0);
         }
     }
 

--- a/gateway-service/src/test/resources/application-test.yml
+++ b/gateway-service/src/test/resources/application-test.yml
@@ -39,8 +39,6 @@ apiml:
             provider: dummy
             zosmf:
                 serviceId: zosmf  # Replace me with the correct z/OSMF service id
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         zosmf:
             useJwtToken: true # if true and z/OSMF returns JWT token use it, otherwise create Zowe JWT token with LTPA token from z/OSMF, default is true
         saf:

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -41,8 +41,6 @@ apiml:
             zosmf:
                 serviceId: zosmf  # Replace me with the correct z/OSMF service id
                 jwtAutoconfiguration: jwt
-            passTicket:
-                timeout: 360 # [s] - default timeout to expire (z/OS has 10 mins as default)
         saf:
             provider: rest
             urls:


### PR DESCRIPTION


Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description

immediately expires passticket command, so it generates fresh passticket for each call

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
