### PR TITLE
feat: websocket timeout and close server on error

### DIFF
--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -216,6 +216,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dserver.address=0.0.0.0 \
     -Dserver.maxConnectionsPerRoute=${ZWE_configs_server_maxConnectionsPerRoute:-100} \
     -Dserver.maxTotalConnections=${ZWE_configs_server_maxTotalConnections:-1000} \
+    -Dserver.webSocket.maxIdleTimeout=${ZWE_configs_server_webSocket_maxIdleTimeout:-3600000} \
     -Dserver.ssl.enabled=${ZWE_configs_server_ssl_enabled:-true} \
     -Dserver.ssl.protocol=${ZWE_configs_server_ssl_protocol:-"TLSv1.2"}  \
     -Dserver.ssl.keyStore="${keystore_location}" \

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -59,6 +59,7 @@ public class WebSocketClientFactory {
             log.debug("Closing Jetty WebSocket client");
             client.stop();
         }
+
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -10,17 +10,19 @@
 
 package org.zowe.apiml.gateway.ws;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import javax.annotation.PreDestroy;
+
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
 
-import javax.annotation.PreDestroy;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Factory for provisioning web socket client
@@ -35,10 +37,15 @@ public class WebSocketClientFactory {
     private final JettyWebSocketClient client;
 
     @Autowired
-    public WebSocketClientFactory(SslContextFactory.Client jettyClientSslContextFactory) {
+    public WebSocketClientFactory(
+        SslContextFactory.Client jettyClientSslContextFactory,
+        @Value("${server.webSocket.maxIdleTimeout:3600000}") int maxIdleWebSocketTimeout
+        ) {
         log.debug("Creating Jetty WebSocket client, with SslFactory: {}",
             jettyClientSslContextFactory);
-        client = new JettyWebSocketClient(new WebSocketClient(new HttpClient(jettyClientSslContextFactory)));
+        WebSocketClient wsClient = new WebSocketClient(new HttpClient(jettyClientSslContextFactory));
+        wsClient.setMaxIdleTimeout(maxIdleWebSocketTimeout);
+        client = new JettyWebSocketClient(wsClient);
         client.start();
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -11,6 +11,10 @@
 package org.zowe.apiml.gateway.ws;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jetty.websocket.api.CloseException;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -42,5 +46,13 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
         log.warn("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
+        if (exception instanceof CloseException && exception.getCause() instanceof TimeoutException) {
+            // Idle timeout
+            webSocketServerSession.close(CloseStatus.NORMAL);
+        } else if (exception instanceof CloseException) {
+            webSocketServerSession.close(new CloseStatus(((CloseException) exception).getStatusCode(), exception.getMessage()));
+        } else {
+            webSocketServerSession.close(new CloseStatus(CloseStatus.SERVER_ERROR.getCode(), exception.getMessage()));
+        }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -51,8 +51,7 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
             webSocketServerSession.close(CloseStatus.NORMAL);
         } else if (exception instanceof CloseException) {
             webSocketServerSession.close(new CloseStatus(((CloseException) exception).getStatusCode(), exception.getMessage()));
-        } else {
-            webSocketServerSession.close(new CloseStatus(CloseStatus.SERVER_ERROR.getCode(), exception.getMessage()));
         }
+        super.handleTransportError(session, exception);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -188,12 +188,12 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         // if the browser closes the session, close the GWs client one as well.
         Optional.ofNullable(routedSessions.get(session.getId()))
-            .map(routedSession -> routedSession.getWebSocketClientSession())
+            .map(WebSocketRoutedSession::getWebSocketClientSession)
             .ifPresent(clientSession -> {
                 try {
                     clientSession.close(status);
                 } catch (IOException e) {
-                    log.debug("Error closing WebSocket connection: {}", e.getMessage());
+                    log.debug("Error closing WebSocket client connection {}: {}", clientSession.getId(), e.getMessage());
                 }
             });
         routedSessions.remove(session.getId());

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
@@ -13,10 +13,15 @@ package org.zowe.apiml.gateway.ws;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 class WebSocketClientFactoryTest {
 
@@ -48,6 +53,25 @@ class WebSocketClientFactoryTest {
         @Test
         void whenGetClient_thenReturnInstance() {
             assertSame(client, webSocketClientFactory.getClientInstance());
+        }
+
+    }
+
+    @Nested
+    class CreatedInstanceWithConfig {
+
+        private WebSocketClientFactory webSocketClientFactory;
+
+        @BeforeEach
+        void setUp() {
+            SslContextFactory.Client sslClient = mock(SslContextFactory.Client.class);
+            this.webSocketClientFactory = new WebSocketClientFactory(sslClient, 1234);
+        }
+
+        @Test
+        void givenInitilizedClient_thenHasNonDefaultIdleConfig() {
+            WebSocketClient wsClient = (WebSocketClient) ReflectionTestUtils.getField(webSocketClientFactory.getClientInstance(), "client");
+            assertEquals(1234, wsClient.getMaxIdleTimeout());
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
@@ -66,7 +66,7 @@ public class WebSocketProxyClientHandlerTest {
             @Test
             void andCloseException_thenForwardError() throws Exception {
                 webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new CloseException(CloseStatus.PROTOCOL_ERROR.getCode(), new Exception("message")));
-                verify(serverSession, times(1)).close(eq(new CloseStatus(1002, "java.lang.Exception: message")));
+                verify(serverSession, times(1)).close(new CloseStatus(1002, "java.lang.Exception: message"));
             }
 
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
@@ -69,12 +69,6 @@ public class WebSocketProxyClientHandlerTest {
                 verify(serverSession, times(1)).close(eq(new CloseStatus(1002, "java.lang.Exception: message")));
             }
 
-            @Test
-            void andOtherException_thenServerErrorClose() throws Exception {
-                webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new RuntimeException("message"));
-                verify(serverSession, times(1)).close(eq(new CloseStatus(1011, "message")));
-            }
-
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jetty.websocket.api.CloseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+@ExtendWith(MockitoExtension.class)
+public class WebSocketProxyClientHandlerTest {
+
+    @Mock
+    private WebSocketSession serverSession;
+
+    private WebSocketProxyClientHandler webSocketProxyClientHandler;
+
+    @BeforeEach
+    void setUp() {
+        webSocketProxyClientHandler = new WebSocketProxyClientHandler(serverSession);
+    }
+
+    @Nested
+    class GivenHandler {
+
+        @Nested
+        class AndConnectionIsClosed {
+
+            @Test
+            void thenCloseServer() throws Exception {
+                webSocketProxyClientHandler.afterConnectionClosed(mock(WebSocketSession.class), CloseStatus.NORMAL);
+                verify(serverSession, times(1)).close(CloseStatus.NORMAL);
+            }
+
+        }
+
+        @Nested
+        class AndConnectionTransportError {
+
+            @Test
+            void andTimeout_thenCloseNormal() throws Exception {
+                webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new CloseException(0, new TimeoutException("null")));
+                verify(serverSession, times(1)).close(CloseStatus.NORMAL);
+            }
+
+            @Test
+            void andCloseException_thenForwardError() throws Exception {
+                webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new CloseException(CloseStatus.PROTOCOL_ERROR.getCode(), new Exception("message")));
+                verify(serverSession, times(1)).close(eq(new CloseStatus(1002, "java.lang.Exception: message")));
+            }
+
+            @Test
+            void andOtherException_thenServerErrorClose() throws Exception {
+                webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new RuntimeException("message"));
+                verify(serverSession, times(1)).close(eq(new CloseStatus(1011, "message")));
+            }
+
+        }
+
+    }
+
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
@@ -10,7 +10,6 @@
 
 package org.zowe.apiml.gateway.ws;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -284,7 +284,7 @@ class WebSocketProxyServerHandlerTest {
     class WhenGettingSubProtocols {
         @Test
         void thenReturnThem() {
-            ArrayList<String> protocol = new ArrayList<>();
+            List<String> protocol = new ArrayList<>();
             protocol.add("protocol");
             ReflectionTestUtils.setField(underTest, "subProtocols", protocol);
             List<String> subProtocols = underTest.getSubProtocols();

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/WebSocketProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/WebSocketProxyTest.java
@@ -10,16 +10,26 @@
 
 package org.zowe.apiml.integration.proxy;
 
-import io.restassured.RestAssured;
+import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.tomcat.websocket.Constants.SSL_CONTEXT_PROPERTY;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.zowe.apiml.util.requests.Endpoints.DISCOVERABLE_WS_HEADER;
+import static org.zowe.apiml.util.requests.Endpoints.DISCOVERABLE_WS_UPPERCASE;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-
-
-
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketHttpHeaders;
@@ -35,19 +45,7 @@ import org.zowe.apiml.util.config.GatewayServiceConfiguration;
 import org.zowe.apiml.util.http.HttpClientUtils;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Base64;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.apache.tomcat.websocket.Constants.SSL_CONTEXT_PROPERTY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.zowe.apiml.util.requests.Endpoints.*;
-import static org.hamcrest.Matchers.is;
+import io.restassured.RestAssured;
 
 @TestsNotMeantForZowe
 @WebsocketTest

--- a/schemas/gateway-schema.json
+++ b/schemas/gateway-schema.json
@@ -197,6 +197,17 @@
                                                     "description": "How many connection should exists in total?",
                                                     "default": 1000
                                                 },
+                                                "webSocket": {
+                                                    "type": "object",
+                                                    "description": "Customize websocket server parameters",
+                                                    "properties": {
+                                                        "maxIdleTimeout": {
+                                                            "type": "integer",
+                                                            "description": "The gateway acts as a server and client. This parameters customizes the default idle timeout for its client role.",
+                                                            "default": 3600000
+                                                        }
+                                                    }
+                                                },
                                                 "ssl": {
                                                     "type": "object",
                                                     "description": "Network encryption for gateway service connections.",


### PR DESCRIPTION
# Description

- Adds a configurable maximum idle timeout for websocket connections (between gateway and the registered service)
By default the jetty client has 5 minute idle timeout. It does not fix the problem in zlux (zlux should implement some way of keep-alive), but it sets a more reasonable time limit for the Desktop usage.

- Improves error handling by properly closing the websocket server upon client (GW) error.

- Fix client websocket session (GW <-> Service) not closing with normal server session (User <-> GW) close

docs-site PR: https://github.com/zowe/docs-site/pull/2871

Linked to https://github.com/zowe/zlux/issues/968

## Type of change

Please delete options that are not relevant.

- [ ] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
