### PR TITLE
chore: Add SSL debugging prop to start scripts

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -165,6 +165,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
     -Dloader.path=${COMMON_LIB} \
     -Djava.library.path=${LIBPATH} \
+    -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
     -jar "${JAR_FILE}" &
 pid=$!
 echo "pid=${pid}"

--- a/api-catalog-package/src/main/resources/manifest.yaml
+++ b/api-catalog-package/src/main/resources/manifest.yaml
@@ -38,3 +38,4 @@ configs:
 #        hideServiceInfo: ""
   port: 7552
   debug: false
+  sslDebug: ""

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -159,6 +159,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java -Xms16m -Xmx512m \
   -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
   -Dserver.ssl.trustStorePassword="${truststore_pass}" \
   -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+  -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
   -Djava.library.path=${LIBPATH} \
   -jar "${JAR_FILE}" &
 pid=$!

--- a/caching-service-package/src/main/resources/manifest.yaml
+++ b/caching-service-package/src/main/resources/manifest.yaml
@@ -31,6 +31,7 @@ apimlServices:
 configs:
   port: 7555
   debug: false
+  sslDebug: ""
 
   storage:
     evictionStrategy: reject

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -110,6 +110,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
     -Dserver.ssl.trustStoreType="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}" \
     -Dserver.ssl.trustStorePassword="${truststore_pass}" \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
+    -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
     -Djava.library.path=${LIBPATH} \
     -jar ${JAR_FILE} &
 

--- a/cloud-gateway-package/src/main/resources/manifest.yaml
+++ b/cloud-gateway-package/src/main/resources/manifest.yaml
@@ -26,3 +26,4 @@ apimlServices:
 configs:
   port: 7563
   debug: false
+  sslDebug: ""

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -162,6 +162,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java -Xms32m -Xmx256m ${QUI
     -Dserver.ssl.trustStorePassword="${truststore_pass}" \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
     -Dloader.path=${DISCOVERY_LOADER_PATH} \
+    -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
     -Djava.library.path=${LIBPATH} \
     -jar "${JAR_FILE}" &
 pid=$!

--- a/discovery-package/src/main/resources/manifest.yaml
+++ b/discovery-package/src/main/resources/manifest.yaml
@@ -38,3 +38,4 @@ configs:
 #        serviceIdPrefixReplacer: ""
   port: 7553
   debug: false
+  sslDebug: ""

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -234,6 +234,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
     -Dloader.path=${GATEWAY_LOADER_PATH} \
     -Djava.library.path=${LIBPATH} \
+    -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
     -jar ${JAR_FILE} &
 
 pid=$!

--- a/gateway-package/src/main/resources/manifest.yaml
+++ b/gateway-package/src/main/resources/manifest.yaml
@@ -31,6 +31,7 @@ apimlServices:
 configs:
   port: 7554
   debug: false
+  sslDebug: ""
 
   apiml:
     security:

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -120,6 +120,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java -Xms16m -Xmx512m \
   -Dserver.ssl.trustStorePassword="${truststore_pass}" \
   -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
   -Dloader.path=${COMMON_LIB} \
+  -Djavax.net.debug=${ZWE_configs_sslDebug:-"none"} \
   -Djava.library.path=${LIBPATH} \
   -jar ${JAR_FILE} &
 pid=$!

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -120,7 +120,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java -Xms16m -Xmx512m \
   -Dserver.ssl.trustStorePassword="${truststore_pass}" \
   -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
   -Dloader.path=${COMMON_LIB} \
-  -Djavax.net.debug=${ZWE_configs_sslDebug:-"none"} \
+  -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
   -Djava.library.path=${LIBPATH} \
   -jar ${JAR_FILE} &
 pid=$!

--- a/metrics-service-package/src/main/resources/manifest.yaml
+++ b/metrics-service-package/src/main/resources/manifest.yaml
@@ -31,3 +31,4 @@ apimlServices:
 configs:
   port: 7551
   debug: false
+  sslDebug: ""


### PR DESCRIPTION
# Description

Add `javax.net.debug` java parameter to the components start scripts to enable SSL debugging.

Related doc: https://github.com/zowe/docs-site/pull/2694

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [x] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
