### PR TITLE
chore: Use job id as jib tag

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -24,7 +24,7 @@ jobs:
 
             -   name: Build with Gradle
                 run: >
-                    ./gradlew jib -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }} -Pzowe.docker.password=${{ secrets.PERSONAL_JB_TOKEN }} -Pzowe.docker.username=balhar-jakub -Pzowe.docker.container=ghcr.io/balhar-jakub/ -Pzowe.docker.tag=${{ github.event.pull_request.number || 'latest' }}
+                    ./gradlew jib -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }} -Pzowe.docker.password=${{ secrets.PERSONAL_JB_TOKEN }} -Pzowe.docker.username=balhar-jakub -Pzowe.docker.container=ghcr.io/balhar-jakub/ -Pzowe.docker.tag=${{ env.JOB_ID }}
 
             -   uses: ./.github/actions/teardown
 
@@ -36,23 +36,23 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             metrics-service:
-                image: ghcr.io/balhar-jakub/metrics-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/metrics-service:${{ env.JOB_ID }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -86,21 +86,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -132,21 +132,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: PH12143,RSU2012
 
@@ -184,21 +184,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: PH12143,RSU2012,PH34201
 
@@ -232,21 +232,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: ''
 
@@ -281,21 +281,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
 
@@ -329,23 +329,23 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             metrics-service:
-                image: ghcr.io/balhar-jakub/metrics-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/metrics-service:${{ env.JOB_ID }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -381,30 +381,30 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
                 env:
                     CACHING_STORAGE_MODE: 'redis'
                     CACHING_STORAGE_REDIS_MASTERNODEURI: 'default:heslo@redis-master:6379'
                     CACHING_STORAGE_REDIS_SSL_ENABLED: false
                     VERIFY_CERTIFICATES: false
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     VERIFY_CERTIFICATES: false
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     VERIFY_CERTIFICATES: false
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
             redis-master:
@@ -448,44 +448,44 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             api-catalog-services-2:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: api-catalog-services-2
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -527,43 +527,43 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_CUSTOMMETADATA_APIML_LB_TYPE: authentication
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
                     APIML_SERVICE_CUSTOMMETADATA_APIML_LB_TYPE: authentication
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
                     APIML_ROUTING_INSTANCEIDHEADER: true
                     APIML_LOADBALANCER_DISTRIBUTE: true
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -622,34 +622,34 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -692,34 +692,34 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -762,38 +762,38 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -836,38 +836,38 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -910,11 +910,11 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
                 env:
                     ZWE_CACHING_SERVICE_PERSISTENT: 'infinispan'
                     JGROUPS_BIND_PORT: "7099"
@@ -926,7 +926,7 @@ jobs:
                     JGROUPS_BIND_ADDRESS: "caching-service"
 
             caching-service-2:
-                image: ghcr.io/balhar-jakub/caching-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
                 env:
                     ZWE_CACHING_SERVICE_PERSISTENT: 'infinispan'
                     JGROUPS_BIND_PORT: "7098"
@@ -938,15 +938,15 @@ jobs:
                     APIML_SERVICE_HOSTNAME: "caching-service-2"
 
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
 
@@ -984,19 +984,19 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -1034,21 +1034,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_SERVICEIDPREFIXREPLACER: "discoverable*,sample"
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ github.event.pull_request.number || 'latest' }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
         steps:
             -   uses: actions/checkout@v2
                 with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -36,23 +36,23 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             metrics-service:
-                image: ghcr.io/balhar-jakub/metrics-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/metrics-service:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -86,21 +86,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -132,21 +132,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: PH12143,RSU2012
 
@@ -184,21 +184,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: PH12143,RSU2012,PH34201
 
@@ -232,21 +232,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: ''
 
@@ -281,21 +281,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
 
@@ -329,23 +329,23 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             metrics-service:
-                image: ghcr.io/balhar-jakub/metrics-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/metrics-service:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -381,30 +381,30 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     CACHING_STORAGE_MODE: 'redis'
                     CACHING_STORAGE_REDIS_MASTERNODEURI: 'default:heslo@redis-master:6379'
                     CACHING_STORAGE_REDIS_SSL_ENABLED: false
                     VERIFY_CERTIFICATES: false
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     VERIFY_CERTIFICATES: false
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     VERIFY_CERTIFICATES: false
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
             redis-master:
@@ -448,44 +448,44 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             api-catalog-services-2:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: api-catalog-services-2
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -527,43 +527,43 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_CUSTOMMETADATA_APIML_LB_TYPE: authentication
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
                     APIML_SERVICE_CUSTOMMETADATA_APIML_LB_TYPE: authentication
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
                     APIML_ROUTING_INSTANCEIDHEADER: true
                     APIML_LOADBALANCER_DISTRIBUTE: true
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -622,34 +622,34 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -692,34 +692,34 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -762,38 +762,38 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -836,38 +836,38 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discoverable-client-2:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: discoverable-client-2
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service:10011/eureka,https://discovery-service-2:10011/eureka
             discovery-service-2:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
                     APIML_DISCOVERY_ALLPEERSURLS: https://discovery-service-2:10011/eureka,https://discovery-service:10011/eureka
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka/,https://discovery-service-2:10011/eureka/
             gateway-service-2:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
                     SERVER_INTERNAL_PORT: 10027
@@ -910,11 +910,11 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             caching-service:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZWE_CACHING_SERVICE_PERSISTENT: 'infinispan'
                     JGROUPS_BIND_PORT: "7099"
@@ -926,7 +926,7 @@ jobs:
                     JGROUPS_BIND_ADDRESS: "caching-service"
 
             caching-service-2:
-                image: ghcr.io/balhar-jakub/caching-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/caching-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZWE_CACHING_SERVICE_PERSISTENT: 'infinispan'
                     JGROUPS_BIND_PORT: "7098"
@@ -938,15 +938,15 @@ jobs:
                     APIML_SERVICE_HOSTNAME: "caching-service-2"
 
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     ZOSMF_APPLIEDAPARS: AuthenticateApar
 
@@ -984,19 +984,19 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -1034,21 +1034,21 @@ jobs:
 
         services:
             api-catalog-services:
-                image: ghcr.io/balhar-jakub/api-catalog-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
             discoverable-client:
-                image: ghcr.io/balhar-jakub/discoverable-client:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
             discovery-service:
-                image: ghcr.io/balhar-jakub/discovery-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 volumes:
                     - /api-defs:/api-defs
                 env:
                     APIML_DISCOVERY_SERVICEIDPREFIXREPLACER: "discoverable*,sample"
             gateway-service:
-                image: ghcr.io/balhar-jakub/gateway-service:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
-                image: ghcr.io/balhar-jakub/mock-services:${{ env.JOB_ID }}
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
         steps:
             -   uses: actions/checkout@v2
                 with:


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

# Description

Use job ID for jib tag instead of `PR number || latest` in case of another jib publish job overriding latest.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
