### PR TITLE
Add octokit.request to push updates into open changelog PR

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,4 +37,5 @@ jobs:
                   cd scripts/release_docs
                   npm install
                   npm install -g conventional-changelog-cli
+                  npm install assert
                   node index.js ${{ secrets.ZOWE_ROBOT_TOKEN }} ${{ github.event.inputs.version }} ${{ github.event.inputs.release_date }} ${{ github.event.inputs.amount_of_versions }} ${{ github.ref_name }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,5 +37,4 @@ jobs:
                   cd scripts/release_docs
                   npm install
                   npm install -g conventional-changelog-cli
-                  npm install assert
                   node index.js ${{ secrets.ZOWE_ROBOT_TOKEN }} ${{ github.event.inputs.version }} ${{ github.event.inputs.release_date }} ${{ github.event.inputs.amount_of_versions }} ${{ github.ref_name }}

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -100,50 +100,50 @@ ${restOfChangelog}`;
 //        });
 
 
+//
+//        console.log("git status output...\n");
+//        let gitStatus = `git status`;
+//
+//        console.log(execSync(gitStatus, {
+//            cwd: '../../'
+//        }).toString());
+//
+//
+//
+//        console.log("git status porcelain output...\n");
+//        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
+//
+//        console.log(execSync(gitStatusPorcelain, {
+//            cwd: '../../'
+//        }).toString());
+//
+//        console.log("what's in the changelog?\n");
+//        let myCommand = `cat CHANGELOG.md`
+//        console.log(execSync(myCommand, {
+//            cwd: '../../'
+//        }).toString());
 
-        console.log("git status output...\n");
-        let gitStatus = `git status`;
 
-        console.log(execSync(gitStatus, {
+        console.log("git add output...\n");
+        let gitAdd = `git add CHANGELOG.md`;
+
+        execSync(gitAdd, {
+            cwd: '../../'
+        });
+
+        console.log("git commit output...\n");
+        let gitCommit = `git commit --signoff -m "Update changelog"`;
+
+        console.log(execSync(gitCommit, {
             cwd: '../../'
         }).toString());
 
 
-
-        console.log("git status porcelain output...\n");
-        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
-
-        console.log(execSync(gitStatusPorcelain, {
+        console.log("git push output...\n");
+        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
+        console.log(execSync(gitPush, {
             cwd: '../../'
         }).toString());
-
-        console.log("what's in the changelog?\n");
-        let myCommand = `cat CHANGELOG.md`
-        console.log(execSync(myCommand, {
-            cwd: '../../'
-        }).toString());
-
-
-//        console.log("git add output...\n");
-//        let gitAdd = `git add CHANGELOG.md`;
-//
-//        execSync(gitAdd, {
-//            cwd: '../../'
-//        });
-//
-//        console.log("git commit output...\n");
-//        let gitCommit = `git commit --signoff -m "Update changelog"`;
-//
-//        console.log(execSync(gitCommit, {
-//            cwd: '../../'
-//        })).toString();
-//
-//
-//        console.log("git push output...\n");
-//        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
-//        console.log(execSync(gitPush, {
-//            cwd: '../../'
-//        })).toString();
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,7 +53,7 @@ ${restOfChangelog}`;
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
     const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" &&
-    pr["title"] == "Automatic update for the Changelog for release" &&
+    pr["title"] == "Automatic update for the Changelog for release - test" &&
     pr["body"] == "Update changelog for new release");
 
     if (changelogPrs.length === 1) {
@@ -102,7 +102,7 @@ ${restOfChangelog}`;
         await octokit.rest.pulls.create({
             owner: 'zowe',
             repo: 'api-layer',
-            title: 'Automatic update for the Changelog for release',
+            title: 'Automatic update for the Changelog for release - test',
             head: branch,
             base: branchToMerge,
             body: 'Update changelog for new release'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -59,7 +59,7 @@ ${restOfChangelog}`;
     if (changelogPrs.length === 1) {
         // PR exists, use that branch to merge new updates
         const prevReleaseBranch = changelogPrs[0]["head"]["ref"];
-        let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
+        let gitCheckoutOrigin = `git fetch origin ${branchToMerge} --quiet && git checkout origin/${prevReleaseBranch}`;
 
         execSync(gitCheckoutOrigin, {
             cwd: '../../'
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git fetch origin && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
+        let gitCommitPush = `git fetch origin ${branchToMerge} && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -82,9 +82,7 @@ ${restOfChangelog}`;
             });
         }
         else {
-            console.log("No new changes in CHANGELOG.md\n");
-            const assert = require('assert');
-            assert(changelogPrs.length <= 1, "More than one pull request exists, cannot add new updates to the changelog");
+            console.log("No new changes added in CHANGELOG.md\n");
         }
     }
     else if (changelogPrs.length === 0) {
@@ -111,7 +109,7 @@ ${restOfChangelog}`;
         });
     }
     else {
-        throw AssertionError("More than one pull request exists, cannot add new updates to the changelog");
+        console.log("More than one pull request exists, cannot add new updates to the changelog");
     }
 
 })()

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,7 +56,7 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-      let gitCommitPush = `git fetch origin ${branchToMerge} && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+      let gitCommitPush = `git fetch origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
       execSync(gitCommitPush, {
           cwd: '../../'
       });

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -58,7 +58,7 @@ ${restOfChangelog}`;
     console.log("functions for PR data:\n")
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
-    const changelogPrs = prs.filter(pr => pr.body == "Update changelog for new release")
+    const changelogPrs = prs.filter(pr => pr["body"] == "Update changelog for new release")
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -61,7 +61,7 @@ ${restOfChangelog}`;
 
     console.log("awaiting PR data...\n")
     const data = await getData();
-    const firstPR = getlLatestPRNumber(data);
+    const firstPR = getLatestPRNumber(data);
     const prChanges = execSync(firstPR).toString();
     console.log(prChanges);
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git log && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+        let gitCommitPush = `git fetch origin && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git fetch origin ${branchToMerge} && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
+        let gitCommitPush = `git fetch origin ${branchToMerge} && git checkout -b origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -70,13 +70,13 @@ ${restOfChangelog}`;
         console.log("PRs is 1...");
         let gitCommitPush = `git fetch origin && git checkout origin/${prevReleaseBranch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
 
-        let touchCommand = `touch myfile`
+        let touchCommand = `touch myfile`;
 
         execSync(touchCommand, {
             cwd: '../../'
         });
 
-        let lsCommand = `ls myfile 2>&1`
+        let lsCommand = `ls myfile; echo $?`;
 
         execSync(lsCommand, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,7 +53,7 @@ ${restOfChangelog}`;
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
     const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" &&
-    pr["title"] == "Automatic update for the Changelog for release - Do Not Merge" &&
+    pr["title"] == "Automatic update for the Changelog for release" &&
     pr["body"] == "Update changelog for new release");
 
     if (changelogPrs.length === 1) {
@@ -102,7 +102,7 @@ ${restOfChangelog}`;
         await octokit.rest.pulls.create({
             owner: 'zowe',
             repo: 'api-layer',
-            title: 'Automatic update for the Changelog for release - Do Not Merge',
+            title: 'Automatic update for the Changelog for release',
             head: branch,
             base: branchToMerge,
             body: 'Update changelog for new release'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -58,7 +58,9 @@ ${restOfChangelog}`;
     console.log("functions for PR data:\n")
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
-    const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" && pr["body"] == "Update changelog for new release")
+    const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" &&
+    pr["title"] == "Automatic update for the Changelog for release - Do Not Merge" &&
+    pr["body"] == "Update changelog for new release")
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -85,7 +85,7 @@ ${restOfChangelog}`;
 //            cwd: '../../'
 //        }).toString());
 
-        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
+        let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
 
         execSync(gitCheckoutOrigin, {
             cwd: '../../'
@@ -106,7 +106,7 @@ ${restOfChangelog}`;
 
         console.log(execSync(gitStatus, {
             cwd: '../../'
-        })).toString();
+        }));
 
 
 
