### PR TITLE
feat: remap client cert

### DIFF
--- a/cloud-gateway-service/build.gradle
+++ b/cloud-gateway-service/build.gradle
@@ -63,11 +63,7 @@ dependencies {
         exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-el"
         exclude group: "org.springframework.boot", module: "spring-boot-starter-reactor-netty"
     }
-
-    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-reactor-netty
     implementation 'org.springframework.boot:spring-boot-starter-reactor-netty:2.7.7'
-    // https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-http
-//    implementation 'io.projectreactor.netty:reactor-netty-http:1.0.26'
 
 
     implementation libraries.spring_context
@@ -81,7 +77,6 @@ dependencies {
         exclude group: "org.springframework", module: "spring-core"
         exclude group: "org.springframework", module: "spring-web"
     }
-    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security
     implementation 'org.springframework.boot:spring-boot-starter-security:2.7.7'
 
     implementation libraries.woodstox

--- a/cloud-gateway-service/build.gradle
+++ b/cloud-gateway-service/build.gradle
@@ -71,12 +71,15 @@ dependencies {
         exclude group: "org.springframework", module: "spring-core"
         exclude group: "org.springframework", module: "spring-web"
     }
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security
+    implementation 'org.springframework.boot:spring-boot-starter-security:2.7.7'
+
     implementation libraries.woodstox
     implementation libraries.jettison
     implementation libraries.jackson_databind
     implementation libraries.guava
     implementation libraries.tomcat_embed_el
