### PR TITLE
chore: Automatically update manifest.json in zowe-install-packaging

### DIFF
--- a/.github/workflows/binary-specific-release.yml
+++ b/.github/workflows/binary-specific-release.yml
@@ -64,7 +64,7 @@ jobs:
                   BUILD_NUMBER: ${{ github.run_number }}
                   BRANCH_NAME: ${{ github.ref_name }}
 
-            - name: Open PR in zowe-install-packaging
+            - name: Upgrade API ML components in zowe-install-packaging
               run: |
                   git config --global user.email "zowe-robot@users.noreply.github.com"
                   git config --global user.name "Zowe Robot"

--- a/.github/workflows/binary-specific-release.yml
+++ b/.github/workflows/binary-specific-release.yml
@@ -64,4 +64,11 @@ jobs:
                   BUILD_NUMBER: ${{ github.run_number }}
                   BRANCH_NAME: ${{ github.ref_name }}
 
+            - name: Open PR in zowe-install-packaging
+              run: |
+                  git config --global user.email "zowe-robot@users.noreply.github.com"
+                  git config --global user.name "Zowe Robot"
+                  cd scripts/release_components
+                  npm install
+                  node index.js ${{ secrets.ZOWE_ROBOT_TOKEN }} ${{ github.event.inputs.release_version }}
             - uses: ./.github/actions/teardown

--- a/.github/workflows/release_and_update_manifest_json.yml
+++ b/.github/workflows/release_and_update_manifest_json.yml
@@ -1,5 +1,5 @@
 # This workflow will release project with Gradle
-name: Binary specific release
+name: Binary specific release and update manifest.json in zowe-install-packaging
 
 on:
     workflow_dispatch:
@@ -64,4 +64,11 @@ jobs:
                   BUILD_NUMBER: ${{ github.run_number }}
                   BRANCH_NAME: ${{ github.ref_name }}
 
+            - name: Upgrade API ML components in zowe-install-packaging
+              run: |
+                  git config --global user.email "zowe-robot@users.noreply.github.com"
+                  git config --global user.name "Zowe Robot"
+                  cd scripts/release_components
+                  npm install
+                  node index.js ${{ secrets.ZOWE_ROBOT_TOKEN }} ${{ github.event.inputs.release_version }}
             - uses: ./.github/actions/teardown

--- a/.github/workflows/release_and_update_manifest_json.yml
+++ b/.github/workflows/release_and_update_manifest_json.yml
@@ -68,7 +68,10 @@ jobs:
               run: |
                   git config --global user.email "zowe-robot@users.noreply.github.com"
                   git config --global user.name "Zowe Robot"
-                  cd scripts/release_components
+                  git clone https://zowe-robot:${{ secrets.ZOWE_ROBOT_TOKEN }}@github.com/zowe/zowe-install-packaging.git
+                  cd zowe-install-packaging
+                  git checkout v2.x/rc
+                  cd ../scripts/release_components
                   npm install
                   node index.js ${{ secrets.ZOWE_ROBOT_TOKEN }} ${{ github.event.inputs.release_version }}
             - uses: ./.github/actions/teardown

--- a/.github/workflows/release_and_update_manifest_json.yml
+++ b/.github/workflows/release_and_update_manifest_json.yml
@@ -1,68 +1,26 @@
 # This workflow will release project with Gradle
-name: Binary specific release and update manifest.json in zowe-install-packaging
+name: Update manifest.json in zowe-install-packaging and create PR
 
 on:
     workflow_dispatch:
         inputs:
             release_version:
-                description: 'The version that is going to be release'
-                required: true
-            new_version:
-                description: 'The version that should be used as a new one after the release.'
+                description: 'The version that is used to upgrade the API ML components and images in the manifest.json'
                 required: true
 
 jobs:
     release:
         runs-on: ubuntu-latest
-        timeout-minutes: 40
+        timeout-minutes: 20
 
         steps:
-            - uses: actions/checkout@v3
+            - name: Set up Node
+              uses: actions/setup-node@v2
               with:
-                  ref: ${{ github.head_ref }}
-                  token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+                  node-version: '14'
 
