### PR TITLE
fix: Correctly Use service title in the UI

### DIFF
--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -79,6 +79,7 @@ export default class DetailPage extends Component {
             history,
             currentTileId,
             fetchNewTiles,
+            selectedService,
         } = this.props;
         let { tiles } = this.props;
         const iconBack = <ChevronLeftIcon />;
@@ -92,12 +93,8 @@ export default class DetailPage extends Component {
             fetchNewTiles();
             fetchTilesStart(currentTileId);
         } else if (services && services.length > 0 && !currentTileId) {
-            const id = history.location.pathname.split('/service/')[1];
-            if (id) {
-                const correctTile = services.find((tile) => tile.services.some((service) => service.serviceId === id));
-                if (correctTile) {
-                    tiles = [correctTile];
-                }
+            if (selectedService) {
+                tiles = [selectedService];
             }
         }
         const apiPortalEnabled = isAPIPortal();
@@ -166,7 +163,7 @@ export default class DetailPage extends Component {
                                 <div className="title-api-container">
                                     {tiles !== undefined && tiles.length === 1 && (
                                         <h2 id="title" className="text-block-11 title1">
-                                            {tiles[0].title}
+                                            {selectedService.title}
                                         </h2>
                                     )}
                                 </div>

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -81,7 +81,7 @@ export default class DetailPage extends Component {
             fetchNewTiles,
             selectedService,
         } = this.props;
-        let { tiles } = this.props;
+        const { tiles } = this.props;
         const iconBack = <ChevronLeftIcon />;
         let error = null;
         if (fetchTilesError !== undefined && fetchTilesError !== null) {
@@ -92,10 +92,6 @@ export default class DetailPage extends Component {
             fetchTilesStop();
             fetchNewTiles();
             fetchTilesStart(currentTileId);
-        } else if (services && services.length > 0 && !currentTileId) {
-            if (selectedService) {
-                tiles = [selectedService];
-            }
         }
         const apiPortalEnabled = isAPIPortal();
         const hasTiles = !fetchTilesError && tiles && tiles.length > 0;
@@ -161,7 +157,7 @@ export default class DetailPage extends Component {
                             )}
                             <div className="detailed-description-container">
                                 <div className="title-api-container">
-                                    {tiles !== undefined && tiles.length === 1 && (
+                                    {selectedService && (
                                         <h2 id="title" className="text-block-11 title1">
                                             {selectedService.title}
                                         </h2>
@@ -169,9 +165,9 @@ export default class DetailPage extends Component {
                                 </div>
                                 {!apiPortalEnabled && (
                                     <div className="paragraph-description-container">
-                                        {tiles !== undefined && tiles.length > 0 && (
+                                        {selectedService && (
                                             <p id="description" className="text-block-12">
-                                                {tiles[0].description}
+                                                {selectedService.description}
                                             </p>
                                         )}
                                     </div>

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.test.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.test.jsx
@@ -57,6 +57,7 @@ describe('>>> Detailed Page component tests', () => {
         const wrapper = shallow(
             <DetailPage
                 tiles={[tile]}
+                selectedService={tile.services[0]}
                 services={tile.services}
                 currentTileId="apicatalog"
                 fetchTilesStart={fetchTilesStart}
@@ -79,6 +80,7 @@ describe('>>> Detailed Page component tests', () => {
             <DetailPage
                 tiles={[tile]}
                 services={tile.services}
+                selectedService={tile.services[0]}
                 currentTileId="apicatalog"
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={fetchNewTiles}
@@ -97,6 +99,7 @@ describe('>>> Detailed Page component tests', () => {
         const wrapper = shallow(
             <DetailPage
                 tiles={[tile]}
+                selectedService={tile.services[0]}
                 fetchNewTiles={jest.fn()}
                 fetchTilesStart={jest.fn()}
                 fetchTilesStop={fetchTilesStop}
@@ -114,6 +117,7 @@ describe('>>> Detailed Page component tests', () => {
             <DetailPage
                 tiles={[tile]}
                 services={tile.services}
+                selectedService={tile.services[0]}
                 currentTileId="apicatalog"
                 fetchTilesStart={jest.fn()}
                 fetchNewTiles={jest.fn()}
@@ -131,6 +135,7 @@ describe('>>> Detailed Page component tests', () => {
         const wrapper = shallow(
             <DetailPage
                 tiles={[tile]}
+                selectedService={tile.services[0]}
                 fetchTilesStart={jest.fn()}
                 fetchNewTiles={jest.fn()}
                 fetchTilesStop={jest.fn()}
@@ -142,12 +147,13 @@ describe('>>> Detailed Page component tests', () => {
         expect(spinner.props().isLoading).toEqual(true);
     });
 
-    it('should display tile title', () => {
+    it('should display service title', () => {
         const isLoading = false;
         const wrapper = shallow(
             <DetailPage
                 tiles={[tile]}
                 services={tile.services}
+                selectedService={tile.services[0]}
                 currentTileId="apicatalog"
                 fetchTilesStart={jest.fn()}
                 fetchNewTiles={jest.fn()}
@@ -158,16 +164,17 @@ describe('>>> Detailed Page component tests', () => {
             />
         );
         const title = wrapper.find('#title');
-        expect(title.props().children).toEqual(tile.title);
+        expect(title.props().children).toEqual(tile.services[0].title);
     });
 
-    it('should display tile description', () => {
+    it('should display service description', () => {
         const isLoading = false;
         const wrapper = shallow(
             <DetailPage
                 tiles={[tile]}
                 services={tile.services}
                 currentTileId="apicatalog"
+                selectedService={tile.services[0]}
                 fetchTilesStart={jest.fn()}
                 fetchNewTiles={jest.fn()}
                 fetchTilesStop={jest.fn()}
@@ -177,7 +184,7 @@ describe('>>> Detailed Page component tests', () => {
             />
         );
         const title = wrapper.find('#description');
-        expect(title.props().children).toEqual(tile.description);
+        expect(title.props().children).toEqual(tile.services[0].description);
     });
 
     it('should set comms failed message when there is a Tile fetch 404 or 500 error', () => {
@@ -191,6 +198,7 @@ describe('>>> Detailed Page component tests', () => {
                 tiles={[tile]}
                 fetchTilesStart={jest.fn()}
                 fetchNewTiles={jest.fn()}
+                selectedService={tile.services[0]}
                 fetchTilesStop={fetchTilesStop}
                 history={history}
                 fetchTilesError={fetchTilesError}
@@ -211,6 +219,7 @@ describe('>>> Detailed Page component tests', () => {
             <DetailPage
                 tiles={[tile]}
                 fetchTilesStart={jest.fn()}
+                selectedService={tile.services[0]}
                 fetchNewTiles={jest.fn()}
                 fetchTilesStop={fetchTilesStop}
                 history={history}
@@ -233,6 +242,7 @@ describe('>>> Detailed Page component tests', () => {
             <DetailPage
                 tiles={[tile]}
                 clearService={clearService}
+                selectedService={tile.services[0]}
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={jest.fn()}
                 fetchTilesStop={fetchTilesStop}
@@ -260,6 +270,7 @@ describe('>>> Detailed Page component tests', () => {
                 tiles={[tile]}
                 services={tile.services[0]}
                 currentTileId="apicatalog"
+                selectedService={tile.services[0]}
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={fetchNewTiles}
                 fetchTilesStop={jest.fn()}
@@ -283,6 +294,7 @@ describe('>>> Detailed Page component tests', () => {
                 tiles={[tile]}
                 services={[tile]}
                 currentTileId="apicatalog"
+                selectedService={tile.services[0]}
                 handleLinkClick={mockHandleLinkClick}
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={fetchNewTiles}
@@ -323,6 +335,7 @@ describe('>>> Detailed Page component tests', () => {
                 tiles={[tile]}
                 services={[tile]}
                 currentTileId={null}
+                selectedService={tile.services[0]}
                 handleLinkClick={mockHandleLinkClick}
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={fetchNewTiles}
@@ -357,6 +370,7 @@ describe('>>> Detailed Page component tests', () => {
                 tiles={[tile]}
                 services={tile.services}
                 currentTileId="apicatalog"
+                selectedService={tile.services[0]}
                 fetchTilesStart={fetchTilesStart}
                 fetchNewTiles={fetchNewTiles}
                 fetchTilesStop={jest.fn()}

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPageContainer.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPageContainer.jsx
@@ -27,7 +27,6 @@ const mapStateToProps = (state) => ({
     tiles: state.tilesReducer.tiles,
     fetchTilesError: state.tilesReducer.error,
     selectedTile: state.selectedServiceReducer.selectedTile,
-    selectedServiceId: state.selectedServiceReducer.selectedService.serviceId,
     selectedService: state.selectedServiceReducer.selectedService,
     isLoading: loadingSelector(state),
     currentTileId: state.tilesReducer.currentTileId,

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPageContainer.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPageContainer.jsx
@@ -28,6 +28,7 @@ const mapStateToProps = (state) => ({
     fetchTilesError: state.tilesReducer.error,
     selectedTile: state.selectedServiceReducer.selectedTile,
     selectedServiceId: state.selectedServiceReducer.selectedService.serviceId,
+    selectedService: state.selectedServiceReducer.selectedService,
     isLoading: loadingSelector(state),
     currentTileId: state.tilesReducer.currentTileId,
 });


### PR DESCRIPTION
# Description

UI was using wrong information from the to show the service title, using the tile rather then the service information.
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
