### PR TITLE
Remove invalid information from internal documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,12 @@ The API Mediation Layer (API ML) provides a single point of access for mainframe
 
 The following platform is required to run the API Mediation Layer:
 
-* Java SE Development Kit 8 
-    * <https://jdk.java.net/java-se-ri/8-MR3> 
-    * <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html> 
-    * <https://www.ibm.com/developerworks/java/jdk/>
+* Java SE Development Kit 8 or 11
+* Java version 17 isn't supported for building yet
 
 The following tools are required to build and develop the API Mediation Layer:
 
-* Node.js version 10.23.3 and npm are required to be installed globally to run npm commands in project root folder.
+* Node.js and npm are required to be installed globally to run npm commands in project root folder.
   
     * <https://nodejs.org/dist/>
     
@@ -71,7 +69,9 @@ Alternatively, to use Docker to run the API ML, consult the [Docker README](dock
 
 ## Security
 
-The API Mediation Layer can use dummy credentials for development purposes. For development purposes, log in using the default setting `user` for the username, and `user` as the password.   
+By default the API Mediation Layer for local development uses mock zOSMF as the authentication provider. For development purposes, log in using the default setting `USER` for the username, and `validPassword` as the password
+
+The API Mediation Layer can also use dummy credentials for development purposes. For development purposes, log in using the default setting `user` for the username, and `user` as the password.   
 
 For more information, see [API Mediation Layer Security](https://docs.zowe.org/stable/extend/extend-apiml/zowe-api-mediation-layer-security-overview).
 
@@ -84,6 +84,7 @@ To run integration tests, follow the instructions in [Integration Tests](integra
 For more information about how the certificates between API ML services are set up for localhost, see [TLS Certificates for localhost](keystore/README.md).
 
 ## Contributor guidelines
+
 To add new functionality, follow the guidelines in [Contributing](CONTRIBUTING.md).
 
 ## Local configuration of services

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -22,15 +22,6 @@ It can be useful to know what code is used. This is available at `/application/i
 
     https://localhost:10010/application/info
 
-
-It is also printed to the log as the very first messsage:
-
-    [DS] 16:32:04.022 [main] INFO org.zowe.apiml.product.service.BuildInfo - Service discovery-service version xyz #n/a on 2018-08-23T14:28:33.223Z by plape03mac850 commit 6fd7c53
-    [GS] 16:32:04.098 [main] INFO org.zowe.apiml.product.service.BuildInfo - Service gateway-service version xyz #n/a on 2018-08-23T14:28:33.231Z by plape03mac850 commit 6fd7c53
-    [DC] 16:32:04.195 [main] INFO org.zowe.apiml.product.service.BuildInfo - Service discoverable-client version xyz #n/a on 2018-08-23T14:28:33.217Z by plape03mac850 commit 6fd7c53
-    [AC] 16:32:04.317 [main] INFO org.zowe.apiml.product.service.BuildInfo - Service api-catalog-services version xyz #n/a on 2018-08-23T14:28:33.201Z by plape03mac850 commit 6fd7c53
-
-
 ## Version Information
 
 It is also possible to know the version of API ML and Zowe (if API ML used as part of Zowe), using the `/gateway/api/v1/version` endpoint in the API Gateway service. E.g.:


### PR DESCRIPTION
# Description

The README.md and diagnostics.md contained invalid information. This PR either removes the information altogether or fixes them. 

The setup was tested on Codespaces with 4 cores, 8GB of RAM, Java 11 and Node 20. 

Linked to #3035 

## Type of change

Please delete options that are not relevant.

- [x] (docs) Change in a documentation