### PR TITLE
fix: Gateway additional registration fixes

### DIFF
--- a/.github/workflows/service-registration.yml
+++ b/.github/workflows/service-registration.yml
@@ -17,7 +17,7 @@ env:
 jobs:
     BuildAndTest:
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 35
 
         steps:
             -   uses: actions/checkout@v3

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -22,6 +22,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
+import org.springframework.cloud.netflix.eureka.InstanceInfoFactory;
 import org.springframework.cloud.netflix.eureka.MutableDiscoveryClientOptionalArgs;
 import org.springframework.cloud.util.ProxyUtils;
 import org.springframework.context.ApplicationContext;
@@ -116,8 +117,9 @@ public class DiscoveryClientConfig {
         return discoveryClientClient;
     }
 
-    private static InstanceInfo getInstanceInfo(AdditionalRegistration apimlRegistration, ApplicationInfoManager bareManager) {
+    private InstanceInfo getInstanceInfo(AdditionalRegistration apimlRegistration, ApplicationInfoManager bareManager) {
         if (!CollectionUtils.isEmpty(apimlRegistration.getRoutes())) {
+            InstanceInfo newInfo = new InstanceInfoFactory().create(bareManager.getEurekaInstanceConfig());
             Map<String, String> metadataWithRoutes = bareManager.getInfo().getMetadata().entrySet().stream().filter(entry -> !entry.getKey().startsWith(ROUTES)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             int index = 0;
             for (AdditionalRegistration.Route route : apimlRegistration.getRoutes()) {
@@ -125,7 +127,7 @@ public class DiscoveryClientConfig {
                 metadataWithRoutes.put(ROUTES + "." + index + "." + ROUTES_SERVICE_URL, route.getServiceUrl());
                 index++;
             }
-            InstanceInfo.Builder builder = new InstanceInfo.Builder(bareManager.getInfo());
+            InstanceInfo.Builder builder = new InstanceInfo.Builder(newInfo);
             builder.setMetadata(metadataWithRoutes);
             return builder.build();
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -22,7 +22,6 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
-import org.springframework.cloud.netflix.eureka.InstanceInfoFactory;
 import org.springframework.cloud.netflix.eureka.MutableDiscoveryClientOptionalArgs;
 import org.springframework.cloud.util.ProxyUtils;
 import org.springframework.context.ApplicationContext;
@@ -107,20 +106,19 @@ public class DiscoveryClientConfig {
         MutableDiscoveryClientOptionalArgs args = new MutableDiscoveryClientOptionalArgs();
         args.setEurekaJerseyClient(eurekaJerseyClientBuilder.build());
 
-        ApplicationInfoManager bareManager = ProxyUtils.getTargetObject(appManager);
-        InstanceInfo ii = getInstanceInfo(apimlRegistration, bareManager);
+        InstanceInfo newInfo = apimlDiscoveryClientFactory.createInstanceInfo(appManager.getEurekaInstanceConfig());
+        InstanceInfo ii = rewriteInstanceInfoRoutes(apimlRegistration, newInfo);
 
-        ApplicationInfoManager perClientAppManager = new ApplicationInfoManager(bareManager.getEurekaInstanceConfig(), ii, null);
+        ApplicationInfoManager perClientAppManager = new ApplicationInfoManager(appManager.getEurekaInstanceConfig(), ii, null);
         final ApimlDiscoveryClient discoveryClientClient = apimlDiscoveryClientFactory.buildApimlDiscoveryClient(perClientAppManager, configBean, args, context);
         discoveryClientClient.registerHealthCheck(healthCheckHandler);
 
         return discoveryClientClient;
     }
 
-    private InstanceInfo getInstanceInfo(AdditionalRegistration apimlRegistration, ApplicationInfoManager bareManager) {
+    private InstanceInfo rewriteInstanceInfoRoutes(AdditionalRegistration apimlRegistration, InstanceInfo newInfo) {
         if (!CollectionUtils.isEmpty(apimlRegistration.getRoutes())) {
-            InstanceInfo newInfo = new InstanceInfoFactory().create(bareManager.getEurekaInstanceConfig());
-            Map<String, String> metadataWithRoutes = bareManager.getInfo().getMetadata().entrySet().stream().filter(entry -> !entry.getKey().startsWith(ROUTES)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, String> metadataWithRoutes = newInfo.getMetadata().entrySet().stream().filter(entry -> !entry.getKey().startsWith(ROUTES)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             int index = 0;
             for (AdditionalRegistration.Route route : apimlRegistration.getRoutes()) {
                 metadataWithRoutes.put(ROUTES + "." + index + "." + ROUTES_GATEWAY_URL, route.getGatewayUrl());
@@ -131,6 +129,6 @@ public class DiscoveryClientConfig {
             builder.setMetadata(metadataWithRoutes);
             return builder.build();
         }
-        return bareManager.getInfo();
+        return newInfo;
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/discovery/ApimlDiscoveryClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/discovery/ApimlDiscoveryClientFactory.java
@@ -11,7 +11,10 @@
 package org.zowe.apiml.gateway.discovery;
 
 import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
+import org.springframework.cloud.netflix.eureka.InstanceInfoFactory;
 import org.springframework.cloud.netflix.eureka.MutableDiscoveryClientOptionalArgs;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -24,5 +27,9 @@ public class ApimlDiscoveryClientFactory {
 
     public ApimlDiscoveryClient buildApimlDiscoveryClient(ApplicationInfoManager perClientAppManager, EurekaClientConfigBean configBean, MutableDiscoveryClientOptionalArgs args, ApplicationContext context) {
         return new ApimlDiscoveryClient(perClientAppManager, configBean, args, context);
+    }
+
+    public InstanceInfo createInstanceInfo(EurekaInstanceConfig instanceConfig) {
+        return new InstanceInfoFactory().create(instanceConfig);
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.gateway.config;
 
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.LeaseInfo;
 import com.netflix.appinfo.MyDataCenterInfo;
@@ -71,5 +72,16 @@ class DiscoveryClientBeanTest {
         wrapper.shutdown();
 
         assertThat(wrapper.getDiscoveryClients()).hasSize(2);
+    }
+
+    @Test
+    void shouldCreateInstanceInfoFromEurekaConfig() {
+        EurekaInstanceConfig config = mock(EurekaInstanceConfig.class);
+        when(config.getNamespace()).thenReturn("");
+        when(config.getAppname()).thenReturn("GATEWAY");
+
+        InstanceInfo instanceInfo = new ApimlDiscoveryClientFactory().createInstanceInfo(config);
+
+        assertThat(instanceInfo.getAppName()).isEqualTo("GATEWAY");
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
@@ -18,6 +18,9 @@ import com.netflix.appinfo.MyDataCenterInfo;
 import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
 import org.springframework.context.ApplicationContext;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
@@ -26,18 +29,23 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
+@ExtendWith(MockitoExtension.class)
 class DiscoveryClientBeanTest {
     DiscoveryClientConfig dcConfig;
+    @Spy
+    private ApimlDiscoveryClientFactory apimlDiscoveryClientFactory;
 
     @BeforeEach
     void setup() {
         ApplicationContext context = mock(ApplicationContext.class);
         EurekaJerseyClientImpl.EurekaJerseyClientBuilder builder = mock(EurekaJerseyClientImpl.EurekaJerseyClientBuilder.class);
-        dcConfig = new DiscoveryClientConfig(null, new ApimlDiscoveryClientFactory(), context, builder);
+        dcConfig = new DiscoveryClientConfig(null, apimlDiscoveryClientFactory, context, builder);
     }
 
     @Test
@@ -50,7 +58,7 @@ class DiscoveryClientBeanTest {
         ApplicationInfoManager manager = mock(ApplicationInfoManager.class);
         InstanceInfo info = new InstanceInfo.Builder(mock(InstanceInfo.class)).setAppName(GATEWAY.name()).build();
 
-        when(manager.getInfo()).thenReturn(info);
+        doReturn(info).when(apimlDiscoveryClientFactory).createInstanceInfo(any());
         when(info.getIPAddr()).thenReturn("127.0.0.1");
 
         when(info.getDataCenterInfo()).thenReturn(new MyDataCenterInfo(DataCenterInfo.Name.MyOwn));

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
@@ -69,9 +70,9 @@ class DiscoveryClientConfigTest {
                 .discoveryServiceUrls("https://host:10011/eureka").routes(new ArrayList<>()).build();
 
             instanceInfo = new InstanceInfo.Builder(baseInstanceInfo).setAppName(GATEWAY.name()).setMetadata(new TreeMap<>()).build();
-            when(appManager.getInfo()).thenReturn(instanceInfo);
-            when(apimlDiscoveryClientFactory.buildApimlDiscoveryClient(any(), any(), any(), any())).thenReturn(discoveryClientClient);
-
+            lenient().when(appManager.getInfo()).thenReturn(instanceInfo);
+            lenient().when(apimlDiscoveryClientFactory.buildApimlDiscoveryClient(any(), any(), any(), any())).thenReturn(discoveryClientClient);
+            lenient().when(apimlDiscoveryClientFactory.createInstanceInfo(any())).thenReturn(instanceInfo);
         }
 
         @Test


### PR DESCRIPTION
# Description

Additional Gateway registration - split InstanceInfo object into 2 instance specific objects

Linked to # (issue)
Part of the # (epic)

## Type of change
- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
