### PR TITLE
fix: Fix bug in Wizard static onboarding method

### DIFF
--- a/api-catalog-ui/frontend/src/components/Wizard/configs/wizard_static_categories.jsx
+++ b/api-catalog-ui/frontend/src/components/Wizard/configs/wizard_static_categories.jsx
@@ -54,7 +54,6 @@ export const staticSpecificCategories = [
                 value: '',
                 question: 'The id of the catalog tile:',
                 regexRestriction: [wizRegex.noWhiteSpaces],
-                dependencies: { type: 'Custom' },
                 tooltip: 'Example: static',
             },
         },


### PR DESCRIPTION
Signed-off-by: at670475 <andrea.tabone@broadcom.com>

# Description

Fixes the main breaking functionality bug (bullet point nr. 1) of the Wizard static onboarding that was preventing the correct creation of the `catalogUiTileId` configuration property in the final yaml when the user chooses an existing tile under `Choose existing catalog tile or create a new one:` dropdown.

Linked to #2647


## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
