### PR TITLE
Fix missing z/OS related metadata

### DIFF
--- a/common-service-core/src/test/java/org/zowe/apiml/util/ClassOrDefaultProxyUtilsTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/util/ClassOrDefaultProxyUtilsTest.java
@@ -250,28 +250,34 @@ class ClassOrDefaultProxyUtilsTest {
             StaticMethods staticMethods = ClassOrDefaultProxyUtils.createProxy(
                 StaticMethods.class,
                 "org.zowe.apiml.util.ClassOrDefaultProxyUtilsTest$StaticMethodsTestClass",
-                MockClass::new
+                    StaticMethodsMockClass::new
             );
             assertEquals(VALUE, staticMethods.getValue());
         }
+
+    }
+
+    @Nested
+    class GivenInvalidMapping {
 
         @Test
         void whenClassIsMissing_thenCallMock() {
             StaticMethods staticMethods = ClassOrDefaultProxyUtils.createProxy(
                     StaticMethods.class,
                     "unknown.Class",
-                    MockClass::new
+                    StaticMethodsMockClass::new
             );
             assertEquals(MOCKED_VALUE, staticMethods.getValue());
         }
 
-        class MockClass implements StaticMethods {
-
-            @Override
-            public String getValue() {
-                return MOCKED_VALUE;
-            }
-
+        @Test
+        void whenMethodDefinitionsAreNotMatching_thenUseMock() {
+            StaticMethods staticMethods = ClassOrDefaultProxyUtils.createProxy(
+                    StaticMethods.class,
+                    "org.zowe.apiml.util.ClassOrDefaultProxyUtilsTest$InvalidStaticMethodsTestClass",
+                    StaticMethodsMockClass::new
+            );
+            assertEquals(MOCKED_VALUE, staticMethods.getValue());
         }
 
     }
@@ -282,6 +288,15 @@ class ClassOrDefaultProxyUtilsTest {
 
     }
 
+    class StaticMethodsMockClass implements StaticMethods {
+
+        @Override
+        public String getValue() {
+            return MOCKED_VALUE;
+        }
+
+    }
+
     public static class StaticMethodsTestClass {
 
         private StaticMethodsTestClass() {
@@ -289,6 +304,13 @@ class ClassOrDefaultProxyUtilsTest {
 
         public static String getValue() {
             return VALUE;
+        }
+
+    }
+
+    public static class InvalidStaticMethodsTestClass {
+
+        private InvalidStaticMethodsTestClass() {
         }
 
     }

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
@@ -99,9 +99,9 @@ public class ApiMediationClientImpl implements ApiMediationClient {
             throw new ServiceDefinitionException("EurekaClient was previously registered for this instance of ApiMediationClient. Call your ApiMediationClient unregister() method before attempting other registration.");
         }
 
+        defaultCustomMetadataHelper.update(config);
         EurekaClientConfig clientConfiguration = eurekaClientConfigProvider.config(config);
         ApplicationInfoManager infoManager = initializeApplicationInfoManager(config);
-        defaultCustomMetadataHelper.update(config);
         eurekaClient = initializeEurekaClient(infoManager, clientConfiguration, config);
     }
 


### PR DESCRIPTION
Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>

# Description

This PR fixes class ClassOrDefaultProxyUtils to support static methods as the original implementation. It is also fixing the setting of metadata from JZos (ZUtil class).

The issue of missing metadata is not just in the fetching data (), but also in the order of the register method:
https://github.com/zowe/api-layer/blob/b5e4056b974b6d69fe0179028c523e0518c2e964/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java#L102-L105

The method `initializeApplicationInfoManager` (or more precise org.zowe.apiml.eurekaservice.client.util.EurekaInstanceConfigCreator#createEurekaInstanceConfig) creates a copy of the map. Therefore registration itself has two different maps with different content. The metadata update process has to be in first position.

Linked to #1927 (issue)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (refactor) Refactor the code 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
