### PR TITLE
fix: Fix responses of security provider including expired account

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/CompoundAuthProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/CompoundAuthProvider.java
@@ -58,7 +58,12 @@ public class CompoundAuthProvider implements AuthenticationProvider {
     }
 
     private AuthenticationProvider getConfiguredLoginAuthProvider() {
-        return authProvidersMap.get(loginProvider.getAuthProviderBeanName());
+        String providerBeanName = loginProvider.getAuthProviderBeanName();
+        AuthenticationProvider authenticationProvider = authProvidersMap.get(providerBeanName);
+        if (authenticationProvider == null) {
+            log.warn("Login provider {} is not available.", providerBeanName);
+        }
+        return authenticationProvider;
     }
 
     public synchronized String getLoginAuthProviderName() {
@@ -95,7 +100,10 @@ public class CompoundAuthProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) {
         AuthenticationProvider configuredLoginAuthProvider = getConfiguredLoginAuthProvider();
-        return configuredLoginAuthProvider.authenticate(authentication);
+        if (configuredLoginAuthProvider != null) {
+            return configuredLoginAuthProvider.authenticate(authentication);
+        }
+        return null;
     }
 
     /**
@@ -121,6 +129,9 @@ public class CompoundAuthProvider implements AuthenticationProvider {
     @Override
     public boolean supports(Class<?> authentication) {
         AuthenticationProvider configuredLoginAuthProvider = getConfiguredLoginAuthProvider();
-        return configuredLoginAuthProvider.supports(authentication);
+        if (configuredLoginAuthProvider != null) {
+            return configuredLoginAuthProvider.supports(authentication);
+        }
+        return false;
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/dummy/DummyAuthenticationProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/dummy/DummyAuthenticationProvider.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.gateway.security.login.dummy;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -32,6 +33,7 @@ import static org.zowe.apiml.security.SecurityUtils.readPassword;
  * Allows Gateway to run without mainframe (z/OSMF service)
  */
 @Component
