### PR TITLE
fix: Don't force response code 200 when adding X-Auth-Failure headers.

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
@@ -31,7 +31,6 @@ import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import java.util.Optional;
 
-import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_DECORATION_FILTER_ORDER;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SERVICE_ID_KEY;
@@ -127,7 +126,6 @@ public class ServiceAuthenticationFilter extends PreZuulFilter {
         logger.log(MessageType.DEBUG, error);
         context.addZuulRequestHeader(AUTH_FAIL_HEADER, error);
         context.addZuulResponseHeader(AUTH_FAIL_HEADER, error);
-        context.setResponseStatusCode(SC_OK);
     }
 
     private boolean isSourceValidForCommand(AuthSource authSource, AuthenticationCommand cmd) {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
@@ -13,8 +13,6 @@ package org.zowe.apiml.gateway.filters.pre;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.exception.ZuulException;
 import com.netflix.zuul.monitoring.CounterFactory;
-import java.security.cert.X509Certificate;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,7 +39,9 @@ import org.zowe.apiml.message.template.MessageTemplate;
 import org.zowe.apiml.security.common.token.TokenExpireException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.security.cert.X509Certificate;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -151,7 +151,9 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
 
         serviceAuthenticationFilter.run();
 
-        verify(RequestContext.getCurrentContext(), times(1)).setResponseStatusCode(200);
+        verify(RequestContext.getCurrentContext()).addZuulRequestHeader(eq(ServiceAuthenticationFilter.AUTH_FAIL_HEADER), anyString());
+        verify(RequestContext.getCurrentContext()).addZuulResponseHeader(eq(ServiceAuthenticationFilter.AUTH_FAIL_HEADER), anyString());
+        verify(RequestContext.getCurrentContext(), never()).setResponseStatusCode(anyInt());
         verify(cmd, never()).apply(any());
     }
 


### PR DESCRIPTION
Signed-off-by: Petr Weinfurt <petr.weinfurt@broadcom.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Linked to #2423 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