@@ -115,29 +115,29 @@ ${restOfChangelog}`;
 
         console.log(execSync(gitStatusPorcelain, {
             cwd: '../../'
-        })).toString();
+        }));
 
 
-        console.log("git add output...\n");
-        let gitAdd = `git add CHANGELOG.md`;
-
-        execSync(gitAdd, {
-            cwd: '../../'
-        });
-
-        console.log("git commit output...\n");
-        let gitCommit = `git commit --signoff -m "Update changelog"`;
-
-        console.log(execSync(gitCommit, {
-            cwd: '../../'
-        })).toString();
-
-
-        console.log("git push output...\n");
-        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
-        console.log(execSync(gitPush, {
-            cwd: '../../'
-        })).toString();
+//        console.log("git add output...\n");
+//        let gitAdd = `git add CHANGELOG.md`;
+//
+//        execSync(gitAdd, {
+//            cwd: '../../'
+//        });
+//
+//        console.log("git commit output...\n");
+//        let gitCommit = `git commit --signoff -m "Update changelog"`;
+//
+//        console.log(execSync(gitCommit, {
+//            cwd: '../../'
+//        })).toString();
+//
+//
+//        console.log("git push output...\n");
+//        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
+//        console.log(execSync(gitPush, {
+//            cwd: '../../'
+//        })).toString();
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,10 +56,10 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-    console.log("fetch unshallow:\n")
-    let fetch = `git fetch --unshallow origin v2.x.x`;
-    const fetchChanges = execSync(fetch).toString();
-    console.log(fetchChanges);
+//    console.log("fetch unshallow:\n")
+//    let fetch = `git fetch --unshallow origin v2.x.x`;
+//    const fetchChanges = execSync(fetch).toString();
+//    console.log(fetchChanges);
 
     console.log("check branches:\n")
     let branchTest = `git branch`;

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -76,11 +76,13 @@ ${restOfChangelog}`;
             cwd: '../../'
         });
 
-        let lsCommand = `echo hi`;
+        let lsCommand = `ls myfile`;
 
