### PR TITLE
feat: separate x509 and oidc mapper configuration

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -104,8 +104,8 @@ jobs:
                     APIML_SECURITY_OIDC_INTROSPECTENDPOINT: /v1/introspect
                     APIML_SECURITY_OIDC_ENABLED: true
                     APIML_SECURITY_OIDC_REGISTRY: zowe.okta.com
-                    APIML_SECURITY_X509_EXTERNALMAPPERUSER: APIMTST
-                    APIML_SECURITY_X509_EXTERNALMAPPERURL: https://gateway-service:10010/zss/api/v1/certificate
+                    APIML_SECURITY_OIDC_IDENTITYMAPPERUSER: APIMTST
+                    APIML_SECURITY_OIDC_IDENTITYMAPPERURL: https://gateway-service:10010/zss/api/v1/certificate/dn
             discovery-service:
                 image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:

--- a/config/docker/gateway-service.yml
+++ b/config/docker/gateway-service.yml
@@ -12,6 +12,8 @@ apiml:
             clientSecret:
             introspectEndpoint:
             registry:
+            identityMapperUrl:
+            identityMapperUser:
         auth:
             zosmf:
                 serviceId: mockzosmf  # Replace me with the correct z/OSMF service id

--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -17,6 +17,8 @@ apiml:
             clientSecret:
             introspectEndpoint:
             registry:
+            identityMapperUrl:
+            identityMapperUser:
         auth:
             jwt:
                 customAuthHeader:

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -47,6 +47,8 @@
 # - ZWE_configs_apiml_security_oidc_clientSecret
 # - ZWE_configs_apiml_security_oidc_introspectEndpoint
 # - ZWE_configs_apiml_security_oidc_registry
+# - ZWE_configs_apiml_security_oidc_identityMapperUrl
+# - ZWE_configs_apiml_security_oidc_identityMapperUser
 # - ZWE_configs_apiml_service_allowEncodedSlashes - Allows encoded slashes on on URLs through gateway
 # - ZWE_configs_apiml_service_corsEnabled
 # - ZWE_configs_certificate_keystore_alias - The alias of the key within the keystore
@@ -234,7 +236,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.security.auth.zosmf.jwtAutoconfiguration=${ZWE_configs_apiml_security_auth_zosmf_jwtAutoconfiguration:-auto} \
     -Dapiml.security.jwtInitializerTimeout=${ZWE_configs_apiml_security_jwtInitializerTimeout:-5} \
     -Dapiml.security.x509.enabled=${ZWE_configs_apiml_security_x509_enabled:-false} \
-    -Dapiml.security.x509.externalMapperUrl=${ZWE_configs_apiml_security_x509_externalMapperUrl:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port:-7554}/zss/api/v1/certificate"} \
+    -Dapiml.security.x509.externalMapperUrl=${ZWE_configs_apiml_security_x509_externalMapperUrl:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port:-7554}/zss/api/v1/certificate/x509/map"} \
     -Dapiml.security.x509.externalMapperUser=${ZWE_configs_apiml_security_x509_externalMapperUser:-${ZWE_zowe_setup_security_users_zowe:-ZWESVUSR}} \
     -Dapiml.security.authorization.provider=${ZWE_configs_apiml_security_authorization_provider:-} \
     -Dapiml.security.authorization.endpoint.enabled=${ZWE_configs_apiml_security_authorization_endpoint_enabled:-false} \
@@ -250,6 +252,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.security.oidc.clientSecret=${ZWE_configs_apiml_security_oidc_clientSecret:-} \
     -Dapiml.security.oidc.introspectEndpoint=${ZWE_configs_apiml_security_oidc_introspectEndpoint:-/v1/introspect} \
     -Dapiml.security.oidc.registry=${ZWE_configs_apiml_security_oidc_registry:-} \
