### PR TITLE
fix: Fix closing WebSocket in case of 401 and other exception

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -11,14 +11,13 @@
 package org.zowe.apiml.gateway.ws;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.concurrent.TimeoutException;
-
 import org.eclipse.jetty.websocket.api.CloseException;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.AbstractWebSocketHandler;
+
+import java.util.concurrent.TimeoutException;
 
 /**
  * Copies data from the client to the server session.
@@ -46,12 +45,21 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
         log.warn("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
-        if (exception instanceof CloseException && exception.getCause() instanceof TimeoutException) {
-            // Idle timeout
-            webSocketServerSession.close(CloseStatus.NORMAL);
-        } else if (exception instanceof CloseException) {
-            webSocketServerSession.close(new CloseStatus(((CloseException) exception).getStatusCode(), exception.getMessage()));
+
+        if (webSocketServerSession.isOpen()) {
+            CloseStatus closeStatus = CloseStatus.NORMAL;
+            if (exception instanceof CloseException) {
+                CloseException closeException = (CloseException) exception;
+                if (!(closeException.getCause() instanceof TimeoutException)) {
+                    // Idle timeout
+                    closeStatus = new CloseStatus(closeException.getStatusCode(), exception.getMessage());
+                }
+            } else {
+                closeStatus = CloseStatus.SERVER_ERROR;
+            }
+            webSocketServerSession.close(closeStatus);
         }
+
         super.handleTransportError(session, exception);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -11,7 +11,9 @@
 package org.zowe.apiml.gateway.ws;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
 import org.eclipse.jetty.websocket.api.CloseException;
+import org.eclipse.jetty.websocket.api.UpgradeException;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -42,22 +44,46 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
         webSocketServerSession.close(status);
     }
 
+    static CloseStatus getCloseStatusByResponseStatus(int responseStatus, String defaultMessage) {
+        if (responseStatus >= 1000) {
+            return new CloseStatus(responseStatus, defaultMessage);
+        }
+
+        if (responseStatus >= 500) {
+            return CloseStatus.SERVER_ERROR.withReason(defaultMessage);
+        }
+
+        switch (responseStatus) {
+            case HttpStatus.SC_UNAUTHORIZED:
+                return CloseStatus.NOT_ACCEPTABLE.withReason("Invalid login credentials");
+            default:
+                return CloseStatus.NOT_ACCEPTABLE.withReason(defaultMessage);
+        }
+    }
+
+    static CloseStatus getCloseStatusByError(Throwable exception) {
+        if (exception instanceof CloseException) {
+            CloseException closeException = (CloseException) exception;
+            if (closeException.getCause() instanceof TimeoutException) {
+                return CloseStatus.NORMAL;
+            }
+            return getCloseStatusByResponseStatus(closeException.getStatusCode(), String.valueOf(exception.getCause()));
+        }
+
+        if (exception instanceof UpgradeException) {
+            UpgradeException upgradeException = (UpgradeException) exception;
+            return getCloseStatusByResponseStatus(upgradeException.getResponseStatusCode(), String.valueOf(exception));
+        }
+
+        return CloseStatus.SERVER_ERROR.withReason(String.valueOf(exception));
+    }
+
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
         log.warn("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
 
         if (webSocketServerSession.isOpen()) {
-            CloseStatus closeStatus = CloseStatus.NORMAL;
-            if (exception instanceof CloseException) {
-                CloseException closeException = (CloseException) exception;
-                if (!(closeException.getCause() instanceof TimeoutException)) {
-                    // Idle timeout
-                    closeStatus = new CloseStatus(closeException.getStatusCode(), exception.getMessage());
-                }
-            } else {
-                closeStatus = CloseStatus.SERVER_ERROR;
-            }
-            webSocketServerSession.close(closeStatus);
+            webSocketServerSession.close(getCloseStatusByError(exception));
         }
 
         super.handleTransportError(session, exception);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandlerTest.java
@@ -10,13 +10,8 @@
 
 package org.zowe.apiml.gateway.ws;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.concurrent.TimeoutException;
-
 import org.eclipse.jetty.websocket.api.CloseException;
+import org.eclipse.jetty.websocket.api.UpgradeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +20,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class WebSocketProxyClientHandlerTest {
@@ -56,6 +56,11 @@ public class WebSocketProxyClientHandlerTest {
         @Nested
         class AndConnectionTransportError {
 
+            @BeforeEach
+            void setUp() {
+                doReturn(true).when(serverSession).isOpen();
+            }
+
             @Test
             void andTimeout_thenCloseNormal() throws Exception {
                 webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new CloseException(0, new TimeoutException("null")));
@@ -67,6 +72,103 @@ public class WebSocketProxyClientHandlerTest {
                 webSocketProxyClientHandler.handleTransportError(mock(WebSocketSession.class), new CloseException(CloseStatus.PROTOCOL_ERROR.getCode(), new Exception("message")));
                 verify(serverSession, times(1)).close(new CloseStatus(1002, "java.lang.Exception: message"));
             }
+
+        }
+
+    }
+
+    @Nested
+    class CloseStatuses {
+
+        @Test
+        void whenResponseCode5xx_thenServerErrorWithMessage() {
+            CloseStatus closeStatus = WebSocketProxyClientHandler.getCloseStatusByResponseStatus(500, "An error message");
+            assertEquals(CloseStatus.SERVER_ERROR.getCode(), closeStatus.getCode());
+            assertEquals("An error message", closeStatus.getReason());
+        }
+
+        @Test
+        void whenResponseCode401_thenNotAcceptableWithMessage() {
+            CloseStatus closeStatus = WebSocketProxyClientHandler.getCloseStatusByResponseStatus(401, "A default message");
+            assertEquals(CloseStatus.NOT_ACCEPTABLE.getCode(), closeStatus.getCode());
+            assertEquals("Invalid login credentials", closeStatus.getReason());
+        }
+
+        @Test
+        void whenUnknownResponseCode_thenNotAcceptableWithMessage() {
+            CloseStatus closeStatus = WebSocketProxyClientHandler.getCloseStatusByResponseStatus(405, "A default message");
+            assertEquals(CloseStatus.NOT_ACCEPTABLE.getCode(), closeStatus.getCode());
+            assertEquals("A default message", closeStatus.getReason());
+        }
+
+        @Test
+        void whenCloseExceptionWithTimeout_thenNormal() {
+            assertEquals(CloseStatus.NORMAL, WebSocketProxyClientHandler.getCloseStatusByError(
+                new CloseException(500, mock(TimeoutException.class)))
+            );
+        }
+
+        @Test
+        void whenCloseExceptionWith401_thenNotAcceptable() {
+            assertEquals(
+                CloseStatus.NOT_ACCEPTABLE.withReason("Invalid login credentials"),
+                WebSocketProxyClientHandler.getCloseStatusByError(new CloseException(401, "unauthMsg"))
+            );
+        }
+
+        @Test
+        void whenCloseExceptionWith500_thenServerError() {
+            assertEquals(
+                CloseStatus.SERVER_ERROR.withReason("null"),
+                WebSocketProxyClientHandler.getCloseStatusByError(new CloseException(502, "errorMsg"))
+            );
+        }
+
+        @Test
+        void whenUpgradeExceptionWith401_thenNotAcceptable() {
+            assertEquals(
+                CloseStatus.NOT_ACCEPTABLE.withReason("Invalid login credentials"),
+                WebSocketProxyClientHandler.getCloseStatusByError(new UpgradeException(null, 401, "unauthMsg"))
+            );
+        }
+
+        @Test
+        void whenUpgradeExceptionWith500_thenServerError() {
+            assertEquals(
+                CloseStatus.SERVER_ERROR.withReason("org.eclipse.jetty.websocket.api.UpgradeException: errorMsg"),
+                WebSocketProxyClientHandler.getCloseStatusByError(new UpgradeException(null, 503, "errorMsg"))
+            );
+        }
+
+        @Test
+        void whenUnknownException_thenServerError() {
+            assertEquals(
+                CloseStatus.SERVER_ERROR.withReason("java.lang.RuntimeException: errorMsg"),
+                WebSocketProxyClientHandler.getCloseStatusByError(new RuntimeException("errorMsg"))
+            );
+        }
+
+    }
+
+    @Nested
+    class ClosingWebSocket {
+
+        private final WebSocketSession session = mock(WebSocketSession.class);
+        private final Throwable exception = new Exception("reason");
+
+        @Test
+        void whenClosed_thenDontClose() throws Exception {
+            WebSocketSession webSocketSession = mock(WebSocketSession.class);
+            new WebSocketProxyClientHandler(webSocketSession).handleTransportError(session, exception);
+            verify(webSocketSession, never()).close(any());
+        }
+
+        @Test
+        void whenOpened_thenClose() throws Exception {
+            WebSocketSession session = mock(WebSocketSession.class);
+            doReturn(true).when(session).isOpen();
+            new WebSocketProxyClientHandler(session).handleTransportError(session, exception);
+            verify(session).close(any());
 
         }
 

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -14,6 +14,7 @@ sonar {
         property "sonar.language", "java"
         property "sonar.links.scm", "https://github.com/zowe/api-layer"
         property "sonar.links.ci", System.getenv()['BUILD_URL'] ?: null
+        property "sonar.scanner.force-deprecated-java-version", true
         if (pullRequest != null) {
             property "sonar.pullrequest.key", System.getenv()['CHANGE_ID'] ?: null
             property "sonar.pullrequest.branch", System.getenv()['CHANGE_BRANCH'] ?: null


### PR DESCRIPTION
# Description

This PR continues in the effort of #2914. In case of invalid credentials, service could return 401 and the log file could be overloaded with messages like:

```
<ZWEAGW1:HttpClient@...(o.z.a.g.w.WebSocketProxyClientHandler) WebSocket transport error in session ...: Failed to upgrade to websocket: Broken pipe
<ZWEAGW1:HttpClient@...(o.z.a.g.w.WebSocketProxyClientHandler) WebSocket transport error in session ...: Failed to upgrade to websocket: Unexpected HTTP Response Status Code: 401 Unauthorized
```

In case of not CloseException there is missing code to close WebSocket (keep in mind there are 2 parts of communication client>GW and GW>service). Therefore, the opposite part of communication remains in the memory until timeout or connection error is still alive. It could lead to memory issues.

This PR closes the second part of communication always if necessary (if it is opened).

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