-            - uses: ./.github/actions/setup
-
-            - name: Print npm version
-              run: npm -v
-
-            - name: Build with Gradle
-              run: ./gradlew build
-
-            - name: Clean git
-              run: git reset --hard HEAD
-
-            - name: Set email
-              run: git config user.email "zowe-robot@users.noreply.github.com"
-
-            - name: Set name
-              run: git config user.name "Zowe Robot"
-
-            - name: Release to NPM automatic
-              run: |
-                  cd onboarding-enabler-nodejs
-                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-                  echo "registry=$DIST_REGISTRY" >> ~/.npmrc
-                  npm version ${{ github.event.inputs.release_version }}
-                  npm publish --access public
-                  git add package.json
-                  git commit -m "[skip ci] Update version"
-                  git push
-                  cd ..
-              env:
-                  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-                  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  DIST_REGISTRY: https://registry.npmjs.org/
-
-            - name: Release with Gradle automatic
-              run: ./gradlew release -x test -x checkstyleTest -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ github.event.inputs.release_version }} -Prelease.newVersion=${{ github.event.inputs.new_version }} -Pzowe.deploy.username=$ARTIFACTORY_USERNAME -Pzowe.deploy.password=$ARTIFACTORY_PASSWORD -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_USERNAME
-              env:
-                  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-                  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-                  BUILD_NUMBER: ${{ github.run_number }}
-                  BRANCH_NAME: ${{ github.ref_name }}
+            - name: Checkout repository
+              uses: actions/checkout@v3
 
             - name: Upgrade API ML components in zowe-install-packaging
               run: |

