### PR TITLE
fix for allowing user to type keyring with either 4 or 2 slashes

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -135,7 +135,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -131,6 +131,21 @@ if [ "${truststore_type}" = "JCERACFKS" ]; then
   truststore_pass="dummy"
 fi
 
+# Workaround for Java desiring safkeyring://// instead of just ://
+# We can handle both cases of user input by just adding extra "//" if we detect its missing.
+ensure_keyring_slashes() {
+  keyring_string="${1}"
+  var_name="${2}"
+  only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
+  if [ -n "${only_two_slashes}" ]; then
+    keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")
+  fi
+  # else, unmodified, perhaps its even p12
+  echo $keyring_string
+}
+
+keystore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}")
+truststore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}")
 
 # NOTE: these are moved from below
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
@@ -159,12 +174,12 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
     -Dspring.profiles.include=$LOG_LEVEL \
     -Dserver.address=0.0.0.0 \
     -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true}  \
-    -Dserver.ssl.keyStore="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}" \
+    -Dserver.ssl.keyStore="${keystore_location}" \
     -Dserver.ssl.keyStoreType="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}" \
     -Dserver.ssl.keyStorePassword="${keystore_pass}" \
     -Dserver.ssl.keyAlias="${ZWE_configs_certificate_keystore_alias:-${ZWE_zowe_certificate_keystore_alias}}" \
     -Dserver.ssl.keyPassword="${keystore_pass}" \
-    -Dserver.ssl.trustStore="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}" \
+    -Dserver.ssl.trustStore="${truststore_location}" \
     -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
     -Dserver.ssl.trustStorePassword="${truststore_pass}" \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -125,6 +125,21 @@ if [ "${truststore_type}" = "JCERACFKS" ]; then
   truststore_pass="dummy"
 fi
 
+# Workaround for Java desiring safkeyring://// instead of just ://
+# We can handle both cases of user input by just adding extra "//" if we detect its missing.
+ensure_keyring_slashes() {
+  keyring_string="${1}"
+  var_name="${2}"
+  only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
+  if [ -n "${only_two_slashes}" ]; then
+    keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")
+  fi
+  # else, unmodified, perhaps its even p12
+  echo $keyring_string
+}
+
+keystore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}")
+truststore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}")
 
 # NOTE: these are moved from below
 #   -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
@@ -156,12 +171,12 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java -Xms16m -Xmx512m \
   -Dcaching.storage.infinispan.initialHosts=${ZWE_configs_storage_infinispan_initialHosts:-localhost[7098]} \
   -Dserver.address=0.0.0.0 \
   -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true}  \
-  -Dserver.ssl.keyStore="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}" \
+  -Dserver.ssl.keyStore="${keystore_location}" \
   -Dserver.ssl.keyStoreType="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}" \
   -Dserver.ssl.keyStorePassword="${keystore_pass}" \
   -Dserver.ssl.keyAlias="${ZWE_configs_certificate_keystore_alias:-${ZWE_zowe_certificate_keystore_alias}}" \
   -Dserver.ssl.keyPassword="${keystore_pass}" \
-  -Dserver.ssl.trustStore="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}" \
+  -Dserver.ssl.trustStore="${truststore_location}" \
   -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
   -Dserver.ssl.trustStorePassword="${truststore_pass}" \
   -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -129,7 +129,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -91,7 +91,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -87,6 +87,22 @@ if [ "${truststore_type}" = "JCERACFKS" ]; then
   truststore_pass="dummy"
 fi
 
+# Workaround for Java desiring safkeyring://// instead of just ://
+# We can handle both cases of user input by just adding extra "//" if we detect its missing.
+ensure_keyring_slashes() {
+  keyring_string="${1}"
+  var_name="${2}"
+  only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
+  if [ -n "${only_two_slashes}" ]; then
+    keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")
+  fi
+  # else, unmodified, perhaps its even p12
+  echo $keyring_string
+}
+
+keystore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}")
+truststore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}")
+
 
 CLOUD_GATEWAY_CODE=CG
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
@@ -106,12 +122,12 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
     -Dserver.ssl.enabled=${ZWE_configs_server_ssl_enabled:-true} \
     -Dserver.maxConnectionsPerRoute=${ZWE_configs_server_maxConnectionsPerRoute:-100} \
     -Dserver.maxTotalConnections=${ZWE_configs_server_maxTotalConnections:-1000} \
-    -Dserver.ssl.keyStore="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}" \
+    -Dserver.ssl.keyStore="${keystore_location}" \
     -Dserver.ssl.keyStoreType="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}" \
     -Dserver.ssl.keyStorePassword="${keystore_pass}" \
     -Dserver.ssl.keyAlias="${ZWE_configs_certificate_keystore_alias:-${ZWE_zowe_certificate_keystore_alias}}" \
     -Dserver.ssl.keyPassword="${keystore_pass}" \
