### PR TITLE
fix: Upgrade swagger parser and exclude bugged version

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -93,7 +93,9 @@ dependencies {
     implementation libraries.apache_commons_lang3
     implementation libraries.spring_boot_starter_thymeleaf
     implementation libraries.apache_velocity
-    implementation libraries.openapidiff
+    implementation(libraries.openapidiff) {
+        exclude group: "io.swagger.parser.v3", module: "swagger-parser-v3"
+    }
     implementation libraries.http_client
     implementation libraries.jetty_client
     implementation libraries.jetty_http
@@ -129,6 +131,9 @@ dependencies {
     implementation libraries.thymeleafSpring
     implementation libraries.logback_core
     implementation libraries.logback_classic
+    implementation(libraries.swagger3_parser) {
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
 
     testImplementation libraries.rest_assured
     testImplementation libraries.spring_mock_mvc

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -109,7 +109,7 @@ class ApiDocV3ServiceTest {
                     ")";
 
                 assertEquals("https://localhost:10010/serviceId/api/v1", actualSwagger.getServers().get(0).getUrl());
-                assertThat(actualSwagger.getPaths(), is(dummyOpenApiObject.getPaths()));
+                assertThat(actualSwagger.getPaths(), samePropertyValuesAs(dummyOpenApiObject.getPaths()));
 
                 assertEquals(expectedDescription, actualSwagger.getInfo().getDescription());
                 assertEquals(EXTERNAL_DOCUMENTATION, actualSwagger.getExternalDocs().getDescription());
@@ -157,7 +157,7 @@ class ApiDocV3ServiceTest {
                     ")";
 
                 assertEquals("https://localhost:10010/serviceId/api/v1", actualSwagger.getServers().get(0).getUrl());
-                assertThat(actualSwagger.getPaths(), is(dummyOpenApiObject.getPaths()));
+                assertThat(actualSwagger.getPaths(), samePropertyValuesAs(dummyOpenApiObject.getPaths()));
 
                 assertEquals(expectedDescription, actualSwagger.getInfo().getDescription());
                 assertEquals(EXTERNAL_DOCUMENTATION, actualSwagger.getExternalDocs().getDescription());
@@ -173,22 +173,20 @@ class ApiDocV3ServiceTest {
                 ApiInfo apiInfo = new ApiInfo(API_ID, "api/v1", API_VERSION, "https://localhost:10014/apicatalog/api-doc", "https://www.zowe.org");
                 ApiDocInfo apiDocInfo = new ApiDocInfo(apiInfo, invalidJson, null);
 
-                Exception exception = assertThrows(UnexpectedTypeException.class, () -> {
-                    apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo);
-                });
+                Exception exception = assertThrows(UnexpectedTypeException.class, () -> apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo));
                 assertEquals("[Null or empty definition]", exception.getMessage());
             }
 
             @Test
             void givenInvalidJson() {
                 String invalidJson = "nonsense";
+                String error = "[Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('nonsense')\n" +
+                    " at [Source: UNKNOWN; byte offset: #UNKNOWN]]";
                 ApiInfo apiInfo = new ApiInfo(API_ID, "api/v1", API_VERSION, "https://localhost:10014/apicatalog/api-doc", "https://www.zowe.org");
                 ApiDocInfo apiDocInfo = new ApiDocInfo(apiInfo, invalidJson, null);
 
-                Exception exception = assertThrows(UnexpectedTypeException.class, () -> {
-                    apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo);
-                });
-                assertEquals("[attribute openapi is not of type `object`]", exception.getMessage());
+                Exception exception = assertThrows(UnexpectedTypeException.class, () -> apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo));
+                assertEquals(error, exception.getMessage());
             }
         }
 
@@ -268,10 +266,15 @@ class ApiDocV3ServiceTest {
         info.setDescription("REST API for the API Catalog service which is a component of the API Mediation Layer. Use this API to retrieve information regarding catalog dashboard tiles, tile contents and its status, API documentation and status for the registered services.");
         info.setVersion("1.0.0");
         openAPI.setInfo(info);
-
+        openAPI.addExtension("x-custom", "value1");
+        openAPI.getInfo().addExtension("x-custom", openAPI.getExtensions());
+        openAPI.getServers().get(0).addExtension("x-custom", openAPI.getExtensions());
+        openAPI.getServers().get(1).addExtension("x-custom", openAPI.getExtensions());
+        openAPI.getServers().get(2).addExtension("x-custom", openAPI.getExtensions());
         Tag tag = new Tag();
         tag.setName("API Catalog");
         tag.setDescription("Current state information");
+        tag.setExtensions(openAPI.getExtensions());
         openAPI.getTags().add(tag);
         if (apimlHidden) {
             tag = new Tag();

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -71,7 +71,6 @@ dependencies {
         exclude group: "org.yaml", module: "snakeyaml"
         exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-el"
     }
-    implementation libraries.snakeyaml
     implementation libraries.spring_boot_starter_websocket
     implementation libraries.spring_boot_starter_thymeleaf
     implementation libraries.spring_boot_starter_cache
@@ -87,7 +86,9 @@ dependencies {
     implementation libraries.xstream
     implementation libraries.json_smart
 
-    implementation libraries.swagger3_parser
+    implementation(libraries.swagger3_parser) {
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
     implementation libraries.jackson_annotations
     implementation libraries.jackson_core
     implementation libraries.jackson_databind

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -69,7 +69,7 @@ ext {
     springDocVersion = '1.6.9'
     spring4Version = '4.3.7.RELEASE' // Used within PJE in tests
     swagger3CoreVersion = '2.0.0'
-    swagger3ParserVersion = '2.0.17'
+    swagger3ParserVersion = '2.1.9'
     swaggerCoreVersion = '1.5.24'
     swaggerJerseyJaxrsVersion = '1.5.10'
     thymeleafVersion = '3.0.15.RELEASE'


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description
Upgrade `swagger-parser-v3` to fix bug with `anyOf` and `allOf` props not being parsed. 

Fixes #2676 

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