-    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.5'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.7'
 
     implementation (libraries.spring_cloud_circuit_breaker){
         exclude group: "org.springframework.security", module: "spring-security-crypto"
@@ -89,12 +92,12 @@ dependencies {
 
     compileOnly libraries.lombok
     annotationProcessor libraries.lombok
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:2.7.5'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:2.7.7'
 
 
     testCompileOnly libraries.lombok
     testAnnotationProcessor libraries.lombok
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.3'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.7'
     testImplementation libraries.rest_assured
 }
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/HttpConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/HttpConfig.java
@@ -64,7 +64,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 @Configuration
@@ -262,7 +265,9 @@ public class HttpConfig {
 
     @Bean
     public MessageService messageService() {
-        return YamlMessageServiceInstance.getInstance();
+        MessageService messageService = YamlMessageServiceInstance.getInstance();
+        messageService.loadMessages("/cloud-gateway-log-messages.yml");
+        return messageService;
     }
 
 }

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/HttpConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/HttpConfig.java
@@ -64,10 +64,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 @Configuration

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
@@ -33,7 +33,7 @@ public class WebSecurity {
     @Bean
     @Primary
     ReactiveUserDetailsService userDetailsService() {
-        return (username) -> Mono.just(User.withUsername(username).password("password").authorities("user").build());
+        return username -> Mono.just(User.withUsername(username).password("password").authorities("user").build());
     }
 
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
@@ -25,7 +25,7 @@ public class WebSecurity {
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
-        http.x509(Customizer.withDefaults())
+        http.x509(Customizer.withDefaults()).csrf().disable()
             .authorizeExchange(exchange -> exchange.anyExchange().permitAll());
         return http.build();
     }

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/WebSecurity.java
@@ -1,0 +1,40 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.cloudgatewayservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class WebSecurity {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http.x509(Customizer.withDefaults())
+            .authorizeExchange(exchange -> exchange.anyExchange().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Primary
+    ReactiveUserDetailsService userDetailsService() {
+        return (username) -> Mono.just(User.withUsername(username).password("password").authorities("user").build());
+    }
+
+
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/PassticketFilterFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/PassticketFilterFactory.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import org.zowe.apiml.cloudgatewayservice.service.InstanceInfoService;
+import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.ticket.TicketRequest;
 import org.zowe.apiml.ticket.TicketResponse;
@@ -39,8 +40,6 @@ public class PassticketFilterFactory extends AbstractGatewayFilterFactory<Passti
     private final MessageService messageService;
     private final String ticketUrl = "%s://%s:%s/%s/api/v1/auth/ticket";
     private final ObjectWriter writer = new ObjectMapper().writer();
-    public static final String AUTH_FAIL_HEADER = "X-Zowe-Auth-Failure";
-
 
     public PassticketFilterFactory(WebClient webClient, InstanceInfoService instanceInfoService, MessageService messageService) {
         super(Config.class);
@@ -85,8 +84,8 @@ public class PassticketFilterFactory extends AbstractGatewayFilterFactory<Passti
     }
 
     private ServerHttpRequest updateHeadersForError(ServerWebExchange exchange, String errorMessage) {
-        ServerHttpRequest request = addRequestHeader(exchange, AUTH_FAIL_HEADER, messageService.createMessage("org.zowe.apiml.security.ticket.generateFailed", errorMessage).mapToLogMessage());
-        exchange.getResponse().getHeaders().add(AUTH_FAIL_HEADER, messageService.createMessage("org.zowe.apiml.security.ticket.generateFailed", errorMessage).mapToLogMessage());
+        ServerHttpRequest request = addRequestHeader(exchange, ApimlConstants.AUTH_FAIL_HEADER, messageService.createMessage("org.zowe.apiml.security.ticket.generateFailed", errorMessage).mapToLogMessage());
+        exchange.getResponse().getHeaders().add(ApimlConstants.AUTH_FAIL_HEADER, messageService.createMessage("org.zowe.apiml.security.ticket.generateFailed", errorMessage).mapToLogMessage());
         return request;
     }
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactory.java
@@ -1,0 +1,108 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Service;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+
+@Service
+@Slf4j
+public class X509FilterFactory extends AbstractGatewayFilterFactory<X509FilterFactory.Config> {
+
+    public static final String PUBLIC_KEY = "X-Certificate-Public";
+    public static final String DISTINGUISHED_NAME = "X-Certificate-DistinguishedName";
+    public static final String COMMON_NAME = "X-Certificate-CommonName";
+
+
+    public X509FilterFactory() {
+        super(Config.class);
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            if (exchange.getRequest().getSslInfo() != null) {
+                X509Certificate[] certificates = exchange.getRequest().getSslInfo().getPeerCertificates();
+                if (certificates != null && certificates.length > 0) {
+                    ServerHttpRequest request = exchange.getRequest().mutate().headers(headers -> {
+                        try {
+                            setHeader(headers, config.getHeaders().split(","), certificates[0]);
+                        } catch (CertificateEncodingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).build();
+                    return chain.filter(exchange.mutate().request(request).build());
+                }
+            }
+            return chain.filter(exchange);
+        });
+    }
+
+
+    private void setHeader(HttpHeaders headers, String[] headerNames, X509Certificate certificate) throws CertificateEncodingException {
+        for (String headerName : headerNames) {
+            switch (headerName.trim()) {
+                case COMMON_NAME:
+                    headers.add(COMMON_NAME, getCommonName(certificate.getSubjectX500Principal().getName()));
+                    break;
+                case PUBLIC_KEY:
+                    headers.add(PUBLIC_KEY, Base64.getEncoder().encodeToString(certificate.getEncoded()));
+                    break;
+                case DISTINGUISHED_NAME:
+                    headers.add(DISTINGUISHED_NAME, certificate.getSubjectDN().getName());
+                    break;
+                default:
+                    log.debug("Unsupported header specified in service metadata, " +
+                        "please review apiml.service.authentication.headers, possible values are: " + PUBLIC_KEY +
+                        ", " + DISTINGUISHED_NAME + ", " + COMMON_NAME + "\nprovided value: " + headerName);
+
+            }
+        }
+    }
+
+    private String getCommonName(String dn){
+        try {
+            LdapName  ldapDN = new LdapName(dn);
+            for (Rdn rdn : ldapDN.getRdns()) {
+                if ("cn".equalsIgnoreCase(rdn.getType())) {
+                    return String.valueOf(rdn.getValue());
+                }
+            }
+        } catch (InvalidNameException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+
+    public static class Config {
+        private String headers;
+
+        public String getHeaders() {
+            return headers;
+        }
+
+        public void setHeaders(String headers) {
+            this.headers = headers;
+        }
+    }
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/RouteLocator.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/RouteLocator.java
@@ -31,9 +31,7 @@ import org.zowe.apiml.util.CorsUtils;
 import reactor.core.publisher.Flux;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 public class RouteLocator implements RouteDefinitionLocator {
@@ -131,6 +129,13 @@ public class RouteLocator implements RouteDefinitionLocator {
                 filerDef.setName("PassticketFilterFactory");
                 filerDef.addArg("applicationName", auth.getApplid());
                 routeDefinition.getFilters().add(filerDef);
+            } else if (AuthenticationScheme.X509.getScheme().equals(schemeName)) {
+                FilterDefinition x509filter = new FilterDefinition();
+                x509filter.setName("X509FilterFactory");
+                Map<String,String> m = new HashMap<>();
+                m.put("headers",auth.getHeaders());
+                x509filter.setArgs(m);
+                routeDefinition.getFilters().add(x509filter);
             }
         }
 

--- a/cloud-gateway-service/src/main/resources/application.yml
+++ b/cloud-gateway-service/src/main/resources/application.yml
@@ -21,6 +21,7 @@ apiml:
 server:
     port: ${apiml.service.port}
     ssl:
+        clientAuth: want
         keyAlias: localhost
         keyPassword: password
         keyStore: keystore/localhost/localhost.keystore.p12

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactoryTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.filters;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/X509FilterFactoryTest.java
@@ -1,0 +1,207 @@
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.http.server.reactive.SslInfo;
+import org.springframework.web.server.ServerWebExchange;
+import org.zowe.apiml.constants.ApimlConstants;
+import org.zowe.apiml.message.core.MessageService;
+import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
+import reactor.core.publisher.Mono;
+
+import javax.naming.ldap.LdapName;
+import javax.security.auth.x500.X500Principal;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class X509FilterFactoryTest {
+    public static final String ALL_HEADERS = "X-Certificate-Public,X-Certificate-DistinguishedName,X-Certificate-CommonName";
+    private final X509Certificate[] x509Certificates = new X509Certificate[1];
+
+    SslInfo sslInfo = mock(SslInfo.class);
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest request = mock(ServerHttpRequest.class);
+    ServerHttpResponse response = mock(ServerHttpResponse.class);
+    X509Certificate certificate = mock(X509Certificate.class);
+    GatewayFilterChain chain = mock(GatewayFilterChain.class);
+    X509FilterFactory factory;
+    X509FilterFactory.Config config;
+    MessageService messageService = YamlMessageServiceInstance.getInstance();
+
+    {
+        messageService.loadMessages("/cloud-gateway-log-messages.yml");
+    }
+
+    @BeforeEach
+    void setup() {
+        factory = new X509FilterFactory(messageService);
+        config = new X509FilterFactory.Config();
+        config.setHeaders(ALL_HEADERS);
+
+        ServerHttpRequest.Builder builder = new ServerHttpRequestBuilderMock();
+        ServerWebExchange.Builder exchangeBuilder = new ServerWebExchangeBuilderMock();
+        x509Certificates[0] = certificate;
+
+        when(exchange.getRequest()).thenReturn(request);
+
+        when(request.getSslInfo()).thenReturn(sslInfo);
+        when(request.mutate()).thenReturn(builder);
+
+        when(sslInfo.getPeerCertificates()).thenReturn(x509Certificates);
+
+
+        when(certificate.getSubjectDN()).thenReturn(new X500Principal("CN=user, OU=JavaSoft, O=Sun Microsystems, C=US"));
+        when(exchange.mutate()).thenReturn(exchangeBuilder);
+
+        when(chain.filter(exchange)).thenReturn(Mono.empty());
+    }
+
+    @Test
+    void givenCertificateInRequest_thenPopulateHeaders() throws Exception {
+        GatewayFilter filter = factory.apply(config);
+        when(certificate.getEncoded()).thenReturn(new byte[2]);
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertEquals("user", exchange.getRequest().getHeaders().get("X-Certificate-CommonName").get(0));
+    }
+
+    @Test
+    void givenCertificateWithIncorrectEncoding_thenProvideInfoInHeader() throws Exception {
+
+        GatewayFilter filter = factory.apply(config);
+        when(certificate.getEncoded()).thenThrow(new CertificateEncodingException("incorrect encoding"));
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertEquals("Invalid client certificate in request. Error message: incorrect encoding", exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER).get(0));
+    }
+
+    @Test
+    void givenNoCertificateInRequest_thenContinueFilterChainWithUntouchedHeaders() {
+
+        GatewayFilter filter = factory.apply(config);
+
+        when(sslInfo.getPeerCertificates()).thenReturn(null);
+        HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+        when(exchange.getResponse()).thenReturn(response);
+        HttpHeaders responseHeaders = new HttpHeaders();
+        when(response.getHeaders()).thenReturn(responseHeaders);
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertEquals("ZWEAG167E No client certificate provided in the request", exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER).get(0));
+        assertEquals("ZWEAG167E No client certificate provided in the request", responseHeaders.get(ApimlConstants.AUTH_FAIL_HEADER).get(0));
+    }
+
+    @Test
+    void givenCorrectDN_returnCommonName() throws Exception {
+        assertEquals("user", X509FilterFactory.getCommonName(new LdapName("CN=user, OU=JavaSoft, O=Sun Microsystems, C=US")));
+    }
+
+    @Test
+    void givenDNWithoutCommonName_returnNull() throws Exception {
+        assertNull(X509FilterFactory.getCommonName(new LdapName("OU=JavaSoft, O=Sun Microsystems, C=US")));
+    }
+
+    public class ServerHttpRequestBuilderMock implements ServerHttpRequest.Builder {
+        HttpHeaders headers = new HttpHeaders();
+
+        @Override
+        public ServerHttpRequest.Builder method(HttpMethod httpMethod) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder uri(URI uri) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder path(String path) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder contextPath(String contextPath) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder header(String headerName, String... headerValues) {
+            headers.add(headerName, headerValues[0]);
+            return this;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder headers(Consumer<HttpHeaders> headersConsumer) {
+            headersConsumer.accept(this.headers);
+            return this;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder sslInfo(SslInfo sslInfo) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder remoteAddress(InetSocketAddress remoteAddress) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest build() {
+            when(request.getHeaders()).thenReturn(headers);
+            return request;
+        }
+    }
+
+    ;
+
+    public class ServerWebExchangeBuilderMock implements ServerWebExchange.Builder {
+        ServerHttpRequest request;
+
+        @Override
+        public ServerWebExchange.Builder request(Consumer<ServerHttpRequest.Builder> requestBuilderConsumer) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange.Builder request(ServerHttpRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        @Override
+        public ServerWebExchange.Builder response(ServerHttpResponse response) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange.Builder principal(Mono<Principal> principalMono) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange build() {
+            when(exchange.getRequest()).thenReturn(request);
+            return exchange;
+        }
+    }
+
+    ;
+
+}

--- a/cloud-gateway-service/src/test/resources/application.yml
+++ b/cloud-gateway-service/src/test/resources/application.yml
@@ -17,6 +17,7 @@ apiml:
 server:
     port: ${apiml.service.port}
     ssl:
+        clientAuth: want
         keyAlias: localhost
         keyPassword: password
         keyStore: ../keystore/localhost/localhost.keystore.p12
@@ -42,6 +43,7 @@ logging:
     level:
         org.springframework.cloud.gateway: DEBUG
         reactor.netty: DEBUG
+        org.springframework.security: DEBUG
 
 
 management:

--- a/cloud-gateway-service/src/test/resources/cloud-gateway-log-messages.yml
+++ b/cloud-gateway-service/src/test/resources/cloud-gateway-log-messages.yml
@@ -1,0 +1,361 @@
+messages:
+    # Info messages
+    # 000-099
+
+    # General messages
+    # 100-199
+
+    # HTTP,Protocol messages
+    # 400-499
+
+    # TLS,Certificate messages
+    # 500-599
+    - key: org.zowe.apiml.gateway.security.x509.missingCertificate
+      number: ZWEAG500
+      type: ERROR
+      text: "Client certificate is missing in request."
+      reason: "No client certificate is present in the HTTPS request."
+      action: "Properly configure client to send client certificate."
+
+    # Various messages
+    # 600-699
+
+    # Service specific messages
+    # 700-999
+
+    - key: org.zowe.apiml.gateway.instanceNotFound
+      number: ZWEAG700
+      type: ERROR
+      text: "No instance of the service '%s' found. Routing will not be available."
+      reason: "The Gateway could not find an instance of the service from the Discovery Service."
+      action: "Check that the service was successfully registered to the Discovery Service and wait for Spring Cloud to refresh the routes definitions."
+
+    - key: org.zowe.apiml.gateway.requestContainEncodedCharacter
+      number: ZWEAG701
+      type: ERROR
+      text: "Service '%s' does not allow encoded characters in the request path: '%s'."
+      reason: "The request that was issued to the Gateway contains an encoded character in the URL path. The service that the request was addressing does not allow this pattern."
+      action: "Contact the system administrator and request enablement of encoded characters in the service."
+
+    - key: org.zowe.apiml.gateway.requestContainEncodedSlash
+      number: ZWEAG702
+      type: ERROR
+      text: "Gateway does not allow encoded slashes in request: '%s'."
+      reason: "The request that was issued to the Gateway contains an encoded slash in the URL path. Gateway configuration does not allow this encoding in the URL."
+      action: "Contact the system administrator and request enablement of encoded slashes in the Gateway."
+
+    - key: org.zowe.apiml.gateway.jwtInitConfigError
+      number: ZWEAG704
+      type: ERROR
+      text: "Configuration error '%s' when trying to read the public and private key for signing JWT: %s"
+      reason: "A problem occurred while trying to read the certificate-key pair from the keystore."
+      action: "Review the mandatory fields used in the configuration such as the keystore location path, the keystore and key password, and the keystore type."
+
+    - key: org.zowe.apiml.gateway.jwtKeyMissing
+      number: ZWEAG705
+      type: ERROR
+      text: "Failed to load public or private key from key with alias '%s' in the keystore '%s'. Gateway is shutting down."
+      reason: "Failed to load a public or private key from the keystore during JWT Token initialization."
+      action: "Check that the key alias is specified and correct. Verify that the keys are present in the keystore."
+
+    - key: org.zowe.apiml.gateway.contextNotPrepared
+      number: ZWEAG706
+      type: ERROR
+      text: "RequestContext is not prepared for load balancing."
+      reason: "Custom Ribbon load balancing is not in place before calling Ribbon."
+      action: "Contact Broadcom support."
+
+    - key: org.zowe.apiml.gateway.requestAborted
+      number: ZWEAG707
+      type: ERROR
+      text: "The request to the URL '%s' aborted without retrying on another instance. Caused by: %s"
+      reason: "The request to the server instance failed and will not be retried on another instance."
+      action: "Refer to 'Caused by' details for troubleshooting."
+
+    - key: org.zowe.apiml.gateway.connectionRefused
+      number: ZWEAG708
+      type: ERROR
+      text: "The request to the URL '%s' failed after retrying on all known service instances. Caused by: %s"
+      reason: "Request to the server instance could not be executed on any known service instance."
+      action: "Verify the status of the requested instance."
+
+    - key: org.zowe.apiml.gateway.serviceUnavailable
+      number: ZWEAG709
+      type: ERROR
+      text: "Service is not available at URL '%s'. Error returned: '%s'"
+      reason: "The service is not available."
+      action: "Make sure that the service is running and is accessible by the URL provided in the message."
+
+    - key: org.zowe.apiml.gateway.loadBalancerDoesNotHaveAvailableServer
+      number: ZWEAG710
+      type: ERROR
+      text: "Load balancer does not have available server for client: %s"
+      reason: "The service is not available. It might be removed by the Circuit Breaker or by requesting specific instance that is not available."
+      action: "Try the request later, or remove the request for the specific instance."
+
+    - key: org.zowe.apiml.security.unauthorized
+      number: ZWEAG711
+      type: ERROR
+      text: "The principal '%s' is missing queried authorization."
+      reason: "The principal does not have the queried access to the resource name within the resource class."
+      action: "No action is needed."
+
+    - key: org.zowe.apiml.gateway.invalidRoute
+      number: ZWEAG712
+      type: ERROR
+      text: "The URI '%s' is an invalid format"
+      reason: "The URI does not follow the format /{serviceId}/{type}/{version}/{endpoint} or /{type}/{version}/{serviceId}/{endpoint}."
+      action: "Use a properly formatted URI."
+
+    - key: org.zowe.apiml.gateway.jwtProducerConfigError
+      number: ZWEAG713
+      type: ERROR
+      text: "Configuration error when trying to establish JWT producer. Events: %s"
+      reason: "A problem occurred while trying to make sure that there is a valid JWT producer available."
+      action: "Based on the specific information in the message, verify that the key configuration is correct, or alternatively, that z/OSMF is available."
+
+    - key: org.zowe.apiml.gateway.keys.unknown
+      number: ZWEAG714
+      type: ERROR
+      text: "Unknown error occurred while retrieving the used public key"
+      reason: "An unknown problem occurred when retrieving the used public key. This should never occur."
+      action: "Try again later."
+
+    - key: org.zowe.apiml.gateway.keys.wrongAmount
+      number: ZWEAG715
+      type: ERROR
+      text: "The wrong amount of keys retrieved. The amount of retrieved keys is: %s"
+      reason: "There are too many keys in the JWK set. As such, it is not possible to choose the correct one."
+      action: "Verify the configuration of the z/OSMF to make sure that z/OSMF provides only one used key."
+
+    - key: org.zowe.apiml.gateway.keys.unknownState
+      number: ZWEAG716
+      type: ERROR
+      text: "The system does not know what key should be used."
+      reason: "Typically z/OSMF is either unavailable or offline."
+      action: "Verify that z/OSMF is available, accessible by the Gateway service, and online."
+
+    - key: org.zowe.apiml.gateway.verifier.wrongServiceId
+      number: ZWEAG717
+      type: ERROR
+      text: "The service id provided is invalid: '%s'"
+      reason: "The provided id is not valid under conformance criteria."
+      action: "Verify the conformance criteria, provide valid service id."
+
+    # Legacy messages
+
+    - key: org.zowe.apiml.security.generic
+      number: ZWEAG100
+      type: ERROR
+      text: "Authentication exception: '%s' for URL '%s'"
+      reason: "A generic failure occurred during authentication."
+      action: "Refer to the specific authentication exception details for troubleshooting."
+
+    - key: org.zowe.apiml.security.invalidMethod
+      number: ZWEAG101
+      type: ERROR
+      text: "Authentication method '%s' is not supported for URL '%s'"
+      reason: "The HTTP request method is not supported by the URL."
+      action: "Use the correct HTTP request method supported by the URL."
+
+    - key: org.zowe.apiml.gateway.security.invalidToken
+      number: ZWEAG102
+      type: ERROR
+      text: "Token is not valid"
+      reason: "The JWT token is not valid."
+      action: "Provide a valid token."
+
+    - key: org.zowe.apiml.gateway.security.expiredToken
+      number: ZWEAG103
+      type: ERROR
+      text: "The token has expired"
+      reason: "The JWT token has expired."
+      action: "Obtain a new token by performing an authentication request."
+
+    - key: org.zowe.apiml.security.serviceUnavailable
+      number: ZWEAG104
+      type: ERROR
+      text: "Authentication service is not available at URL '%s'. Error returned: '%s'"
+      reason: "The authentication service is not available."
+      action: "Make sure that the authentication service is running and is accessible by the URL provided in the message."
+
+    - key: org.zowe.apiml.security.authRequired
+      number: ZWEAG105
+      type: ERROR
+      text: "Authentication is required for URL '%s'"
+      reason: "Authentication is required."
+      action: "Provide valid authentication."
+
+    - key: org.zowe.apiml.security.loginEndpointInDummyMode
+      number: ZWEAG106
+      type: WARNING
+      text: "Login endpoint is running in dummy mode. Use credentials '%s'/'%s' to log in. Do not use this option in the production environment."
+      reason: "The authentication is running in dummy mode."
+      action: "Ensure that this option is not being used in a production environment."
+
+    - key: org.zowe.apiml.security.invalidAuthenticationProvider
+      number: ZWEAG107
+      type: WARNING
+      text: "Incorrect value: apiml.security.auth.provider = '%s'. The authentication provider is not set correctly. The default 'zosmf' authentication provider is being used."
+      reason: "An incorrect value of the apiml.security.auth.provider parameter is set in the configuration."
+      action: "Ensure that the value of apiml.security.auth.provider is set either to 'dummy' if you want to use dummy mode, or to 'zosmf' if you want to use the z/OSMF authentication provider."
+
+    - key: org.zowe.apiml.security.zosmfInstanceNotFound
+      number: ZWEAG108
+      type: ERROR
+      text: "z/OSMF instance '%s' not found or incorrectly configured. Gateway is shutting down."
+      reason: "The Gateway could not find the z/OSMF instance from the Discovery Service or it could not communicate with the provided z/OSMF instance."
+      action: "Ensure that the z/OSMF instance is configured correctly and that it is successfully registered to the Discovery Service and that the API Mediation Layer can communicate with the provided z/OSMF instance. The default timeout is 5 minutes. On a slower system, add the variable components.gateway.apiml.security.jwtInitializerTimeout:... and the value in minutes into Zowe's configuration to override this value."
+
+    - key: org.zowe.apiml.security.zosmfDomainIsEmpty
+      number: ZWEAG109
+      type: ERROR
+      text: "z/OSMF response does not contain field '%s'."
+      reason: "The z/OSMF domain cannot be read."
+      action: "Review the z/OSMF domain value contained in the response received from the 'zosmf/info' REST endpoint."
+
+    - key: org.zowe.apiml.security.errorParsingZosmfResponse
+      number: ZWEAG110
+      type: ERROR
+      text: "Error parsing z/OSMF response. Error returned: '%s"
+      reason: "An error occurred while parsing the z/OSMF JSON response."
+      action: "Check the JSON response received from the 'zosmf/info' REST endpoint."
+
+    # Login messages (120 - 130)
+    - key: org.zowe.apiml.security.login.invalidCredentials
+      number: ZWEAG120
+      type: ERROR
+      text: "Invalid username or password for URL '%s'"
+      reason: "The username and/or password are invalid."
+      action: "Provide a valid username and password."
+
+    - key: org.zowe.apiml.security.login.invalidInput
+      number: ZWEAG121
+      type: ERROR
+      text: "Authorization header is missing, or the request body is missing or invalid for URL '%s'"
+      reason: "The authorization header is missing, or the request body is missing or invalid."
+      action: "Provide valid authentication."
+
+    - key: org.zowe.apiml.security.login.invalidTokenType
+      number: ZWEAS123
+      type: ERROR
+      text: "Invalid token type in response from Authentication service."
+      reason: "Could not retrieve the proper authentication token from the Authentication service response."
+      action: "Review your APIML authentication provider configuration and ensure your Authentication service is working."
+
+    # Query messages (130 - 140)
+    - key: org.zowe.apiml.security.query.invalidToken
+      number: ZWEAG130
+      type: ERROR
+      text: "Token is not valid for URL '%s'"
+      reason: "The token is not valid."
+      action: "Provide a valid token."
+
+    - key: org.zowe.apiml.security.query.tokenNotProvided
+      number: ZWEAG131
+      type: ERROR
+      text: "No authorization token provided for URL '%s'"
+      reason: "No authorization token is provided."
+      action: "Provide a valid authorization token."
+
+    # Ticket messages (140 - 149)
+    - key: org.zowe.apiml.security.ticket.invalidApplicationName
+      number: ZWEAG140
+      type: ERROR
+      text: "The 'applicationName' parameter name is missing."
+      reason: "The application name is not provided."
+      action: "Provide the 'applicationName' parameter."
+
+    - key: org.zowe.apiml.security.ticket.generateFailed
+      number: ZWEAG141
+      type: ERROR
+      text: "The generation of the PassTicket failed. Reason: %s"
+      reason: "An error occurred in the SAF Auth Service. Review the reason in the error message."
+      action: "Supply a valid user and application name, and check that corresponding permissions have been set up."
+
+    # IDT messages (150 - 159)
+    - key: org.zowe.apiml.security.idt.failed
+      number: ZWEAG150
+      type: ERROR
+      text: "SAF IDT generation failed. Reason: %s"
+      reason: "An error occurred during SAF verification. Review the reason in the error message."
+      action: "Verify the Identity Token configuration."
+
+    - key: org.zowe.apiml.security.idt.auth.failed
+      number: ZWEAG151
+      type: ERROR
+      text: "SAF IDT is not generated because authentication or authorization failed. Reason: %s"
+      reason: "The user credentials were rejected during SAF verification. Review the reason in the error message."
+      action: "Provide a valid username and password."
+
+    - key: org.zowe.apiml.gateway.security.schema.missingAuthentication
+      number: ZWEAG160
+      type: ERROR
+      text: "No authentication provided in the request"
+      reason: "The JWT token or client certificate was not provided with the request"
+      action: "Configure your client to provide valid authentication."
+
+    - key: org.zowe.apiml.gateway.security.schema.x509.mappingFailed
+      number: ZWEAG161
+      type: ERROR
+      text: "No user was found"
+      reason: "It was not possible to map provided token or certificate to the mainframe identity."
+      action: "Ask your security administrator to connect your token or client certificate with your mainframe user."
+
+    - key: org.zowe.apiml.gateway.security.token.authenticationFailed
+      number: ZWEAG162
+      type: ERROR
+      text: "Gateway service failed to obtain token."
+      reason: "Authentication request to get token failed."
+      action: "Contact your administrator."
+
+    - key: org.zowe.apiml.gateway.security.scheme.x509ParsingError
+      number: ZWEAG163
+      type: ERROR
+      text: "Error occurred while parsing X509 certificate."
+      reason: "%s"
+      action: "Configure your client to provide valid x509 certificate."
+
+    - key: org.zowe.apiml.gateway.security.scheme.x509ValidationError
+      number: ZWEAG164
+      type: ERROR
+      text: "Error occurred while validating X509 certificate. %s"
+      reason: "X509 certificate cannot be validated or the certificate cannot be used for client authentication."
+      action: "Configure your client to provide valid x509 certificate."
+
+    - key: org.zowe.apiml.gateway.security.scheme.x509ExtendedKeyUsageError
+      number: ZWEAG165
+      type: ERROR
+      text: "X509 certificate is missing the client certificate extended usage definition"
+      reason: "X509 certificate cannot be used for client authentication."
+      action: "Configure your client to provide valid x509 certificate."
+
+    - key: org.zowe.apiml.gateway.security.scheme.zosmfSchemeNotSupported
+      number: ZWEAG166
+      type: ERROR
+      text: "ZOSMF authentication scheme is not supported for this API ML instance."
+      reason: "z/OSMF is not used as security provider for API ML."
+      action: "Contact your administrator."
+
+    - key: org.zowe.apiml.gateway.security.schema.missingX509Authentication
+      number: ZWEAG167
+      type: ERROR
+      text: "No client certificate provided in the request"
+      reason: "The X509 client certificate was not provided with the request"
+      action: "Configure your client to provide valid certificate."
+
+    - key: org.zowe.apiml.gateway.security.invalidAuthentication
+      number: ZWEAG168
+      type: ERROR
+      text: "Invalid authentication provided in request"
+      reason: "The JWT token or client certificate is not valid"
+      action: "Configure your client to provide valid authentication."
+
+
+    # Revoke personal access token
+    - key: org.zowe.apiml.security.query.invalidRevokeRequestBody
+      number: ZWEAT607
+      type: ERROR
+      text: "Body in the revoke request is not valid."
+      reason: "The request body is not valid"
+      action: "Use a valid body in the request. Format of a message: {userId: string, (optional)timestamp: long} or {serviceId: string, (optional)timestamp: long}."

--- a/common-service-core/src/main/java/org/zowe/apiml/constants/ApimlConstants.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/ApimlConstants.java
@@ -24,4 +24,5 @@ public final class ApimlConstants {
     public static final String COOKIE_AUTH_NAME = "apimlAuthenticationToken";
     public static final String PAT_COOKIE_AUTH_NAME = "personalAccessToken";
     public static final String PAT_HEADER_NAME = "PRIVATE-TOKEN";
+    public static final String AUTH_FAIL_HEADER = "X-Zowe-Auth-Failure";
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilter.java
@@ -17,6 +17,7 @@ import org.springframework.cloud.netflix.zuul.util.ZuulRuntimeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.zowe.apiml.auth.Authentication;
+import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.gateway.security.service.ServiceAuthenticationServiceImpl;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSchemeException;
@@ -42,7 +43,6 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
  * load balancer. The request will be modified after specific instance will be selected.
  */
 public class ServiceAuthenticationFilter extends PreZuulFilter {
-    public static final String AUTH_FAIL_HEADER = "X-Zowe-Auth-Failure";
     @InjectApimlLogger
     private final ApimlLogger logger = ApimlLogger.empty();
 
@@ -124,8 +124,8 @@ public class ServiceAuthenticationFilter extends PreZuulFilter {
 
     private void sendErrorMessage(String error, RequestContext context) {
         logger.log(MessageType.DEBUG, error);
-        context.addZuulRequestHeader(AUTH_FAIL_HEADER, error);
-        context.addZuulResponseHeader(AUTH_FAIL_HEADER, error);
+        context.addZuulRequestHeader(ApimlConstants.AUTH_FAIL_HEADER, error);
+        context.addZuulResponseHeader(ApimlConstants.AUTH_FAIL_HEADER, error);
     }
 
     private boolean isSourceValidForCommand(AuthSource authSource, AuthenticationCommand cmd) {

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/SafIdtSchemeTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
-import static org.zowe.apiml.gateway.filters.pre.ServiceAuthenticationFilter.AUTH_FAIL_HEADER;
+import static org.zowe.apiml.constants.ApimlConstants.AUTH_FAIL_HEADER;
 
 /**
  * This test verifies that the token/client certificate was exchanged. The input is a valid apimlJwtToken/client certificate.
@@ -149,9 +149,9 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
                 //@formatter:off
                 given()
                     .cookie(withInvalidToken)
-                .when()
+                    .when()
                     .get(basePath + serviceWithDefaultConfiguration.getPath())
-                .then()
+                    .then()
                     .statusCode(is(HttpStatus.SC_OK));
                 //@formatter:on
 
@@ -159,7 +159,7 @@ class SafIdtSchemeTest extends AcceptanceTestWithTwoServices {
                 verify(mockClient, times(1)).execute(captor.capture());
 
                 verify(mockTemplate, times(0))
-                        .exchange(any(), eq(HttpMethod.POST), any(), eq(SafRestAuthenticationService.Token.class));
+                    .exchange(any(), eq(HttpMethod.POST), any(), eq(SafRestAuthenticationService.Token.class));
 
                 Header zoweAuthFailureHeader = captor.getValue().getFirstHeader(AUTH_FAIL_HEADER);
                 assertNotNull(zoweAuthFailureHeader);

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/X509SchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/X509SchemeTest.java
@@ -31,10 +31,8 @@ import java.io.IOException;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.zowe.apiml.gateway.filters.pre.ServiceAuthenticationFilter.AUTH_FAIL_HEADER;
+import static org.mockito.Mockito.*;
+import static org.zowe.apiml.constants.ApimlConstants.AUTH_FAIL_HEADER;
 
 /**
  * This test verifies that only the client certificate is passed through the X509scheme to the southbound service.

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/pre/ServiceAuthenticationFilterTest.java
@@ -25,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.auth.AuthenticationScheme;
+import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.gateway.security.service.ServiceAuthenticationServiceImpl;
 import org.zowe.apiml.gateway.security.service.schema.AuthenticationCommand;
 import org.zowe.apiml.gateway.security.service.schema.source.AuthSource;
@@ -100,7 +101,7 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
 
         when(serviceAuthenticationService.getAuthSourceByAuthentication(authentication)).thenReturn(Optional.empty());
         serviceAuthenticationFilter.run();
-        verify(serviceAuthenticationService, times(1)).getAuthenticationCommand("service", authentication,null);
+        verify(serviceAuthenticationService, times(1)).getAuthenticationCommand("service", authentication, null);
         verify(serviceAuthenticationService, times(2)).getAuthenticationCommand(anyString(), any(Authentication.class), any());
 
         reset(requestContext);
@@ -151,8 +152,8 @@ class ServiceAuthenticationFilterTest extends CleanCurrentRequestContextTest {
 
         serviceAuthenticationFilter.run();
 
-        verify(RequestContext.getCurrentContext()).addZuulRequestHeader(eq(ServiceAuthenticationFilter.AUTH_FAIL_HEADER), anyString());
-        verify(RequestContext.getCurrentContext()).addZuulResponseHeader(eq(ServiceAuthenticationFilter.AUTH_FAIL_HEADER), anyString());
+        verify(RequestContext.getCurrentContext()).addZuulRequestHeader(eq(ApimlConstants.AUTH_FAIL_HEADER), anyString());
+        verify(RequestContext.getCurrentContext()).addZuulResponseHeader(eq(ApimlConstants.AUTH_FAIL_HEADER), anyString());
         verify(RequestContext.getCurrentContext(), never()).setResponseStatusCode(anyInt());
         verify(cmd, never()).apply(any());
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/schema/SafIdtSchemeTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.zowe.apiml.auth.AuthenticationScheme.SAF_IDT;
-import static org.zowe.apiml.gateway.filters.pre.ServiceAuthenticationFilter.AUTH_FAIL_HEADER;
+import static org.zowe.apiml.constants.ApimlConstants.AUTH_FAIL_HEADER;
 
 class SafIdtSchemeTest {
     private SafIdtScheme underTest;

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/PassticketSchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/PassticketSchemeTest.java
@@ -56,7 +56,6 @@ public class PassticketSchemeTest implements TestWithStartedInstances {
     private final static URI requestUrl = HttpRequestUtils.getUriFromGateway(REQUEST_INFO_ENDPOINT);
     private final static URI discoverablePassticketUrl = HttpRequestUtils.getUriFromGateway(PASSTICKET_TEST_ENDPOINT);
     static CloudGatewayConfiguration conf = ConfigReader.environmentConfiguration().getCloudGatewayConfiguration();
-    public static final String AUTH_FAIL_HEADER = "X-Zowe-Auth-Failure";
 
     public static Stream<Arguments> getTokens() {
         return Stream.of(
@@ -117,7 +116,7 @@ public class PassticketSchemeTest implements TestWithStartedInstances {
                 .get(scgUrl)
                 .then()
                 .body("headers.x-zowe-auth-failure", startsWith("ZWEAG141E"))
-                .header(AUTH_FAIL_HEADER, startsWith("ZWEAG141E"))
+                .header(ApimlConstants.AUTH_FAIL_HEADER, startsWith("ZWEAG141E"))
                 .statusCode(200);
         }
     }


### PR DESCRIPTION
# Description

Spring cloud gateway is now capable of populating special headers with information from the client certificates.

Linked to #2044 
Part of the #2029 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
