### PR TITLE
Add API Catalog standalone mode - only remove authentication

### DIFF
--- a/api-catalog-services/README.md
+++ b/api-catalog-services/README.md
@@ -2,9 +2,8 @@
 
 ## Standalone mode
 
-Standalone mode allows publicly display, without need for authentication, 
-services that are stored on the disk. API Catalog does not connect to any other
-service. 
+Standalone mode allows displaying, without the need for authentication, services
+that are stored on the disk. API Catalog does not connect to any other service.
 
 ### Configuration
 

--- a/api-catalog-services/README.md
+++ b/api-catalog-services/README.md
@@ -1,0 +1,12 @@
+# API Catalog Services
+
+## Standalone mode
+
+Standalone mode allows publicly display, without need for authentication, 
+services that are stored on the disk. API Catalog does not connect to any other
+service. 
+
+### Configuration
+
+ - `apiml.catalog.standalone.enabled` 
+    specifies whether to enable standalone mode

--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok
+    annotationProcessor libraries.spring_boot_configuration_processor
 
     implementation group: 'io.swagger', name: 'swagger-models', version: '1.6.2'
     implementation(libraries.spring_boot_starter_web) {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -14,8 +14,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -171,6 +173,23 @@ public class SecurityConfiguration {
             }
             return http.build();
         }
+
+        @Configuration
+        @Order(Ordered.HIGHEST_PRECEDENCE)
+        @ConditionalOnProperty(value = "apiml.catalog.standalone.enabled", havingValue = "true")
+        public class StandaloneConfig {
+
+            @Bean
+            public SecurityFilterChain permitAll(HttpSecurity http) throws Exception {
+                return http
+                    .authorizeRequests()
+                    .anyRequest().permitAll()
+                    .and()
+                    .build();
+            }
+
+        }
+
     }
 
     private HttpSecurity baseConfiguration(HttpSecurity http) throws Exception {

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/listeners/GatewayLookupEventListener.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/listeners/GatewayLookupEventListener.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.apicatalog.services.status.listeners;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -26,6 +27,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Initializes Catalog instances from Eureka
  */
 @Component
+@ConditionalOnProperty(
+    value = "apiml.catalog.standalone.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 @RequiredArgsConstructor
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class GatewayLookupEventListener {

--- a/api-catalog-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-catalog-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,15 @@
+{
+    "properties": [
+        {
+            "name": "apiml.catalog.standalone",
+            "type": "java.util.Map",
+            "description": "API Catalog standalone configuration.\nStandalone mode allows publicly display, without need for authentication, services that are stored on the disk. API Catalog does not connect to any other\nservice."
+        },
+        {
+            "name": "apiml.catalog.standalone.enabled",
+            "type": "java.lang.Boolean",
+            "defaultValue": "false",
+            "description": "Specifies whether to enable standalone mode.\nStandalone mode allows publicly display, without need for authentication, services that are stored on the disk. API Catalog does not connect to any other\nservice."
+        }
+    ]
+}

--- a/api-catalog-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-catalog-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,13 +3,13 @@
         {
             "name": "apiml.catalog.standalone",
             "type": "java.util.Map",
-            "description": "API Catalog standalone configuration.\nStandalone mode allows publicly display, without need for authentication, services that are stored on the disk. API Catalog does not connect to any other\nservice."
+            "description": "API Catalog standalone configuration.\nStandalone mode allows displaying, without the need for authentication, services that are stored on the disk. API Catalog does not connect to any other service."
         },
         {
             "name": "apiml.catalog.standalone.enabled",
             "type": "java.lang.Boolean",
             "defaultValue": "false",
-            "description": "Specifies whether to enable standalone mode.\nStandalone mode allows publicly display, without need for authentication, services that are stored on the disk. API Catalog does not connect to any other\nservice."
+            "description": "Specifies whether to enable standalone mode.\nStandalone mode allows displaying, without the need for authentication, services that are stored on the disk. API Catalog does not connect to any other service."
         }
     ]
 }


### PR DESCRIPTION
# Description

Standalone mode allows displaying, without the need for authentication, services that are stored on the disk. API Catalog does not connect to any other service. 

**Part 1** This PR just removes authentication in standalone mode.

**Notes:**
The original updated class was not united tested since it is a just configuration. Does not make sense to cover it.

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
