### PR TITLE
refactor: CGW:  move additional registration parser to common place

### DIFF
--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -132,12 +132,6 @@ public class ConnectionsConfig {
         }
     }
 
-    @Bean
-    @Qualifier("apimlEurekaJerseyClient")
-    EurekaJerseyClient getEurekaJerseyClient() {
-        return factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId).build();
-    }
-
 
     HttpsFactory factory() {
         HttpsConfig config = HttpsConfig.builder()
@@ -180,12 +174,18 @@ public class ConnectionsConfig {
         }
     }
 
+    @Bean
+    @Qualifier("primaryApimlEurekaJerseyClient")
+    EurekaJerseyClient getEurekaJerseyClient() {
+        return factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId).build();
+    }
+
     @Bean(destroyMethod = "shutdown")
     @RefreshScope
     @ConditionalOnMissingBean(EurekaClient.class)
-    public EurekaClient eurekaClient(ApplicationInfoManager manager, EurekaClientConfig config,
-                                     @Qualifier("apimlEurekaJerseyClient") EurekaJerseyClient eurekaJerseyClient,
-                                     @Autowired(required = false) HealthCheckHandler healthCheckHandler) {
+    public CloudEurekaClient primaryEurekaClient(ApplicationInfoManager manager, EurekaClientConfig config,
+                                                 @Qualifier("primaryApimlEurekaJerseyClient") EurekaJerseyClient eurekaJerseyClient,
+                                                 @Autowired(required = false) HealthCheckHandler healthCheckHandler) {
         ApplicationInfoManager appManager;
         if (AopUtils.isAopProxy(manager)) {
             appManager = ProxyUtils.getTargetObject(manager);

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfigTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfigTest.java
@@ -23,7 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
 @ComponentScan(basePackages = "org.zowe.apiml.cloudgatewayservice")
@@ -59,7 +61,7 @@ class ConnectionsConfigTest {
 
         @Test
         void thenCreateIt() {
-            Assertions.assertNotNull(connectionsConfig.eurekaClient(manager, config, eurekaJerseyClient, healthCheckHandler));
+            Assertions.assertNotNull(connectionsConfig.primaryEurekaClient(manager, config, eurekaJerseyClient, healthCheckHandler));
         }
     }
 

--- a/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistration.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistration.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.config;
+package org.zowe.apiml.config;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,7 +29,7 @@ public class AdditionalRegistration {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    static class Route {
+    public static class Route {
         private String gatewayUrl;
         private String serviceUrl;
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationCondition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationCondition.java
@@ -14,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.web.context.support.StandardServletEnvironment;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,7 +29,7 @@ public class AdditionalRegistrationCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         String dcUrls = context.getEnvironment().getProperty("apiml.service.additionalRegistration[0].discoveryServiceUrls");
-        List<String> additionalKeys = ((StandardServletEnvironment) context.getEnvironment()).getSystemEnvironment()
+        List<String> additionalKeys = ((StandardEnvironment) context.getEnvironment()).getSystemEnvironment()
             .entrySet().stream().map(e -> e.getKey().toUpperCase()).filter(key -> DISCOVERYSERVICEURLS_PATTERN.matcher(key).matches())
             .collect(Collectors.toList());
         boolean isAdditionalRegistrationsDetected = dcUrls != null || !additionalKeys.isEmpty();

--- a/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationCondition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationCondition.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.config;
+package org.zowe.apiml.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,7 @@ import org.springframework.web.context.support.StandardServletEnvironment;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.zowe.apiml.gateway.config.AdditionalRegistrationConfig.DISCOVERYSERVICEURLS_PATTERN;
+import static org.zowe.apiml.config.AdditionalRegistrationParser.DISCOVERYSERVICEURLS_PATTERN;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationParser.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationParser.java
@@ -8,15 +8,10 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.config;
+package org.zowe.apiml.config;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.StandardEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,24 +24,15 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
-@Slf4j
-@Configuration
-@RequiredArgsConstructor
-public class AdditionalRegistrationConfig {
+public class AdditionalRegistrationParser {
+
 
     public static final String ADDITIONAL_REGISTRATION_INDEX_GROUP_NAME = "index";
-    public static final Pattern DISCOVERYSERVICEURLS_PATTERN = Pattern.compile("^ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_DISCOVERYSERVICEURLS$");
-    public static final Pattern ROUTE_SERVICEURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_SERVICEURL");
-    public static final Pattern ROUTE_GATEWAYURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_GATEWAYURL");
+    public static final Pattern DISCOVERYSERVICEURLS_PATTERN = Pattern.compile("^ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_DISCOVERYSERVICEURLS$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern ROUTE_SERVICEURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_SERVICEURL", Pattern.CASE_INSENSITIVE);
+    public static final Pattern ROUTE_GATEWAYURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_GATEWAYURL", Pattern.CASE_INSENSITIVE);
 
-    @Bean
-    public List<AdditionalRegistration> additionalRegistration(StandardEnvironment environment) {
-        List<AdditionalRegistration> additionalRegistrations = extractAdditionalRegistrations(System.getenv());
-        log.debug("Parsed {} additional regs, \t first: {}", additionalRegistrations.size(), additionalRegistrations.stream().findFirst().orElse(null));
-        return additionalRegistrations;
-    }
-
-    public static List<AdditionalRegistration> extractAdditionalRegistrations(Map<String, String> allProperties) {
+    public List<AdditionalRegistration> extractAdditionalRegistrations(Map<String, String> allProperties) {
         if (allProperties == null) {
             return new ArrayList<>();
         }
@@ -62,7 +48,7 @@ public class AdditionalRegistrationConfig {
             parseGatewayUrl(entry.getKey()).ifPresent(pair -> putRouteGatewayUrl(map, pair, entry.getValue()));
         }
         map.values().forEach(registration -> registration.setRoutes(registration.getRoutes().stream()
-            .filter(AdditionalRegistrationConfig::isRouteDefined).collect(Collectors.toList())));
+            .filter(AdditionalRegistrationParser::isRouteDefined).collect(Collectors.toList())));
         return new ArrayList<>(map.values());
     }
 
@@ -127,5 +113,4 @@ public class AdditionalRegistrationConfig {
     private static boolean isRouteDefined(AdditionalRegistration.Route route) {
         return route != null && (isNotBlank(route.getGatewayUrl()) || isNotBlank(route.getServiceUrl()));
     }
-
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationParser.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/config/AdditionalRegistrationParser.java
@@ -29,8 +29,8 @@ public class AdditionalRegistrationParser {
 
     public static final String ADDITIONAL_REGISTRATION_INDEX_GROUP_NAME = "index";
     public static final Pattern DISCOVERYSERVICEURLS_PATTERN = Pattern.compile("^ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_DISCOVERYSERVICEURLS$", Pattern.CASE_INSENSITIVE);
-    public static final Pattern ROUTE_SERVICEURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_SERVICEURL", Pattern.CASE_INSENSITIVE);
-    public static final Pattern ROUTE_GATEWAYURL_PATTERN = Pattern.compile("ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_GATEWAYURL", Pattern.CASE_INSENSITIVE);
+    public static final Pattern ROUTE_SERVICEURL_PATTERN = Pattern.compile("^ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_SERVICEURL$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern ROUTE_GATEWAYURL_PATTERN = Pattern.compile("^ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_(?<index>\\d+)_ROUTES_(?<routeIndex>\\d+)_GATEWAYURL$", Pattern.CASE_INSENSITIVE);
 
     public List<AdditionalRegistration> extractAdditionalRegistrations(Map<String, String> allProperties) {
         if (allProperties == null) {

--- a/common-service-core/src/test/java/org/zowe/apiml/config/AdditionalRegistrationConditionTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/config/AdditionalRegistrationConditionTest.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-package org.zowe.apiml.gateway.config;
+package org.zowe.apiml.config;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.ConditionContext;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -28,7 +28,11 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.CollectionUtils;
+import org.zowe.apiml.config.AdditionalRegistration;
+import org.zowe.apiml.config.AdditionalRegistrationCondition;
+import org.zowe.apiml.config.AdditionalRegistrationParser;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClient;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 
@@ -59,6 +63,13 @@ public class DiscoveryClientConfig {
     private final ApimlDiscoveryClientFactory apimlDiscoveryClientFactory;
     private final ApplicationContext context;
     private final EurekaJerseyClientImpl.EurekaJerseyClientBuilder eurekaJerseyClientBuilder;
+
+    @Bean
+    public List<AdditionalRegistration> additionalRegistration(StandardEnvironment environment) {
+        List<AdditionalRegistration> additionalRegistrations = new AdditionalRegistrationParser().extractAdditionalRegistrations(System.getenv());
+        log.debug("Parsed {} additional regs, \t first: {}", additionalRegistrations.size(), additionalRegistrations.stream().findFirst().orElse(null));
+        return additionalRegistrations;
+    }
 
     @Bean(destroyMethod = "shutdown")
     @RefreshScope

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
@@ -24,6 +24,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
 import org.springframework.context.ApplicationContext;
+import org.zowe.apiml.config.AdditionalRegistration;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 
 import java.util.Arrays;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
@@ -24,6 +24,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.zowe.apiml.config.AdditionalRegistration;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClient;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 


### PR DESCRIPTION
# Description

move additional registrations parser to common place so that it were possible to reuse it from GW and CGW

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [x] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
