### PR TITLE
Improve templates to ask for willingness to help. 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,6 +40,6 @@ Add any other context about the problem here.
 
 **Willingness to help**
 If you are willing to help with debugging and reproducing the problem or
-with fixing the problem, please state it in the created issue. 
+with fixing the problem, please state your willingness to assist in the created issue. 
 
 https://github.com/zowe/api-layer/wiki/Issue-management

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,4 +38,8 @@ If applicable, add server logs collected at the time of your problem.
 **Additional context**
 Add any other context about the problem here.
 
+**Willingness to help**
+If you are willing to help with debugging and reproducing the problem or
+with fixing the problem, please state it in the created issue. 
+
 https://github.com/zowe/api-layer/wiki/Issue-management

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,7 +16,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Willingness to help**
 If you are willing to help with feedback on the implementation or with the actual implementation, 
-please state it in the created issue. We will take it into account when figuring what to work on. 
+please state your willingness to assist in the created issue. We will take it into account when figuring what to work on. 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,5 +14,9 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Willingness to help**
+If you are willing to help with feedback on the implementation or with the actual implementation, 
+please state it in the created issue. We will take it into account when figuring what to work on. 
+
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Description

To reflect the created issue policy within Zowe, add the information on willingness being taken into account when deciding what to work on. 

## Type of change

Please delete options that are not relevant.

- [x] (docs) Change in a documentation