### PR TITLE
fix: dynamically update favicon

### DIFF
--- a/api-catalog-ui/frontend/src/utils/utilFunctions.js
+++ b/api-catalog-ui/frontend/src/utils/utilFunctions.js
@@ -87,7 +87,15 @@ export const customUIStyle = async (uiConfig) => {
     const root = document.documentElement;
     const logo = document.getElementById('logo');
     if (logo && uiConfig.logo) {
-        logo.src = await fetchImagePath();
+        let link = document.querySelector("link[rel~='icon']");
+        if (!link) {
+            link = document.createElement('link');
+            link.rel = 'icon';
+            document.getElementsByTagName('head')[0].appendChild(link);
+        }
+        const img = await fetchImagePath();
+        link.href = img;
+        logo.src = img;
     }
 
     if (uiConfig.backgroundColor) {

--- a/api-catalog-ui/frontend/src/utils/utilFunctions.test.js
+++ b/api-catalog-ui/frontend/src/utils/utilFunctions.test.js
@@ -67,7 +67,9 @@ describe('>>> Util Functions tests', () => {
         const homepage = document.getElementsByClassName('apis')[0];
         const detailPage = document.getElementsByClassName('content')[0];
         const description = document.getElementById('description');
+        const link = document.querySelector("link[rel~='icon']");
         expect(logo.src).toContain('img-url');
+        expect(link.href).toContain('img-url');
         expect(header.style.getPropertyValue('background-color')).toBe('red');
         expect(divider.style.getPropertyValue('background-color')).toBe('red');
         expect(title.style.getPropertyValue('color')).toBe('red');


### PR DESCRIPTION
# Description

Small change to dynamically update the favicon in the browser tab of the open Catalog UI, when the customised logo is set.
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