--- a/scripts/release_components/index.js
+++ b/scripts/release_components/index.js
@@ -65,7 +65,7 @@ const version = process.argv[3];
         }
     }
     else if (apimlReleasePrs.length === 0) {
-        // make new PR since none exists for changelog
+        // make new PR since none exists for components upgrade
 
         await writeFile('../../manifest.json.template', manifestJsonContent);
 

--- a/scripts/release_components/index.js
+++ b/scripts/release_components/index.js
@@ -53,15 +53,15 @@ const version = process.argv[3];
         let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
 
         execSync(gitCheckoutOrigin, {
-            cwd: '../../'
+            cwd: '../../zowe-install-packaging'
         });
 
-        await writeFile('../../manifest.json.template', JSON.stringify(manifestJsonContent, null, 2));
+        await writeFile('../../zowe-install-packaging/manifest.json.template', JSON.stringify(manifestJsonContent, null, 2));
 
         let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
 
         let gitStatusPorcelainOutput = execSync(gitStatusPorcelain, {
-            cwd: '../../'
+            cwd: '../../zowe-install-packaging'
         }).toString();
 
         if (gitStatusPorcelainOutput.length !== 0) {
@@ -69,7 +69,7 @@ const version = process.argv[3];
             let gitCommitPush = `git add manifest.json.template && git commit --signoff -m "Update manifest.json" && git push origin HEAD:${prevReleaseBranch}`;
 
             execSync(gitCommitPush, {
-                cwd: '../../'
+                cwd: '../../zowe-install-packaging'
             });
         }
         else {
@@ -79,7 +79,7 @@ const version = process.argv[3];
     else if (apimlReleasePrs.length === 0) {
         // make new PR since none exists for components upgrade
 
-        await writeFile('../../manifest.json.template', JSON.stringify(manifestJsonContent, null, 2));
+        await writeFile('../../zowe-install-packaging/manifest.json.template', JSON.stringify(manifestJsonContent, null, 2));
 
         const branch = `apiml/release/${version.replace(/\./g, "_")}`;
         console.log("New release branch created " + branch + "\n");
@@ -87,7 +87,7 @@ const version = process.argv[3];
         let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add manifest.json.template && git commit --signoff -m "Update manifest.json" && git push origin ${branch}`;
 
         execSync(gitCommitPush, {
-            cwd: '../../'
+            cwd: '../../zowe-install-packaging'
         });
 
         await octokit.rest.pulls.create({

--- a/scripts/release_components/index.js
+++ b/scripts/release_components/index.js
@@ -1,0 +1,92 @@
+import {Octokit} from "octokit";
+import {execSync} from "child_process";
+import {writeFile} from "fs/promises";
+
+const githubToken = process.argv[2];
+const version = process.argv[3];
+
+/**
+ * Create and check out release branch from zowe-install-packaging,
+ * bump API ML components' version in the manifest.json.template file and open PR against RC base branch, if not open already.
+ */
+(async function () {
+    const branchToMerge = 'v2.x/rc'
+    const octokit = new Octokit({auth: githubToken});
+    const manifestJsonContent = await octokit.rest.repos.getContent({
+        owner: 'zowe',
+        repo: 'zowe-install-packaging',
+        path: 'manifest.json.template',
+        ref: branchToMerge,
+    }).split(/\r?\n/);
+
+    const updatedManifestJson = manifestJsonContent.filter(line => {
+        line.includes("org.zowe.apiml") && line.notEqual("org.zowe.apiml.cloud-gateway-package") && line.notEqual("common-java-lib-package")
+    }).map(line => {
+        return line.replace("\"version\": \"(\d+\.\d+\.\d+)\"", `\"version\": \"${version}\"`)
+    }).join("\n");
+
+    const prs = (await octokit.request("GET /repos/zowe/zowe-install-packaging/pulls")).data;
+
+    const apimlReleasePrs = prs.filter(pr => pr["user"]["login"] === "zowe-robot" &&
+        pr["title"] === `Upgrade API ML components for Zowe ${version}` &&
+        pr["body"] === "Update manifest.json with bumped API ML components.");
+
+    if (apimlReleasePrs.length === 1) {
+        // PR exists, use that branch to merge new updates
+
+        const prevReleaseBranch = apimlReleasePrs[0]["head"]["ref"];
+        let gitCheckoutOrigin = `git fetch origin --quiet && git checkout origin/${prevReleaseBranch}`;
+
+        execSync(gitCheckoutOrigin, {
+            cwd: '../../'
+        });
+
+        await writeFile('../../manifest.json.template', updatedManifestJson);
+
+        let gitStatusPorcelain = `git status --porcelain --untracked-files=no`;
+
+        let gitStatusPorcelainOutput = execSync(gitStatusPorcelain, {
+            cwd: '../../'
+        }).toString();
+
+        if (gitStatusPorcelainOutput.length !== 0) {
+            console.log("Pushing updates to " + prevReleaseBranch + "\n");
+            let gitCommitPush = `git add manifest.json.template && git commit --signoff -m "Update manifest.json" && git push origin HEAD:${prevReleaseBranch}`;
+
+            execSync(gitCommitPush, {
+                cwd: '../../'
+            });
+        }
+        else {
+            console.log("No new changes added in manifest.json.template");
+        }
+    }
+    else if (apimlReleasePrs.length === 0) {
+        // make new PR since none exists for changelog
+
+        await writeFile('../../manifest.json.template', updatedManifestJson);
+
+        const branch = `apiml/release/${version.replace(/\./g, "_")}`;
+        console.log("New release branch created " + branch + "\n");
+
+        let gitCommitPush = `git branch ${branch} && git checkout ${branch} && git add manifest.json.template && git commit --signoff -m "Update manifest.json" && git push origin ${branch}`;
+
+        execSync(gitCommitPush, {
+            cwd: '../../'
+        });
+
+        await octokit.rest.pulls.create({
+            owner: 'zowe',
+            repo: 'zowe-install-packaging',
+            title: `Upgrade API ML components for Zowe ${version}`,
+            head: branch,
+            base: branchToMerge,
+            body: 'Update manifest.json with bumped API ML components.'
+        });
+    }
+    else {
+        console.log("More than one pull request exists, cannot add new updates to the manifest.json for API ML components upgrade");
+    }
+
+})()
+

--- a/scripts/release_components/package.json
+++ b/scripts/release_components/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bump_components_in_manifest",
+  "version": "1.0.0",
+  "description": "Script to upgrade API ML components version in the manifest.json of zowe install packaging",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "EPL-2.0",
+  "dependencies": {
+      "octokit": "1.7.1"
+   }
+}


### PR DESCRIPTION
# Description

Improve release process by automatically updating the `manifest.json.template` and open PR in zowe-install-packaging, after API ML gets released.

Linked to #2580 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
