### PR TITLE
fix: retrieve swagger api docs with or without certificate config enabled

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
@@ -19,6 +19,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponents;
@@ -49,7 +51,10 @@ import java.util.Optional;
 @Slf4j
 public class APIDocRetrievalService {
 
-    private final CloseableHttpClient httpClient;
+    @Autowired
+    @Qualifier("secureHttpClientWithoutKeystore")
+    private final CloseableHttpClient secureHttpClientWithoutKeystore;
+
     private final InstanceRetrievalService instanceRetrievalService;
     private final GatewayClient gatewayClient;
 
@@ -300,7 +305,7 @@ public class APIDocRetrievalService {
 
         String responseBody = null;
         try {
-            CloseableHttpResponse response = httpClient.execute(httpGet);
+            CloseableHttpResponse response = secureHttpClientWithoutKeystore.execute(httpGet);
             final HttpEntity responseEntity = response.getEntity();
             if (responseEntity != null) {
                 responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);


### PR DESCRIPTION
Signed-off-by: Amanda D'Errico <amanda.derrico@ibm.com>

# Description

`secureHttpClientWithoutKeystore` is needed to handle GET requests to all `swaggerUrl`s, especially when server certificates are being used as client certificates in client authentication.

Linked to # ([2318](https://github.com/zowe/api-layer/issues/2318))
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
