### PR TITLE
fix: Fix stack overflow during cleaning websocket client

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -10,10 +10,13 @@
 
 package org.zowe.apiml.gateway.ws;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
 
@@ -25,13 +28,14 @@ import javax.annotation.PreDestroy;
  * Manages the client lifecycle
  */
 @Component
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE) // for testing purposes
 @Slf4j
 public class WebSocketClientFactory {
 
     private final JettyWebSocketClient client;
 
+    @Autowired
     public WebSocketClientFactory(SslContextFactory.Client jettyClientSslContextFactory) {
-
         log.debug("Creating Jetty WebSocket client, with SslFactory: {}",
             jettyClientSslContextFactory);
         client = new JettyWebSocketClient(new WebSocketClient(new HttpClient(jettyClientSslContextFactory)));
@@ -43,10 +47,10 @@ public class WebSocketClientFactory {
     }
 
     @PreDestroy
-    private void closeClient() {
+    void closeClient() {
         if (client.isRunning()) {
             log.debug("Closing Jetty WebSocket client");
-            closeClient();
+            client.stop();
         }
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+class WebSocketClientFactoryTest {
+
+    @Nested
+    class CreatedInstance {
+
+        private WebSocketClientFactory webSocketClientFactory;
+        private JettyWebSocketClient client;
+
+        @BeforeEach
+        void setUp() {
+            this.client = mock(JettyWebSocketClient.class);
+            this.webSocketClientFactory = new WebSocketClientFactory(this.client);
+        }
+
+        @Test
+        void givenRunningClient_whenClose_thenStopClient() {
+            doReturn(true).when(client).isRunning();
+            webSocketClientFactory.closeClient();
+            verify(client).stop();
+        }
+
+        @Test
+        void givenStoppedClient_whenClose_thenDoNothing() {
+            webSocketClientFactory.closeClient();
+            verify(client, never()).stop();
+        }
+
+        @Test
+        void whenGetClient_thenReturnInstance() {
+            assertSame(client, webSocketClientFactory.getClientInstance());
+        }
+
+    }
+
+}


### PR DESCRIPTION
# Description

This PR fixes the issue when Spring is trying to destroy the class `WebSocketClientFactory`. The recurse call will overfull stack and it can break any other treatment.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
