### PR TITLE
fix: Fix normalization of baseUrl in ZAAS client

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
@@ -14,8 +14,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.Tolerate;
 
-import java.util.Objects;
-
 @Data
 @Builder
 public class ConfigProperties {
@@ -32,7 +30,10 @@ public class ConfigProperties {
     private boolean httpOnly;
     private boolean nonStrictVerifySslCertificatesOfServices;
 
-    private static final String GATEWAY_SERVICE_ID = "gateway";
+    @SuppressWarnings("squid:S1075")
+    private static final String OLD_PATH_FORMAT = "/api/v1/gateway";
+    @SuppressWarnings("squid:S1075")
+    private static final String NEW_PATH_FORMAT = "/gateway/api/v1";
 
     @Builder.Default
     private String tokenPrefix = "apimlAuthenticationToken";
@@ -58,22 +59,22 @@ public class ConfigProperties {
     }
 
     public void setApimlBaseUrl(String baseUrl) {
-        if (baseUrl == null) { // default path
-            apimlBaseUrl = "/gateway/api/v1/auth";
-        } else if (baseUrl.contains("/") && baseUrl.contains(GATEWAY_SERVICE_ID)) {
-            String[] baseUrlParts = baseUrl.split("/");
-            if (Objects.equals(baseUrlParts[2], GATEWAY_SERVICE_ID)) {
-                apimlBaseUrl = "/gateway/" + baseUrlParts[0] + "/" + baseUrlParts[1] + "/auth";
-            } else if (Objects.equals(baseUrlParts[3], GATEWAY_SERVICE_ID)) {
-                apimlBaseUrl = "/gateway/" + baseUrlParts[1] + "/" + baseUrlParts[2] + "/auth";
-            } else if (!baseUrl.startsWith("/")) { // starts with gateway/..
-                apimlBaseUrl = "/" + baseUrl;
-            } else {
-                apimlBaseUrl = baseUrl;
-            }
-        } else {
-            apimlBaseUrl = baseUrl;
+        // set default path if it is missing
+        if (baseUrl == null) {
+            baseUrl = "/gateway/api/v1/auth";
         }
+
+        // if path does not start with / add it
+        if (!baseUrl.startsWith("/")) {
+            baseUrl = "/" + baseUrl;
+        }
+
+        // replace old path format with the new one
+        if (baseUrl.startsWith(OLD_PATH_FORMAT)) {
+            baseUrl = NEW_PATH_FORMAT + baseUrl.substring(OLD_PATH_FORMAT.length());
+        }
+
+        apimlBaseUrl = baseUrl;
     }
 
 }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientApimlBaseUrlTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientApimlBaseUrlTest.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.zaasclient.service.internal;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.zowe.apiml.zaasclient.config.ConfigProperties;
 
@@ -31,11 +32,26 @@ class ZaasClientApimlBaseUrlTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"/api/v1/zaasClient/auth", "api.v1.zaasClient.auth"})
-    void givenBaseUrl_thenDontChangeBaseUrl(String baseUrl) {
+    @CsvSource({
+        "/api/v1/zaasClient/auth,/api/v1/zaasClient/auth",
+        "api/v1/zaasClient/auth,/api/v1/zaasClient/auth",
+        "anyUrl,/anyUrl",
+        "anyUrl/,/anyUrl/",
+        "/api/v1/gateway,/gateway/api/v1",
+        "api/v1/gateway,/gateway/api/v1",
+        "/api/v1/gateway/x,/gateway/api/v1/x",
+        "api/v1/gateway/x,/gateway/api/v1/x",
+        "/gateway/api/v1,/gateway/api/v1",
+        "gateway/api/v1,/gateway/api/v1",
+        "/gateway/api/v1/x,/gateway/api/v1/x",
+        "gateway/api/v1/x,/gateway/api/v1/x",
+        "/anyOther/gateway/doNotChange,/anyOther/gateway/doNotChange",
+        "anyOther/gateway/doNotChange,/anyOther/gateway/doNotChange"
+    })
+    void givenBaseUrl_thenNormalizeIt(String input, String normalized) {
         ConfigProperties configProperties = new ConfigProperties();
-        configProperties.setApimlBaseUrl(baseUrl);
-        assertThat(configProperties.getApimlBaseUrl(), is(baseUrl));
+        configProperties.setApimlBaseUrl(input);
+        assertThat(configProperties.getApimlBaseUrl(), is(normalized));
     }
 
     @Test


### PR DESCRIPTION
# Description

This PR fixes way how to normalize basePath to auth endpoints for ZAAS client.

Linked to #3095

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
