### PR TITLE
fix: newlines and ssl error message in z/OSMF validation

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/AbstractZosmfService.java
@@ -151,7 +151,7 @@ public abstract class AbstractZosmfService {
     protected RuntimeException handleExceptionOnCall(String url, RuntimeException re) {
         if (re instanceof ResourceAccessException) {
             if (re.getCause() instanceof SSLHandshakeException) {
-                apimlLog.log("org.zowe.apiml.security.auth.zosmf.sslError");
+                apimlLog.log("org.zowe.apiml.security.auth.zosmf.sslError", re.getMessage());
             } else {
                 apimlLog.log("org.zowe.apiml.security.serviceUnavailable", url, re.getMessage());
             }

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -383,7 +383,9 @@ messages:
       number: ZWEAG182
       type: ERROR
       text: >
-        SSL Misconfiguration, z/OSMF is not accessible. Please verify the following:
+        SSL Misconfiguration, z/OSMF is not accessible.
+        Message: %s
+        Please verify the following:
           - CN (Common Name) and z/OSMF hostname have to match.
           - Certificate is expired
           - TLS version match

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -113,26 +113,26 @@ messages:
       text: "Configuration error when trying to establish JWT producer. Events: %s"
       reason: "A problem occurred while trying to make sure that there is a valid JWT producer available. A possible cause of the problem is that API ML does not recognize the authentication type used by z/OSMF."
       action: >
-        Based on the specific information in the message, verify that the key configuration is correct, or alternatively, that z/OSMF is available. If z/OSMF is available, specify the authentication type used by z/OSMF in your configuration settings.\n
-        \n
-        Use the following configuration format:\n
-        ```\n
-          apiml:\n
-            security:\n
-              auth:\n
-                zosmf:\n
-                  jwtAutoconfiguration:\n
-        ```\n
-        Apply one of the following values:\n
-        \n
-        * **auto**\n
-          Signifies that API ML is enabled to resolve the JWT producer\n
-        \n
-        * **jwt**\n
-          Signifies that z/OSMF supports JWT (APAR PH12143 is applied)\n
-        \n
-        * **ltpa**\n
-          Signifies that z/OSMF does not support JWT"
+        Based on the specific information in the message, verify that the key configuration is correct, or alternatively, that z/OSMF is available. If z/OSMF is available, specify the authentication type used by z/OSMF in your configuration settings.
+
+        Use the following configuration format:
+        ```
+          apiml:
+            security:
+              auth:
+                zosmf:
+                  jwtAutoconfiguration:
+        ```
+        Apply one of the following values:
+
+        * **auto**
+          Signifies that API ML is enabled to resolve the JWT producer
+
+        * **jwt**
+          Signifies that z/OSMF supports JWT (APAR PH12143 is applied)
+
+        * **ltpa**
+          Signifies that z/OSMF does not support JWT
 
     - key: org.zowe.apiml.gateway.keys.unknown
       number: ZWEAG714
@@ -383,10 +383,11 @@ messages:
       number: ZWEAG182
       type: ERROR
       text: >
-        SSL Misconfiguration, z/OSMF is not accessible. Please verify the following: \n
-          - CN (Common Name) and z/OSMF hostname have to match.\n
-          - Certificate is expired\n
-          - TLS version match\n
+        SSL Misconfiguration, z/OSMF is not accessible. Please verify the following:
+          - CN (Common Name) and z/OSMF hostname have to match.
+          - Certificate is expired
+          - TLS version match
+          - z/OSMF server certificate is trusted in Zowe's truststore
         Enable debugging to see further details in stack trace
       reason: "z/OSMF connection has an incorrect configuration."
       action: "Verify z/OSMF connection details. Verify z/OSMF can be accessed with HTTPS"

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -857,7 +857,7 @@ class ZosmfServiceTest {
                 assertTrue(values.length() > 0);
                 assertTrue(values.contains("ResourceAccessException accessing"), values);
 
-                verify(apimlLogger, times(1)).log("org.zowe.apiml.security.auth.zosmf.sslError");
+                verify(apimlLogger, times(1)).log("org.zowe.apiml.security.auth.zosmf.sslError", "resource access exception; nested exception is javax.net.ssl.SSLHandshakeException: handshake exception");
             }
 
             @Test


### PR DESCRIPTION
# Description

- Remove `\n` characters that appear in log.
- Add exception message to SSL misconfiguration error.

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
