### PR TITLE
Improve API catalog documentation for command to build standalone

### DIFF
--- a/api-catalog-services/README.md
+++ b/api-catalog-services/README.md
@@ -6,6 +6,9 @@ Standalone mode allows displaying, without the need for authentication, services
 that are stored on the disk. Standalone API Catalog does not connect to any
 other service.
 
+It requires building the UI module differently. For more information please follow 
+[the documentation about UI](../api-catalog-ui/frontend/README.md).
+
 ### Configuration
 
  - `apiml.catalog.standalone.enabled` 

--- a/api-catalog-ui/frontend/README.md
+++ b/api-catalog-ui/frontend/README.md
@@ -16,7 +16,15 @@ To build the UI:
 NPM: `npm run build`.
 Gradle: `./gradlew api-catalog-ui:build`
 
-**Note:** To build UI for standalone API catalog use command: `npx env-cmd -f api-catalog-ui/frontend/.env.standalone ./gradlew api-catalog-ui:build`
+### Standalone mode
+
+Standalone mode allows running API Catalog to visualize the mocked services. It uses different URL paths. Therefore, 
+it requires building the UI module with the proper environment file ([`.env.standalone`](.env.standalone)). There are 
+a couple ways how to switch the environment file. The easist one is using the NPM command 
+[`env-cmd`](https://www.npmjs.com/package/env-cmd). Basically, it requires adding 
+`npx env-cmd -f api-catalog-ui/frontend/.env.standalone` in the front of the regular command.
+
+**Example:** `npx env-cmd -f api-catalog-ui/frontend/.env.standalone ./gradlew api-catalog-ui:build`
 
 ## Testing
 

--- a/api-catalog-ui/frontend/README.md
+++ b/api-catalog-ui/frontend/README.md
@@ -16,6 +16,8 @@ To build the UI:
 NPM: `npm run build`.
 Gradle: `./gradlew api-catalog-ui:build`
 
+**Note:** To build UI for standalone API catalog use command: `npx env-cmd -f api-catalog-ui/frontend/.env.standalone ./gradlew api-catalog-ui:build`
+
 ## Testing
 
 The front end is covered by Unit tests and e2e tests. The testing part of the CI/CD pipeline, but manual testing can be done locally. 


### PR DESCRIPTION
Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>

# Description

This PR adds an example of command how to build API Catalog UI with standalone env file.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [x] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