-        execSync(lsCommand, {
+        const myOut = execSync(lsCommand, {
             cwd: '../../'
         });
+
+        console.log(myOut);
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,15 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git fetch origin ${branchToMerge} && git checkout -b origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
+        let gitLog = `git log`;
+        const mygitlog = execSync(gitCommitPush, {
+            cwd: '../../'
+        }).toString();
+
+        console.log("printing git log\n");
+        console.log(mygitlog);
+
+        let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -76,7 +76,7 @@ ${restOfChangelog}`;
             cwd: '../../'
         });
 
-        let lsCommand = `ls myfile; echo $?`;
+        let lsCommand = `echo hi`;
 
         execSync(lsCommand, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,7 +56,7 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
     console.log("functions for PR data:\n")
-    const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
+    const getData = () => octokit.request('/repos/zowe/api-layer/pulls');
     const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
     console.log("awaiting PR data...\n")
@@ -66,28 +66,29 @@ ${restOfChangelog}`;
     console.log(prChanges);
 
 
-
-    console.log("fetch unshallow:\n")
-    let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git pull`;
-    const fetchChanges = execSync(fetch).toString();
-    console.log(fetchChanges);
-
-    console.log("check branches:\n")
-    let branchTest = `git branch`;
-    const branchChanges = execSync(branchTest).toString();
-    console.log(branchChanges);
+    // uncomment out later
+//    console.log("fetch unshallow:\n")
+//    let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git pull`;
+//    const fetchChanges = execSync(fetch).toString();
+//    console.log(fetchChanges);
+//
+//    console.log("check branches:\n")
+//    let branchTest = `git branch`;
+//    const branchChanges = execSync(branchTest).toString();
+//    console.log(branchChanges);
 
 //    console.log("checkout origin for v2.x.x and check branches:\n")
 //    let checkoutBranch = `git checkout origin/v2.x.x && git branch`;
 //    const checkoutBranchChanges = execSync(checkoutBranch).toString();
 //    console.log(checkoutBranchChanges);
 
+    // uncomment out later
+//      let gitCommitPush = `git fetch --unshallow origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+//      execSync(gitCommitPush, {
+//          cwd: '../../'
+//      });
 
-      let gitCommitPush = `git fetch --unshallow origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
-      execSync(gitCommitPush, {
-          cwd: '../../'
-      });
-
+        // uncomment out later
   //    await octokit.rest.pulls.create({
   //        owner: 'zowe',
   //        repo: 'api-layer',

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -82,7 +82,7 @@ ${restOfChangelog}`;
             });
         }
         else {
-            console.log("No new changes added in CHANGELOG.md\n");
+            console.log("No new changes added in CHANGELOG.md");
         }
     }
     else if (changelogPrs.length === 0) {

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,14 +93,6 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitLog = `git log`;
-        const mygitlog = execSync(gitLog, {
-            cwd: '../../'
-        }).toString();
-
-        console.log("printing git log\n");
-        console.log(mygitlog);
-
         let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
 
         execSync(gitCommitPush, {

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -94,7 +94,7 @@ ${restOfChangelog}`;
         console.log("New release branch created " + branch + "\n");
 
         let gitLog = `git log`;
-        const mygitlog = execSync(gitCommitPush, {
+        const mygitlog = execSync(gitLog, {
             cwd: '../../'
         }).toString();
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -55,7 +55,7 @@ ${restOfChangelog}`;
 
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
-
+    console.log("display PR data:\n")
     const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
     console.log(getData);
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,6 +56,22 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
+    console.log("fetch unshallow:\n")
+    let fetch = `git fetch --unshallow origin v2.x.x`;
+    const fetchChanges = execSync(fetch).toString();
+    console.log(fetchChanges);
+
+    console.log("check branches:\n")
+    let branchTest = `git branch`;
+    const branchChanges = execSync(branchTest).toString();
+    console.log(branchChanges);
+
+    console.log("checkout origin for v2.x.x and check branches:\n")
+    let checkoutBranch = `git checkout origin/v2.x.x && git branch`;
+    const checkoutBranchChanges = execSync(checkoutBranch).toString();
+    console.log(checkoutBranchChanges);
+
+
       let gitCommitPush = `git fetch --unshallow origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
       execSync(gitCommitPush, {
           cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,20 +56,20 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-//    console.log("fetch unshallow:\n")
-//    let fetch = `git fetch --unshallow origin v2.x.x`;
-//    const fetchChanges = execSync(fetch).toString();
-//    console.log(fetchChanges);
+    console.log("fetch unshallow:\n")
+    let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git fetch --unshallow origin apiml/GH2503/GHA_update_existing_PR`;
+    const fetchChanges = execSync(fetch).toString();
+    console.log(fetchChanges);
 
     console.log("check branches:\n")
     let branchTest = `git branch`;
     const branchChanges = execSync(branchTest).toString();
     console.log(branchChanges);
 
-    console.log("checkout origin for v2.x.x and check branches:\n")
-    let checkoutBranch = `git checkout origin/v2.x.x && git branch`;
-    const checkoutBranchChanges = execSync(checkoutBranch).toString();
-    console.log(checkoutBranchChanges);
+//    console.log("checkout origin for v2.x.x and check branches:\n")
+//    let checkoutBranch = `git checkout origin/v2.x.x && git branch`;
+//    const checkoutBranchChanges = execSync(checkoutBranch).toString();
+//    console.log(checkoutBranchChanges);
 
 
       let gitCommitPush = `git fetch --unshallow origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -80,7 +80,7 @@ ${restOfChangelog}`;
 
         const myOut = execSync(lsCommand, {
             cwd: '../../'
-        });
+        }).toString();
 
         console.log(myOut);
     }

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -70,19 +70,19 @@ ${restOfChangelog}`;
         console.log("PRs is 1...");
 
         let gitBranch = `git branch`;
-        let gitCheckout = `git checkout origin/${prevReleaseBranch}`;
+        let gitCheckout = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
         console.log(execSync(gitBranch, {
             cwd: '../../'
-        }));
+        }).toString());
 
 
         console.log(execSync(gitCheckout, {
             cwd: '../../'
-        }));
+        }).toString());
 
         console.log(execSync(gitBranch, {
             cwd: '../../'
-        }));
+        }).toString());
 
 //        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
 //

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -71,15 +71,16 @@ ${restOfChangelog}`;
 
         let gitBranch = `git branch`;
         let gitCheckout = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
+        console.log("my old git branch:\n")
         console.log(execSync(gitBranch, {
             cwd: '../../'
         }).toString());
 
-
-        console.log(execSync(gitCheckout, {
+        execSync(gitCheckout, {
             cwd: '../../'
-        }).toString());
+        });
 
