### PR TITLE
Fix start of metrics-service

### DIFF
--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -91,6 +91,9 @@ key_pass="${ZWE_configs_certificate_key_password:-${ZWE_zowe_certificate_key_pas
 truststore_type="${ZWE_configs_certificate_truststore_type:-${ZWE_zowe_certificate_truststore_type:-PKCS12}}"
 truststore_pass="${ZWE_configs_certificate_truststore_password:-${ZWE_zowe_certificate_truststore_password}}"
 
+keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}"
+truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
+
 # NOTE: these are moved from below
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 # -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \


### PR DESCRIPTION
# Description

If enable metrics-service in Zowe yaml it will fail to start because of empty file path to keystore. You can see following error in the logs:
```log
java.io.FileNotFoundException:  (EDC5129I No such file or directory. (errno2=0x05620062))
 	at java.io.FileInputStream.open(FileInputStream.java:212)
 	at java.io.FileInputStream.<init>(FileInputStream.java:152)
 	at org.zowe.apiml.security.SecurityUtils.loadKeyStore(SecurityUtils.java:195)
 	at org.zowe.apiml.security.HttpsFactory.validateSslConfig(HttpsFactory.java:230)
 	at org.zowe.apiml.security.HttpsFactory.createSecureSslContext(HttpsFactory.java:214)
 	at org.zowe.apiml.security.HttpsFactory.createSecureSslSocketFactory(HttpsFactory.java:241)
 	at org.zowe.apiml.security.HttpsFactory.createSslSocketFactory(HttpsFactory.java:86)
 	at org.zowe.apiml.security.HttpsFactory.createSecureHttpClient(HttpsFactory.java:67)
 	at org.zowe.apiml.product.web.HttpConfig.init(HttpConfig.java:146)
```
The fix is adding missing parameters in start.sh of metrics-service.

## Type of change

- [X] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