+    -Dapiml.security.oidc.identityMapperUrl=${ZWE_configs_apiml_security_oidc_identityMapperUrl:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port:-7554}/zss/api/v1/certificate/dn"} \
+    -Dapiml.security.oidc.identityMapperUser=${ZWE_configs_apiml_security_oidc_identityMapperUser:-${ZWE_zowe_setup_security_users_zowe:-ZWESVUSR}} \
     -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
     -Dloader.path=${GATEWAY_LOADER_PATH} \
     -Djava.library.path=${LIBPATH} \

--- a/gateway-package/src/main/resources/manifest.yaml
+++ b/gateway-package/src/main/resources/manifest.yaml
@@ -50,10 +50,20 @@ configs:
         resourceNamePrefix: "APIML."
       x509:
         enabled: false
-        # default value is https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port}/zss/api/v1/certificate
+        # default value is https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port}/zss/api/v1/certificate/x509/map
         externalMapperUrl:
         # default value is Zowe runtime user defined in zowe.yaml "zowe.setup.security.users.zowe"
         externalMapperUser:
+      oidc:
+        enabled: false
+        clientId:
+        clientSecret:
+        introspectEndpoint:
+        registry:
+        # default value is https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port}/zss/api/v1/certificate/dn
+        identityMapperUrl:
+        # default value is Zowe runtime user defined in zowe.yaml "zowe.setup.security.users.zowe"
+        identityMapperUser:
       saf:
           provider:
           urls:

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
@@ -11,7 +11,6 @@
 package org.zowe.apiml.gateway.security.mapping;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -22,7 +21,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.zowe.apiml.gateway.security.mapping.model.MapperResponse;
