### PR TITLE
Fix media type in mock controller

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/standalone/ExampleService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/standalone/ExampleService.java
@@ -50,7 +50,9 @@ import java.util.*;
 @ConditionalOnProperty(value = "apiml.catalog.standalone.enabled", havingValue = "true")
 public class ExampleService {
 
-    private static final Example DEFAULT_EXAMPLE = Example.builder().responseCode(200).content("{}").build();
+    private static final Example DEFAULT_EXAMPLE = Example.builder()
+        .responseCode(200).content("{}").mediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
+        .build();
 
     /**
      * Collection of know responses. The key of the map represents method type. The list itself is all known
@@ -76,7 +78,7 @@ public class ExampleService {
     static void addExample(String method, String path, int responseCode, String mediaType, String content) {
         Example example = Example.builder()
             .method(method).path(path)
-            .responseCode(responseCode).content(content)
+            .responseCode(responseCode).mediaType(mediaType).content(content)
             .build();
 
         List<Example> byMethod = examples.computeIfAbsent(method, k -> Collections.synchronizedList(new ArrayList<>()));
@@ -185,10 +187,11 @@ public class ExampleService {
      */
     public void replyExample(HttpServletResponse httpServletResponse, String method, String path) throws IOException {
         Example example = getExample(method, path);
+        httpServletResponse.setContentType(example.getMediaType());
+        httpServletResponse.setStatus(example.getResponseCode());
         try (PrintWriter pw = httpServletResponse.getWriter()) {
             pw.print(example.getContent());
         }
-        httpServletResponse.setStatus(example.getResponseCode());
     }
 
     /**
@@ -203,6 +206,7 @@ public class ExampleService {
         private final String method;
         private final int responseCode;
         private final String content;
+        private final String mediaType;
 
         /**
          * Checking if the ant pattern of the example is matching with the requested path

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/MockControllerTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/controllers/api/MockControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -53,6 +54,7 @@ class MockControllerTest {
         void whenGetRequest() throws Exception {
             mockMvc.perform(get("/mock/something"))
                 .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(content().string("{}"));
             verify(exampleService).replyExample(any(), eq("GET"), eq("/something"));
         }
@@ -61,6 +63,7 @@ class MockControllerTest {
         void whenPostRequest() throws Exception {
             mockMvc.perform(post("/mock/something/else"))
                 .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(content().string("{}"));
             verify(exampleService).replyExample(any(), eq("POST"), eq("/something/else"));
         }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/standalone/ExampleServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/standalone/ExampleServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -78,6 +79,7 @@ class ExampleServiceTest {
             exampleService.replyExample(response, "GET", "/unknown");
             assertEquals(200, response.getStatus());
             assertEquals("{}", response.getContentAsString());
+            assertEquals(MediaType.APPLICATION_JSON_VALUE, response.getHeaders("Content-Type").get(0));
         }
 
     }


### PR DESCRIPTION
Signed-off-by: Pavel Jareš <pavel.jares@broadcom.com>

# Description

This PR fixes the response of the mock controller (missing property in #2758). It adds media type to avoid error messages in Swagger UI.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
