### PR TITLE
fix: Fix processing of Open API docs by API Catalog (JavaTimeModule)

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
@@ -11,6 +11,8 @@
 package org.zowe.apiml.apicatalog.swagger.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.models.ExternalDocs;
 import io.swagger.models.Path;
 import io.swagger.models.Scheme;
@@ -54,11 +56,17 @@ public class ApiDocV2Service extends AbstractApiDocService<Swagger, Path> {
         updateExternalDoc(swagger, apiDocInfo);
 
         try {
-            return Json.mapper().writeValueAsString(swagger);
+            return initializeObjectMapper().writeValueAsString(swagger);
         } catch (JsonProcessingException e) {
             log.debug("Could not convert Swagger to JSON", e);
             throw new ApiDocTransformationException("Could not convert Swagger to JSON");
         }
+    }
+
+    private ObjectMapper initializeObjectMapper() {
+        ObjectMapper objectMapper = Json.mapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
     }
 
     /**

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
@@ -74,7 +75,7 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
             return initializeObjectMapper().writeValueAsString(openAPI);
         } catch (JsonProcessingException e) {
             log.debug("Could not convert OpenAPI to JSON", e);
-            throw new ApiDocTransformationException("Could not convert Swagger to JSON");
+            throw new ApiDocTransformationException("Could not convert Swagger to JSON: " + e.getMessage());
         }
     }
 
@@ -194,6 +195,8 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
 
         objectMapper.registerModule(simpleModule);
         objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+
+        objectMapper.registerModule(new JavaTimeModule());
 
         return objectMapper;
     }


### PR DESCRIPTION
# Description

For specific OpenAPI docs API Catalog fails with an error `Java 8 date/time type `java.time.LocalDate` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling`

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