+@ConditionalOnProperty(value = "apiml.security.auth.provider", havingValue = "dummy")
 public class DummyAuthenticationProvider extends DaoAuthenticationProvider {
     private static final String DUMMY_PROVIDER = "Dummy provider";
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/dummy/InMemoryUserDetailsService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/dummy/InMemoryUserDetailsService.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,6 +31,7 @@ import java.util.List;
  */
 @Component
 @Qualifier("dummyService")
+@ConditionalOnProperty(value = "apiml.security.auth.provider", havingValue = "dummy")
 public class InMemoryUserDetailsService implements UserDetailsService {
     private final BCryptPasswordEncoder passwordEncoder;
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/saf/ZosAuthenticationProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/saf/ZosAuthenticationProvider.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -26,6 +27,7 @@ import org.zowe.apiml.security.common.login.LoginRequest;
 
 @Component
 @Slf4j
+@ConditionalOnExpression("#{('${apiml.security.auth.provider:zosmf}' == 'zosmf') or ('${apiml.security.auth.provider:zosmf}' == 'dummy') or ('${apiml.security.auth.provider:zosmf}' == 'saf')}")
 public class ZosAuthenticationProvider implements AuthenticationProvider, InitializingBean {
     private PlatformUser platformUser = null;
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProvider.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.gateway.security.login.zosmf;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -32,6 +33,7 @@ import static org.zowe.apiml.gateway.security.service.zosmf.ZosmfService.TokenTy
  */
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(value = "apiml.security.auth.provider", havingValue = "zosmf", matchIfMissing = true)
 public class ZosmfAuthenticationProvider implements AuthenticationProvider {
 
     private final AuthenticationService authenticationService;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/TokenCreationServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/TokenCreationServiceTest.java
@@ -20,6 +20,8 @@ import org.zowe.apiml.passticket.PassTicketService;
 import org.zowe.apiml.security.common.error.AuthenticationTokenException;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,7 +50,7 @@ class TokenCreationServiceTest {
         providers = mock(Providers.class);
         authenticationService = mock(AuthenticationService.class);
 
-        underTest = new TokenCreationService(providers, zosmfAuthenticationProvider, passTicketService, authenticationService);
+        underTest = new TokenCreationService(providers, Optional.of(zosmfAuthenticationProvider), passTicketService, authenticationService);
         underTest.zosmfApplId = "IZUDFLT";
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/AccessTokenServiceTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/AccessTokenServiceTest.java
@@ -213,12 +213,12 @@ public class AccessTokenServiceTest {
             given().contentType(ContentType.JSON).body(bodyContent).when()
                 .post(VALIDATE_ENDPOINT)
                 .then().statusCode(200);
-//            revoke all tokens fro USERNAME
+//            revoke all tokens for USERNAME
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("userId", SecurityUtils.USERNAME);
             given().contentType(ContentType.JSON).config(SslContext.clientCertApiml).body(requestBody)
                 .when().delete(REVOKE_FOR_USER_ENDPOINT)
-                .then().statusCode(401);
+                .then().statusCode(403);
 //            validate after revocation rule
             given().contentType(ContentType.JSON).body(bodyContent).when()
                 .post(VALIDATE_ENDPOINT)

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/SafLoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/SafLoginTest.java
@@ -11,16 +11,25 @@
 package org.zowe.apiml.integration.authentication.providers;
 
 import io.restassured.RestAssured;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.zowe.apiml.security.common.login.LoginRequest;
 import org.zowe.apiml.util.SecurityUtils;
 import org.zowe.apiml.util.TestWithStartedInstances;
 import org.zowe.apiml.util.categories.SAFAuthTest;
+import org.zowe.apiml.util.config.ConfigReader;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
@@ -52,4 +61,47 @@ class SafLoginTest implements TestWithStartedInstances {
             }
         }
     }
+
+    @Nested
+    class ExpiredPassword {
+
+        private final String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
+        private final String EXPIRED_PASSWORD = "expiredPassword";
+
+        @ParameterizedTest(name = "givenExpiredAccountCredentialsInBody {index} {0} ")
+        @MethodSource("org.zowe.apiml.integration.authentication.providers.LoginTest#loginUrlsSource")
+        void givenExpiredAccountCredentialsInBody(URI loginUrl) {
+            LoginRequest loginRequest = new LoginRequest(USERNAME, EXPIRED_PASSWORD.toCharArray());
+
+            given()
+                .contentType(JSON)
+                .body(loginRequest)
+            .when()
+                .post(loginUrl)
+            .then()
+                .statusCode(is(SC_UNAUTHORIZED))
+                .body(
+                    "messages.find { it.messageNumber == 'ZWEAT412E' }.messageContent", containsString("expire")
+                );
+        }
+
+        @ParameterizedTest(name = "givenExpiredAccountCredentialsInHeader {index} {0} ")
+        @MethodSource("org.zowe.apiml.integration.authentication.providers.LoginTest#loginUrlsSource")
+        void givenExpiredAccountCredentialsInHeader(URI loginUrl) {
+            String headerValue = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + EXPIRED_PASSWORD).getBytes(StandardCharsets.UTF_8));
+
+            given()
+                .contentType(JSON)
+                .header(HttpHeaders.AUTHORIZATION, headerValue)
+            .when()
+                .post(loginUrl)
+            .then()
+                .statusCode(is(SC_UNAUTHORIZED))
+                .body(
+                    "messages.find { it.messageNumber == 'ZWEAT412E' }.messageContent", containsString("expire")
+                );
+        }
+
+    }
+
 }


### PR DESCRIPTION
# Description

This fix improves the amount of Spring beans responsible for authentication. Currently, the code generates for each type of authentication a specific bean(s). It is not necessary because if the configuration contains for example `saf` as the provider, there is no reason to instantiate bean for z/OSMF. 

The worst behavior was about the `dummy` provider. Spring Security configuration tried to construct an authentication manager because there was no one defined (during the processing) and was defined bean `InMemoryUserDetailsService`. Therefore it automatically creates a manager using this provider as a default one.

The treatment of authentication tries to invoke each registered provider (supported by the type of authentication). In case there is an exception it also calls the parent one (the default one - in our case DAO provider with user list of `dummy` provider). It returns a different error (ie. invalid credentials instead of expired account). In theory, it could accept the access, but it requires the credentials of a `dummy` provider (basically users with IDs `user` and `expire`).

This PR creates the provider's beans by condition (ignore not used) and adds IT to verify if the expired password is working.

Linked to #2888
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