-    -Dserver.ssl.trustStore="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}" \
+    -Dserver.ssl.trustStore="${truststore_location}" \
     -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
     -Dserver.ssl.trustStorePassword="${truststore_pass}" \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -137,7 +137,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -133,6 +133,22 @@ if [ "${truststore_type}" = "JCERACFKS" ]; then
   truststore_pass="dummy"
 fi
 
+# Workaround for Java desiring safkeyring://// instead of just ://
+# We can handle both cases of user input by just adding extra "//" if we detect its missing.
+ensure_keyring_slashes() {
+  keyring_string="${1}"
+  var_name="${2}"
+  only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
+  if [ -n "${only_two_slashes}" ]; then
+    keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")
+  fi
+  # else, unmodified, perhaps its even p12
+  echo $keyring_string
+}
+
+keystore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}")
+truststore_location=$(ensure_keyring_slashes "${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}")
+#echo "keystore='$keystore_location' truststore='$truststore_location'"
 
 # NOTE: these are moved from below
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
@@ -157,12 +173,12 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java -Xms32m -Xmx256m ${QUI
     -Dapiml.security.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \
     -Dapiml.security.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
     -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true} \
-    -Dserver.ssl.keyStore="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}" \
+    -Dserver.ssl.keyStore="${keystore_location}" \
     -Dserver.ssl.keyStoreType="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}" \
     -Dserver.ssl.keyStorePassword="${keystore_pass}" \
     -Dserver.ssl.keyAlias="${ZWE_configs_certificate_keystore_alias:-${ZWE_zowe_certificate_keystore_alias}}" \
     -Dserver.ssl.keyPassword="${keystore_pass}" \
-    -Dserver.ssl.trustStore="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}" \
+    -Dserver.ssl.trustStore="${truststore_location}" \
     -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
     -Dserver.ssl.trustStorePassword="${truststore_pass}" \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -177,7 +177,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -103,7 +103,6 @@ fi
 # We can handle both cases of user input by just adding extra "//" if we detect its missing.
 ensure_keyring_slashes() {
   keyring_string="${1}"
-  var_name="${2}"
   only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
   if [ -n "${only_two_slashes}" ]; then
     keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -99,6 +99,18 @@ if [ "${truststore_type}" = "JCERACFKS" ]; then
   truststore_pass="dummy"
 fi
 
+# Workaround for Java desiring safkeyring://// instead of just ://
+# We can handle both cases of user input by just adding extra "//" if we detect its missing.
+ensure_keyring_slashes() {
+  keyring_string="${1}"
+  var_name="${2}"
+  only_two_slashes=$(echo "${keyring_string}" | grep "^safkeyring://[^//]")
+  if [ -n "${only_two_slashes}" ]; then
+    keyring_string=$(echo "${keyring_string}" | sed "s#safkeyring://#safkeyring:////#")
+  fi
+  # else, unmodified, perhaps its even p12
+  echo $keyring_string
+}
 
 # NOTE: these are moved from below
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
@@ -119,12 +131,12 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java -Xms16m -Xmx512m \
   -Dapiml.service.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
   -Dserver.address=0.0.0.0 \
   -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true} \
-  -Dserver.ssl.keyStore="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}" \
+  -Dserver.ssl.keyStore="${keystore_location}" \
   -Dserver.ssl.keyStoreType="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}" \
   -Dserver.ssl.keyStorePassword="${keystore_pass}" \
   -Dserver.ssl.keyAlias="${ZWE_configs_certificate_keystore_alias:-${ZWE_zowe_certificate_keystore_alias}}" \
   -Dserver.ssl.keyPassword="${keystore_pass}" \
-  -Dserver.ssl.trustStore="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}" \
+  -Dserver.ssl.trustStore="${truststore_location}" \
   -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
   -Dserver.ssl.trustStorePassword="${truststore_pass}" \
   -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \


### PR DESCRIPTION
# Description

When using keyrings, you typically have to have a path starting with "safkeyring:////"
Users often think they have made a mistake by putting 4 slashes, but that's what the code needs.
But, why not let the user type only 2 slashes, and just add the extra 2 when needed?
This PR allows either 4 or 2 slashes, by just adding 2 slashes when only 2 are seen.
This code should not harm USS file cases, as it specifically reacts to seeing "safkeyring://" at the front of the keystore & truststore variables.

## Type of change
- [x] (fix) Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Testing:

I left a commented out echo in discovery start.sh, and tried the following patterns

```
zowe:
  certificate:
    keystore:
      file: "safkeyring:////myuser/myring"
    truststore:
      file: "/u/user/keystore/localhost/localhost.truststore.p12"
```

which printed
`keystore='safkeyring:////myuser/myring' truststore='/u/user/keystore/localhost/localhost.truststore.p12'`

then tried


```
zowe:
  certificate:
    keystore:
      file: "safkeyring://myuser/myring"
    truststore:
      file: "/u/user/keystore/localhost/localhost.truststore.p12"
```

which printed
`keystore='safkeyring:////myuser/myring' truststore='/u/user/keystore/localhost/localhost.truststore.p12'`

So you can see, the 2 slashes got added when needed, and otherwise the strings were not modified.