### PR TITLE
fix: Integration tests for new Cloud Gateway routing

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -144,6 +144,7 @@ jobs:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_HOSTNAME: gateway-service-2
+                    APIML_SERVICE_APIMLID: apiml2
                     SERVER_INTERNAL_PORT: 10027
             cloud-gateway-service:
                 image: ghcr.io/balhar-jakub/cloud-gateway-service:${{ github.run_id }}-${{ github.run_number }}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactory.java
@@ -21,6 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
+/**
+ * This predicate is responsible for checking if the request header is missing. If the header is missing, routing
+ * will continue.
+ * It is used in org.zowe.apiml.cloudgatewayservice.service.routing.ByBasePath to prevent routing if the header is set.
+ */
 @Service
 public class MissingHeaderRoutePredicateFactory extends AbstractRoutePredicateFactory<MissingHeaderRoutePredicateFactory.Config> {
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactory.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactory.java
@@ -1,0 +1,65 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import java.util.function.Predicate;
+
+import javax.validation.constraints.NotEmpty;
+
+import lombok.Getter;
+import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
+import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.server.ServerWebExchange;
+
+@Service
+public class MissingHeaderRoutePredicateFactory extends AbstractRoutePredicateFactory<MissingHeaderRoutePredicateFactory.Config> {
+
+    public MissingHeaderRoutePredicateFactory() {
+        super(Config.class);
+    }
+
+    @Override
+    public Predicate<ServerWebExchange> apply(Config config) {
+        return new GatewayPredicate() {
+            @Override
+            public boolean test(ServerWebExchange exchange) {
+                return !exchange.getRequest().getHeaders().containsKey(config.header);
+            }
+
+            @Override
+            public Object getConfig() {
+                return config;
+            }
+
+            @Override
+            public String toString() {
+                return String.format("Missing header: %s", config.header);
+            }
+        };
+    }
+
+    @Getter
+    @Validated
+    public static class Config {
+
+        @NotEmpty
+        private String header;
+
+        public Config setHeader(String header) {
+            this.header = header;
+            return this;
+        }
+
+    }
+
+}

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/routing/ByBasePath.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/service/routing/ByBasePath.java
@@ -29,6 +29,8 @@ import org.zowe.apiml.util.StringUtils;
 @Component
 public class ByBasePath extends RouteDefinitionProducer {
 
+    private static final String TARGET_HEADER_NAME = "X-Forward-To";
+
     public ByBasePath(DiscoveryLocatorProperties properties) {
         super(properties);
     }
@@ -47,11 +49,16 @@ public class ByBasePath extends RouteDefinitionProducer {
 
     @Override
     protected void setCondition(RouteDefinition routeDefinition, ServiceInstance serviceInstance, RoutedService routedService) {
-        PredicateDefinition predicate = new PredicateDefinition();
-        predicate.setName("Path");
+        PredicateDefinition headerPredicate = new PredicateDefinition();
+        headerPredicate.setName("MissingHeader");
+        headerPredicate.addArg("header", TARGET_HEADER_NAME);
+        routeDefinition.getPredicates().add(headerPredicate);
+
+        PredicateDefinition pathPredicate = new PredicateDefinition();
+        pathPredicate.setName("Path");
         String predicateValue = constructUrl(serviceInstance.getServiceId(), routedService.getGatewayUrl(), "**");
-        predicate.addArg("pattern", predicateValue);
-        routeDefinition.getPredicates().add(predicate);
+        pathPredicate.addArg("pattern", predicateValue);
+        routeDefinition.getPredicates().add(pathPredicate);
     }
 
     @Override

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.cloudgatewayservice.filters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MissingHeaderRoutePredicateFactoryTest {
+
+    private Predicate<ServerWebExchange> predicate;
+
+    @BeforeEach
+    void setup() {
+        MissingHeaderRoutePredicateFactory.Config config = new MissingHeaderRoutePredicateFactory.Config();
+        config.setHeader("myheader");
+        predicate = new MissingHeaderRoutePredicateFactory().apply(config);
+    }
+
+    @ParameterizedTest(name = "When header {1} is set to {2} and the filter works with header {0} the value after processing should be {3}")
+    @CsvSource({
+        "myheader,GW,false",
+        "myheader,,false",
+        "otherheader,othervalue,true",
+        ",,true",
+    })
+    void testPredicate(String headerName, String headerValue, boolean result) {
+        MockServerHttpRequest request;
+        if (headerName != null) {
+            request = MockServerHttpRequest
+                .get("/")
+                .header(headerName, headerValue).build();
+        } else {
+            request = MockServerHttpRequest
+                .get("/").build();
+        }
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        assertThat(predicate.test(exchange)).isEqualTo(result);
+    }
+
+    @Test
+    void testToStringFormat() {
+        assertThat(predicate.toString()).contains("Missing header: myheader");
+    }
+}

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactoryTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/MissingHeaderRoutePredicateFactoryTest.java
@@ -33,7 +33,7 @@ class MissingHeaderRoutePredicateFactoryTest {
         predicate = new MissingHeaderRoutePredicateFactory().apply(config);
     }
 
-    @ParameterizedTest(name = "When header {1} is set to {2} and the filter works with header {0} the value after processing should be {3}")
+    @ParameterizedTest(name = "When header {0} is set to {1}, the value after processing should be {2}")
     @CsvSource({
         "myheader,GW,false",
         "myheader,,false",

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/service/routing/ByBasePathTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/service/routing/ByBasePathTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.mock;
 
 class ByBasePathTest {
 
+    private static final String TARGET_HEADER_NAME = "X-Forward-To";
+
     @Nested
     class CommonParts {
 
@@ -67,10 +69,14 @@ class ByBasePathTest {
 
             new ByBasePath(new DiscoveryLocatorProperties()).setCondition(routeDefinition, serviceInstance, routedService);
 
-            assertEquals(1, routeDefinition.getPredicates().size());
-            PredicateDefinition predicateDefinition = routeDefinition.getPredicates().get(0);
-            assertEquals("Path", predicateDefinition.getName());
-            assertEquals(pattern, predicateDefinition.getArgs().get("pattern"));
+            assertEquals(2, routeDefinition.getPredicates().size());
+            PredicateDefinition headerPredicate = routeDefinition.getPredicates().get(0);
+            assertEquals("MissingHeader", headerPredicate.getName());
+            assertEquals(TARGET_HEADER_NAME, headerPredicate.getArgs().get("header"));
+
+            PredicateDefinition pathPredicate = routeDefinition.getPredicates().get(1);
+            assertEquals("Path", pathPredicate.getName());
+            assertEquals(pattern, pathPredicate.getArgs().get("pattern"));
         }
 
         @ParameterizedTest(name = "to map URLs of service {0} from {1} to {2} is constructed pattern {3} and replacement {4} arguments")

--- a/config/local/cloud-gateway-service.yml
+++ b/config/local/cloud-gateway-service.yml
@@ -1,0 +1,23 @@
+apiml:
+    service:
+        hostname: localhost
+eureka:
+    client:
+        serviceUrl:
+            defaultZone: https://localhost:10011/eureka/
+server:
+    ssl:
+        keyAlias: localhost
+        keyPassword: password
+        keyStore: keystore/localhost/localhost.keystore.p12
+        keyStorePassword: password
+        keyStoreType: PKCS12
+        trustStore: keystore/localhost/localhost.truststore.p12
+        trustStorePassword: password
+        trustStoreType: PKCS12
+spring:
+    output:
+        ansi:
+            enabled: always
+    profiles:
+        include: debug

--- a/config/local/gateway-service.yml
+++ b/config/local/gateway-service.yml
@@ -1,7 +1,7 @@
 spring.profiles.include: diag
 apiml:
     service:
-        apimlId: local1
+        apimlId: apiml1
         hostname: localhost
         ipAddress: 127.0.0.1
         port: 10010

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -59,6 +59,7 @@
 # - ZWE_configs_certificate_truststore_type
 # - ZWE_configs_debug
 # - ZWE_configs_port - the port the api gateway service will use
+# - ZWE_configs_apimlId
 # - ZWE_configs_server_internal_ssl_certificate_keystore_alias
 # - ZWE_configs_server_internal_ssl_certificate_keystore_file
 # - ZWE_configs_server_internal_enabled
@@ -131,6 +132,12 @@ else
   nonStrictVerifySslCertificatesOfServices=false
 fi
 
+if [ "${ZWE_configs_server_ssl_enabled:-true}" = "true" ]; then
+    httpProtocol="https"
+else
+    httpProtocol="http"
+fi
+
 if [ -z "${ZWE_configs_apiml_catalog_serviceId}" ]
 then
     APIML_GATEWAY_CATALOG_ID="apicatalog"
@@ -200,6 +207,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"} \
     -Dapiml.service.allowEncodedSlashes=${ZWE_configs_apiml_service_allowEncodedSlashes:-true} \
     -Dapiml.service.corsEnabled=${ZWE_configs_apiml_service_corsEnabled:-false} \
+    -Dapiml.service.externalUrl="${httpProtocol}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}" \
+    -Dapiml.service.apimlId=${ZWE_configs_apimlId:-} \
     -Dapiml.catalog.serviceId=${APIML_GATEWAY_CATALOG_ID:-apicatalog} \
     -Dapiml.cache.storage.location=${ZWE_zowe_workspaceDirectory}/api-mediation/${ZWE_PARAMETER_HA_INSTANCE:-localhost} \
     -Dapiml.logs.location=${ZWE_zowe_logDirectory} \

--- a/gateway-package/src/main/resources/manifest.yaml
+++ b/gateway-package/src/main/resources/manifest.yaml
@@ -32,6 +32,7 @@ configs:
   port: 7554
   debug: false
   sslDebug: ""
+  apimlId:
 
   apiml:
     security:

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/CloudGatewayRoutingTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/CloudGatewayRoutingTest.java
@@ -1,0 +1,61 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.functional.gateway;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.zowe.apiml.util.TestWithStartedInstances;
+import org.zowe.apiml.util.categories.DiscoverableClientDependentTest;
+import org.zowe.apiml.util.config.CloudGatewayConfiguration;
+import org.zowe.apiml.util.config.ConfigReader;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static io.restassured.RestAssured.given;
+import static org.zowe.apiml.util.requests.Endpoints.DISCOVERABLE_GREET;
+
+@DiscoverableClientDependentTest
+@Tag("CloudGatewayServiceRouting")
+public class CloudGatewayRoutingTest implements TestWithStartedInstances {
+
+    private static final String HEADER_X_FORWARD_TO = "X-Forward-To";
+    static CloudGatewayConfiguration conf = ConfigReader.environmentConfiguration().getCloudGatewayConfiguration();
+
+    @ParameterizedTest(name = "When header X-Forward-To is set to {1} should return 200")
+    @CsvSource({
+        "apiml1" + DISCOVERABLE_GREET,
+        "cloud-gateway" + DISCOVERABLE_GREET,
+        DISCOVERABLE_GREET,
+    })
+    void testRoutingWithBasePath(String basePath) throws URISyntaxException {
+        RestAssured.useRelaxedHTTPSValidation();
+
+        String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), basePath);
+        given().get(new URI(scgUrl)).then().statusCode(200);
+    }
+
+    @ParameterizedTest(name = "When header X-Forward-To is set to {1} should return 200")
+    @CsvSource({
+        "apiml1",
+        "cloud-gateway/discoverableclient",
+        "discoverableclient",
+    })
+    void testRoutingWithHeader(String forwardTo) throws URISyntaxException {
+        RestAssured.useRelaxedHTTPSValidation();
+
+        String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), DISCOVERABLE_GREET);
+        given().header(HEADER_X_FORWARD_TO, forwardTo)
+            .get(new URI(scgUrl)).then().statusCode(200);
+    }
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/CloudGatewayRoutingTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/CloudGatewayRoutingTest.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.functional.gateway;
 
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -36,14 +37,17 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
 
     static CloudGatewayConfiguration conf = ConfigReader.environmentConfiguration().getCloudGatewayConfiguration();
 
+    @BeforeEach
+    void setup() {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
     @ParameterizedTest(name = "When base path is {0} should return 200")
     @CsvSource({
         "/apiml1" + DISCOVERABLE_GREET,
         DISCOVERABLE_GREET,
     })
     void testRoutingWithBasePath(String basePath) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), basePath);
         given().get(new URI(scgUrl)).then().statusCode(200);
     }
@@ -54,8 +58,6 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
         "discoverableclient",
     })
     void testRoutingWithHeader(String forwardTo) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), DISCOVERABLE_GREET);
         given().header(HEADER_X_FORWARD_TO, forwardTo)
             .get(new URI(scgUrl)).then().statusCode(200);
