### PR TITLE
fix: Fix bug in the swagger

### DIFF
--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -96,9 +96,26 @@ export default class SwaggerUI extends Component {
 
     setSwaggerState = () => {
         const { selectedService, selectedVersion } = this.props;
-        const codeSnippets =
-            selectedService.apis[selectedVersion || selectedService.defaultApiVersion].codeSnippet ||
-            selectedService.apis.default.codeSnippet;
+        let codeSnippets = null;
+        if (
+            selectedService.apis[selectedVersion] !== null &&
+            selectedService.apis[selectedVersion] !== undefined &&
+            Object.hasOwn(selectedService.apis[selectedVersion], 'codeSnippet')
+        ) {
+            codeSnippets = selectedService.apis[selectedVersion].codeSnippet;
+        } else if (
+            selectedService.apis[selectedService.defaultApiVersion] !== null &&
+            selectedService.apis[selectedService.defaultApiVersion] !== undefined &&
+            Object.hasOwn(selectedService.apis[selectedService.defaultApiVersion], 'codeSnippet')
+        ) {
+            codeSnippets = selectedService.apis[selectedService.defaultApiVersion].codeSnippet;
+        } else if (
+            selectedService.apis.default !== null &&
+            selectedService.apis.default !== undefined &&
+            Object.hasOwn(selectedService.apis.default, 'codeSnippet')
+        ) {
+            codeSnippets = selectedService.apis.default.codeSnippet;
+        }
         try {
             // If no version selected use the default apiDoc
             if (

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -96,20 +96,9 @@ export default class SwaggerUI extends Component {
 
     setSwaggerState = () => {
         const { selectedService, selectedVersion } = this.props;
-        let codeSnippets = null;
-        if (
-            selectedService.apis[selectedVersion || selectedService.defaultApiVersion] !== null &&
-            selectedService.apis[selectedVersion || selectedService.defaultApiVersion] !== undefined &&
-            Object.hasOwn(selectedService.apis[selectedVersion || selectedService.defaultApiVersion], 'codeSnippet')
-        ) {
-            codeSnippets = selectedService.apis[selectedVersion || selectedService.defaultApiVersion].codeSnippet;
-        } else if (
-            selectedService.apis.default !== null &&
-            selectedService.apis.default !== undefined &&
-            Object.hasOwn(selectedService.apis.default, 'codeSnippet')
-        ) {
-            codeSnippets = selectedService.apis.default.codeSnippet;
-        }
+        const codeSnippets =
+            selectedService.apis[selectedVersion || selectedService.defaultApiVersion].codeSnippet ||
+            selectedService.apis.default.codeSnippet;
         try {
             // If no version selected use the default apiDoc
             if (

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -101,19 +101,19 @@ export default class SwaggerUI extends Component {
             if (
                 selectedService.apis[selectedVersion] !== null &&
                 selectedService.apis[selectedVersion] !== undefined &&
-                selectedService.apis[selectedVersion].codeSnippet !== undefined
+                'codeSnippet' in selectedService.apis[selectedVersion]
             ) {
                 codeSnippets = selectedService.apis[selectedVersion].codeSnippet;
             } else if (
                 selectedService.apis[selectedService.defaultApiVersion] !== null &&
                 selectedService.apis[selectedService.defaultApiVersion] !== undefined &&
-                selectedService.apis[selectedService.defaultApiVersion].codeSnippet !== undefined
+                'codeSnippet' in selectedService.apis[selectedService.defaultApiVersion]
             ) {
                 codeSnippets = selectedService.apis[selectedService.defaultApiVersion].codeSnippet;
             } else if (
                 selectedService.apis.default !== null &&
                 selectedService.apis.default !== undefined &&
-                selectedService.apis.default.codeSnippet !== undefined
+                'codeSnippet' in selectedService.apis.default
             ) {
                 codeSnippets = selectedService.apis.default.codeSnippet;
             }

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -97,24 +97,29 @@ export default class SwaggerUI extends Component {
     setSwaggerState = () => {
         const { selectedService, selectedVersion } = this.props;
         let codeSnippets = null;
-        if (
-            selectedService.apis[selectedVersion] !== null &&
-            selectedService.apis[selectedVersion] !== undefined &&
-            Object.hasOwn(selectedService.apis[selectedVersion], 'codeSnippet')
-        ) {
-            codeSnippets = selectedService.apis[selectedVersion].codeSnippet;
-        } else if (
-            selectedService.apis[selectedService.defaultApiVersion] !== null &&
-            selectedService.apis[selectedService.defaultApiVersion] !== undefined &&
-            Object.hasOwn(selectedService.apis[selectedService.defaultApiVersion], 'codeSnippet')
-        ) {
-            codeSnippets = selectedService.apis[selectedService.defaultApiVersion].codeSnippet;
-        } else if (
-            selectedService.apis.default !== null &&
-            selectedService.apis.default !== undefined &&
-            Object.hasOwn(selectedService.apis.default, 'codeSnippet')
-        ) {
-            codeSnippets = selectedService.apis.default.codeSnippet;
+        if (selectedService.apis.length !== 0) {
+            if (
+                selectedService.apis[selectedVersion] !== null &&
+                selectedService.apis[selectedVersion] !== undefined &&
+                selectedService.apis[selectedVersion].codeSnippet !== undefined
+                // Object.hasOwn(selectedService.apis[selectedVersion], 'codeSnippet')
+            ) {
+                codeSnippets = selectedService.apis[selectedVersion].codeSnippet;
+            } else if (
+                selectedService.apis[selectedService.defaultApiVersion] !== null &&
+                selectedService.apis[selectedService.defaultApiVersion] !== undefined &&
+                selectedService.apis[selectedService.defaultApiVersion].codeSnippet !== undefined
+                // Object.hasOwn(selectedService.apis[selectedService.defaultApiVersion], 'codeSnippet')
+            ) {
+                codeSnippets = selectedService.apis[selectedService.defaultApiVersion].codeSnippet;
+            } else if (
+                selectedService.apis.default !== null &&
+                selectedService.apis.default !== undefined &&
+                selectedService.apis.default.codeSnippet !== undefined
+                // Object.hasOwn(selectedService.apis.default, 'codeSnippet')
+            ) {
+                codeSnippets = selectedService.apis.default.codeSnippet;
+            }
         }
         try {
             // If no version selected use the default apiDoc

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -102,21 +102,18 @@ export default class SwaggerUI extends Component {
                 selectedService.apis[selectedVersion] !== null &&
                 selectedService.apis[selectedVersion] !== undefined &&
                 selectedService.apis[selectedVersion].codeSnippet !== undefined
-                // Object.hasOwn(selectedService.apis[selectedVersion], 'codeSnippet')
             ) {
                 codeSnippets = selectedService.apis[selectedVersion].codeSnippet;
             } else if (
                 selectedService.apis[selectedService.defaultApiVersion] !== null &&
                 selectedService.apis[selectedService.defaultApiVersion] !== undefined &&
                 selectedService.apis[selectedService.defaultApiVersion].codeSnippet !== undefined
-                // Object.hasOwn(selectedService.apis[selectedService.defaultApiVersion], 'codeSnippet')
             ) {
                 codeSnippets = selectedService.apis[selectedService.defaultApiVersion].codeSnippet;
             } else if (
                 selectedService.apis.default !== null &&
                 selectedService.apis.default !== undefined &&
                 selectedService.apis.default.codeSnippet !== undefined
-                // Object.hasOwn(selectedService.apis.default, 'codeSnippet')
             ) {
                 codeSnippets = selectedService.apis.default.codeSnippet;
             }

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
@@ -16,14 +16,6 @@ describe('>>> Swagger component tests', () => {
     afterEach(() => {
         document.body.innerHTML = '';
     });
-    beforeAll(() => {
-        // eslint-disable-next-line no-extend-native
-        Object.defineProperty(Object.prototype, 'hasOwn', {
-            value(prop) {
-                return Object.prototype.hasOwnProperty.call(this, prop);
-            },
-        });
-    });
 
     it('should not render swagger if apiDoc is null', () => {
         const service = {

--- a/api-catalog-ui/frontend/src/utils/generateSnippets.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.js
@@ -63,6 +63,7 @@ export function getSnippetContent(req, target, codeSnippet) {
  * @param title the code snippet title
  * @param syntax the syntax used for indentation
  * @param target the language target
+ * @param codeSnippet the code snippet
  * @returns codeSnippet the code snippet
  */
 export function generateSnippet(system, title, syntax, target, codeSnippet) {

--- a/api-catalog-ui/frontend/src/utils/generateSnippets.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.js
@@ -88,16 +88,18 @@ export function CustomizedSnippedGenerator(codeSnippets) {
                         (ori, system) =>
                         (state, ...args) => {
                             let useSet = ori(state, ...args);
-                            // eslint-disable-next-line no-restricted-syntax
-                            for (const codeSnippet of codeSnippets) {
-                                const newSnippet = generateSnippet(
-                                    system,
-                                    `Customized Snippet - ${codeSnippet.language}`,
-                                    codeSnippet.language,
-                                    'target',
-                                    codeSnippet
-                                );
-                                useSet = useSet.set(codeSnippet.endpoint + codeSnippet.language, newSnippet);
+                            if (codeSnippets !== null && codeSnippets !== undefined) {
+                                // eslint-disable-next-line no-restricted-syntax
+                                for (const codeSnippet of codeSnippets) {
+                                    const newSnippet = generateSnippet(
+                                        system,
+                                        `Customized Snippet - ${codeSnippet.language}`,
+                                        codeSnippet.language,
+                                        'target',
+                                        codeSnippet
+                                    );
+                                    useSet = useSet.set(codeSnippet.endpoint + codeSnippet.language, newSnippet);
+                                }
                             }
                             useSet = useSet
                                 .set(


### PR DESCRIPTION
# Description

There was some weird issue caused by the `hasOwn` method to check for properties in object, which from time to time was breaking the UI, causing the failure of e2e tests.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
