### PR TITLE
fix: Fix DC UI

### DIFF
--- a/discoverable-client/src/main/resources/static/index.html
+++ b/discoverable-client/src/main/resources/static/index.html
@@ -82,7 +82,7 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script type="text/javascript" src="webjars/jquery/3.4.1/jquery.min.js"></script>
+<script type="text/javascript" src="webjars/jquery/3.6.0/jquery.min.js"></script>
 <script type="text/javascript" src="webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <script src="js/hello.js"></script>
 </body>

--- a/discoverable-client/src/main/resources/static/js/hello.js
+++ b/discoverable-client/src/main/resources/static/js/hello.js
@@ -1,5 +1,5 @@
 function unsecureCall() {
-    var name = $('#name').val();
+    let name = $('#name').val();
     $.ajax({
         url: "api/v1/" + ((name) ? (name + "/greeting") : "greeting")
     }).then(function (data) {
@@ -17,7 +17,7 @@ function openWebsocket() {
     } else {
         wsUri = "ws:";
     }
-    wsUri += "//" + loc.host;
+    wsUri += "//" + "user:pass@" + loc.host;
     console.log(loc.pathname);
     if (loc.pathname.startsWith("/ui/")) {
         // UI applications accessed via the gateway will use a URL with "/ui/" at the beginning,
@@ -31,7 +31,7 @@ function openWebsocket() {
     return new WebSocket(wsUri);
 }
 
-var connection = openWebsocket();
+let connection = openWebsocket();
 
 connection.onopen = function () {
     $('#ws-content').text('Websocket connection established');
@@ -47,6 +47,6 @@ connection.onmessage = function (message) {
 }
 
 function websocketCall() {
-    var text = $('#ws-text').val();
+    let text = $('#ws-text').val();
     connection.send(text);
 }

--- a/discoverable-client/src/main/resources/static/js/hello.js
+++ b/discoverable-client/src/main/resources/static/js/hello.js
@@ -11,7 +11,7 @@ function unsecureCall() {
 
 
 function openWebsocket() {
-    var loc = window.location, wsUri;
+    let loc = window.location, wsUri;
     if (loc.protocol === "https:") {
         wsUri = "wss:";
     } else {


### PR DESCRIPTION
# Description

* Update of the jquery library which was preventing the Discoverable Client UI to properly work.
* Add Basic Auth to the websocket requests to make it work.

**Note:** This is a partial fix. For some reason the websocket calls are not working when using Chrome and Edge, failing:

```
hello.js:31 
        
       WebSocket connection to 'wss://user:pass@localhost:10012/discoverableclient/ws/uppercase' failed: Error during WebSocket handshake: Incorrect 'Sec-WebSocket-Accept' header value
```

On Firefox and Safari it works fine.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
