### PR TITLE
fix: Remove duplicated instance info from debug info header

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/RequestContextUtils.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/RequestContextUtils.java
@@ -40,8 +40,11 @@ public class RequestContextUtils {
 
     public static void addDebugInfo(String debug) {
         String existingDebugInfo = getDebugInfo();
-        RequestContext.getCurrentContext().set(DEBUG_INFO_KEY,
-            existingDebugInfo.isEmpty() ? debug : existingDebugInfo + "|" + debug);
+        if (!existingDebugInfo.contains(debug)) {
+            RequestContext.getCurrentContext().set(DEBUG_INFO_KEY,
+                existingDebugInfo.isEmpty() ? debug : existingDebugInfo + "|" + debug);
+        }
+
     }
 
     public static String getDebugInfo() {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/RequestContextUtils.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/RequestContextUtils.java
@@ -40,9 +40,10 @@ public class RequestContextUtils {
 
     public static void addDebugInfo(String debug) {
         String existingDebugInfo = getDebugInfo();
-        if (!existingDebugInfo.contains(debug)) {
-            RequestContext.getCurrentContext().set(DEBUG_INFO_KEY,
-                existingDebugInfo.isEmpty() ? debug : existingDebugInfo + "|" + debug);
+        if (existingDebugInfo.isEmpty()) {
+            RequestContext.getCurrentContext().set(DEBUG_INFO_KEY, debug);
+        } else if (!existingDebugInfo.contains(debug)) {
+            RequestContext.getCurrentContext().set(DEBUG_INFO_KEY, existingDebugInfo + "|" + debug);
         }
 
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/HttpClientProxyConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ribbon/http/HttpClientProxyConfig.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Configuration class creates proxy bean for ClosableHttpClient that interceps method calls
+ * Configuration class creates proxy bean for ClosableHttpClient that intercepts method calls
  * <p>
  * Actions on intercept are:
  * Decide which client to use for call (with/without) certificate

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/RequestContextUtilsTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ribbon/RequestContextUtilsTest.java
@@ -13,11 +13,13 @@ package org.zowe.apiml.gateway.ribbon;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.zuul.context.RequestContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.zowe.apiml.gateway.ribbon.RequestContextUtils.DEBUG_INFO_KEY;
 import static org.zowe.apiml.gateway.ribbon.RequestContextUtils.INSTANCE_INFO_KEY;
 
 class RequestContextUtilsTest {
@@ -54,5 +56,29 @@ class RequestContextUtilsTest {
         RequestContext.getCurrentContext().set(INSTANCE_INFO_KEY, info);
         RequestContextUtils.setInstanceInfo(null);
         assertThat(RequestContextUtils.getInstanceInfo().isPresent(), is(false));
+    }
+
+    @Nested
+    class GivenDebugInfo {
+
+        @Nested
+        class WhenAddDifferentDebugInfo {
+            @Test
+            void thenStoreInfo() {
+                RequestContextUtils.addDebugInfo("debugInfo1");
+                RequestContextUtils.addDebugInfo("debugInfo2");
+                assertThat(RequestContext.getCurrentContext().get(DEBUG_INFO_KEY), is("debugInfo1|debugInfo2"));
+            }
+        }
+
+        @Nested
+        class WhenAddDuplicatedDebugInfo {
+            @Test
+            void thenDontStoreDuplicatedRecord() {
+                RequestContextUtils.addDebugInfo("debugInfo1");
+                RequestContextUtils.addDebugInfo("debugInfo1");
+                assertThat(RequestContext.getCurrentContext().get(DEBUG_INFO_KEY), is("debugInfo1"));
+            }
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

Avoid appending of duplicated Instance Info records in the `apimlRibbonRetryDebug` in case of retry failure.
Fixes #1533 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
