### PR TITLE
chore: do not include jars in package

### DIFF
--- a/apiml-sample-extension/build.gradle
+++ b/apiml-sample-extension/build.gradle
@@ -24,9 +24,9 @@ gitProperties {
 }
 
 dependencies {
-    implementation libraries.spring_doc
-    implementation libraries.spring_webmvc
-    implementation libraries.guava
+    compileOnly libraries.spring_doc
+    compileOnly libraries.spring_webmvc
+    compileOnly libraries.guava
 }
 
 jar {


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

# Description
Use dependencies only for compilation, all of them are available in gateway, no need to include them in the distribution package. It will also decrease policy violations in the future
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
