### PR TITLE
feat: fix z/OSMF not available logging before validation

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
@@ -147,16 +147,14 @@ public class AuthExceptionHandler extends AbstractExceptionHandler {
 
     //500
     private void handleAuthenticationException(HttpServletRequest request, HttpServletResponse response, RuntimeException ex) throws ServletException {
-        log.debug(ERROR_MESSAGE_500, ex.getMessage());
-        log.debug("", ex);
+        log.debug(ERROR_MESSAGE_500, ex);
         final ApiMessageView message = messageService.createMessage(ErrorType.AUTH_GENERAL.getErrorMessageKey(), ex.getMessage(), request.getRequestURI()).mapToView();
         final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
         writeErrorResponse(message, status, response);
     }
 
     private void handleServiceNotAccessibleException(HttpServletRequest request, HttpServletResponse response, RuntimeException ex) throws ServletException {
-        log.debug(ERROR_MESSAGE_500, ex.getMessage());
-        log.debug("", ex);
+        log.debug(ERROR_MESSAGE_500, ex);
 
         final ApiMessageView message = messageService.createMessage(ErrorType.SERVICE_UNAVAILABLE.getErrorMessageKey(), ex.getMessage(), request.getRequestURI()).mapToView();
         final HttpStatus status = HttpStatus.SERVICE_UNAVAILABLE;

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
@@ -81,10 +81,6 @@ public class AuthExceptionHandler extends AbstractExceptionHandler {
         }
     }
 
-    private void handleServiceNotAccessibleException(HttpServletRequest request, HttpServletResponse response,
-            RuntimeException ex) {
-    }
-
     private void handleZosAuthenticationException(HttpServletResponse response, ZosAuthenticationException ex) throws ServletException {
         final ApiMessageView message = messageService.createMessage(ex.getPlatformError().errorMessage, ex.getMessage()).mapToView();
         final HttpStatus status = ex.getPlatformError().responseCode;
@@ -155,6 +151,15 @@ public class AuthExceptionHandler extends AbstractExceptionHandler {
         log.debug("", ex);
         final ApiMessageView message = messageService.createMessage(ErrorType.AUTH_GENERAL.getErrorMessageKey(), ex.getMessage(), request.getRequestURI()).mapToView();
         final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        writeErrorResponse(message, status, response);
+    }
+
+    private void handleServiceNotAccessibleException(HttpServletRequest request, HttpServletResponse response, RuntimeException ex) throws ServletException {
+        log.debug(ERROR_MESSAGE_500, ex.getMessage());
+        log.debug("", ex);
+
+        final ApiMessageView message = messageService.createMessage(ErrorType.SERVICE_UNAVAILABLE.getErrorMessageKey(), ex.getMessage(), request.getRequestURI()).mapToView();
+        final HttpStatus status = HttpStatus.SERVICE_UNAVAILABLE;
         writeErrorResponse(message, status, response);
     }
 }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/AuthExceptionHandler.java
@@ -74,9 +74,15 @@ public class AuthExceptionHandler extends AbstractExceptionHandler {
             handleInvalidTokenTypeException(request, response, ex);
         } else if (ex instanceof AuthenticationException) {
             handleAuthenticationException(request, response, ex);
+        } else if (ex instanceof ServiceNotAccessibleException) {
+            handleServiceNotAccessibleException(request, response, ex);
         } else {
             throw new ServletException(ex);
         }
+    }
+
+    private void handleServiceNotAccessibleException(HttpServletRequest request, HttpServletResponse response,
+            RuntimeException ex) {
     }
 
     private void handleZosAuthenticationException(HttpServletResponse response, ZosAuthenticationException ex) throws ServletException {

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/AuthExceptionHandlerTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/AuthExceptionHandlerTest.java
@@ -213,6 +213,20 @@ class AuthExceptionHandlerTest {
         });
     }
 
