### PR TITLE
feat: Support of other keyring types

### DIFF
--- a/api-catalog-ui/frontend/src/components/Wizard/configs/wizard_base_categories.jsx
+++ b/api-catalog-ui/frontend/src/components/Wizard/configs/wizard_base_categories.jsx
@@ -285,7 +285,7 @@ export const baseCategories = [
             keyStoreType: {
                 value: 'PKCS12',
                 question: 'Type of the keystore:',
-                options: ['PKCS12', 'JKS', 'JCERACFKS'],
+                options: ['PKCS12', 'JKS', 'JCEKS', 'JCECCAKS', 'JCERACFKS', 'JCECCARACFKS', 'JCEHYBRIDRACFKS'],
             },
             trustStore: {
                 value: '',
@@ -301,7 +301,7 @@ export const baseCategories = [
             trustStoreType: {
                 value: 'PKCS12',
                 question: 'Truststore type:',
-                options: ['PKCS12', 'JKS', 'JCERACFKS'],
+                options: ['PKCS12', 'JKS', 'JCEKS', 'JCECCAKS', 'JCERACFKS', 'JCECCARACFKS', 'JCEHYBRIDRACFKS'],
             },
         },
     },

--- a/certificate-analyser/src/test/java/org/zowe/apiml/StoresTest.java
+++ b/certificate-analyser/src/test/java/org/zowe/apiml/StoresTest.java
@@ -14,8 +14,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class StoresTest {
 
@@ -45,8 +44,9 @@ class StoresTest {
             ApimlConf conf = new ApimlConf();
             new CommandLine(conf).parseArgs(args);
             StoresNotInitializeException e = assertThrows(StoresNotInitializeException.class, () -> new Stores(conf));
-            assertEquals("Error while loading keystore file. Error message: ../wrongPath/localhost.truststore.p12 (No such file or directory)\n" +
-                "Possible solution: Verify correct path to the keystore. Change owner or permission to the keystore file.",e.getMessage());
+            String message = e.getMessage().replace("\\wrongPath\\", "/wrongPath/"); // replace to fix issue on windows
+            assertTrue(message.contains("Error while loading keystore file. Error message: ../wrongPath/localhost.truststore.p12"));
+            assertTrue(message.contains("Possible solution: Verify correct path to the keystore. Change owner or permission to the keystore file."));
         }
     }
 

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigValidator.java
@@ -28,7 +28,6 @@ public class EurekaInstanceConfigValidator {
 
     private static final String UNSET_VALUE_STRING = "{apiml.";
     private static final char[] UNSET_VALUE_CHAR_ARRAY = UNSET_VALUE_STRING.toCharArray();
-    private static final String KEYRING_KEY = "JCERACFKS";
 
     private final List<String> missingSslParameters = new ArrayList<>();
     private final List<String> missingRoutesParameters = new ArrayList<>();
@@ -100,18 +99,24 @@ public class EurekaInstanceConfigValidator {
         }
     }
 
+    private boolean isKeyring(String in) {
+        if (in == null) return false;
+        if (!in.startsWith("JCE")) return false;
+        return in.endsWith("KS");
+    }
+
     private void validateSsl(Ssl ssl) {
         validateSslParameters(ssl, missingSslParameters);
         if (isInvalid(ssl.getTrustStorePassword()) && (isInvalid(ssl.getTrustStoreType()) ||
-                (!isInvalid(ssl.getTrustStoreType()) && !ssl.getTrustStoreType().equals(KEYRING_KEY)))) {
+                (!isInvalid(ssl.getTrustStoreType()) && !isKeyring(ssl.getTrustStoreType())))) {
             addParameterToProblemsList("trustStorePassword", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyStorePassword()) && (isInvalid(ssl.getKeyStoreType()) ||
-                (!isInvalid(ssl.getKeyStoreType()) && !ssl.getKeyStoreType().equals(KEYRING_KEY)))) {
+                (!isInvalid(ssl.getKeyStoreType()) && !isKeyring(ssl.getKeyStoreType())))) {
             addParameterToProblemsList("keyStorePassword", missingSslParameters);
         }
         if (isInvalid(ssl.getKeyPassword()) && (isInvalid(ssl.getKeyStoreType()) ||
-            (!isInvalid(ssl.getKeyStoreType()) && !ssl.getKeyStoreType().equals(KEYRING_KEY)))) {
+            (!isInvalid(ssl.getKeyStoreType()) && !isKeyring(ssl.getKeyStoreType())))) {
             addParameterToProblemsList("keyPassword", missingSslParameters);
         }
 


### PR DESCRIPTION
# Description

This PR adds other types (see the list: `JCEKS`, `JCECCAKS`, `JCERACFKS`, `JCECCARACFKS`, `JCEHYBRIDRACFKS`).

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
