### PR TITLE
fix: style updates for Catalog UI and Caching Fix for static file distribution in API Catalog

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
@@ -12,8 +12,11 @@ package org.zowe.apiml.apicatalog.config;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.Duration;
 
 @Configuration
 @ComponentScan("org.zowe.apiml.product.web")
@@ -22,7 +25,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
-            .addResourceHandler("/resources/**")
-            .addResourceLocations("/resources/**", "/resources/static/**", "/resources/templates/**");
+        .addResourceHandler("/resources/index.html")
+        .setCacheControl(CacheControl.noCache())
+        .addResourceLocations("/resources/index.html");
+
+        registry
+        .addResourceHandler("/resources/**")
+        .setCacheControl(CacheControl.maxAge(Duration.ofDays(365L)))
+        .addResourceLocations("/resources/**", "/resources/static/**", "/resources/templates/**");
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
@@ -25,9 +25,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
-        .addResourceHandler("/resources/index.html")
-        .setCacheControl(CacheControl.noCache())
-        .addResourceLocations("/resources/index.html");
+        .addResourceHandler("/index.html")
+        .setCacheControl(CacheControl
+            .noStore()
+            .cachePrivate()
+            .mustRevalidate())
+        .addResourceLocations("/static/index.html", "classpath:/static/index.html");
 
         registry
         .addResourceHandler("/resources/**")

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/config/WebConfig.java
@@ -33,6 +33,11 @@ public class WebConfig implements WebMvcConfigurer {
         .addResourceLocations("/static/index.html", "classpath:/static/index.html");
 
         registry
+        .addResourceHandler("/static/**")
+        .setCacheControl(CacheControl.maxAge(Duration.ofDays(365L)))
+        .addResourceLocations("classpath:/META-INF/resources/", "classpath:/resources/", "classpath:/static/", "classpath:/public/", "classpath:/static/static/");
+
+        registry
         .addResourceHandler("/resources/**")
         .setCacheControl(CacheControl.maxAge(Duration.ofDays(365L)))
         .addResourceLocations("/resources/**", "/resources/static/**", "/resources/templates/**");

--- a/api-catalog-ui/frontend/src/components/DetailPage/_detailPage.scss
+++ b/api-catalog-ui/frontend/src/components/DetailPage/_detailPage.scss
@@ -8,7 +8,9 @@ body .detail-content {
   }
   h2#title {
     color: $color_1;
-    font-weight: initial;
+    font-size: 34px;
+    font-style: normal;
+    font-weight: 400;
   }
   .swagger-ui {
     display: block;
@@ -66,13 +68,7 @@ body .detail-content {
             visibility: hidden;
         }
         h2.title {
-          @extend .MuiTypography-h4;
-          margin-top: 0px;
-
-          span {
-            font-weight: normal;
-            visibility: visible;
-          }
+          display: none;
         }
         .version {
           &:before {

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -252,9 +252,9 @@ export default class ServiceTab extends Component {
                             <Typography id="swagger-label" className="title2" size="medium" variant="outlined">
                                 Swagger
                             </Typography>
-                            {!apiPortalEnabled && containsVersion && currentService && (
+                            {containsVersion && currentService && (
                                 <Typography id="version-label" variant="subtitle2">
-                                    Version
+                                    Service ID and Version:
                                 </Typography>
                             )}
                         </div>

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -258,7 +258,7 @@ export default class ServiceTab extends Component {
                                 </Typography>
                             )}
                         </div>
-                        {!apiPortalEnabled && containsVersion && currentService && (
+                        {containsVersion?.length > 1 && currentService && (
                             <div id="version-div">
                                 <Select
                                     displayEmpty

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -258,7 +258,7 @@ export default class ServiceTab extends Component {
                                 </Typography>
                             )}
                         </div>
-                        {currentService && (
+                        {currentService && apiVersions?.length && (
                             <div id="version-div">
                                 <Select
                                     disabled={apiVersions.length < 2}

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.jsx
@@ -258,11 +258,17 @@ export default class ServiceTab extends Component {
                                 </Typography>
                             )}
                         </div>
-                        {containsVersion?.length > 1 && currentService && (
+                        {currentService && (
                             <div id="version-div">
                                 <Select
+                                    disabled={apiVersions.length < 2}
                                     displayEmpty
                                     id="version-menu"
+                                    style={
+                                        apiVersions.length < 2
+                                            ? { backgroundColor: '#e4e4e4', color: '#6b6868', opacity: '0.5' }
+                                            : { backgroundColor: '#fff', color: '#0056B3' }
+                                    }
                                     value={
                                         this.state.selectedVersion
                                             ? this.state.selectedVersion

--- a/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceTab/ServiceTab.test.jsx
@@ -236,7 +236,7 @@ describe('>>> ServiceTab component tests', () => {
         expect(handleDialogOpenSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should disable the button if apiVersions length is less than 2', () => {
+    it('should hide the button and dropdown if apiVersions length is less than 2', () => {
         const selectService = jest.fn();
         const apiVersions = ['1.0.0'];
         selectedService.apiVersions = apiVersions;
@@ -246,9 +246,15 @@ describe('>>> ServiceTab component tests', () => {
         wrapper.setState({ apiVersions });
 
         const button = wrapper.find('#compare-button');
-
+        const dropdownMenu = wrapper.find('#version-menu');
         expect(button.prop('disabled')).toEqual(true);
+        expect(dropdownMenu.prop('disabled')).toEqual(true);
         expect(button.prop('style')).toEqual({
+            backgroundColor: '#e4e4e4',
+            color: '#6b6868',
+            opacity: '0.5',
+        });
+        expect(dropdownMenu.prop('style')).toEqual({
             backgroundColor: '#e4e4e4',
             color: '#6b6868',
             opacity: '0.5',

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
@@ -21,6 +21,7 @@ import {
     DialogActions,
     Divider,
 } from '@material-ui/core';
+import PropTypes from 'prop-types';
 import CloseIcon from '@material-ui/icons/Close';
 
 export default class ServiceVersionDiff extends Component {
@@ -126,3 +127,11 @@ export default class ServiceVersionDiff extends Component {
         );
     }
 }
+
+ServiceVersionDiff.propTypes = {
+    versions: PropTypes.shape({
+        length: PropTypes.func.isRequired,
+    }).isRequired,
+    serviceId: PropTypes.string.isRequired,
+    getDiff: PropTypes.func.isRequired,
+};

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
@@ -72,7 +72,7 @@ export default class ServiceVersionDiff extends Component {
                         <div className="api-diff-form">
                             <Typography data-testid="compare-label">Compare</Typography>
                             <FormControl className="formField">
-                                <InputLabel shrink>Version</InputLabel>
+                                <InputLabel shrink>Version:</InputLabel>
                                 <Select
                                     data-testid="select-1"
                                     label="versionSelect1"
@@ -91,7 +91,7 @@ export default class ServiceVersionDiff extends Component {
                             </FormControl>
                             <Typography data-testid="label-with">with</Typography>
                             <FormControl className="formField">
-                                <InputLabel shrink>Version</InputLabel>
+                                <InputLabel shrink>Version:</InputLabel>
                                 <Select
                                     data-testid="select-2"
                                     className="select-diff"

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.jsx
@@ -25,13 +25,12 @@ import CloseIcon from '@material-ui/icons/Close';
 
 export default class ServiceVersionDiff extends Component {
     constructor(props) {
-        const { version1, version2, selectedVersion } = props;
+        const { versions } = props;
         super(props);
         this.state = {
-            selectedVersion1: version1 ? { text: version1 } : undefined,
-            selectedVersion2: version2 ? { text: version2 } : undefined,
+            selectedVersion1: versions?.length ? versions[versions.length - 2] : undefined,
+            selectedVersion2: versions?.length ? versions[versions.length - 1] : undefined,
             open: props.isDialogOpen,
-            defaultVersion: selectedVersion,
         };
 
         this.handleVersion1Change = this.handleVersion1Change.bind(this);
@@ -39,11 +38,12 @@ export default class ServiceVersionDiff extends Component {
     }
 
     componentDidMount() {
-        this.setState({ selectedVersion1: null, selectedVersion2: null });
+        const { serviceId, getDiff } = this.props;
+        const { selectedVersion1, selectedVersion2 } = this.state;
+        getDiff(serviceId, selectedVersion1, selectedVersion2);
     }
 
     handleVersion1Change = (event) => {
-        this.setState({ defaultVersion: null });
         this.setState({ selectedVersion1: event.target.value });
     };
 
@@ -78,7 +78,7 @@ export default class ServiceVersionDiff extends Component {
                                     label="versionSelect1"
                                     className="select-diff"
                                     displayEmpty
-                                    value={this.state.defaultVersion || selectedVersion1}
+                                    value={selectedVersion1}
                                     onChange={this.handleVersion1Change}
                                     sx={selectorStyle}
                                 >
@@ -108,11 +108,11 @@ export default class ServiceVersionDiff extends Component {
                                 </Select>
                             </FormControl>
                             <IconButton
-                                disabled={!selectedVersion2}
+                                disabled={!selectedVersion1 && !selectedVersion2}
                                 id="diff-button"
                                 data-testid="diff-button"
                                 onClick={() => {
-                                    getDiff(serviceId, this.state.defaultVersion ?? selectedVersion1, selectedVersion2);
+                                    getDiff(serviceId, selectedVersion1, selectedVersion2);
                                 }}
                             >
                                 Show

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
@@ -62,14 +62,13 @@ describe('>>> ServiceVersionDiff component tests', () => {
         expect(getDiff.mock.calls.length).toBe(1);
     });
 
-    it('should set current tile id with default version', () => {
+    it('should call get diff once the component is mounted', () => {
         const getDiff = jest.fn();
         const serviceVersionDiff = shallow(
             <ServiceVersionDiff getDiff={getDiff} serviceId="service" versions={['v1', 'v2']} version2="v2" />
         );
         serviceVersionDiff.setState({ defaultVersion: 'v1' });
 
-        serviceVersionDiff.find('[data-testid="diff-button"]').first().simulate('click');
         expect(getDiff.mock.calls.length).toBe(1);
     });
 });

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
@@ -11,7 +11,7 @@ import { shallow } from 'enzyme';
 import ServiceVersionDiff from './ServiceVersionDiff';
 
 describe('>>> ServiceVersionDiff component tests', () => {
-    it('Should disable the compare button', () => {
+    it('Should display all the compare items', () => {
         const serviceVersionDiff = shallow(<ServiceVersionDiff serviceId="service" versions={['v1', 'v2']} />);
 
         expect(serviceVersionDiff.find('.api-diff-container').exists()).toEqual(true);
@@ -34,8 +34,6 @@ describe('>>> ServiceVersionDiff component tests', () => {
         expect(serviceVersionDiff.find('[data-testid="menu-items-2"]').first().prop('value')).toEqual('v1');
 
         expect(serviceVersionDiff.find('[data-testid="diff-button"]').first().prop('children')).toEqual('Show');
-
-        expect(serviceVersionDiff.find('[data-testid="diff-button"]').first().prop('disabled')).toEqual(true);
     });
 
     it('Should call getDiff when button pressed', () => {

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
@@ -12,7 +12,8 @@ import ServiceVersionDiff from './ServiceVersionDiff';
 
 describe('>>> ServiceVersionDiff component tests', () => {
     it('Should display all the compare items', () => {
-        const serviceVersionDiff = shallow(<ServiceVersionDiff serviceId="service" versions={['v1', 'v2']} />);
+        const getDiff = jest.fn();
+        const serviceVersionDiff = shallow(<ServiceVersionDiff getDiff={getDiff} serviceId="service" versions={['v1', 'v2']} />);
 
         expect(serviceVersionDiff.find('.api-diff-container').exists()).toEqual(true);
         expect(serviceVersionDiff.find('.api-diff-form').exists()).toEqual(true);
@@ -49,7 +50,7 @@ describe('>>> ServiceVersionDiff component tests', () => {
         );
 
         serviceVersionDiff.find('[data-testid="diff-button"]').first().simulate('click');
-        expect(getDiff.mock.calls.length).toBe(1);
+        expect(getDiff.mock.calls.length).toBe(2);
     });
 
     it('Should call getDiff when default version', () => {
@@ -59,7 +60,7 @@ describe('>>> ServiceVersionDiff component tests', () => {
         );
 
         serviceVersionDiff.find('[data-testid="diff-button"]').first().simulate('click');
-        expect(getDiff.mock.calls.length).toBe(1);
+        expect(getDiff.mock.calls.length).toBe(2);
     });
 
     it('should call get diff once the component is mounted', () => {

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiff.test.jsx
@@ -13,7 +13,9 @@ import ServiceVersionDiff from './ServiceVersionDiff';
 describe('>>> ServiceVersionDiff component tests', () => {
     it('Should display all the compare items', () => {
         const getDiff = jest.fn();
-        const serviceVersionDiff = shallow(<ServiceVersionDiff getDiff={getDiff} serviceId="service" versions={['v1', 'v2']} />);
+        const serviceVersionDiff = shallow(
+            <ServiceVersionDiff getDiff={getDiff} serviceId="service" versions={['v1', 'v2']} />
+        );
 
         expect(serviceVersionDiff.find('.api-diff-container').exists()).toEqual(true);
         expect(serviceVersionDiff.find('.api-diff-form').exists()).toEqual(true);

--- a/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiffContainer.test.jsx
+++ b/api-catalog-ui/frontend/src/components/ServiceVersionDiff/ServiceVersionDiffContainer.test.jsx
@@ -10,10 +10,12 @@
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
 import ServiceVersionDiffContainer from './ServiceVersionDiffContainer';
 
-const mockStore = configureStore();
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('ServiceVersionDiff Container', () => {
     let store;

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.jsx
@@ -38,7 +38,7 @@ function transformSwaggerToCurrentHost(swagger) {
 function setFilterBarStyle() {
     const filterInput = document.getElementsByClassName('operation-filter-input');
     if (filterInput && filterInput.length > 0) {
-        filterInput.item(0).placeholder = 'Filter APIs';
+        filterInput.item(0).placeholder = 'Search in endpoints...';
     }
     if (isAPIPortal() && !document.getElementById('filter-label')) {
         const divInfo = document.querySelector('.info');

--- a/api-catalog-ui/frontend/src/reducers/index.jsx
+++ b/api-catalog-ui/frontend/src/reducers/index.jsx
@@ -31,5 +31,17 @@ const reducers = {
     wizardReducer,
 };
 
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready.then((registration) => {
+        registration.unregister();
+
+        if (caches) {
+            // Service worker cache should be cleared with caches.delete()
+            caches.keys().then(async (names) => {
+                await Promise.all(names.map((name) => caches.delete(name)));
+            });
+        }
+    });
+}
 // eslint-disable-next-line import/prefer-default-export
 export const rootReducer = combineReducers(reducers);

--- a/api-catalog-ui/frontend/src/reducers/index.jsx
+++ b/api-catalog-ui/frontend/src/reducers/index.jsx
@@ -31,23 +31,5 @@ const reducers = {
     wizardReducer,
 };
 
-if ('serviceWorker' in navigator) {
-    caches.keys().then((cacheNames) => {
-        cacheNames.forEach((cacheName) => {
-            caches.delete(cacheName);
-        });
-    });
-}
-async function unregisterAndClearCaches() {
-    const registrations = await navigator.serviceWorker.getRegistrations();
-    const unregisterPromises = registrations.map((registration) => registration.unregister());
-
-    const allCaches = await caches.keys();
-    const cacheDeletionPromises = allCaches.map((cache) => caches.delete(cache));
-
-    await Promise.all([...unregisterPromises, ...cacheDeletionPromises]);
-}
-
-unregisterAndClearCaches();
 // eslint-disable-next-line import/prefer-default-export
 export const rootReducer = combineReducers(reducers);

--- a/api-catalog-ui/frontend/src/reducers/index.jsx
+++ b/api-catalog-ui/frontend/src/reducers/index.jsx
@@ -31,6 +31,13 @@ const reducers = {
     wizardReducer,
 };
 
+if ('serviceWorker' in navigator) {
+    caches.keys().then((cacheNames) => {
+        cacheNames.forEach((cacheName) => {
+            caches.delete(cacheName);
+        });
+    });
+}
 async function unregisterAndClearCaches() {
     const registrations = await navigator.serviceWorker.getRegistrations();
     const unregisterPromises = registrations.map((registration) => registration.unregister());

--- a/api-catalog-ui/frontend/src/reducers/index.jsx
+++ b/api-catalog-ui/frontend/src/reducers/index.jsx
@@ -31,17 +31,16 @@ const reducers = {
     wizardReducer,
 };
 
-if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then((registration) => {
-        registration.unregister();
+async function unregisterAndClearCaches() {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    const unregisterPromises = registrations.map((registration) => registration.unregister());
 
-        if (caches) {
-            // Service worker cache should be cleared with caches.delete()
-            caches.keys().then(async (names) => {
-                await Promise.all(names.map((name) => caches.delete(name)));
-            });
-        }
-    });
+    const allCaches = await caches.keys();
+    const cacheDeletionPromises = allCaches.map((cache) => caches.delete(cache));
+
+    await Promise.all([...unregisterPromises, ...cacheDeletionPromises]);
 }
+
+unregisterAndClearCaches();
 // eslint-disable-next-line import/prefer-default-export
 export const rootReducer = combineReducers(reducers);

--- a/api-catalog-ui/frontend/src/utils/utilFunctions.js
+++ b/api-catalog-ui/frontend/src/utils/utilFunctions.js
@@ -24,7 +24,7 @@ function checkForSwagger(service) {
             }
         }
     });
-    if (!hasSwagger && service.apiDoc?.length > 0) {
+    if (!hasSwagger && service?.apiDoc) {
         // eslint-disable-next-line no-param-reassign
         hasSwagger = true;
     }

--- a/api-catalog-ui/frontend/src/utils/utilFunctions.js
+++ b/api-catalog-ui/frontend/src/utils/utilFunctions.js
@@ -10,7 +10,8 @@
 
 import getBaseUrl from '../helpers/urls';
 
-function checkForSwagger(service, hasSwagger) {
+function checkForSwagger(service) {
+    let hasSwagger = false;
     const serviceAPIKeys = Object.keys(service.apis);
     serviceAPIKeys.forEach((api) => {
         // Statically defined api service has a swagger url for default, but details page doesn't like that.
@@ -23,6 +24,10 @@ function checkForSwagger(service, hasSwagger) {
             }
         }
     });
+    if (!hasSwagger && service.apiDoc?.length > 0) {
+        // eslint-disable-next-line no-param-reassign
+        hasSwagger = true;
+    }
     return hasSwagger;
 }
 
@@ -47,7 +52,7 @@ export default function countAdditionalContents(service) {
             videosCounter = service.videos.length;
         }
         if (service.apis) {
-            hasSwagger = checkForSwagger(service, hasSwagger);
+            hasSwagger = checkForSwagger(service);
         }
     }
     return { useCasesCounter, tutorialsCounter, videosCounter, hasSwagger };

--- a/api-catalog-ui/frontend/src/utils/utilFunctions.js
+++ b/api-catalog-ui/frontend/src/utils/utilFunctions.js
@@ -24,10 +24,6 @@ function checkForSwagger(service) {
             }
         }
     });
-    if (!hasSwagger && service?.apiDoc) {
-        // eslint-disable-next-line no-param-reassign
-        hasSwagger = true;
-    }
     return hasSwagger;
 }
 


### PR DESCRIPTION
# Description

- Updates in styles for API Catalog in portal mode.
- Fix in cache-control header, it is now managed as per the react recommendation (index.html in no-store mode) and rest of static content can be cached for up to one year, since the static files are hashed anyway.

## Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