@@ -42,36 +40,32 @@ import java.nio.charset.StandardCharsets;
 @RequiredArgsConstructor
 public abstract class ExternalMapper {
 
+    private final String mapperUrl;
+    private final String mapperUser;
     private final CloseableHttpClient httpClientProxy;
     private final TokenCreationService tokenCreationService;
     private final AuthConfigurationProperties authConfigurationProperties;
 
     protected static final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Value("${apiml.security.x509.externalMapperUrl:}")
-    protected String externalMapperUrl;
-    @Value("${apiml.security.x509.externalMapperUser:}")
-    protected String externalMapperUser;
-
     MapperResponse callExternalMapper(@NotNull HttpEntity payload) {
-        if (StringUtils.isBlank(externalMapperUser)) {
+        if (StringUtils.isBlank(mapperUrl)) {
+            log.warn("Configuration error: External identity mapper URL is not set.");
+            return null;
+        }
+        if (StringUtils.isBlank(mapperUser)) {
             log.warn("Configuration error: External identity mapper user is not set.");
             return null;
         }
         try {
-            URI mapperUri = getMapperURI();
-            if (mapperUri == null) {
-                return null;
-            }
-            HttpPost httpPost = new HttpPost(mapperUri);
+            HttpPost httpPost = new HttpPost(new URI(mapperUrl));
             httpPost.setEntity(payload);
 
-            String jwtToken = tokenCreationService.createJwtTokenWithoutCredentials(externalMapperUser);
+            String jwtToken = tokenCreationService.createJwtTokenWithoutCredentials(mapperUser);
             httpPost.setHeader(new BasicHeader("Cookie", authConfigurationProperties.getCookieProperties().getCookieName() + "=" + jwtToken));
+            httpPost.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
             log.debug("Executing request against external identity mapper API: {}", httpPost);
-            if (getMapperType().equals(Type.OIDC)) {
-                httpPost.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-            }
+
             HttpResponse httpResponse = httpClientProxy.execute(httpPost);
 
             final int statusCode = httpResponse.getStatusLine() != null ? httpResponse.getStatusLine().getStatusCode() : 0;
@@ -80,7 +74,7 @@ public abstract class ExternalMapper {
                 response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
             }
             if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
-                log.debug("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+                log.warn("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
                 return null;
             }
             log.debug("External identity mapper API returned: {}", response);
@@ -88,41 +82,12 @@ public abstract class ExternalMapper {
                 return objectMapper.readValue(response, MapperResponse.class);
             }
         } catch (IOException e) {
-            log.debug("Error occurred while communicating with external identity mapper", e);
+            log.warn("Error occurred while communicating with external identity mapper", e);
+        } catch (URISyntaxException e) {
+            log.warn("Configuration error: Failed to construct the external identity mapper URI.", e);
         }
+
         return null;
     }
-
-    enum Type {
-        X509("/x509/map"),
-        OIDC("/dn");
-
-        @Getter
-        private final String urlSuffix;
-
-        Type(String urlSuffix) {
-            this.urlSuffix = urlSuffix;
-        }
-    }
-
-    private URI getMapperURI() {
-        if (StringUtils.isBlank(externalMapperUrl)) {
-            log.warn("Configuration error: External identity mapper URL is not set.");
-        } else {
-            // do not introduce braking change - if externalMapperUrl for x509 has been already configured
-            // with the /x509/map at the end then make sure to remove the suffix before
-            // the mapper URI is constructed properly with the mapperType suffix
-            String url = StringUtils.removeEndIgnoreCase(externalMapperUrl, getMapperType().getUrlSuffix());
-            url = StringUtils.removeEnd(url, "/");
-            try {
-                return new URI(url + getMapperType().getUrlSuffix());
-            } catch (URISyntaxException e) {
-                log.warn("Configuration error: Failed to construct the external identity mapper URL.", e);
-            }
-        }
-        return null;
-    }
-
-    protected abstract Type getMapperType();
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/OIDCExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/OIDCExternalMapper.java
@@ -40,8 +40,12 @@ public class OIDCExternalMapper extends ExternalMapper implements Authentication
     @InjectApimlLogger
     private final ApimlLogger apimlLog = ApimlLogger.empty();
 
-    public OIDCExternalMapper(CloseableHttpClient httpClientProxy, TokenCreationService tokenCreationService, AuthConfigurationProperties authConfigurationProperties) {
-        super(httpClientProxy, tokenCreationService, authConfigurationProperties);
+    public OIDCExternalMapper(@Value("${apiml.security.oidc.identityMapperUrl:}") String mapperUrl,
+                              @Value("${apiml.security.oidc.identityMapperUser:}") String mapperUser,
+                              CloseableHttpClient httpClientProxy,
+                              TokenCreationService tokenCreationService,
+                              AuthConfigurationProperties authConfigurationProperties) {
+        super(mapperUrl, mapperUser, httpClientProxy, tokenCreationService, authConfigurationProperties);
     }
 
     public String mapToMainframeUserId(AuthSource authSource) {
@@ -82,8 +86,4 @@ public class OIDCExternalMapper extends ExternalMapper implements Authentication
         return null;
     }
 
-    @Override
-    protected Type getMapperType() {
-        return Type.OIDC;
-    }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/X509ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/X509ExternalMapper.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.gateway.security.mapping.model.MapperResponse;
@@ -36,8 +37,12 @@ import java.security.cert.X509Certificate;
 )
 public class X509ExternalMapper extends ExternalMapper implements AuthenticationMapper {
 
-    public X509ExternalMapper(CloseableHttpClient httpClientProxy, TokenCreationService tokenCreationService, AuthConfigurationProperties authConfigurationProperties) {
-        super(httpClientProxy, tokenCreationService, authConfigurationProperties);
+    public X509ExternalMapper(@Value("${apiml.security.x509.externalMapperUrl:}") String mapperUrl,
+                              @Value("${apiml.security.x509.externalMapperUser:}") String mapperUser,
+                              CloseableHttpClient httpClientProxy,
+                              TokenCreationService tokenCreationService,
+                              AuthConfigurationProperties authConfigurationProperties) {
+        super(mapperUrl, mapperUser, httpClientProxy, tokenCreationService, authConfigurationProperties);
     }
 
     /**
@@ -63,8 +68,4 @@ public class X509ExternalMapper extends ExternalMapper implements Authentication
         return null;
     }
 
-    @Override
-    protected Type getMapperType() {
-        return Type.X509;
-    }
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -75,6 +75,8 @@ apiml:
             clientSecret:
             introspectEndpoint:
             registry:
+            identityMapperUrl:
+            identityMapperUser:
         auth:
             jwt:
                 customAuthHeader:

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/mapping/OIDCExternalMapperTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/mapping/OIDCExternalMapperTest.java
@@ -76,10 +76,8 @@ class OIDCExternalMapperTest {
     void setup() {
         authSource = new OIDCAuthSource("OIDC_access_token");
         authSource.setDistributedId("distributed_ID");
-        oidcExternalMapper = new OIDCExternalMapper(httpClient, tokenCreationService, authConfigurationProperties);
+        oidcExternalMapper = new OIDCExternalMapper("https://domain.com/mapper", "mapper_user", httpClient, tokenCreationService, authConfigurationProperties);
         oidcExternalMapper.registry = "test_registry";
-        oidcExternalMapper.externalMapperUser = "mapper_user";
-        oidcExternalMapper.externalMapperUrl = "https://domain.com/mapper";
 
         responseEntity = new BasicHttpEntity();
         responseEntity.setContent(IOUtils.toInputStream(SUCCESS_MAPPER_RESPONSE, StandardCharsets.UTF_8));

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/mapping/X509ExternalMapperTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/mapping/X509ExternalMapperTest.java
@@ -40,7 +40,7 @@ class X509ExternalMapperTest {
         x509Certificate = mock(X509Certificate.class);
         when(x509Certificate.getEncoded()).thenReturn(new byte[2]);
         x509AuthSource = new X509AuthSource(x509Certificate);
-        x509ExternalMapper = spy(new X509ExternalMapper(mock(CloseableHttpClient.class), mock(TokenCreationService.class), mock(AuthConfigurationProperties.class)));
+        x509ExternalMapper = spy(new X509ExternalMapper("https://domain.com/mapper", "mapper_user", mock(CloseableHttpClient.class), mock(TokenCreationService.class), mock(AuthConfigurationProperties.class)));
     }
 
     @Nested

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -42,7 +42,7 @@ apiml:
         ssl:
             verifySslCertificatesOfServices: true
         x509:
-            externalMapperUrl: http://localhost:8542/certificate
+            externalMapperUrl: http://localhost:8542/certificate/x509/map
             externalMapperUser: validUserForMap
         auth:
             provider: dummy

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -36,6 +36,8 @@ apiml:
             clientSecret:
             introspectEndpoint:
             registry:
+            identityMapperUrl: http://localhost:8542/certificate/dn
+            identityMapperUser: validUserForMap
         filterChainConfiguration: new
         allowTokenRefresh: true
         jwtInitializerTimeout: 5

--- a/mock-services/src/main/resources/application.yml
+++ b/mock-services/src/main/resources/application.yml
@@ -40,6 +40,7 @@ zosmf:
 zss:
     userMapping:
             "[zoweson@zowe.com]": USER
+#            "[pw623414@broadcom.net]": USER
 
 ---
 spring:

--- a/mock-services/src/main/resources/application.yml
+++ b/mock-services/src/main/resources/application.yml
@@ -40,7 +40,6 @@ zosmf:
 zss:
     userMapping:
             "[zoweson@zowe.com]": USER
-#            "[pw623414@broadcom.net]": USER
 
 ---
 spring:


### PR DESCRIPTION
# Description

This should be the final gateway configuration to enable oidc access tokens:
```
apiml:
  security:
    oidc:
      enabled: true
      clientId: <client_id>
      clientSecret:  <client_secret>
      introspectEndpoint: /v1/introspect
      registry: <registry_name_used_in_SAF>
      # default value is https://${ZWE_haInstance_hostname:-localhost}:${ZWE_configs_port}/zss/api/v1/certificate/dn
      identityMapperUrl:
      # default value is Zowe runtime user defined in zowe.yaml "zowe.setup.security.users.zowe"
      identityMapperUser:
```

Linked to #2887 
Part of the #2481 

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