+    @Test
+    void testAuthServiceUnavailable() throws ServletException, IOException {
+        authExceptionHandler.handleException(
+            httpServletRequest,
+            httpServletResponse,
+            new ServiceNotAccessibleException("URI"));
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), httpServletResponse.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpServletResponse.getContentType());
+
+        Message message = messageService.createMessage(ErrorType.SERVICE_UNAVAILABLE.getErrorMessageKey(), httpServletRequest.getRequestURI());
+        verify(objectMapper).writeValue(httpServletResponse.getWriter(), message.mapToView());
+    }
+
     @TestConfiguration
     static class ContextConfiguration {
         @Bean

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/service/ServiceStartupEventHandler.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/service/ServiceStartupEventHandler.java
@@ -28,7 +28,7 @@ public class ServiceStartupEventHandler {
     @SuppressWarnings("squid:S1172")
     public void onServiceStartup(String serviceName, int delayFactor) {
         long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
-        apimlLog.log("org.zowe.apiml.common.serviceStarted",serviceName, uptime / 1000.0);
+        apimlLog.log("org.zowe.apiml.common.serviceStarted", serviceName, uptime / 1000.0);
 
         new java.util.Timer().schedule(new java.util.TimerTask() {
             @Override

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java-library'
 
 import java.util.regex.Matcher
+import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.gradle.plugins.ide.eclipse.model.ClasspathEntry
+import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
 
 //noinspection GroovyAssignabilityCheck
 group 'org.zowe.apiml'
@@ -59,6 +62,18 @@ allprojects {
 
     eclipse {
         classpath {
+            file {
+                whenMerged { classpath ->
+                    for (ClasspathEntry entry : classpath.getEntries()) {
+                        if (entry instanceof AbstractClasspathEntry) {
+                            AbstractClasspathEntry theEntry = (AbstractClasspathEntry) entry
+                            if (theEntry.path != null && theEntry.path.contains('org.eclipse.jdt.launching.JRE_CONTAINER')) {
+                                theEntry.accessRules.add(new AccessRule('accessible', 'com/sun/net/httpserver/**'))
+                            }
+                        }
+                    }
+                }
+            }
             downloadJavadoc = true
             downloadSources = true
         }

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -98,7 +98,7 @@ if [ "$(uname)" = "OS/390" ]; then
 fi
 
 # setting the cookieName based on the instances
-
+ZWE_components_gateway_apiml_security_auth_uniqueCookie="${ZWE_components_gateway_apiml_security_auth_uniqueCookie:-false}"
 if [ "${ZWE_components_gateway_apiml_security_auth_uniqueCookie}" = "true"]; then
     cookieName="apimlAuthenticationToken.${ZWE_zowe_cookieIdentifier}"
 fi

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -39,31 +39,27 @@
 # - ZWE_zowe_certificate_keystore_type - The default keystore type to use for SSL certificates
 # - ZWE_zowe_verifyCertificates - if we accept only verified certificates
 # - ZWE_configs_apiml_discovery_serviceIdPrefixReplacer - The service ID prefix replacer to be V2 conformant
-if [ -n "${LAUNCH_COMPONENT}" ]
-then
+if [ -n "${LAUNCH_COMPONENT}" ]; then
     JAR_FILE="${LAUNCH_COMPONENT}/discovery-service-lite.jar"
 else
     JAR_FILE="$(pwd)/bin/discovery-service-lite.jar"
 fi
 
-echo "jar file: "${JAR_FILE}
+echo "jar file: ${JAR_FILE}"
 # script assumes it's in the discovery component directory and common_lib needs to be relative path
-if [ -z "${CMMN_LB}" ]
-then
+if [ -z "${CMMN_LB}" ]; then
     COMMON_LIB="../apiml-common-lib/bin/api-layer-lite-lib-all.jar"
 else
-    COMMON_LIB=${CMMN_LB}
+    COMMON_LIB="${CMMN_LB}"
 fi
 
-if [ -z "${LIBRARY_PATH}" ]
-then
+if [ -z "${LIBRARY_PATH}" ]; then
     LIBRARY_PATH="../common-java-lib/bin/"
 fi
 # API Mediation Layer Debug Mode
-export LOG_LEVEL=
+unset LOG_LEVEL
 
-if [ "${ZWE_configs_debug}" = "true" ]
-then
+if [ "${ZWE_configs_debug}" = "true" ]; then
   export LOG_LEVEL="debug"
 fi
 
@@ -97,9 +93,8 @@ else
   nonStrictVerifySslCertificatesOfServices=true
 fi
 
-if [ "$(uname)" = "OS/390" ]
-then
-    QUICK_START=-Xquickstart
+if [ "$(uname)" = "OS/390" ]; then
+    QUICK_START="-Xquickstart"
 fi
 
 # setting the cookieName based on the instances
@@ -108,21 +103,20 @@ if [ "${ZWE_components_gateway_apiml_security_auth_uniqueCookie}" = "true"]; the
     cookieName="apimlAuthenticationToken.${ZWE_zowe_cookieIdentifier}"
 fi
 
-DISCOVERY_LOADER_PATH=${COMMON_LIB}
+DISCOVERY_LOADER_PATH="${COMMON_LIB}"
 
-if [ -n "${ZWE_GATEWAY_SHARED_LIBS}" ]
-then
+if [ -n "${ZWE_GATEWAY_SHARED_LIBS}" ]; then
     DISCOVERY_LOADER_PATH=${ZWE_DISCOVERY_SHARED_LIBS},${DISCOVERY_LOADER_PATH}
 fi
 
 LIBPATH="$LIBPATH":"/lib"
 LIBPATH="$LIBPATH":"/usr/lib"
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/classic
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/bin/j9vm
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/classic
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/default
-LIBPATH="$LIBPATH":"${JAVA_HOME}"/lib/s390/j9vm
+LIBPATH="$LIBPATH":"${JAVA_HOME}/bin"
+LIBPATH="$LIBPATH":"${JAVA_HOME}/bin/classic"
+LIBPATH="$LIBPATH":"${JAVA_HOME}/bin/j9vm"
+LIBPATH="$LIBPATH":"${JAVA_HOME}/lib/s390/classic"
+LIBPATH="$LIBPATH":"${JAVA_HOME}/lib/s390/default"
+LIBPATH="$LIBPATH":"${JAVA_HOME}/lib/s390/j9vm"
 LIBPATH="$LIBPATH":"${LIBRARY_PATH}"
 
 keystore_type="${ZWE_configs_certificate_keystore_type:-${ZWE_zowe_certificate_keystore_type:-PKCS12}}"

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayApplication.java
@@ -12,12 +12,10 @@ package org.zowe.apiml.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.FilterType;
@@ -27,12 +25,9 @@ import org.zowe.apiml.extension.ExtensionConfigReader;
 import org.zowe.apiml.extension.ExtensionsLoader;
 import org.zowe.apiml.gateway.ribbon.GatewayRibbonConfig;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
-import org.zowe.apiml.product.service.ServiceStartupEventHandler;
 import org.zowe.apiml.product.version.BuildInfo;
 
 import static org.zowe.apiml.extension.ZoweRuntimeEnvironment.defaultEnv;
-
-import javax.annotation.Nonnull;
 
 @EnableZuulProxy
 @EnableWebSecurity
@@ -52,7 +47,7 @@ import javax.annotation.Nonnull;
 @EnableEurekaClient
 @EnableWebSocket
 @EnableAspectJAutoProxy
-public class GatewayApplication implements ApplicationListener<ApplicationReadyEvent> {
+public class GatewayApplication {
 
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(GatewayApplication.class);
@@ -61,11 +56,5 @@ public class GatewayApplication implements ApplicationListener<ApplicationReadyE
         app.setLogStartupInfo(false);
         new BuildInfo().logBuildInfo();
         app.run(args);
-    }
-
-    @Override
-    public void onApplicationEvent(@Nonnull final ApplicationReadyEvent event) {
-        new ServiceStartupEventHandler().onServiceStartup("Gateway Service",
-            ServiceStartupEventHandler.DEFAULT_DELAY_FACTOR);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.gateway;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
@@ -25,7 +26,8 @@ import java.util.TimerTask;
 @RequiredArgsConstructor
 public class GatewayStartupListener implements ApplicationListener<ApplicationReadyEvent> {
 
-    private static final long PERIOD = Duration.ofSeconds(15).toMillis(); // should be configurable
+    @Value("${apiml.startupCheckInterval:15}")
+    private int interval;
 
     private final Providers providers;
 
@@ -41,7 +43,7 @@ public class GatewayStartupListener implements ApplicationListener<ApplicationRe
                     }
                 }
 
-            }, 0, PERIOD);
+            }, 0, Duration.ofSeconds(interval).toMillis());
         } else {
             notifyStartup();
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.gateway;
 
 import lombok.RequiredArgsConstructor;
@@ -6,7 +16,6 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.gateway.security.login.Providers;
-import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.product.service.ServiceStartupEventHandler;
 
 import java.time.Duration;
@@ -18,10 +27,9 @@ import java.util.TimerTask;
 @RequiredArgsConstructor
 public class GatewayStartupListener implements ApplicationListener<ApplicationReadyEvent> {
 
-    private static final long PERIOD = Duration.ofSeconds(0).toMillis();
+    private static final long PERIOD = Duration.ofSeconds(15).toMillis(); // should be configurable
 
     private final Providers providers;
-    private final ZosmfService zosmfService;
 
     public void onApplicationEvent(ApplicationReadyEvent event) {
         if (providers.isZosfmUsed()) {
@@ -33,8 +41,6 @@ public class GatewayStartupListener implements ApplicationListener<ApplicationRe
                     if (providers.isZosmfAvailableAndOnline()) {
                         cancel();
                         notifyStartup();
-                    } else if () { // if it went over time?
-                        cancel();
                     }
                 }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
@@ -11,7 +11,6 @@
 package org.zowe.apiml.gateway;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
@@ -23,7 +22,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class GatewayStartupListener implements ApplicationListener<ApplicationReadyEvent> {
 
@@ -33,7 +31,6 @@ public class GatewayStartupListener implements ApplicationListener<ApplicationRe
 
     public void onApplicationEvent(ApplicationReadyEvent event) {
         if (providers.isZosfmUsed()) {
-            log.debug(null);
             new Timer().scheduleAtFixedRate(new TimerTask() {
 
                 @Override

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/GatewayStartupListener.java
@@ -1,0 +1,51 @@
+package org.zowe.apiml.gateway;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.zowe.apiml.gateway.security.login.Providers;
+import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
+import org.zowe.apiml.product.service.ServiceStartupEventHandler;
+
+import java.time.Duration;
+import java.util.Timer;
+import java.util.TimerTask;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GatewayStartupListener implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final long PERIOD = Duration.ofSeconds(0).toMillis();
+
+    private final Providers providers;
+    private final ZosmfService zosmfService;
+
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (providers.isZosfmUsed()) {
+            log.debug(null);
+            new Timer().scheduleAtFixedRate(new TimerTask() {
+
+                @Override
+                public void run() {
+                    if (providers.isZosmfAvailableAndOnline()) {
+                        cancel();
+                        notifyStartup();
+                    } else if () { // if it went over time?
+                        cancel();
+                    }
+                }
+
+            }, 0, PERIOD);
+        } else {
+            notifyStartup();
+        }
+    }
+
+    private void notifyStartup() {
+        new ServiceStartupEventHandler().onServiceStartup("Gateway Service",
+            ServiceStartupEventHandler.DEFAULT_DELAY_FACTOR);
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
@@ -121,6 +121,8 @@ public abstract class AbstractZosmfService {
      *
      * @param zosmf the z/OSMF service id
      * @return the uri
+     *
+     * @throws ServiceNotAccessibleException if z/OSMF is not available in discovery service
      */
     protected String getURI(String zosmf) {
         Supplier<ServiceNotAccessibleException> authenticationServiceExceptionSupplier = () -> {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -232,7 +232,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             infoURIEndpoint = getURI(getZosmfServiceId()) + ZOSMF_INFO_END_POINT;
         } catch (ServiceNotAccessibleException e) {
-            log.debug("URI not available because z/OSMF is not registered or wrong URL in Discovery Service");
+            log.debug("URI not available because z/OSMF instance '{}' is not registered or wrong URL in Discovery Service", getZosmfServiceId());
             return false;
         }
 
@@ -342,7 +342,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             url = getURI(getZosmfServiceId()) + ZOSMF_AUTHENTICATE_END_POINT;
         } catch (ServiceNotAccessibleException e) {
-            log.debug("authentication endpoint is not available because z/OSMF is not registered or wrong URL in Discovery Service");
+            log.debug("authentication endpoint is not available because z/OSMF instance '{}'' is not registered or wrong URL in Discovery Service", getZosmfServiceId());
             return false;
         }
 
@@ -376,7 +376,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             url = getURI(getZosmfServiceId()) + authConfigurationProperties.getZosmf().getJwtEndpoint();
         } catch (ServiceNotAccessibleException e) {
-            log.debug("jwt endpoint is not available because z/OSMF is not registered or wrong URL in Discovery Service");
+            log.debug("jwt endpoint is not available because z/OSMF instance '{}' is not registered or wrong URL in Discovery Service", getZosmfServiceId());
             return false;
         }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -232,7 +232,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             infoURIEndpoint = getURI(getZosmfServiceId()) + ZOSMF_INFO_END_POINT;
         } catch (ServiceNotAccessibleException e) {
-
+            log.debug("URI not available because z/OSMF is not registered or wrong URL in Discovery Service");
             return false;
         }
 
@@ -342,6 +342,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             url = getURI(getZosmfServiceId()) + ZOSMF_AUTHENTICATE_END_POINT;
         } catch (ServiceNotAccessibleException e) {
+            log.debug("authentication endpoint is not available because z/OSMF is not registered or wrong URL in Discovery Service");
             return false;
         }
 
@@ -375,6 +376,7 @@ public class ZosmfService extends AbstractZosmfService {
         try {
             url = getURI(getZosmfServiceId()) + authConfigurationProperties.getZosmf().getJwtEndpoint();
         } catch (ServiceNotAccessibleException e) {
+            log.debug("jwt endpoint is not available because z/OSMF is not registered or wrong URL in Discovery Service");
             return false;
         }
 

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -432,10 +432,3 @@ messages:
       text: z/OSMF JWT builder endpoint call (%s) failed with %s
       reason: z/OSMF returned an error code when calling JWT endpoint.
       action: Review z/OSMF status. Contact your system administrator.
-
-    - key: org.zowe.apiml.security.auth.zosmf.jwtEndpointError
-      number: ZWEAG188
-      type: WARNING
-      text: z/OSMF JWT builder endpoint call (%s) failed with %s
-      reason: z/OSMF returned an error code when calling JWT endpoint.
-      action: Review z/OSMF status. Contact your system administrator.

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -372,7 +372,6 @@ messages:
       reason: "Webfinger provider contains incorrect configuration."
       action: "Contact the administrator to validate webfinger configuration in gateway service."
 
-    # z/OSMF messages
     - key: org.zowe.apiml.security.auth.zosmf.serviceId
       number: ZWEAG181
       type: WARNING
@@ -426,6 +425,13 @@ messages:
       text: The check of z/OSMF JWT authentication endpoint has failed. Using z/OSMF info endpoint as backup.
       reason: z/OSMF JWT endpoint was not found.
       action: Ensure APAR PH12143 (https://www.ibm.com/support/pages/apar/PH12143) fix has been applied.
+
+    - key: org.zowe.apiml.security.auth.zosmf.jwtEndpointError
+      number: ZWEAG188
+      type: WARNING
+      text: z/OSMF JWT builder endpoint call (%s) failed with %s
+      reason: z/OSMF returned an error code when calling JWT endpoint.
+      action: Review z/OSMF status. Contact your system administrator.
 
     - key: org.zowe.apiml.security.auth.zosmf.jwtEndpointError
       number: ZWEAG188

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -136,7 +136,7 @@ class ZosmfServiceTest {
             validationStrategyList);
 
         ZosmfService zosmfService = spy(zosmfServiceObj);
-        doReturn("http://host:port").when(zosmfService).getURI(any());
+        doReturn("http://host:1433").when(zosmfService).getURI(any());
 
         ReflectionTestUtils.setField(zosmfService, "meAsProxy", zosmfService);
         return zosmfService;
@@ -602,9 +602,9 @@ class ZosmfServiceTest {
         void thenReturnGivenData() {
             ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
             doReturn(true).when(zosmfService).loginEndpointExists();
-            assertThat(zosmfService.getEndpointMap(), IsMapContaining.hasEntry("http://host:port" + ZosmfService.ZOSMF_AUTHENTICATE_END_POINT, true));
+            assertThat(zosmfService.getEndpointMap(), IsMapContaining.hasEntry("http://host:1433" + ZosmfService.ZOSMF_AUTHENTICATE_END_POINT, true));
             doReturn(false).when(zosmfService).loginEndpointExists();
-            assertThat(zosmfService.getEndpointMap(), IsMapContaining.hasEntry("http://host:port" + ZosmfService.ZOSMF_AUTHENTICATE_END_POINT, false));
+            assertThat(zosmfService.getEndpointMap(), IsMapContaining.hasEntry("http://host:1433" + ZosmfService.ZOSMF_AUTHENTICATE_END_POINT, false));
         }
     }
 
@@ -752,7 +752,7 @@ class ZosmfServiceTest {
     @Nested
     class WhenTestingIfTheZosmfIsAvailable {
         private ZosmfService underTest;
-        private final String ZOSMF_URL = "http://host:port";
+        private final String ZOSMF_URL = "http://host:1433";
 
         @BeforeEach
         void setUp() {
@@ -889,7 +889,7 @@ class ZosmfServiceTest {
     @Nested
     class WhenVerifyingAuthenticationEndpoint {
 
-        private final String ZOSMF_URL = "http://host:port";
+        private final String ZOSMF_URL = "http://host:1433";
 
         private ZosmfService underTest;
 


### PR DESCRIPTION
# Description

- using `getURI()` has a side effect of verifying z/OSMF registration in eureka. This case is now controlled in the methods where it's verifying exactly that, to not print extra logging.
- gateway started message will appear after z/OSMF is available if it's the authentication provider (TBD I think it will shutdown anyway if z/OSMF is not available and it's not the set provider)

## Type of change

Please delete options that are not relevant.

- [ ] (feat) New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