@@ -67,8 +69,6 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
         NON_EXISTING_SERVICE_ENDPOINT,
     })
     void testRoutingWithIncorrectServiceInBasePath(String basePath) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), basePath);
         given().get(new URI(scgUrl)).then().statusCode(404);
     }
@@ -79,8 +79,6 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
         NON_EXISTING_SERVICE_ID,
     })
     void testRoutingWithIncorrectServiceInHeader(String forwardTo) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), NON_EXISTING_SERVICE_ENDPOINT);
         given().header(HEADER_X_FORWARD_TO, forwardTo)
             .get(new URI(scgUrl)).then().statusCode(404);
@@ -91,8 +89,6 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
         "apiml1,/apiml1" + DISCOVERABLE_GREET,
     })
     void testWrongRoutingWithHeader(String forwardTo, String endpoint) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), endpoint);
         given().header(HEADER_X_FORWARD_TO, forwardTo)
             .get(new URI(scgUrl)).then().statusCode(404);
@@ -104,8 +100,6 @@ class CloudGatewayRoutingTest implements TestWithStartedInstances {
         WRONG_VERSION_ENPOINT,
     })
     void testWrongRoutingWithBasePath(String basePath) throws URISyntaxException {
-        RestAssured.useRelaxedHTTPSValidation();
-
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), basePath);
         given().get(new URI(scgUrl)).then().statusCode(404);
     }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/X509SchemeTest.java
