### PR TITLE
fix: mitigate storing password in the memory

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/content/AbstractSecureContentFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/content/AbstractSecureContentFilter.java
@@ -72,8 +72,9 @@ public abstract class AbstractSecureContentFilter extends OncePerRequestFilter {
         Optional<AbstractAuthenticationToken> authenticationToken = extractContent(request);
 
         if (authenticationToken.isPresent()) {
+            Authentication authentication = null;
             try {
-                Authentication authentication = authenticationManager.authenticate(authenticationToken.get());
+                authentication = authenticationManager.authenticate(authenticationToken.get());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 filterChain.doFilter(request, response);
             } catch (AuthenticationException authenticationException) {
@@ -81,9 +82,9 @@ public abstract class AbstractSecureContentFilter extends OncePerRequestFilter {
             } catch (RuntimeException e) {
                 resourceAccessExceptionHandler.handleException(request, response, e);
             } finally {
-                Authentication authentication = authenticationToken.get();
+                // TODO: remove once fixed directly in Spring - org.springframework.security.core.CredentialsContainer#eraseCredentials
                 if (authentication != null) {
-                    Object credentials = authenticationToken.get().getCredentials();
+                    Object credentials = authentication.getCredentials();
                     if (credentials instanceof char[]) {
                         Arrays.fill((char[]) credentials, (char) 0);
                     }

--- a/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
+++ b/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
@@ -88,6 +88,7 @@ public class GatewaySecurityService {
         } catch (IOException e) {
             responseHandler.handleException(e);
         } finally {
+            // TODO: remove once fixed directly in Spring - org.springframework.security.core.CredentialsContainer#eraseCredentials
             loginRequest.evictSensitiveData();
         }
         return Optional.empty();


### PR DESCRIPTION
# Description

In Java is a known issue that passwords stored as String are not under control. It can be minimized by using char arrays instead of String. It will not completely solve the issue, just reduce it a little bit. This PR changes the password stored as a string into an array of chars where possible.

This PR adds a part explored during the implementation of #2862.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
