### PR TITLE
Set the host for the micronaut sample tests

### DIFF
--- a/onboarding-enabler-micronaut-sample-app/src/test/resources/application.yml
+++ b/onboarding-enabler-micronaut-sample-app/src/test/resources/application.yml
@@ -4,6 +4,7 @@ micronaut:
   server:
       port: ${apiml.service.port}
       context-path: /${apiml.service.serviceId}
+      host: ${apiml.service.hostname}
   ssl:
       enabled: true
       key-store:


### PR DESCRIPTION
# Description

If the hostname is set to something else than localhost (i.e. overriding `/etc/hostname`) the test could fail because the certificate will not match the common name.

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
