### PR TITLE
fix: additionalProperties must be outside of properties attribute

### DIFF
--- a/schemas/caching-schema.json
+++ b/schemas/caching-schema.json
@@ -8,8 +8,8 @@
             "properties": {
                 "components": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
-                        "additionalProperties": true,
                         "caching-service": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},

--- a/schemas/catalog-schema.json
+++ b/schemas/catalog-schema.json
@@ -8,8 +8,8 @@
             "properties": {
                 "components": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
-                        "additionalProperties": true,
                         "api-catalog": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},

--- a/schemas/discovery-schema.json
+++ b/schemas/discovery-schema.json
@@ -8,8 +8,8 @@
             "properties": {
                 "components": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
-                        "additionalProperties": true,
                         "discovery-service": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},

--- a/schemas/gateway-schema.json
+++ b/schemas/gateway-schema.json
@@ -8,8 +8,8 @@
             "properties": {
                 "components": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
-                        "additionalProperties": true,
                         "gateway-service": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},

--- a/schemas/metrics-schema.json
+++ b/schemas/metrics-schema.json
@@ -8,8 +8,8 @@
             "properties": {
                 "components": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
-                        "additionalProperties": true,
                         "metrics-service": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

# Description

In PR 3006, I noticed that the apiml schemas are not valid - "additionalProperties" has a specific meaning and it must be next to but outside of "properties" without this change, configmgr says validation failed because "top level attribute must be an object" (because it was inside "properties", it was expecting an object)
Swapping it around gives the intended behavior (no warnings)

I'll be making more PRs in other repos to do this same change wherever it exists.

Linked to https://github.com/zowe/zowe-install-packaging/pull/3006
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
