### PR TITLE
fix: use empty keystore for outbound calls

### DIFF
--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -191,6 +191,7 @@ public class ConnectionsConfig {
             @Override
             public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
                 if ("routingFilter".equals(beanName)) {
+                    log.debug("Updating routing bean {}", NettyRoutingFilterApiml.class);
                     // once is creating original bean by autoconfiguration replace it with custom implementation
                     return new NettyRoutingFilterApiml(httpClient, headersFiltersProvider, properties, justTruststore, withKeystore);
                 }
@@ -212,10 +213,15 @@ public class ConnectionsConfig {
             trustManagerFactory.init(trustStore);
             builder.trustManager(trustManagerFactory);
 
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             if (setKeystore) {
                 KeyStore keyStore = SecurityUtils.loadKeyStore(keyStoreType, keyStorePath, keyStorePassword);
-                KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
                 keyManagerFactory.init(keyStore, keyStorePassword);
+                builder.keyManager(keyManagerFactory);
+            } else {
+                KeyStore emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
+                emptyKeystore.load(null, null);
+                keyManagerFactory.init(emptyKeystore, null);
                 builder.keyManager(keyManagerFactory);
             }
 

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/NettyRoutingFilterApiml.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/NettyRoutingFilterApiml.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.cloudgatewayservice.config;
 
 import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.config.HttpClientProperties;
 import org.springframework.cloud.gateway.filter.NettyRoutingFilter;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import static org.springframework.cloud.gateway.support.RouteMetadataUtils.CONNECT_TIMEOUT_ATTR;
 import static org.zowe.apiml.constants.ApimlConstants.HTTP_CLIENT_USE_CLIENT_CERTIFICATE;
 
+@Slf4j
 public class NettyRoutingFilterApiml extends NettyRoutingFilter {
 
     private final HttpClient httpClientNoCert;
@@ -49,8 +51,7 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
         Integer connectTimeout;
         if (connectTimeoutAttr instanceof Integer) {
             connectTimeout = (Integer) connectTimeoutAttr;
-        }
-        else {
+        } else {
             connectTimeout = Integer.parseInt(connectTimeoutAttr.toString());
         }
         return connectTimeout;
@@ -62,6 +63,7 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
         boolean useClientCert = Optional.ofNullable((Boolean) exchange.getAttribute(HTTP_CLIENT_USE_CLIENT_CERTIFICATE)).orElse(Boolean.FALSE);
         HttpClient httpClient = useClientCert ? httpClientClientCert : httpClientNoCert;
 
+        log.debug("Using client with keystore {}", useClientCert);
         Object connectTimeoutAttr = route.getMetadata().get(CONNECT_TIMEOUT_ATTR);
         if (connectTimeoutAttr != null) {
             // if there is configured timeout, respect it


### PR DESCRIPTION
# Description

Cloud gateway running In certain environments uses default keystore instead of empty for calls that should not be signed. This change is setting an empty keystore in that scenarios.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