+        console.log("my new git branch:\n")
         console.log(execSync(gitBranch, {
             cwd: '../../'
         }).toString());

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,19 +93,20 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git fetch origin && git log`
+        let gitCommitPush = `git fetch origin && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${branch}`;
+
         execSync(gitCommitPush, {
             cwd: '../../'
         });
 
-//        await octokit.rest.pulls.create({
-//            owner: 'zowe',
-//            repo: 'api-layer',
-//            title: 'Automatic update for the Changelog for release',
-//            head: branch,
-//            base: branchToMerge,
-//            body: 'Update changelog for new release'
-//        });
+        await octokit.rest.pulls.create({
+            owner: 'zowe',
+            repo: 'api-layer',
+            title: 'Automatic update for the Changelog for release',
+            head: branch,
+            base: branchToMerge,
+            body: 'Update changelog for new release'
+        });
     }
     else {
         console.log("More than one pull request exists, cannot add new updates to the changelog");

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -76,7 +76,7 @@ ${restOfChangelog}`;
             cwd: '../../'
         });
 
-        let lsCommand = `ls myfile`
+        let lsCommand = `ls myfile 2>&1`
 
         execSync(lsCommand, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
 
         await writeFile('../../CHANGELOG.md', changelogToStore);
 
-        let gitCommitPush = `git pull && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
+        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -64,7 +64,7 @@ ${restOfChangelog}`;
 //    console.log("awaiting PR data...\n")
 //    const data = await getData();
 //    const firstPR = getLatestPRNumber(data).toString();
-    console.log(prs);
+    console.log(changelogPrs);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,13 +56,13 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
     console.log("functions for PR data:\n")
-    const data = await octokit.request("GET /repos/zowe/api-layer/pulls");
+    const prs = await octokit.request("GET /repos/zowe/api-layer/pulls");
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")
 //    const data = await getData();
 //    const firstPR = getLatestPRNumber(data).toString();
-    console.log(data[0]);
+    console.log(prs.data);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -102,9 +102,9 @@ ${restOfChangelog}`;
         console.log("git add output...\n");
         let gitAdd = `git add CHANGELOG.md`;
 
-        console.log(execSync(gitAdd, {
+        execSync(gitAdd, {
             cwd: '../../'
-        })).toString();
+        });
 
         console.log("git commit output...\n");
         let gitCommit = `git commit --signoff -m "Update changelog"`;

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,7 +56,7 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-      let gitCommitPush = `git fetch origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+      let gitCommitPush = `git fetch --unshallow origin v2.x.x && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
       execSync(gitCommitPush, {
           cwd: '../../'
       });

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,18 +53,21 @@ ${restOfChangelog}`;
     const octokit = new Octokit({auth: githubToken});
     const branch = `apiml/release/${version.replace(/\./g, "_")}`;
 
-    let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+    // if PR exists, find branch associated with it then checkout that branch and make changes to that
+    // else regular process
+
+    let gitCommitPush = `git fetch origin ${branchToMerge} --quiet && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog second commit" && git push origin ${branch}`;
     execSync(gitCommitPush, {
         cwd: '../../'
     });
 
-    await octokit.rest.pulls.create({
-        owner: 'zowe',
-        repo: 'api-layer',
-        title: 'Automatic update for the Changelog for release',
-        head: branch,
-        base: branchToMerge,
-        body: 'Update changelog for new release'
-    });
+//    await octokit.rest.pulls.create({
+//        owner: 'zowe',
+//        repo: 'api-layer',
+//        title: 'Automatic update for the Changelog for release',
+//        head: branch,
+//        base: branchToMerge,
+//        body: 'Update changelog for new release'
+//    });
 })()
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -69,35 +69,35 @@ ${restOfChangelog}`;
 
         console.log("PRs is 1...");
 
-        let gitBranch = `git branch`;
-        let gitCheckout = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
-        console.log("my old git branch:\n")
-        console.log(execSync(gitBranch, {
-            cwd: '../../'
-        }).toString());
+//        let gitBranch = `git branch`;
+//        let gitCheckout = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
+//        console.log("my old git branch:\n")
+//        console.log(execSync(gitBranch, {
+//            cwd: '../../'
+//        }).toString());
+//
+//        execSync(gitCheckout, {
+//            cwd: '../../'
+//        });
+//
+//        console.log("my new git branch:\n")
+//        console.log(execSync(gitBranch, {
+//            cwd: '../../'
+//        }).toString());
 
-        execSync(gitCheckout, {
+        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
+
+        execSync(gitCheckoutOrigin, {
             cwd: '../../'
         });
 
-        console.log("my new git branch:\n")
-        console.log(execSync(gitBranch, {
-            cwd: '../../'
-        }).toString());
+        await writeFile('../../CHANGELOG.md', changelogToStore);
 
-//        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
-//
-//        execSync(gitCheckoutOrigin, {
-//            cwd: '../../'
-//        });
-//
-//        await writeFile('../../CHANGELOG.md', changelogToStore);
-//
-//        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
-//
-//        execSync(gitCommitPush, {
-//            cwd: '../../'
-//        });
+        let gitCommitPush = `git pull && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
+
+        execSync(gitCommitPush, {
+            cwd: '../../'
+        });
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -99,6 +99,25 @@ ${restOfChangelog}`;
 //            cwd: '../../'
 //        });
 
+
+
+        console.log("git status output...\n");
+        let gitStatus = `git status`;
+
+        console.log(execSync(gitStatus, {
+            cwd: '../../'
+        })).toString();
+
+
+
+        console.log("git status porcelain output...\n");
+        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
+
+        console.log(execSync(gitStatusPorcelain, {
+            cwd: '../../'
+        })).toString();
+
+
         console.log("git add output...\n");
         let gitAdd = `git add CHANGELOG.md`;
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,7 +53,7 @@ ${restOfChangelog}`;
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
     const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" &&
