### PR TITLE
fix: handle WebSocket connection failure

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -177,6 +177,9 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
 
         log.debug(String.format("Opening routed WebSocket session from %s to %s with %s by %s", uri.toString(), targetUrl, webSocketClientFactory, this));
 
+        WebSocketRoutedSession session = webSocketRoutedSessionFactory.session(webSocketSession, targetUrl, webSocketClientFactory);
+        routedSessions.put(webSocketSession.getId(), session);
+
 
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -206,7 +206,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
             try {
                 session.sendMessageToServer(webSocketMessage);
             } catch (WebSocketException e) {
-                log.debug("Error sending WebSocket message: {}", e.getMessage());
+                log.debug("Error sending WebSocket message. Closing session due to exception:", e);
                 routedSessions.remove(webSocketSession.getId());
             }
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -210,7 +210,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
                 session.sendMessageToServer(webSocketMessage);
             } catch (WebSocketException e) {
                 log.debug("Error sending WebSocket message. Closing session due to exception:", e);
-                routedSessions.remove(webSocketSession.getId());
+                afterConnectionClosed(webSocketSession, CloseStatus.SESSION_NOT_RELIABLE);
             }
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
@@ -17,7 +17,7 @@ public interface WebSocketRoutedSessionFactory {
      * Create valid client websocket session based on the existing session, target Url and SSL Context.
      * @param webSocketSession Valid Server side WebSocket Session.
      * @param targetUrl Full websocket URL towards the server
-     * @param sslContextFactory Factory producing the current SSL Context.
+     * @param webSocketClientFactory Factory producing the current SSL Context.
      * @return Valid routed session handling the client session
      */
     WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -202,12 +202,11 @@ class WebSocketProxyServerHandlerTest {
         }
 
         @Test
-        void whenTheConnectionIsClosed_thenTheSessionIsClosedAndRemovedFromRepository() throws Exception {
+        void whenTheConnectionIsClosed_thenTheSessionIsClosedAndRemovedFromRepository() {
             CloseStatus normalClose = CloseStatus.NORMAL;
 
             underTest.afterConnectionClosed(establishedSession, normalClose);
 
-            verify(establishedSession).close(normalClose);
             assertThat(routedSessions.entrySet(), hasSize(0));
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -23,6 +23,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.RoutedServices;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -226,6 +227,17 @@ class WebSocketProxyServerHandlerTest {
             doThrow(new WebSocketException("error")).when(routedSessions.get("123")).sendMessageToServer(passedMessage);
             underTest.handleMessage(establishedSession, passedMessage);
             assertTrue(routedSessions.isEmpty());
+        }
+
+        @Test
+        void whenSessionIsNull_thenCloseAndReturn() throws IOException {
+            routedSessions.remove("123");
+            routedSessions.put("123", null);
+            WebSocketMessage<String> passedMessage = mock(WebSocketMessage.class);
+
+            underTest.handleMessage(establishedSession, passedMessage);
+            assertTrue(routedSessions.isEmpty());
+            verify(establishedSession, times(1)).close(CloseStatus.SESSION_NOT_RELIABLE);
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -191,13 +191,14 @@ class WebSocketProxyServerHandlerTest {
     class GivenValidExistingSession {
         WebSocketSession establishedSession;
         WebSocketRoutedSession internallyStoredSession;
+        WebSocketMessage<String> passedMessage;
 
         @BeforeEach
         void prepareSessionMock() {
             establishedSession = mock(WebSocketSession.class);
             String validSessionId = "123";
             when(establishedSession.getId()).thenReturn(validSessionId);
-
+            passedMessage = mock(WebSocketMessage.class);
             internallyStoredSession = mock(WebSocketRoutedSession.class);
             routedSessions.put(validSessionId, internallyStoredSession);
         }
@@ -213,8 +214,6 @@ class WebSocketProxyServerHandlerTest {
 
         @Test
         void whenTheMessageIsReceived_thenTheMessageIsPassedToTheSession() throws Exception {
-            WebSocketMessage<String> passedMessage = mock(WebSocketMessage.class);
-
             underTest.handleMessage(establishedSession, passedMessage);
 
             verify(internallyStoredSession).sendMessageToServer(passedMessage);
@@ -222,8 +221,6 @@ class WebSocketProxyServerHandlerTest {
 
         @Test
         void whenExceptionIsThrown_thenRemoveRoutedSession() throws Exception {
-            WebSocketMessage<String> passedMessage = mock(WebSocketMessage.class);
-
             doThrow(new WebSocketException("error")).when(routedSessions.get("123")).sendMessageToServer(passedMessage);
             underTest.handleMessage(establishedSession, passedMessage);
             assertTrue(routedSessions.isEmpty());
@@ -231,9 +228,7 @@ class WebSocketProxyServerHandlerTest {
 
         @Test
         void whenSessionIsNull_thenCloseAndReturn() throws IOException {
-            routedSessions.remove("123");
-            routedSessions.put("123", null);
-            WebSocketMessage<String> passedMessage = mock(WebSocketMessage.class);
+            routedSessions.replace("123", null);
 
             underTest.handleMessage(establishedSession, passedMessage);
             assertTrue(routedSessions.isEmpty());

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.ws;
 
+import org.eclipse.jetty.websocket.api.WebSocketException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -216,6 +218,15 @@ class WebSocketProxyServerHandlerTest {
             underTest.handleMessage(establishedSession, passedMessage);
 
             verify(internallyStoredSession).sendMessageToServer(passedMessage);
+        }
+
+        @Test
+        void whenExceptionIsThrown_thenRemoveRoutedSession() throws Exception {
+            WebSocketMessage<String> passedMessage = mock(WebSocketMessage.class);
+
+            doThrow(new WebSocketException("error")).when(routedSessions.get("123")).sendMessageToServer(passedMessage);
+            underTest.handleMessage(establishedSession, passedMessage);
+            assertTrue(routedSessions.isEmpty());
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -25,7 +25,9 @@ import org.zowe.apiml.product.routing.RoutedServices;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -235,5 +237,42 @@ class WebSocketProxyServerHandlerTest {
             verify(establishedSession, times(1)).close(CloseStatus.SESSION_NOT_RELIABLE);
         }
 
+        @Test
+        void whenClosingSessionThrowException_thenCatchIt() throws IOException {
+            CloseStatus status = CloseStatus.SESSION_NOT_RELIABLE;
+            doThrow(new IOException()).when(establishedSession).close(status);
+            underTest.afterConnectionClosed(establishedSession, status);
+            assertTrue(routedSessions.isEmpty());
+        }
+
+        @Test
+        void whenClosingRoutedSessionThrowException_thenCatchIt() throws IOException {
+            CloseStatus status = CloseStatus.SESSION_NOT_RELIABLE;
+            doThrow(new IOException()).when(routedSessions.get("123")).close(status);
+            underTest.afterConnectionClosed(establishedSession, status);
+            assertTrue(routedSessions.isEmpty());
+        }
+
+    }
+
+    @Nested
+    class WhenGettingRoutedSessions {
+        @Test
+        void thenReturnThem() {
+            Map<String, WebSocketRoutedSession> expectedRoutedSessions = underTest.getRoutedSessions();
+            assertThat(expectedRoutedSessions, is(routedSessions));
+        }
+    }
+
+    @Nested
+    class WhenGettingSubProtocols {
+        @Test
+        void thenReturnThem() {
+            ArrayList protocol = new ArrayList();
+            protocol.add("protocol");
+            ReflectionTestUtils.setField(underTest, "subProtocols", protocol);
+            List<String> subProtocols = underTest.getSubProtocols();
+            assertThat(subProtocols, is(protocol));
+        }
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -186,6 +186,20 @@ class WebSocketProxyServerHandlerTest {
 
                 verify(establishedSession).close(new CloseStatus(CloseStatus.SERVICE_RESTARTED.getCode(), "Requested service service-without-instance does not have available instance"));
             }
+
+            @Test
+            void givenNullService_thenCloseWebSocket() throws Exception {
+                when(establishedSession.getUri()).thenReturn(new URI("wss://gatewayHost:1443/service-without-instance/ws/v1/valid-path"));
+                when(lbClient.choose(any())).thenReturn(null);
+                RoutedServices routesForSpecificValidService = mock(RoutedServices.class);
+                when(routesForSpecificValidService.findServiceByGatewayUrl("ws/v1"))
+                    .thenReturn(null);
+                underTest.addRoutedServices("service-without-instance", routesForSpecificValidService);
+
+                underTest.afterConnectionEstablished(establishedSession);
+
+                verify(establishedSession).close(new CloseStatus(CloseStatus.NOT_ACCEPTABLE.getCode(), "Requested ws/v1 url is not known by the gateway"));
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Properly handle Websocket connection failure that might happens when trying to send message to avoid storing `routedSession` object in the hashmap and that could lead to `java.lang.OutOfMemoryError`.

Linked to #2716 


## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