@@ -49,7 +49,7 @@ class X509SchemeTest implements TestWithStartedInstances {
 
     @Test
     @Tag("CloudGatewayServiceRouting")
-    void givenValidCLientCert_thenForwardDetailsInHeader() {
+    void givenValidClientCert_thenForwardDetailsInHeader() {
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), X509_ENDPOINT);
         given().config(SslContext.clientCertValid)
             .when()

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/CloudGatewayProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/CloudGatewayProxyTest.java
@@ -41,8 +41,18 @@ class CloudGatewayProxyTest {
         String scgUrl = String.format("%s://%s:%s/%s", conf.getScheme(), conf.getHost(), conf.getPort(), "gateway/version");
         given().header(HEADER_X_FORWARD_TO, "apiml1")
             .get(new URI(scgUrl)).then().statusCode(200);
-        given().header(HEADER_X_FORWARD_TO, "apiml1")
+        given().header(HEADER_X_FORWARD_TO, "apiml2")
             .get(new URI(scgUrl)).then().statusCode(200);
+    }
+
+    @Test
+    void givenBasePath_thenRouteToProvidedHost() throws URISyntaxException {
+        RestAssured.useRelaxedHTTPSValidation();
+
+        String scgUrl1 = String.format("%s://%s:%s/%s", conf.getScheme(), conf.getHost(), conf.getPort(), "apiml1/gateway/version");
+        String scgUrl2 = String.format("%s://%s:%s/%s", conf.getScheme(), conf.getHost(), conf.getPort(), "apiml2/gateway/version");
+        given().get(new URI(scgUrl1)).then().statusCode(200);
+        given().get(new URI(scgUrl2)).then().statusCode(200);
     }
 
     @Test


### PR DESCRIPTION
# Description

Added integration tests for the new routing in Cloud Gateway, which was implemented in #3031.

Also fixed bug during "by header" routing: when `X-Forward-To` header is present in the request, but SCG can't route to service indicated in the header (e.g. wrong service) it moved to secondary routing rule - ByBasePath. It fixed by adding a predicate to ByBasePath to check if header is present.

And propagated `apiml.service.externalUrl` and `apiml.service.apimlId` parameters through start.sh. 
**Note:** There is no need to force the setup of apimlId parameter, becasue by default it is set as joined combination of Gateway hostname and port.

Linked to #2884
Part of the #2651

## Type of change

Please delete options that are not relevant.

- [X] (fix) Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [X] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
