### PR TITLE
(feat) Cloud gateway forwards client cert in a header to domain gateway

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -140,6 +140,8 @@ jobs:
                 image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
             gateway-service:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_X509_AUTHVIAHEADER: true
             gateway-service-2:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -149,11 +151,12 @@ jobs:
                 image: ghcr.io/balhar-jakub/cloud-gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_GATEWAY_TIMEOUT: 2
+                    APIML_SERVICE_GATEWAY_PROXY_ENABLED: true
             discoverable-client:
                 image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
                 with:
                     ref: ${{ github.head_ref }}
 
@@ -199,7 +202,7 @@ jobs:
             mock-services:
                 image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
                 with:
                     ref: ${{ github.head_ref }}
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -142,6 +142,7 @@ jobs:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SECURITY_X509_AUTHVIAHEADER: true
+                    APIML_SECURITY_X509_PUBLICKEYURL: https://cloud-gateway-service:10023/gateway/.well-known/jwks.json
             gateway-service-2:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/security/SecurityConfiguration.java
@@ -45,6 +45,7 @@ import org.zowe.apiml.security.common.content.CookieContentFilter;
 import org.zowe.apiml.security.common.filter.CategorizeCertsFilter;
 import org.zowe.apiml.security.common.login.LoginFilter;
 import org.zowe.apiml.security.common.login.ShouldBeAlreadyAuthenticatedFilter;
+import org.zowe.apiml.security.common.verify.CertificateValidator;
 
 import java.util.Collections;
 import java.util.Set;
