### PR TITLE
fix: caching service references non-existent schema

### DIFF
--- a/caching-service-package/src/main/resources/manifest.yaml
+++ b/caching-service-package/src/main/resources/manifest.yaml
@@ -9,7 +9,7 @@ title: Caching service for internal usage
 description: Service that provides caching API.
 license: EPL-2.0
 schemas:
-    configs: gateway-schema.json
+    configs: caching-schema.json
 repository:
   type: git
   url: https://github.com/zowe/api-layer.git


### PR DESCRIPTION
# Description

In https://github.com/zowe/zowe-install-packaging/pull/3006 it was noticed that the servers fail to start due to the caching service referencing the gateway's schema which is not present in its folder. However, the caching service does have its own schema so it just seems to be a simple typo.

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
