### PR TITLE
feat: Add centralRegistryUrls config parameter to zowe.yaml

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -163,6 +163,8 @@ jobs:
                     APIML_SERVICE_FORWARDCLIENTCERTENABLED: true
             discoverable-client:
                 image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
+            mock-services:
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
 
         steps:
             -   uses: actions/checkout@v3

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -52,6 +52,7 @@
 # - ZWE_configs_apiml_security_oidc_identityMapperUrl
 # - ZWE_configs_apiml_security_oidc_identityMapperUser
 # - ZWE_configs_apiml_service_allowEncodedSlashes - Allows encoded slashes on on URLs through gateway
+# - ZWE_configs_apiml_service_centralRegistryUrls - List of additional Discovery Services URLs to register with
 # - ZWE_configs_apiml_service_corsEnabled
 # - ZWE_configs_certificate_keystore_alias - The alias of the key within the keystore
 # - ZWE_configs_certificate_keystore_file - The keystore to use for SSL certificates
@@ -208,6 +209,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.service.port=${ZWE_configs_port:-7554} \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"} \
     -Dapiml.service.allowEncodedSlashes=${ZWE_configs_apiml_service_allowEncodedSlashes:-true} \
+    -Dapiml.service.centralRegistryUrls=${ZWE_configs_apiml_service_centralRegistryUrls:-} \
     -Dapiml.service.corsEnabled=${ZWE_configs_apiml_service_corsEnabled:-false} \
     -Dapiml.service.externalUrl="${httpProtocol}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}" \
     -Dapiml.service.apimlId=${ZWE_configs_apimlId:-} \

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -43,6 +43,7 @@ apiml:
         scheme: https  # "https" or "http"
         preferIpAddress: false
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
+        centralRegistryUrls: # List of additional Discovery Services URLs to register with
 
     httpclient:
         conn-pool:

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -16,6 +16,7 @@ apiml:
         allowEncodedSlashes: true
         discoveryServiceUrls: https://localhost:10011/eureka/
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
+        centralRegistryUrls: # List of additional Discovery Services URLs to register with
     loadBalancer:
         distribute: false
     gateway:

--- a/schemas/cloud-gateway-schema.json
+++ b/schemas/cloud-gateway-schema.json
@@ -10,7 +10,7 @@
                     "type": "object",
                     "additionalProperties": true,
                     "properties": {
-                        "discovery-service": {
+                        "cloud-gateway-service": {
                             "allOf": [
                                 {"$ref":  "https://zowe.org/schemas/v2/server-base#zoweComponent"},
                                 {
@@ -18,10 +18,17 @@
                                     "properties": {
                                         "apiml": {
                                             "type": "object",
+                                            "description": "Zowe API ML specific properties.",
                                             "properties": {
-                                                "serviceIdPrefixReplacer": {
-                                                    "type": "string",
-                                                    "description": "A comma separated tuple to replace service ID with new one in API ML registry."
+                                                "service": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "forwardClientCertEnabled": {
+                                                            "type": "boolean",
+                                                            "description": "Enables forwarding client certificate from request to next gateway in a special request header.",
+                                                            "default": false
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },

--- a/schemas/gateway-schema.json
+++ b/schemas/gateway-schema.json
@@ -148,6 +148,10 @@
                                                             "description": "Allow URLs on gateway to contain encoded slashes.",
                                                             "default": true
                                                         },
+                                                        "centralRegistryUrls": {
+                                                            "type": "string",
+                                                            "description": "List of additional Discovery Services URLs to register with."
+                                                        },
                                                         "corsEnabled": {
                                                             "type": "boolean",
                                                             "description": "Allow CORS on gateway.",

--- a/schemas/gateway-schema.json
+++ b/schemas/gateway-schema.json
@@ -102,6 +102,15 @@
                                                                     "description": "Enable if client certificate should be considered as a source of authentication.",
                                                                     "default": false
                                                                 },
+                                                                "acceptForwardedCert":  {
+                                                                    "type": "boolean",
+                                                                    "description": "Enable if the the Client Certificate forwarded in a dedicated header should be accepted",
+                                                                    "default": false
+                                                                },
+                                                                "certificatesUrl": {
+                                                                    "type": "string",
+                                                                    "description": "URL of the Central Gateway and its endpoint where it provides its public certificates."
+                                                                },
                                                                 "externalMapperUrl": {
                                                                     "type": "string",
                                                                     "description": "URL of the service where certificate will be mapped to user. ZSS is used if no value is provided."
@@ -149,8 +158,10 @@
                                                             "default": true
                                                         },
                                                         "centralRegistryUrls": {
-                                                            "type": "string",
-                                                            "description": "List of additional Discovery Services URLs to register with."
+                                                            "type": "array",
+                                                            "description": "List of additional Discovery Services URLs to register with.",
+                                                            "minItems": 1,
+                                                            "uniqueItems": true
                                                         },
                                                         "corsEnabled": {
                                                             "type": "boolean",


### PR DESCRIPTION
# Description

This PR adds the `apiml.service.centralRegistryUrls` optional configuration parameter to the zowe.yaml

Linked to #2425 
Part of the #2651

## Type of change

Please delete options that are not relevant.

- [ ] (fix) Bug fix (non-breaking change which fixes an issue)
- [ ] (feat) New feature (non-breaking change which adds functionality)
- [ ] (docs) Change in a documentation
- [ ] (refactor) Refactor the code 
- [ ] (chore) Chore, repository cleanup, updates the dependencies.
- [ ] (BREAKING CHANGE or !) Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
