### PR TITLE
Fix exception handling in extensions config reader

### DIFF
--- a/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionConfigReader.java
+++ b/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionConfigReader.java
@@ -59,7 +59,7 @@ public class ExtensionConfigReader {
             if (enabledComponents.contains(installedComponent)) {
                 try {
                     extensions.add(readComponentManifest(installedComponent));
-                } catch (Exception e) {
+                } catch (ExtensionManifestReadException e) {
                     log.error("Failed reading component {} manifest", installedComponent, e);
                 }
             }
@@ -75,7 +75,8 @@ public class ExtensionConfigReader {
         if (definition.isPresent()) {
             return definition.get();
         } else {
-            return readComponentManifestWithCharset(Charset.forName("IBM1047"), manifestYamlPath, manifestJsonPath).orElseThrow(() -> new RuntimeException("Could not read manifest in IBM1047 encoding"));
+            return readComponentManifestWithCharset(Charset.forName("IBM1047"), manifestYamlPath, manifestJsonPath)
+                .orElseThrow(() -> new ExtensionManifestReadException("Could not read manifest in IBM1047 encoding"));
         }
     }
 
@@ -91,6 +92,7 @@ public class ExtensionConfigReader {
                 return Optional.empty();
             }
         } catch (Exception e) {
+            log.debug("Failed to read {}/{} with charset {}", yamlPath, jsonPath, charset, e);
             return Optional.empty();
         }
     }

--- a/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionConfigReader.java
+++ b/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionConfigReader.java
@@ -76,7 +76,7 @@ public class ExtensionConfigReader {
             return definition.get();
         } else {
             return readComponentManifestWithCharset(Charset.forName("IBM1047"), manifestYamlPath, manifestJsonPath)
-                .orElseThrow(() -> new ExtensionManifestReadException("Could not read manifest in IBM1047 encoding"));
+                .orElseThrow(() -> new ExtensionManifestReadException("Could not read manifest in either " + Charset.defaultCharset() + " nor in IBM1047 encoding"));
         }
     }
 
@@ -89,6 +89,7 @@ public class ExtensionConfigReader {
             } else if (Files.exists(jsonPath)) {
                 return Optional.ofNullable(jsonMapper.readValue(new String(Files.readAllBytes(jsonPath), charset), ExtensionDefinition.class));
             } else {
+                log.debug("None of these files were found: {} nor {} ", yamlPath, jsonPath);
                 return Optional.empty();
             }
         } catch (Exception e) {

--- a/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionManifestReadException.java
+++ b/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionManifestReadException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.extension;
 
 public class ExtensionManifestReadException extends RuntimeException {

--- a/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionManifestReadException.java
+++ b/apiml-extension-loader/src/main/java/org/zowe/apiml/extension/ExtensionManifestReadException.java
@@ -1,0 +1,18 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.extension;
+
+public class ExtensionManifestReadException extends RuntimeException {
+
+    public ExtensionManifestReadException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Pablo Hernán Carle <pablo.carle@broadcom.com>

# Description

Fix exception handling in extensions config as it shouldn't fail on the failure to read one file.

## Type of change

- [x] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

