### PR TITLE
fix: Fix navigation issue in Catalog when using browser back button

### DIFF
--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -40,7 +40,7 @@ export default class DetailPage extends Component {
                 goBackButton.style.removeProperty('display');
             }
         }
-        const { fetchTilesStart, currentTileId, fetchNewTiles, history } = this.props;
+        const { fetchTilesStart, currentTileId, fetchNewTiles } = this.props;
         fetchNewTiles();
         if (currentTileId) {
             fetchTilesStart(currentTileId);

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -45,10 +45,6 @@ export default class DetailPage extends Component {
         if (currentTileId) {
             fetchTilesStart(currentTileId);
         }
-        if (!localStorage.getItem('serviceId')) {
-            const id = history.location.pathname.split('/service/')[1];
-            localStorage.setItem('serviceId', id);
-        }
     }
 
     componentWillUnmount() {

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -49,7 +49,6 @@ export default class DetailPage extends Component {
             const id = history.location.pathname.split('/service/')[1];
             localStorage.setItem('serviceId', id);
         }
-        localStorage.removeItem('selectedTab');
     }
 
     componentWillUnmount() {

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServiceNavigationBar.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServiceNavigationBar.test.jsx
@@ -101,7 +101,6 @@ describe('>>> ServiceNavigationBar component tests', () => {
         const instance = serviceNavigationBar.instance();
         instance.handleTabClick('apicatalog');
         expect(storeCurrentTileId).toHaveBeenCalled();
-        localStorage.removeItem('serviceId');
     });
 
     it('should display mobile view if api portal enabled', () => {

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServiceNavigationBar.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServiceNavigationBar.test.jsx
@@ -115,4 +115,31 @@ describe('>>> ServiceNavigationBar component tests', () => {
         expect(serviceNavigationBar.find('.mobile-menu-close-btn icon-btn')).toBeDefined();
         expect(serviceNavigationBar.find('.mobile-menu-close')).toBeDefined();
     });
+
+    it('should handle browser go back event', () => {
+        const mockHref = 'https://localhost/service/apicatalog';
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: mockHref,
+            },
+            writable: true,
+        });
+        const storeCurrentTileId = jest.fn();
+        const clear = jest.fn();
+
+        const serviceNavigationBar = shallow(
+            <ServicesNavigationBar
+                match={match}
+                clear={clear}
+                services={[tile]}
+                storeCurrentTileId={storeCurrentTileId}
+                currentTileId="apicatalog"
+            />
+        );
+
+        const instance = serviceNavigationBar.instance();
+        instance.handlePopstate();
+
+        expect(storeCurrentTileId).toHaveBeenCalledWith(expect.any(String));
+    });
 });

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
@@ -17,7 +17,12 @@ import { closeMobileMenu, isAPIPortal } from '../../utils/utilFunctions';
 import MenuCloseImage from '../../assets/images/xmark.svg';
 
 export default class ServicesNavigationBar extends Component {
+    componentDidMount() {
+        window.addEventListener('popstate', this.handlePopstate);
+    }
+
     componentWillUnmount() {
+        window.removeEventListener('popstate', this.handlePopstate);
         const { clear } = this.props;
         clear();
     }
@@ -38,6 +43,21 @@ export default class ServicesNavigationBar extends Component {
         if (correctTile) {
             storeCurrentTileId(correctTile.id);
             closeMobileMenu();
+        }
+    };
+
+    handlePopstate = () => {
+        const { services, storeCurrentTileId } = this.props;
+        const url = window.location.href;
+        if (url && url.includes('/service')) {
+            const parts = url.split('/');
+            const serviceId = parts[parts.length - 1];
+            const correctTile = services.find((tile) =>
+                tile.services.some((service) => service.serviceId === serviceId)
+            );
+            if (correctTile) {
+                storeCurrentTileId(correctTile.id);
+            }
         }
     };
 

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
@@ -32,9 +32,8 @@ export default class ServicesNavigationBar extends Component {
         filterText(value);
     };
 
-    handleTabChange = (event, selectedTab) => {
+    handleTabChange = () => {
         localStorage.removeItem('serviceId');
-        localStorage.setItem('selectedTab', selectedTab);
     };
 
     handleTabClick = (id) => {
@@ -75,7 +74,10 @@ export default class ServicesNavigationBar extends Component {
         const { match, services, searchCriteria } = this.props;
         const hasTiles = services && services.length > 0;
         const hasSearchCriteria = searchCriteria !== undefined && searchCriteria !== null && searchCriteria.length > 0;
-        let selectedTab = Number(localStorage.getItem('selectedTab'));
+        const url = window.location.href;
+        const parts = url.split('/');
+        const serviceId = parts[parts.length - 1];
+        let selectedTab;
         let allServices;
         let allServiceIds;
         if (hasTiles) {
@@ -87,6 +89,8 @@ export default class ServicesNavigationBar extends Component {
                     selectedTab = allServiceIds.indexOf(id);
                 }
             }
+            const index = allServices.findIndex((item) => item.serviceId === serviceId);
+            selectedTab = Number(index);
         }
         const TruncatedTabLabel = withStyles(this.styles)(({ classes, label }) => (
             <Tooltip title={label} placement="bottom">

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
@@ -32,10 +32,6 @@ export default class ServicesNavigationBar extends Component {
         filterText(value);
     };
 
-    handleTabChange = () => {
-        localStorage.removeItem('serviceId');
-    };
-
     handleTabClick = (id) => {
         const { storeCurrentTileId, services } = this.props;
         const correctTile = services.find((tile) => tile.services.some((service) => service.serviceId === id));
@@ -79,16 +75,8 @@ export default class ServicesNavigationBar extends Component {
         const serviceId = parts[parts.length - 1];
         let selectedTab;
         let allServices;
-        let allServiceIds;
         if (hasTiles) {
             allServices = services.flatMap((tile) => tile.services);
-            allServiceIds = allServices.map((service) => service.serviceId);
-            if (localStorage.getItem('serviceId')) {
-                const id = localStorage.getItem('serviceId');
-                if (allServiceIds.includes(id)) {
-                    selectedTab = allServiceIds.indexOf(id);
-                }
-            }
             const index = allServices.findIndex((item) => item.serviceId === serviceId);
             selectedTab = Number(index);
         }

--- a/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
+++ b/api-catalog-ui/frontend/src/components/ServicesNavigationBar/ServicesNavigationBar.jsx
@@ -11,6 +11,7 @@
 import { Component } from 'react';
 import { Tab, Tabs, Tooltip, Typography, withStyles, Button } from '@material-ui/core';
 import { Link as RouterLink } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import Shield from '../ErrorBoundary/Shield/Shield';
 import SearchCriteria from '../Search/SearchCriteria';
 import { closeMobileMenu, isAPIPortal } from '../../utils/utilFunctions';
@@ -44,7 +45,7 @@ export default class ServicesNavigationBar extends Component {
     handlePopstate = () => {
         const { services, storeCurrentTileId } = this.props;
         const url = window.location.href;
-        if (url && url.includes('/service')) {
+        if (url?.includes('/service')) {
             const parts = url.split('/');
             const serviceId = parts[parts.length - 1];
             const correctTile = services.find((tile) =>
@@ -73,7 +74,7 @@ export default class ServicesNavigationBar extends Component {
         const url = window.location.href;
         const parts = url.split('/');
         const serviceId = parts[parts.length - 1];
-        let selectedTab;
+        let selectedTab = Number(0);
         let allServices;
         if (hasTiles) {
             allServices = services.flatMap((tile) => tile.services);
@@ -118,7 +119,7 @@ export default class ServicesNavigationBar extends Component {
                 )}
                 {hasTiles && (
                     <Tabs
-                        value={selectedTab || 0}
+                        value={selectedTab}
                         onChange={this.handleTabChange}
                         variant="scrollable"
                         orientation="vertical"
@@ -143,3 +144,10 @@ export default class ServicesNavigationBar extends Component {
         );
     }
 }
+
+ServicesNavigationBar.propTypes = {
+    storeCurrentTileId: PropTypes.func.isRequired,
+    services: PropTypes.shape({
+        find: PropTypes.func.isRequired,
+    }).isRequired,
+};


### PR DESCRIPTION
# Description

Fix issue happening in the Catalog when using the built-in browser back button. The navigation was not working properly, so the user was not redirected to the service swagger, but was rather getting an error finding the service ID.

Fixes #3135 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