@@ -69,6 +70,7 @@ public class SecurityConfiguration {
     private final HandlerInitializer handlerInitializer;
     private final GatewayLoginProvider gatewayLoginProvider;
     private final GatewayTokenProvider gatewayTokenProvider;
+    private final CertificateValidator certificateValidator;
     @Qualifier("publicKeyCertificatesBase64")
     private final Set<String> publicKeyCertificatesBase64;
     @Value("${server.attls.enabled:false}")
@@ -124,7 +126,7 @@ public class SecurityConfiguration {
         }
 
         private CategorizeCertsFilter reversedCategorizeCertFilter() {
-            CategorizeCertsFilter out = new CategorizeCertsFilter(publicKeyCertificatesBase64);
+            CategorizeCertsFilter out = new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator);
             out.setCertificateForClientAuth(crt -> out.getPublicKeyCertificatesBase64().contains(out.base64EncodePublicKey(crt)));
             out.setNotCertificateForClientAuth(crt -> !out.getPublicKeyCertificatesBase64().contains(out.base64EncodePublicKey(crt)));
             return out;

--- a/apiml-security-common/build.gradle
+++ b/apiml-security-common/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation libs.spring.expression
     implementation libs.spring.web
     implementation libs.spring.webmvc
+    implementation libs.nimbusJoseJwt
 
     compileOnly libs.javax.servlet.api
     compileOnly libs.lombok

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -13,8 +13,6 @@ package org.zowe.apiml.security.common.filter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.zowe.apiml.security.common.verify.CertificateValidator;
 
@@ -41,7 +39,6 @@ import java.util.stream.Collectors;
  */
 @RequiredArgsConstructor
 @Slf4j
-@Component
 public class CategorizeCertsFilter extends OncePerRequestFilter {
 
     private static final String ATTRNAME_CLIENT_AUTH_X509_CERTIFICATE = "client.auth.X509Certificate";
@@ -49,8 +46,6 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
     private static final String LOG_FORMAT_FILTERING_CERTIFICATES = "Filtering certificates: {} -> {}";
     private static final String X_AUTH_SOURCE = "x-auth-source";
     private static final String X_AUTH_SIGNATURE = "x-auth-signature";
-    @Value("${apiml.security.x509.authViaHeader:false}")
-    private boolean x509AuthViaHeader;
     private final Set<String> publicKeyCertificatesBase64;
     private final CertificateValidator certificateValidator;
 
@@ -89,7 +84,7 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
      */
     private void categorizeCerts(ServletRequest request) {
         X509Certificate[] certs = (X509Certificate[]) request.getAttribute(ATTRNAME_JAVAX_SERVLET_REQUEST_X509_CERTIFICATE);
-        if (x509AuthViaHeader) {
+        if (certificateValidator.isCertInHeader()) {
             HttpServletRequest httpRequest = (HttpServletRequest) request;
             String certFromHeader = httpRequest.getHeader(X_AUTH_SOURCE);
             String certSignature = httpRequest.getHeader(X_AUTH_SIGNATURE);

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -80,7 +80,7 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
                     Stream<X509Certificate> newCertsStream = Stream.concat(certsStream, Stream.of(certificate));
                     certs = newCertsStream.toArray(X509Certificate[]::new);
                 } catch (CertificateException | IOException e) {
-                    log.error("Cannot extract X509 certificate from the authentication header {}", X_AUTH_SOURCE);
+                    log.error("Cannot extract X509 certificate from the authentication header {}", X_AUTH_SOURCE, e);
                 }
             }
         }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -13,6 +13,8 @@ package org.zowe.apiml.security.common.filter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -20,25 +22,33 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This filter processes certificates on request. It decides, which certificates are considered for client authentication
  */
 @RequiredArgsConstructor
 @Slf4j
+@Component
 public class CategorizeCertsFilter extends OncePerRequestFilter {
 
     private static final String ATTRNAME_CLIENT_AUTH_X509_CERTIFICATE = "client.auth.X509Certificate";
     private static final String ATTRNAME_JAVAX_SERVLET_REQUEST_X509_CERTIFICATE = "javax.servlet.request.X509Certificate";
     private static final String LOG_FORMAT_FILTERING_CERTIFICATES = "Filtering certificates: {} -> {}";
-
+    private static final String X_AUTH_SOURCE = "x-auth-source";
+    @Value("${apiml.security.x509.authViaHeader:false}")
+    private boolean x509AuthViaHeader;
     private final Set<String> publicKeyCertificatesBase64;
 
     public Set<String> getPublicKeyCertificatesBase64() {
@@ -53,6 +63,27 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
      */
     private void categorizeCerts(ServletRequest request) {
         X509Certificate[] certs = (X509Certificate[]) request.getAttribute(ATTRNAME_JAVAX_SERVLET_REQUEST_X509_CERTIFICATE);
+        if (x509AuthViaHeader) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            if (certs == null) {
+                certs = new X509Certificate[0];
+            }
+            String certFromHeader = httpRequest.getHeader(X_AUTH_SOURCE);
+            if (certFromHeader != null && !certFromHeader.isEmpty()) {
+                try {
+                    byte[] decodedCertData = Base64.getDecoder().decode(certFromHeader);
+                    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                    InputStream certStream = new ByteArrayInputStream(decodedCertData);
+                    X509Certificate certificate = (X509Certificate) cf.generateCertificate(certStream);
+                    certStream.close();
+                    Stream<X509Certificate> certsStream = Arrays.stream(certs);
+                    Stream<X509Certificate> newCertsStream = Stream.concat(certsStream, Stream.of(certificate));
+                    certs = newCertsStream.toArray(X509Certificate[]::new);
+                } catch (CertificateException | IOException e) {
+                    log.error("Cannot extract X509 certificate from the authentication header {}", X_AUTH_SOURCE);
+                }
+            }
+        }
         if (certs != null) {
             request.setAttribute(ATTRNAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(certs, certificateForClientAuth));
             request.setAttribute(ATTRNAME_JAVAX_SERVLET_REQUEST_X509_CERTIFICATE, selectCerts(certs, notCertificateForClientAuth));

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -1,0 +1,74 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.security.common.verify;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.*;
+import java.security.spec.RSAPublicKeySpec;
+
+/**
+ * Service to retrieve the public key during initialization of CertificateValidator bean. The public key is then used to verify the
+ * certificate's signature provided on the request header.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CertificateValidator {
+    private PublicKey publicKey;
+    private static final String ALGORITHM = "SHA256withRSA";
+    @Value("${apiml.security.x509.publicKeyUrl:}")
+    private String publicKeyEndpoint;
+
+    @Cacheable(value = "publicKey", key = "#publicKey", condition = "#publicKey != null")
+    public void initializePublicKey() {
+        try {
+            JWKSet jwkSet = JWKSet.load(new URL(publicKeyEndpoint));
+
+            RSAKey rsaKey = (RSAKey) jwkSet.getKeys().get(0);
+
+            BigInteger modulus = rsaKey.getModulus().decodeToBigInteger();
+            BigInteger publicExponent = rsaKey.getPublicExponent().decodeToBigInteger();
+
+            RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(modulus, publicExponent);
+
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            publicKey = keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (Exception e) {
+            log.error("Failed to initialize public key. {}", e.getMessage());
+        }
+    }
+
+    public boolean verify(byte[] data, byte[] dataSignature) throws SignatureException {
+        initializePublicKey();
+        Signature signature;
+        try {
+            signature = Signature.getInstance(ALGORITHM);
+            signature.initVerify(publicKey);
+            signature.update(data);
+            return signature.verify(dataSignature);
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("Failed to verify the signature. The cryptographic algorithm {} is not available in the environment. {}", ALGORITHM, e.getMessage());
+            throw new SignatureException(e);
+        } catch (InvalidKeyException e) {
+            log.warn("Failed to verify the signature due to the invalid public key. {}", e.getMessage());
+            throw new SignatureException(e);
+        }
+    }
+}

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -18,10 +18,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import java.math.BigInteger;
 import java.net.URL;
 import java.security.*;
-import java.security.spec.RSAPublicKeySpec;
 
 /**
  * Service to retrieve the public key during initialization of CertificateValidator bean. The public key is then used to verify the
@@ -40,16 +38,8 @@ public class CertificateValidator {
     public void initializePublicKey() {
         try {
             JWKSet jwkSet = JWKSet.load(new URL(publicKeyEndpoint));
-
             RSAKey rsaKey = (RSAKey) jwkSet.getKeys().get(0);
-
-            BigInteger modulus = rsaKey.getModulus().decodeToBigInteger();
-            BigInteger publicExponent = rsaKey.getPublicExponent().decodeToBigInteger();
-
-            RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(modulus, publicExponent);
-
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            publicKey = keyFactory.generatePublic(rsaPublicKeySpec);
+            publicKey = rsaKey.toPublicKey();
         } catch (Exception e) {
             log.error("Failed to initialize public key. {}", e.getMessage());
         }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.security.common.verify;
 
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +32,10 @@ import java.security.*;
 public class CertificateValidator {
     private PublicKey publicKey;
     private static final String ALGORITHM = "SHA256withRSA";
+
+    @Getter
+    @Value("${apiml.security.x509.authViaHeader:false}")
+    private boolean certInHeader;
     @Value("${apiml.security.x509.publicKeyUrl:}")
     private String publicKeyEndpoint;
 

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
@@ -51,7 +51,7 @@ class CategorizeCertsFilterTest {
 
         @BeforeEach
         void setUp() {
-            filter = new CategorizeCertsFilter(Collections.emptySet());
+            filter = new CategorizeCertsFilter(Collections.emptySet(), null);
         }
 
         @Nested
@@ -126,7 +126,7 @@ class CategorizeCertsFilterTest {
             filter = new CategorizeCertsFilter(new HashSet<>(Arrays.asList(
                 X509Utils.correctBase64("apimlCert1"),
                 X509Utils.correctBase64("apimlCert2")
-            )));
+            )), null);
         }
 
         @Nested

--- a/cloud-gateway-service/build.gradle
+++ b/cloud-gateway-service/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation libs.spring.aop
     implementation libs.spring.expression
     implementation libs.bcpkix
+    implementation libs.nimbusJoseJwt
 
     compileOnly libs.lombok
     annotationProcessor libs.lombok

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/JwkSetRestController.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/JwkSetRestController.java
@@ -1,0 +1,46 @@
+package org.zowe.apiml.cloudgatewayservice.controller;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.zowe.apiml.cloudgatewayservice.security.AuthSourceSign;
+
+import java.security.interfaces.RSAPublicKey;
+
+@RequiredArgsConstructor
+@RestController
+public class JwkSetRestController {
+
+    private final AuthSourceSign authSourceSign;
+
+    @GetMapping("/.well-known/jwks.json")
+    @ResponseBody
+    public ResponseEntity<Object> keys() {
+        JWKSet publicKeys = getJwkPublicKeys();
+        if (publicKeys == null) {
+            return new ResponseEntity<>("No public key available.", HttpStatus.NOT_FOUND);
+        } else {
+            return new ResponseEntity<>(publicKeys.toJSONObject(true), HttpStatus.OK);
+        }
+    }
+
+
+    private JWKSet getJwkPublicKeys() {
+        if (authSourceSign.getPublicKey() == null) {
+            return null;
+        }
+        final RSAKey rsaKey = new RSAKey.Builder((RSAPublicKey) authSourceSign.getPublicKey())
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+        return new JWKSet(rsaKey);
+    }
+
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.controller;
 
 import com.nimbusds.jose.JWSAlgorithm;

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
@@ -15,6 +15,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -28,6 +29,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(WellKnownRestController.CONTROLLER_PATH)
+@ConditionalOnProperty(name = "apiml.service.gateway.proxy.enabled", havingValue = "true")
 public class WellKnownRestController {
     public static final String CONTROLLER_PATH = "/gateway/.well-known";
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestController.java
@@ -26,6 +26,11 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 
+/**
+ * Controller to provide the /.well-known information. Especially the jwk set with the public key used
+ * for the verification of digital signature.
+ * Currently, this controller should be available only when the Cloud Gateway is in proxy mode.
+ */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(WellKnownRestController.CONTROLLER_PATH)

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactory.java
@@ -1,0 +1,61 @@
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Service;
+import org.zowe.apiml.message.core.MessageService;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+
+/**
+ * Objective is to include new header in the request which contain authentication source (client cert)
+ * for further processing by the domain gateway.
+ */
+@Service
+@Slf4j
+public class AuthSourceFilterFactory extends AbstractGatewayFilterFactory<AuthSourceFilterFactory.Config> {
+
+    public AuthSourceFilterFactory(MessageService messageService) {
+        super(Config.class);
+        this.messageService = messageService;
+    }
+
+    private final MessageService messageService;
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            String authSource = "none";
+            if (exchange.getRequest().getSslInfo() != null) {
+                X509Certificate[] certificates = exchange.getRequest().getSslInfo().getPeerCertificates();
+                if (certificates != null && certificates.length > 0) {
+                    byte[] certBytes = new byte[0];
+                    try {
+                        certBytes = certificates[0].getEncoded();
+                    } catch (CertificateEncodingException e) {
+                        throw new RuntimeException(e);
+                    }
+                    authSource = Base64.getEncoder().encodeToString(certBytes);
+                }
+            }
+            String finalAuthSource = authSource;
+            ServerHttpRequest request = exchange.getRequest().mutate().headers(headers -> {
+                headers.add(config.getHeaderName(), finalAuthSource);
+
+            }).build();
+            return chain.filter(exchange.mutate().request(request).build());
+        });
+    }
+
+    @Getter
+    @Setter
+    public static class Config {
+        private String headerName;
+    }
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactory.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.filters;
 
 import lombok.Getter;

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSign.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSign.java
@@ -1,0 +1,99 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.cloudgatewayservice.security;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.zowe.apiml.security.HttpsConfig;
+import org.zowe.apiml.security.SecurityUtils;
+
+import javax.annotation.PostConstruct;
+import java.security.*;
+
+@Service
+@Slf4j
+public class AuthSourceSign {
+
+    @Value("${server.ssl.keyStore:#{null}}")
+    private String keyStore;
+
+    @Value("${server.ssl.keyStorePassword:#{null}}")
+    private char[] keyStorePassword;
+
+    @Value("${server.ssl.keyPassword:#{null}}")
+    private char[] keyPassword;
+
+    @Value("${server.ssl.keyStoreType:PKCS12}")
+    private String keyStoreType;
+
+    @Value("${server.ssl.keyAlias:#{null}}")
+    private String keyAlias;
+
+    private PrivateKey privateKey;
+
+    @Getter
+    private PublicKey publicKey;
+
+    private static final String ALGORITHM = "SHA256withRSA";
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public byte[] sign(byte[] data) throws SignatureException {
+        Signature signature;
+        try {
+            signature = Signature.getInstance(ALGORITHM);
+            signature.initSign(privateKey, secureRandom);
+            signature.update(data);
+            return signature.sign();
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("Failed to create the signature. The cryptographic algorithm {} is not available in the environment. {}", ALGORITHM, e.getMessage());
+            throw new SignatureException(e);
+        } catch (InvalidKeyException e) {
+            log.warn("Failed to create the signature due to the invalid private key. {}", e.getMessage());
+            throw new SignatureException(e);
+        }
+    }
+
+    public boolean verify(byte[] data, byte[] dataSignature) throws SignatureException {
+        Signature signature;
+        try {
+            signature = Signature.getInstance(ALGORITHM);
+            signature.initVerify(publicKey);
+            signature.update(data);
+            return signature.verify(dataSignature);
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("Failed to verify the signature. The cryptographic algorithm {} is not available in the environment. {}", ALGORITHM, e.getMessage());
+            throw new SignatureException(e);
+        } catch (InvalidKeyException e) {
+            log.warn("Failed to verify the signature due to the invalid public key. {}", e.getMessage());
+            throw new SignatureException(e);
+        }
+    }
+
+    @PostConstruct
+    private void loadKeys() {
+        HttpsConfig config = currentConfig();
+        privateKey = (PrivateKey) SecurityUtils.loadKey(config);
+        publicKey = SecurityUtils.loadPublicKey(config);
+    }
+
+    private HttpsConfig currentConfig() {
+        return HttpsConfig.builder()
+                .keyAlias(keyAlias)
+                .keyStore(keyStore)
+                .keyPassword(keyPassword)
+                .keyStorePassword(keyStorePassword)
+                .keyStoreType(keyStoreType)
+                .build();
+    }
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSign.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSign.java
@@ -20,6 +20,10 @@ import org.zowe.apiml.security.SecurityUtils;
 import javax.annotation.PostConstruct;
 import java.security.*;
 
+/**
+ * This service provides a digital signature of any authentication source (or any byte array)
+ * and the associated public key which can be used for the signature verification.
+ */
 @Service
 @Slf4j
 public class AuthSourceSign {
@@ -41,6 +45,9 @@ public class AuthSourceSign {
 
     private PrivateKey privateKey;
 
+    /**
+     * Get the public key for the signature verification
+     */
     @Getter
     private PublicKey publicKey;
 
@@ -48,6 +55,14 @@ public class AuthSourceSign {
 
     private final SecureRandom secureRandom = new SecureRandom();
 
+    /**
+     * Generates the digital signature of the provided data array.
+     * The algorithm used for the signature is {@value #ALGORITHM}.
+     *
+     * @param data Byte array of the data which should be signed.
+     * @return The digital signature in the form of byte array
+     * @throws SignatureException when generating signature fails. The message provides details of the failure.
+     */
     public byte[] sign(byte[] data) throws SignatureException {
         Signature signature;
         try {
@@ -64,6 +79,15 @@ public class AuthSourceSign {
         }
     }
 
+    /**
+     * Verifies the validity of the signature and provided data array. The public key provided by {@link AuthSourceSign#getPublicKey()}
+     * is used for the verification. (This method is currently used only in tests)
+     *
+     * @param data          The byte array of data which should be verified
+     * @param dataSignature The byte array of the associated signature
+     * @return True if the signature is valid for provided block of data. False otherwise.
+     * @throws SignatureException when validation of the signature fails. The message provides details of the failure.
+     */
     public boolean verify(byte[] data, byte[] dataSignature) throws SignatureException {
         Signature signature;
         try {
@@ -89,11 +113,11 @@ public class AuthSourceSign {
 
     private HttpsConfig currentConfig() {
         return HttpsConfig.builder()
-                .keyAlias(keyAlias)
-                .keyStore(keyStore)
-                .keyPassword(keyPassword)
-                .keyStorePassword(keyStorePassword)
-                .keyStoreType(keyStoreType)
-                .build();
+            .keyAlias(keyAlias)
+            .keyStore(keyStore)
+            .keyPassword(keyPassword)
+            .keyStorePassword(keyStorePassword)
+            .keyStoreType(keyStoreType)
+            .build();
     }
 }

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/ProxyRouteLocator.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/ProxyRouteLocator.java
@@ -43,6 +43,10 @@ public class ProxyRouteLocator extends RouteLocator {
 
         routeDefinition.getPredicates().add(predicate);
 
+        FilterDefinition filterDef = new FilterDefinition();
+        filterDef.setName("AuthSourceFilterFactory");
+        filterDef.addArg("headerName", "X-auth-source");
+        routeDefinition.getFilters().add(filterDef);
         for (FilterDefinition filter : getFilters()) {
             routeDefinition.getFilters().add(filter);
         }

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/ProxyRouteLocator.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/ProxyRouteLocator.java
@@ -45,7 +45,8 @@ public class ProxyRouteLocator extends RouteLocator {
 
         FilterDefinition filterDef = new FilterDefinition();
         filterDef.setName("AuthSourceFilterFactory");
-        filterDef.addArg("headerName", "X-auth-source");
+        filterDef.addArg("authSourceHeader", "X-auth-source");
+        filterDef.addArg("authSignatureHeader", "X-auth-signature");
         routeDefinition.getFilters().add(filterDef);
         for (FilterDefinition filter : getFilters()) {
             routeDefinition.getFilters().add(filter);

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestControllerTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestControllerTest.java
@@ -1,0 +1,99 @@
+package org.zowe.apiml.cloudgatewayservice.controller;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.zowe.apiml.cloudgatewayservice.security.AuthSourceSign;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.text.ParseException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@WebFluxTest(controllers = WellKnownRestController.class, excludeAutoConfiguration = {ReactiveSecurityAutoConfiguration.class})
+class WellKnownRestControllerTest {
+    private PublicKey publicKey;
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @MockBean
+    private AuthSourceSign mockAuthSourceSign;
+
+    @Nested
+    class GivenSinglePublicKeyIsAvailable {
+
+        @BeforeEach
+        void setUp() throws NoSuchAlgorithmException {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            publicKey = keyPair.getPublic();
+            when(mockAuthSourceSign.getPublicKey()).thenReturn(publicKey);
+        }
+
+        @Test
+        void thenJWKSetIsProvided() throws IOException, ParseException, JOSEException {
+            FluxExchangeResult<String> result =
+                webTestClient.get()
+                    .uri("/gateway/.well-known/jwks.json")
+                    .accept(MediaType.ALL)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .returnResult(String.class);
+            verify(mockAuthSourceSign, times(1)).getPublicKey();
+            assertNotNull(result);
+            InputStream jsonBody = new ByteArrayInputStream(result.getResponseBodyContent());
+            List<JWK> keys = JWKSet.load(jsonBody).getKeys();
+            assertEquals(1, keys.size());
+            PublicKey resultPublicKey = keys.get(0).toRSAKey().toPublicKey();
+            assertEquals(publicKey, resultPublicKey);
+        }
+    }
+
+    @Nested
+    class GivenNoPublicKeyExists {
+
+        @BeforeEach
+        void setUp() {
+            when(mockAuthSourceSign.getPublicKey()).thenReturn(null);
+        }
+
+        @Test
+        void thenReturnEmptyJWKSet() throws IOException, ParseException, JOSEException {
+            FluxExchangeResult<String> result =
+                webTestClient.get()
+                    .uri("/gateway/.well-known/jwks.json")
+                    .accept(MediaType.ALL)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .returnResult(String.class);
+            verify(mockAuthSourceSign, times(1)).getPublicKey();
+            assertNotNull(result);
+            InputStream jsonBody = new ByteArrayInputStream(result.getResponseBodyContent());
+            List<JWK> keys = JWKSet.load(jsonBody).getKeys();
+            assertEquals(0, keys.size());
+        }
+    }
+}

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestControllerTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/controller/WellKnownRestControllerTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.controller;
 
 import com.nimbusds.jose.JOSEException;

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactoryTest.java
@@ -1,0 +1,193 @@
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.http.server.reactive.SslInfo;
+import org.springframework.web.server.ServerWebExchange;
+import org.zowe.apiml.cloudgatewayservice.security.AuthSourceSign;
+import org.zowe.apiml.constants.ApimlConstants;
+import reactor.core.publisher.Mono;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthSourceFilterFactoryTest {
+
+    private static final String AUTH_SOURCE_HEADER = "auth-source";
+    private static final String AUTH_SIGNATURE_HEADER = "auth-signature";
+    private static final byte[] CERTIFICATE_BYTES = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
+    private static final byte[] CERTIFICATE_SIGNATURE = "1234567890".getBytes();
+    private final X509Certificate[] x509Certificates = new X509Certificate[1];
+
+    SslInfo sslInfo = mock(SslInfo.class);
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest request = mock(ServerHttpRequest.class);
+    X509Certificate certificate = mock(X509Certificate.class);
+    GatewayFilterChain chain = mock(GatewayFilterChain.class);
+    AuthSourceSign authSourceSign = mock(AuthSourceSign.class);
+    AuthSourceFilterFactory factory;
+    AuthSourceFilterFactory.Config config;
+
+    @BeforeEach
+    void setup() throws CertificateEncodingException, SignatureException {
+        factory = new AuthSourceFilterFactory(authSourceSign);
+        config = new AuthSourceFilterFactory.Config();
+        config.setAuthSourceHeader(AUTH_SOURCE_HEADER);
+        config.setAuthSignatureHeader(AUTH_SIGNATURE_HEADER);
+
+        ServerHttpRequest.Builder builder = new ServerHttpRequestBuilderMock();
+        ServerWebExchange.Builder exchangeBuilder = new ServerWebExchangeBuilderMock();
+        x509Certificates[0] = certificate;
+        when(certificate.getEncoded()).thenReturn(CERTIFICATE_BYTES);
+        when(authSourceSign.sign(CERTIFICATE_BYTES)).thenReturn(CERTIFICATE_SIGNATURE);
+
+        when(exchange.getRequest()).thenReturn(request);
+
+        when(request.getSslInfo()).thenReturn(sslInfo);
+        when(request.mutate()).thenReturn(builder);
+
+        when(sslInfo.getPeerCertificates()).thenReturn(x509Certificates);
+
+        when(exchange.mutate()).thenReturn(exchangeBuilder);
+        when(chain.filter(exchange)).thenReturn(Mono.empty());
+    }
+    @Test
+    void givenCertificateInRequest_thenAddHeaders() throws Exception {
+        GatewayFilter filter = factory.apply(config);
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertNull(exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER));
+        assertNotNull(exchange.getRequest().getHeaders().get(AUTH_SOURCE_HEADER));
+        assertNotNull(exchange.getRequest().getHeaders().get(AUTH_SIGNATURE_HEADER));
+        assertEquals(Base64.getEncoder().encodeToString(CERTIFICATE_BYTES), exchange.getRequest().getHeaders().get(AUTH_SOURCE_HEADER).get(0));
+        assertEquals(Base64.getEncoder().encodeToString(CERTIFICATE_SIGNATURE), exchange.getRequest().getHeaders().get(AUTH_SIGNATURE_HEADER).get(0));
+    }
+
+    @Test
+    void givenCertificateWithIncorrectEncoding_thenProvideInfoInHeader() throws Exception {
+        GatewayFilter filter = factory.apply(config);
+        when(certificate.getEncoded()).thenThrow(new CertificateEncodingException("incorrect encoding"));
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertNotNull(exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER));
+        assertEquals("Invalid client certificate in request. Error message: incorrect encoding", exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER).get(0));
+    }
+
+    @Test
+    void givenErrorDuringSigning_thenProvideErrorInHeader() throws Exception {
+        GatewayFilter filter = factory.apply(config);
+        when(authSourceSign.sign(CERTIFICATE_BYTES)).thenThrow(new SignatureException("invalid private key"));
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertNotNull(exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER));
+        assertEquals("Failed to sign the client certificate in request. Error message: invalid private key", exchange.getRequest().getHeaders().get(ApimlConstants.AUTH_FAIL_HEADER).get(0));
+    }
+
+    @Test
+    void givenNoCertificateInRequest_thenContinueFilterChainWithUntouchedHeaders() {
+        GatewayFilter filter = factory.apply(config);
+        when(sslInfo.getPeerCertificates()).thenReturn(null);
+        Mono<Void> result = filter.filter(exchange, chain);
+        result.block();
+        assertNull(exchange.getRequest().getHeaders());
+    }
+
+    private class ServerHttpRequestBuilderMock implements ServerHttpRequest.Builder {
+        HttpHeaders headers = new HttpHeaders();
+
+        @Override
+        public ServerHttpRequest.Builder method(HttpMethod httpMethod) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder uri(URI uri) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder path(String path) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder contextPath(String contextPath) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder header(String headerName, String... headerValues) {
+            headers.add(headerName, headerValues[0]);
+            return this;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder headers(Consumer<HttpHeaders> headersConsumer) {
+            headersConsumer.accept(this.headers);
+            return this;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder sslInfo(SslInfo sslInfo) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest.Builder remoteAddress(InetSocketAddress remoteAddress) {
+            return null;
+        }
+
+        @Override
+        public ServerHttpRequest build() {
+            when(request.getHeaders()).thenReturn(headers);
+            return request;
+        }
+    }
+
+    private class ServerWebExchangeBuilderMock implements ServerWebExchange.Builder {
+        ServerHttpRequest request;
+
+        @Override
+        public ServerWebExchange.Builder request(Consumer<ServerHttpRequest.Builder> requestBuilderConsumer) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange.Builder request(ServerHttpRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        @Override
+        public ServerWebExchange.Builder response(ServerHttpResponse response) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange.Builder principal(Mono<Principal> principalMono) {
+            return null;
+        }
+
+        @Override
+        public ServerWebExchange build() {
+            when(exchange.getRequest()).thenReturn(request);
+            return exchange;
+        }
+    }
+}

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/AuthSourceFilterFactoryTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.filters;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSignTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSignTest.java
@@ -1,0 +1,77 @@
+package org.zowe.apiml.cloudgatewayservice.security;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthSourceSignTest {
+
+    private static PublicKey publicKey;
+    private static PrivateKey privateKey;
+    private AuthSourceSign authSourceSign;
+
+    @BeforeAll
+    static void setup() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        publicKey = keyPair.getPublic();
+        privateKey = keyPair.getPrivate();
+    }
+
+    @Nested
+    class GivenValidKeys {
+
+        {
+            authSourceSign = new AuthSourceSign();
+            ReflectionTestUtils.setField(authSourceSign, "privateKey", privateKey);
+            ReflectionTestUtils.setField(authSourceSign, "publicKey", publicKey);
+        }
+
+        @Test
+        void whenSigning_thenSignatureIsProduced() throws SignatureException {
+            byte[] data = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
+            byte[] signature = authSourceSign.sign(data);
+            assertNotNull(signature);
+            assertTrue(authSourceSign.verify(data, signature));
+        }
+
+        @Test
+        void getPublicKey() {
+            assertEquals(publicKey, authSourceSign.getPublicKey());
+        }
+    }
+
+    @Nested
+    class GivenInvalidKeys {
+
+        {
+            authSourceSign = new AuthSourceSign();
+            ReflectionTestUtils.setField(authSourceSign, "privateKey", null);
+            ReflectionTestUtils.setField(authSourceSign, "publicKey", null);
+        }
+
+        @Test
+        void whenSigning_thenExceptionIsThrown() throws SignatureException {
+            byte[] data = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
+            SignatureException thrown = assertThrows(SignatureException.class, () -> {
+                authSourceSign.sign(data);
+            });
+            assertEquals("java.security.InvalidKeyException: Key must not be null", thrown.getMessage());
+        }
+
+        @Test
+        void whenVerifying_thenExceptionIsThrown() throws SignatureException {
+            byte[] data = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes();
+            byte[] signature = "12345".getBytes();
+            SignatureException thrown = assertThrows(SignatureException.class, () -> {
+                authSourceSign.verify(data, signature);
+            });
+            assertEquals("java.security.InvalidKeyException: Key must not be null", thrown.getMessage());
+        }
+    }
+}

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSignTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/security/AuthSourceSignTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.cloudgatewayservice.security;
 
 import org.junit.jupiter.api.BeforeAll;

--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -32,6 +32,8 @@ apiml:
             verifySslCertificatesOfServices: true
         x509:
             enabled: true
+            authViaHeader: false
+
     banner: console
 
 spring:

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -64,6 +64,7 @@ import org.zowe.apiml.security.common.filter.CategorizeCertsFilter;
 import org.zowe.apiml.security.common.filter.StoreAccessTokenInfoFilter;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
 import org.zowe.apiml.security.common.login.*;
+import org.zowe.apiml.security.common.verify.CertificateValidator;
 
 import java.util.Collections;
 import java.util.Set;
@@ -100,6 +101,7 @@ public class NewSecurityConfiguration {
     private final FailedAccessTokenHandler failedAccessTokenHandler;
     @Qualifier("publicKeyCertificatesBase64")
     private final Set<String> publicKeyCertificatesBase64;
+    private final CertificateValidator certificateValidator;
     private final X509AuthenticationProvider x509AuthenticationProvider;
     @Value("${server.attls.enabled:false}")
     private boolean isAttlsEnabled;
@@ -160,7 +162,7 @@ public class NewSecurityConfiguration {
             public void configure(HttpSecurity http) throws Exception {
                 AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
                 //drive filter order this way
-                http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
+                http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                     .addFilterBefore(loginFilter("/**", authenticationManager), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                     .addFilterAfter(x509AuthenticationFilter("/**"), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class) // this filter consumes certificates from custom attribute and maps them to credentials and authenticates them
                     .addFilterAfter(new ShouldBeAlreadyAuthenticatedFilter("/**", handlerInitializer.getAuthenticationFailureHandler()), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class); // this filter stops processing of filter chaing because there is nothing on /auth/login endpoint
@@ -222,7 +224,7 @@ public class NewSecurityConfiguration {
             public void configure(HttpSecurity http) throws Exception {
                 AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
                 //drive filter order this way
-                http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
+                http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                     .addFilterBefore(new StoreAccessTokenInfoFilter(handlerInitializer.getUnAuthorizedHandler().getHandler()), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                     .addFilterBefore(accessTokenFilter("/**", authenticationManager), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                     .addFilterAfter(x509AuthenticationFilter("/**"), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class) // this filter consumes certificates from custom attribute and maps them to credentials and authenticates them
@@ -272,7 +274,7 @@ public class NewSecurityConfiguration {
             private class CustomSecurityFilters extends AbstractHttpConfigurer<AccessToken.CustomSecurityFilters, HttpSecurity> {
                 @Override
                 public void configure(HttpSecurity http) {
-                    http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
+                    http.addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                         .addFilterBefore(loginFilter(http), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class)
                         .addFilterAfter(x509AuthenticationFilter(), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class);
                 }
@@ -559,7 +561,7 @@ public class NewSecurityConfiguration {
             }
 
             private CategorizeCertsFilter reversedCategorizeCertFilter() {
-                CategorizeCertsFilter out = new CategorizeCertsFilter(publicKeyCertificatesBase64);
+                CategorizeCertsFilter out = new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator);
                 out.setCertificateForClientAuth(crt -> out.getPublicKeyCertificatesBase64().contains(out.base64EncodePublicKey(crt)));
                 out.setNotCertificateForClientAuth(crt -> !out.getPublicKeyCertificatesBase64().contains(out.base64EncodePublicKey(crt)));
                 return out;
@@ -613,7 +615,7 @@ public class NewSecurityConfiguration {
                 .permitAll()
                 .and().logout().disable()
                 // sort out client and apiml internal certificates
-                .addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64), AnonymousAuthenticationFilter.class)
+                .addFilterBefore(new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator), AnonymousAuthenticationFilter.class)
                 .build();
         }
     }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -86,6 +86,7 @@ apiml:
             provider: zosmf
         x509:
             enabled: false
+            authViaHeader: false
             externalMapperUrl:
         saf:
             provider: rest

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -87,6 +87,7 @@ apiml:
         x509:
             enabled: false
             authViaHeader: false
+            publicKeyUrl:
             externalMapperUrl:
         saf:
             provider: rest

--- a/gateway-service/src/main/resources/ehcache.xml
+++ b/gateway-service/src/main/resources/ehcache.xml
@@ -15,5 +15,6 @@
     <cache name="zosmfJwtEndpoint" diskPersistent="false" maxEntriesLocalHeap="10" eternal="false" timeToIdleSeconds="3600" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
     <cache name="validationOIDCToken" diskPersistent="false" maxEntriesLocalHeap="1000" eternal="false" timeToIdleSeconds="20" timeToLiveSeconds="20" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
     <cache name="parseOIDCToken" diskPersistent="false" maxEntriesLocalHeap="1000" eternal="false" timeToIdleSeconds="20" timeToLiveSeconds="20" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
+    <cache name="publicKey" diskPersistent="false" maxEntriesLocalHeap="1000" eternal="false" timeToIdleSeconds="20" timeToLiveSeconds="20" memoryStoreEvictionPolicy="LRU" transactionalMode="off" />
 
 </ehcache>

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
@@ -92,7 +92,7 @@ class X509SchemeTest implements TestWithStartedInstances {
                 String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), X509_ENDPOINT);
                 given()
                     .header("X-Request-Id", "gateway" + gatewayHost)
-                    .config(SslContext.clientCertValid)
+                    .header("x-auth-source", SslContext.clientCertValid)
                     .when()
                     .get(scgUrl)
                     .then()

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
@@ -27,7 +27,7 @@ import org.zowe.apiml.util.http.HttpRequestUtils;
 import java.net.URI;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.zowe.apiml.util.requests.Endpoints.X509_ENDPOINT;
 
@@ -81,6 +81,22 @@ class X509SchemeTest implements TestWithStartedInstances {
                     .when()
                     .get(X509SchemeTest.URL)
                     .then()
+                    .body("dn", startsWith("CN=APIMTST"))
+                    .body("cn", is("APIMTST")).statusCode(200);
+            }
+
+            @Test
+            @Tag("CloudGatewayServiceRouting")
+            void givenCorrectClientCertificateInHeader() {
+                String gatewayHost = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getHost();
+                String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), X509_ENDPOINT);
+                given()
+                    .header("X-Request-Id", "gateway" + gatewayHost)
+                    .config(SslContext.clientCertValid)
+                    .when()
+                    .get(scgUrl)
+                    .then()
+                    .body("publicKey", is(not(nullValue())))
                     .body("dn", startsWith("CN=APIMTST"))
                     .body("cn", is("APIMTST")).statusCode(200);
             }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
@@ -86,22 +86,6 @@ class X509SchemeTest implements TestWithStartedInstances {
             }
 
             @Test
-            @Tag("CloudGatewayServiceRouting")
-            void givenCorrectClientCertificateInHeader() {
-                String gatewayHost = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getHost();
-                String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), X509_ENDPOINT);
-                given()
-                    .header("X-Request-Id", "gateway" + gatewayHost)
-                    .header("x-auth-source", SslContext.clientCertValid)
-                    .when()
-                    .get(scgUrl)
-                    .then()
-                    .body("publicKey", is(not(nullValue())))
-                    .body("dn", startsWith("CN=APIMTST"))
-                    .body("cn", is("APIMTST")).statusCode(200);
-            }
-
-            @Test
             void givenApimlCertificateInRequest() {
                 given()
                     .config(SslContext.clientCertApiml)

--- a/integration-tests/src/test/java/org/zowe/apiml/util/requests/Endpoints.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/requests/Endpoints.java
@@ -70,4 +70,6 @@ public class Endpoints {
     public final static String API_SERVICE_VERSION_DIFF_ENDPOINT = "/apicatalog/api/v1/apidoc/discoverableclient/zowe.apiml.discoverableclient.rest v1.0.0/zowe.apiml.discoverableclient.rest v2.0.0";
     public final static String API_SERVICE_VERSION_DIFF_ENDPOINT_WRONG_VERSION = "/apicatalog/api/v1/apidoc/discoverableclient/zowe.apiml.discoverableclient.rest v1.0.0/zowe.apiml.discoverableclient.rest v3.0.0";
     public final static String API_SERVICE_VERSION_DIFF_ENDPOINT_WRONG_SERVICE = "/apicatalog/api/v1/apidoc/invalidService/v1/v2";
+
+    public final static String CLOUD_GATEWAY_WELL_KNOWN_JWKS = "/gateway/.well-known/jwks.json";
 }


### PR DESCRIPTION
# Description

When the Spring Cloud Gateway is set as proxy for the domain gateways we want to be able to forward the x509 client certificate to the domain gatway for further processing (mapping to MF userid).

SCGW now takes a client cert from the request, generates digital signature and put the Base64 encoded cert and signature to dedicated request headers (`X-Auth-Source` and `X-Auth-Signature`). It also provides the public key for signature validation in the form of JWK set at the `/gateway/.well-known/jwks.json` URL.

The domain GW needs to be configured to accept such auth source with the `apiml.security.x509.authViaHeader` set to `true` and also it needs to know the full URL to retrieve the public key for the signature verification ( configured in `apiml.security.x509.publicKeyUrl`).
The `CategorizeCertsFilter class` then decides if the auth source in the header is trusted and put it back to the request for futher processing.


Linked to #2885
Part of the #2651

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [x] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
