### PR TITLE
fix: Context path from application property in mock catalog controller

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/standalone/ApiDocTransformForMock.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/standalone/ApiDocTransformForMock.java
@@ -30,12 +30,17 @@ public class ApiDocTransformForMock {
     @Value("${service.schema:https}")
     private String schema;
 
+    @Value("${server.servlet.contextPath:/apicatalog}")
+    private String contextPath;
+
     @Bean
     @Primary
     public GatewayConfigProperties gatewayConfigPropertiesForMock() {
+        String path = this.contextPath.endsWith("/") ? this.contextPath.substring(0, this.contextPath.lastIndexOf('/')) : this.contextPath;
+
         return GatewayConfigProperties.builder()
             .scheme(schema)
-            .hostname(String.format("%s:%s/apicatalog/mock", hostname, port))
+            .hostname(String.format("%s:%s%s/mock", hostname, port, path))
             .build();
     }
 


### PR DESCRIPTION
# Description

Context path was fixed in the mock controller for the standalone catalog

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