-    pr["title"] == "Automatic update for the Changelog for release - test" &&
+    pr["title"] == "Automatic update for the Changelog for release" &&
     pr["body"] == "Update changelog for new release");
 
     if (changelogPrs.length === 1) {
@@ -102,7 +102,7 @@ ${restOfChangelog}`;
         await octokit.rest.pulls.create({
             owner: 'zowe',
             repo: 'api-layer',
-            title: 'Automatic update for the Changelog for release - test',
+            title: 'Automatic update for the Changelog for release',
             head: branch,
             base: branchToMerge,
             body: 'Update changelog for new release'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,18 +53,21 @@ ${restOfChangelog}`;
     const octokit = new Octokit({auth: githubToken});
     const branch = `apiml/release/${version.replace(/\./g, "_")}`;
 
-    let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
-    execSync(gitCommitPush, {
-        cwd: '../../'
-    });
+      // if PR exists, find branch associated with it then checkout that branch and make changes to that
+      // else regular process
 
-    await octokit.rest.pulls.create({
-        owner: 'zowe',
-        repo: 'api-layer',
-        title: 'Automatic update for the Changelog for release - Do Not Merge',
-        head: branch,
-        base: branchToMerge,
-        body: 'Update changelog for new release'
-    });
+      let gitCommitPush = `git fetch origin ${branchToMerge} --quiet && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+      execSync(gitCommitPush, {
+          cwd: '../../'
+      });
+
+  //    await octokit.rest.pulls.create({
+  //        owner: 'zowe',
+  //        repo: 'api-layer',
+  //        title: 'Automatic update for the Changelog for release',
+  //        head: branch,
+  //        base: branchToMerge,
+  //        body: 'Update changelog for new release'
+  //    });
 })()
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -83,7 +83,8 @@ ${restOfChangelog}`;
         }
         else {
             console.log("No new changes in CHANGELOG.md\n");
-            throw AssertionError("More than one pull request exists, cannot add new updates to the changelog");
+            const assert = require('assert');
+            assert(changelogPrs.length <= 1, "More than one pull request exists, cannot add new updates to the changelog");
         }
     }
     else if (changelogPrs.length === 0) {

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -61,9 +61,8 @@ ${restOfChangelog}`;
 
     console.log("awaiting PR data...\n")
     const data = await getData();
-    const firstPR = getLatestPRNumber(data);
-    const prChanges = execSync(firstPR).toString();
-    console.log(prChanges);
+    const firstPR = getLatestPRNumber(data).toString();
+    console.log(firstPR);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,10 +53,10 @@ ${restOfChangelog}`;
     const octokit = new Octokit({auth: githubToken});
     const branch = `apiml/release/${version.replace(/\./g, "_")}`;
 
-      // if PR exists, find branch associated with it then checkout that branch and make changes to that
+      // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-      let gitCommitPush = `git fetch origin ${branchToMerge} --quiet && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+      let gitCommitPush = `git fetch origin ${branchToMerge} && git checkout origin/${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
       execSync(gitCommitPush, {
           cwd: '../../'
       });

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -68,19 +68,35 @@ ${restOfChangelog}`;
         console.log("prev release branch is: " + prevReleaseBranch);
 
         console.log("PRs is 1...");
-        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
 
-        execSync(gitCheckoutOrigin, {
+        let gitBranch = `git branch`;
+        let gitCheckout = `git checkout origin/${prevReleaseBranch}`;
+        console.log(execSync(gitBranch, {
             cwd: '../../'
-        });
+        }));
 
-        await writeFile('../../CHANGELOG.md', changelogToStore);
 
-        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
-
-        execSync(gitCommitPush, {
+        console.log(execSync(gitCheckout, {
             cwd: '../../'
-        });
+        }));
+
+        console.log(execSync(gitBranch, {
+            cwd: '../../'
+        }));
+
+//        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
+//
+//        execSync(gitCheckoutOrigin, {
+//            cwd: '../../'
+//        });
+//
+//        await writeFile('../../CHANGELOG.md', changelogToStore);
+//
+//        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
+//
+//        execSync(gitCommitPush, {
+//            cwd: '../../'
+//        });
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -68,21 +68,19 @@ ${restOfChangelog}`;
         console.log("prev release branch is: " + prevReleaseBranch);
 
         console.log("PRs is 1...");
-        let gitCommitPush = `git fetch origin && git checkout origin/${prevReleaseBranch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
+        let gitCheckoutOrigin = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
 
-        let touchCommand = `touch myfile`;
-
-        execSync(touchCommand, {
+        execSync(gitCheckoutOrigin, {
             cwd: '../../'
         });
 
-        let lsCommand = `ls myfile`;
+        await writeFile('../../CHANGELOG.md', changelogToStore);
 
-        const myOut = execSync(lsCommand, {
+        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
+
+        execSync(gitCommitPush, {
             cwd: '../../'
-        }).toString();
-
-        console.log(myOut);
+        });
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -61,7 +61,7 @@ ${restOfChangelog}`;
     await octokit.rest.pulls.create({
         owner: 'zowe',
         repo: 'api-layer',
-        title: 'Automatic update for the Changelog for release',
+        title: 'Automatic update for the Changelog for release - Do Not Merge',
         head: branch,
         base: branchToMerge,
         body: 'Update changelog for new release'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -117,6 +117,12 @@ ${restOfChangelog}`;
             cwd: '../../'
         }).toString());
 
+        console.log("what's in the changelog?\n");
+        let myCommand = `cat CHANGELOG.md`
+        console.log(execSync(myCommand, {
+            cwd: '../../'
+        }).toString());
+
 
 //        console.log("git add output...\n");
 //        let gitAdd = `git add CHANGELOG.md`;

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -57,7 +57,8 @@ ${restOfChangelog}`;
       // else regular process
     console.log("display PR data:\n")
     const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
-    console.log(getData);
+    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
+    console.log(getLatestPRNumber);
 
 
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -58,7 +58,8 @@ ${restOfChangelog}`;
     console.log("display PR data:\n")
     const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
     const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
-    console.log(getLatestPRNumber);
+    const prChanges = execSync(getLatestPRNumber).toString();
+    console.log(prChanges);
 
 
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -48,8 +48,6 @@ ${addedFixes}
 
 ${restOfChangelog}`;
 
-    await writeFile('../../CHANGELOG.md', changelogToStore);
-
     const octokit = new Octokit({auth: githubToken});
 //    const branch = `apiml/release/${version.replace(/\./g, "_")}`;
 
@@ -72,12 +70,23 @@ ${restOfChangelog}`;
         console.log("PRs is 1...");
         let gitCommitPush = `git fetch origin && git checkout origin/${prevReleaseBranch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
 
-        execSync(gitCommitPush, {
+        let touchCommand = `touch myfile`
+
+        execSync(touchCommand, {
+            cwd: '../../'
+        });
+
+        let lsCommand = `ls myfile`
+
+        execSync(lsCommand, {
             cwd: '../../'
         });
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog
+
+        await writeFile('../../CHANGELOG.md', changelogToStore);
+
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("new release branch is: " + branch);
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -62,25 +62,27 @@ ${restOfChangelog}`;
     pr["title"] == "Automatic update for the Changelog for release - Do Not Merge" &&
     pr["body"] == "Update changelog for new release");
 
-    console.log(changelogPrs);
+//    console.log(changelogPrs);
 
     var assert = require('assert');
-    assert(changelogPrs <= 1, "More than one pull request exists, cannot add new updates to the changelog");
+    assert(changelogPrs.length <= 1, "More than one pull request exists, cannot add new updates to the changelog");
 
-    if (changelogPrs === 1) {
+    if (changelogPrs.length === 1) {
         // PR exists, use that branch to merge new updates
         const prevReleaseBranch = changelogPrs[0]["head"]["ref"];
+        console.log("prev release branch is: " + prevReleaseBranch);
 
-        console.log("PRs is 1...")
+        console.log("PRs is 1...");
         let gitCommitPush = `git fetch origin && git checkout origin/${prevReleaseBranch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${prevReleaseBranch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'
         });
     }
-    else if (changelogPrs === 0) {
+    else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
+        console.log("new release branch is: " + branch);
 
         console.log("PRs is 0...")
         let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,6 +56,11 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
+    const getData = () => await octokit.request('/api-layer/pulls/zowe-robot');
+    console.log(getData);
+
+
+
     console.log("fetch unshallow:\n")
     let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git pull`;
     const fetchChanges = execSync(fetch).toString();

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -62,7 +62,7 @@ ${restOfChangelog}`;
 //    console.log("awaiting PR data...\n")
 //    const data = await getData();
 //    const firstPR = getLatestPRNumber(data).toString();
-    console.log(data);
+    console.log(data[0]);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -58,7 +58,7 @@ ${restOfChangelog}`;
     console.log("functions for PR data:\n")
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
-//    const changelogPrs = prs.filter()
+    const changelogPrs = prs.filter(pr => pr.body == "Update changelog for new release")
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -106,7 +106,7 @@ ${restOfChangelog}`;
 
         console.log(execSync(gitStatus, {
             cwd: '../../'
-        }));
+        }).toString());
 
 
 
@@ -115,7 +115,7 @@ ${restOfChangelog}`;
 
         console.log(execSync(gitStatusPorcelain, {
             cwd: '../../'
-        }));
+        }).toString());
 
 
 //        console.log("git add output...\n");

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -64,9 +64,6 @@ ${restOfChangelog}`;
 
 //    console.log(changelogPrs);
 
-    var assert = require('assert');
-    assert(changelogPrs.length <= 1, "More than one pull request exists, cannot add new updates to the changelog");
-
     if (changelogPrs.length === 1) {
         // PR exists, use that branch to merge new updates
         const prevReleaseBranch = changelogPrs[0]["head"]["ref"];
@@ -99,6 +96,9 @@ ${restOfChangelog}`;
             base: branchToMerge,
             body: 'Update changelog for new release'
         });
+    }
+    else {
+        throw AssertionError("More than one pull request exists, cannot add new updates to the changelog");
     }
 
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
+        let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git log && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,11 +93,32 @@ ${restOfChangelog}`;
 
         await writeFile('../../CHANGELOG.md', changelogToStore);
 
-        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${prevReleaseBranch}`;
+//        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${prevReleaseBranch}`;
+//
+//        execSync(gitCommitPush, {
+//            cwd: '../../'
+//        });
 
-        execSync(gitCommitPush, {
+        console.log("git add output...\n");
+        let gitAdd = `git add CHANGELOG.md`;
+
+        console.log(execSync(gitAdd, {
             cwd: '../../'
-        });
+        })).toString();
+
+        console.log("git commit output...\n");
+        let gitCommit = `git commit --signoff -m "Update changelog"`;
+
+        console.log(execSync(gitCommit, {
+            cwd: '../../'
+        })).toString();
+
+
+        console.log("git push output...\n");
+        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
+        console.log(execSync(gitPush, {
+            cwd: '../../'
+        })).toString();
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,13 +56,13 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
     console.log("functions for PR data:\n")
-    const getData = () => octokit.request('/repos/zowe/api-layer/pulls');
-    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
+    const data = await octokit.request("GET /repos/zowe/api-layer/pulls");
+//    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
-    console.log("awaiting PR data...\n")
-    const data = await getData();
-    const firstPR = getLatestPRNumber(data).toString();
-    console.log(firstPR);
+//    console.log("awaiting PR data...\n")
+//    const data = await getData();
+//    const firstPR = getLatestPRNumber(data).toString();
+    console.log(data);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,7 +93,7 @@ ${restOfChangelog}`;
 
         await writeFile('../../CHANGELOG.md', changelogToStore);
 
-        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin`;
+        let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${prevReleaseBranch}`;
 
         execSync(gitCommitPush, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -58,7 +58,7 @@ ${restOfChangelog}`;
     console.log("functions for PR data:\n")
     const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
 
-    const changelogPrs = prs.filter(pr => pr["body"] == "Update changelog for new release")
+    const changelogPrs = prs.filter(pr => pr["user"]["login"] == "zowe-robot" && pr["body"] == "Update changelog for new release")
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -57,7 +57,7 @@ ${restOfChangelog}`;
       // else regular process
 
     console.log("fetch unshallow:\n")
-    let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git fetch --unshallow origin apiml/GH2503/GHA_update_existing_PR`;
+    let fetch = `git checkout origin/apiml/GH2503/GHA_update_existing_PR && git pull`;
     const fetchChanges = execSync(fetch).toString();
     console.log(fetchChanges);
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -69,22 +69,6 @@ ${restOfChangelog}`;
 
         console.log("PRs is 1...");
 
-//        let gitBranch = `git branch`;
-//        let gitCheckout = `git fetch origin && git checkout origin/${prevReleaseBranch}`;
-//        console.log("my old git branch:\n")
-//        console.log(execSync(gitBranch, {
-//            cwd: '../../'
-//        }).toString());
-//
-//        execSync(gitCheckout, {
-//            cwd: '../../'
-//        });
-//
-//        console.log("my new git branch:\n")
-//        console.log(execSync(gitBranch, {
-//            cwd: '../../'
-//        }).toString());
-
         let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
 
         execSync(gitCheckoutOrigin, {
@@ -99,51 +83,52 @@ ${restOfChangelog}`;
 //            cwd: '../../'
 //        });
 
-
-
-        console.log("git status output...\n");
-        let gitStatus = `git status`;
-
-        console.log(execSync(gitStatus, {
-            cwd: '../../'
-        }).toString());
-
-
-
         console.log("git status porcelain output...\n");
         let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
 
-        console.log(execSync(gitStatusPorcelain, {
+        let gitStatusPorcelainOutput = execSync(gitStatusPorcelain, {
             cwd: '../../'
-        }).toString());
+        }).toString();
 
-        console.log("what's in the changelog?\n");
-        let myCommand = `cat CHANGELOG.md`
-        console.log(execSync(myCommand, {
-            cwd: '../../'
-        }).toString());
+        if (gitStatusPorcelainOutput.length != 0) {
+            console.log("output exists from git status\n");
+            let gitCommitPush = `git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin HEAD:${prevReleaseBranch}`;
 
+            execSync(gitCommitPush, {
+                cwd: '../../'
+            });
+        }
+        else {
+            console.log("no output from git status\n");
+        }
 
-        console.log("git add output...\n");
-        let gitAdd = `git add CHANGELOG.md`;
-
-        execSync(gitAdd, {
-            cwd: '../../'
-        });
-
-        console.log("git commit output...\n");
-        let gitCommit = `git commit --signoff -m "Update changelog"`;
-
-        console.log(execSync(gitCommit, {
-            cwd: '../../'
-        }).toString());
-
-
-        console.log("git push output...\n");
-        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
-        console.log(execSync(gitPush, {
-            cwd: '../../'
-        }).toString());
+//        console.log("what's in the changelog?\n");
+//        let myCommand = `cat CHANGELOG.md`
+//        console.log(execSync(myCommand, {
+//            cwd: '../../'
+//        }).toString());
+//
+//
+//        console.log("git add output...\n");
+//        let gitAdd = `git add CHANGELOG.md`;
+//
+//        execSync(gitAdd, {
+//            cwd: '../../'
+//        });
+//
+//        console.log("git commit output...\n");
+//        let gitCommit = `git commit --signoff -m "Update changelog"`;
+//
+//        console.log(execSync(gitCommit, {
+//            cwd: '../../'
+//        }).toString());
+//
+//
+//        console.log("git push output...\n");
+//        let gitPush = `git push origin HEAD:${prevReleaseBranch}`;
+//        console.log(execSync(gitPush, {
+//            cwd: '../../'
+//        }).toString());
     }
     else if (changelogPrs.length === 0) {
         // make new PR since none exist for changelog

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,13 +56,15 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
     console.log("functions for PR data:\n")
-    const prs = await octokit.request("GET /repos/zowe/api-layer/pulls");
+    const prs = (await octokit.request("GET /repos/zowe/api-layer/pulls")).data;
+
+//    const changelogPrs = prs.filter()
 //    const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
 
 //    console.log("awaiting PR data...\n")
 //    const data = await getData();
 //    const firstPR = getLatestPRNumber(data).toString();
-    console.log(prs.data);
+    console.log(prs);
 
 
     // uncomment out later

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -55,10 +55,14 @@ ${restOfChangelog}`;
 
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
-    console.log("display PR data:\n")
+    console.log("functions for PR data:\n")
     const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
     const getLatestPRNumber = (data) => data.length === 0 ? 0 : data[0];
-    const prChanges = execSync(getLatestPRNumber).toString();
+
+    console.log("awaiting PR data...\n")
+    const data = await getData();
+    const firstPR = getlLatestPRNumber(data);
+    const prChanges = execSync(firstPR).toString();
     console.log(prChanges);
 
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -59,7 +59,7 @@ ${restOfChangelog}`;
     if (changelogPrs.length === 1) {
         // PR exists, use that branch to merge new updates
         const prevReleaseBranch = changelogPrs[0]["head"]["ref"];
-        let gitCheckoutOrigin = `git fetch origin ${branchToMerge} --quiet && git checkout origin/${prevReleaseBranch}`;
+        let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
 
         execSync(gitCheckoutOrigin, {
             cwd: '../../'

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -56,7 +56,7 @@ ${restOfChangelog}`;
       // if PR exists (indicate with zowe robot or automatic changelog...), find branch associated with it then checkout that branch and make changes to that
       // else regular process
 
-    const getData = () => await octokit.request('/api-layer/pulls/zowe-robot');
+    const getData = () => octokit.request('/api-layer/pulls/zowe-robot');
     console.log(getData);
 
 

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -100,28 +100,28 @@ ${restOfChangelog}`;
 //        });
 
 
-//
-//        console.log("git status output...\n");
-//        let gitStatus = `git status`;
-//
-//        console.log(execSync(gitStatus, {
-//            cwd: '../../'
-//        }).toString());
-//
-//
-//
-//        console.log("git status porcelain output...\n");
-//        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
-//
-//        console.log(execSync(gitStatusPorcelain, {
-//            cwd: '../../'
-//        }).toString());
-//
-//        console.log("what's in the changelog?\n");
-//        let myCommand = `cat CHANGELOG.md`
-//        console.log(execSync(myCommand, {
-//            cwd: '../../'
-//        }).toString());
+
+        console.log("git status output...\n");
+        let gitStatus = `git status`;
+
+        console.log(execSync(gitStatus, {
+            cwd: '../../'
+        }).toString());
+
+
+
+        console.log("git status porcelain output...\n");
+        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
+
+        console.log(execSync(gitStatusPorcelain, {
+            cwd: '../../'
+        }).toString());
+
+        console.log("what's in the changelog?\n");
+        let myCommand = `cat CHANGELOG.md`
+        console.log(execSync(myCommand, {
+            cwd: '../../'
+        }).toString());
 
 
         console.log("git add output...\n");

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -93,20 +93,19 @@ ${restOfChangelog}`;
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
 
-        let gitCommitPush = `git fetch origin && git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
-
+        let gitCommitPush = `git fetch origin && git log`
         execSync(gitCommitPush, {
             cwd: '../../'
         });
 
-        await octokit.rest.pulls.create({
-            owner: 'zowe',
-            repo: 'api-layer',
-            title: 'Automatic update for the Changelog for release',
-            head: branch,
-            base: branchToMerge,
-            body: 'Update changelog for new release'
-        });
+//        await octokit.rest.pulls.create({
+//            owner: 'zowe',
+//            repo: 'api-layer',
+//            title: 'Automatic update for the Changelog for release',
+//            head: branch,
+//            base: branchToMerge,
+//            body: 'Update changelog for new release'
+//        });
     }
     else {
         console.log("More than one pull request exists, cannot add new updates to the changelog");

--- a/scripts/release_docs/index.js
+++ b/scripts/release_docs/index.js
@@ -53,21 +53,18 @@ ${restOfChangelog}`;
     const octokit = new Octokit({auth: githubToken});
     const branch = `apiml/release/${version.replace(/\./g, "_")}`;
 
-    // if PR exists, find branch associated with it then checkout that branch and make changes to that
-    // else regular process
-
-    let gitCommitPush = `git fetch origin ${branchToMerge} --quiet && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog second commit" && git push origin ${branch}`;
+    let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add CHANGELOG.md && git commit --signoff -m "Update changelog" && git push origin ${branch}`;
     execSync(gitCommitPush, {
         cwd: '../../'
     });
 
-//    await octokit.rest.pulls.create({
-//        owner: 'zowe',
-//        repo: 'api-layer',
-//        title: 'Automatic update for the Changelog for release',
-//        head: branch,
-//        base: branchToMerge,
-//        body: 'Update changelog for new release'
-//    });
+    await octokit.rest.pulls.create({
+        owner: 'zowe',
+        repo: 'api-layer',
+        title: 'Automatic update for the Changelog for release',
+        head: branch,
+        base: branchToMerge,
+        body: 'Update changelog for new release'
+    });
 })()
 


### PR DESCRIPTION
# Description

When updates need to go into the changelog, octokit.request will send a GET request and push to the current open changelog PR instead of creating a new one.

Refer to example PR [Automatic update for the Changelog for release #2519](https://github.com/zowe/api-layer/pull/2519) to see the changelog updates. Workflow [#64](https://github.com/zowe/api-layer/actions/runs/2714943691) first runs on v2.5.0 and amount of versions=1 and then workflow [#66](https://github.com/zowe/api-layer/actions/runs/2715270714) runs on v2.5.1 and amount of versions=3.

Linked to # ([2503](https://github.com/zowe/api-layer/issues/2503))
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
