### PR TITLE
fix: eureka/status endpoint fix

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/HandlerInitializer.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/HandlerInitializer.java
@@ -35,7 +35,9 @@ public class HandlerInitializer {
     public HandlerInitializer(SuccessfulLoginHandler successfulLoginHandler,
                               @Qualifier("plainAuth")
                               UnauthorizedHandler unAuthorizedHandler,
+                              @Qualifier("basicAuth")
                               BasicAuthUnauthorizedHandler basicAuthUnauthorizedHandler,
+                              @Qualifier("failedAuthenticationHandler")
                               FailedAuthenticationHandler authenticationFailureHandler,
                               ResourceAccessExceptionHandler resourceAccessExceptionHandler) {
         this.successfulLoginHandler = successfulLoginHandler;

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/handler/FailedAuthenticationHandler.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/handler/FailedAuthenticationHandler.java
@@ -10,13 +10,13 @@
 
 package org.zowe.apiml.security.common.handler;
 
-import org.springframework.context.annotation.Primary;
-import org.zowe.apiml.security.common.error.AuthExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.zowe.apiml.security.common.error.AuthExceptionHandler;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
  * Authentication error handler
  */
 @Slf4j
-@Component
+@Component("failedAuthenticationHandler")
 @Primary
 @RequiredArgsConstructor
 public class FailedAuthenticationHandler implements AuthenticationFailureHandler {

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -60,6 +60,8 @@ server:
     ssl:
         enabled: false
 
+archaius.deployment.environment: test
+
 eureka:
     instance:
         instanceId: ${apiml.service.hostname}:${apiml.service.id}:${apiml.service.port}


### PR DESCRIPTION
# Description

eureka/status endpoint stopped working as an NPE in XStream was triggered by a null value in the `environment` value in the response of this endpoint.
This value is not really used in API ML, as before it was using `test` as a value always.
This PR sets a default value for the property read by Netflix eureka without any assumptions.
Also, some small fixes for startup of the application in vscode which was not working through the IDE.

I couldn't find which dependency made this change but it seems that before the dependencies change there was a default for `archaius.deployment.environment`

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
