### PR TITLE
ref: GH2883 Move ServicesInfoService to the apiml-common

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/services/ServiceInfo.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/services/ServiceInfo.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.services;
+package org.zowe.apiml.product.services;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.netflix.appinfo.InstanceInfo;

--- a/apiml-common/src/main/java/org/zowe/apiml/product/services/ServicesInfoService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/services/ServicesInfoService.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.services;
+package org.zowe.apiml.product.services;
 
 import com.fasterxml.jackson.core.Version;
 import com.netflix.appinfo.InstanceInfo;
@@ -17,7 +17,6 @@ import com.netflix.discovery.shared.Application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.zowe.apiml.auth.Authentication;
 import org.zowe.apiml.config.ApiInfo;
@@ -28,7 +27,14 @@ import org.zowe.apiml.product.routing.ServiceType;
 import org.zowe.apiml.product.routing.transform.TransformService;
 import org.zowe.apiml.product.routing.transform.URLTransformationException;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
@@ -37,7 +43,6 @@ import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_DESCRIPT
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_TITLE;
 
 @Slf4j
-@Service
 @RequiredArgsConstructor
 public class ServicesInfoService {
 
@@ -45,8 +50,8 @@ public class ServicesInfoService {
     public static final String CURRENT_VERSION = "1";
 
     private final EurekaClient eurekaClient;
-    private final GatewayConfigProperties gatewayConfigProperties;
     private final EurekaMetadataParser eurekaMetadataParser;
+    private final GatewayConfigProperties gatewayConfigProperties;
     private final TransformService transformService;
 
     public List<ServiceInfo> getServicesInfo() {

--- a/apiml-common/src/test/java/org/zowe/apiml/product/services/ServicesInfoServiceTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/services/ServicesInfoServiceTest.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.services;
+package org.zowe.apiml.product.services;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
@@ -21,24 +21,37 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.config.ApiInfo;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
-import org.zowe.apiml.gateway.config.GatewayConfig;
 import org.zowe.apiml.product.gateway.GatewayClient;
 import org.zowe.apiml.product.gateway.GatewayConfigProperties;
 import org.zowe.apiml.product.routing.transform.TransformService;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.AUTHENTICATION_APPLID;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.AUTHENTICATION_SCHEME;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.ROUTES;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.ROUTES_GATEWAY_URL;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.ROUTES_SERVICE_URL;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_DESCRIPTION;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_TITLE;
 
 @ExtendWith(MockitoExtension.class)
 class ServicesInfoServiceTest {
@@ -81,15 +94,12 @@ class ServicesInfoServiceTest {
     private static final String SERVICE_SERVICE_ID = "serviceId";
     private static final String SERVICE_API_ID = "apiId";
     private static final String SERVICE_API_VERSION = "version";
-
     @Mock
     private EurekaClient eurekaClient;
 
-    @Mock
-    ConfigurableEnvironment env;
+    private final GatewayConfigProperties gatewayConfigProperties = GatewayConfigProperties.builder()
+            .scheme(GW_SCHEME).hostname(GW_HOSTNAME + ":" + GW_PORT).build();
 
-    private final GatewayConfigProperties gatewayConfigProperties = new GatewayConfig(env)
-            .getGatewayConfigProperties(GW_HOSTNAME, GW_PORT, GW_SCHEME);
     private final EurekaMetadataParser eurekaMetadataParser = new EurekaMetadataParser();
     private final TransformService transformService = new TransformService(new GatewayClient(gatewayConfigProperties));
 
@@ -97,7 +107,7 @@ class ServicesInfoServiceTest {
 
     @BeforeEach
     void setUp() {
-        servicesInfoService = new ServicesInfoService(eurekaClient, gatewayConfigProperties, eurekaMetadataParser, transformService);
+        servicesInfoService = new ServicesInfoService(eurekaClient, eurekaMetadataParser, gatewayConfigProperties, transformService);
     }
 
     @Test

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServerInfoConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServerInfoConfig.java
@@ -10,9 +10,13 @@
 
 package org.zowe.apiml.gateway.services;
 
+import com.netflix.discovery.EurekaClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
+import org.zowe.apiml.product.gateway.GatewayConfigProperties;
+import org.zowe.apiml.product.routing.transform.TransformService;
+import org.zowe.apiml.product.services.ServicesInfoService;
 
 @Configuration
 public class ServerInfoConfig {
@@ -20,6 +24,13 @@ public class ServerInfoConfig {
     @Bean
     public EurekaMetadataParser getEurekaMetadataParser() {
         return new EurekaMetadataParser();
+    }
+
+
+    @Bean
+    public ServicesInfoService servicesInfoService(EurekaClient eurekaClient,
+                                                   EurekaMetadataParser eurekaMetadataParser, GatewayConfigProperties gatewayConfigProperties, TransformService transformService) {
+        return new ServicesInfoService(eurekaClient, eurekaMetadataParser, gatewayConfigProperties, transformService);
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoController.java
@@ -13,14 +13,23 @@ package org.zowe.apiml.gateway.services;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zowe.apiml.product.services.ServiceInfo;
+import org.zowe.apiml.product.services.ServicesInfoService;
 
 import java.util.List;
 
-import static org.zowe.apiml.gateway.services.ServicesInfoService.CURRENT_VERSION;
-import static org.zowe.apiml.gateway.services.ServicesInfoService.VERSION_HEADER;
+import static org.zowe.apiml.product.services.ServicesInfoService.CURRENT_VERSION;
+import static org.zowe.apiml.product.services.ServicesInfoService.VERSION_HEADER;
+
 
 @RestController
 @RequiredArgsConstructor

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/services/ServicesInfoControllerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/services/ServicesInfoControllerTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.zowe.apiml.product.services.ServiceInfo;
+import org.zowe.apiml.product.services.ServicesInfoService;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,8 +26,8 @@ import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static org.zowe.apiml.gateway.services.ServicesInfoController.SERVICES_URL;
-import static org.zowe.apiml.gateway.services.ServicesInfoService.CURRENT_VERSION;
-import static org.zowe.apiml.gateway.services.ServicesInfoService.VERSION_HEADER;
+import static org.zowe.apiml.product.services.ServicesInfoService.CURRENT_VERSION;
+import static org.zowe.apiml.product.services.ServicesInfoService.VERSION_HEADER;
 
 @ExtendWith(MockitoExtension.class)
 class ServicesInfoControllerTest {


### PR DESCRIPTION
# Description

Move ServicesInfoService class to apiml-common in order to make it accessible by both gateway and cloudgateway services

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [x] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
