### PR TITLE
(v1) Replace github action set-output command

### DIFF
--- a/.github/actions/image-publish-setup/action.yml
+++ b/.github/actions/image-publish-setup/action.yml
@@ -27,6 +27,6 @@ runs:
             shell: bash
             run: |
                 version=$(cat gradle.properties | awk '/version=/' | awk -F= '{print$2;}')
-                echo "::set-output name=version::$version"
+                echo "version=$version" >> $GITHUB_OUTPUT
 
         -   uses: zowe-actions/shared-actions/prepare-workflow@main


### PR DESCRIPTION
# Description

Addresses a deprecation by Github, see issue https://github.com/zowe/zowe-install-packaging/issues/3378 .