### PR TITLE
fix: Fix disabling EhCache

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -60,7 +60,7 @@ import static org.zowe.apiml.constants.EurekaMetadataDefinition.ROUTES_SERVICE_U
 @Configuration
 @RequiredArgsConstructor
 // There is an issue - clashing of XML configuration
-@DependsOn({"cacheConfig", "cacheManagerFactoryBean"})
+@DependsOn({"cacheConfig", "cacheManager"})
 public class DiscoveryClientConfig {
     private final AbstractDiscoveryClientOptionalArgs<?> optionalArgs;
     private final ApimlDiscoveryClientFactory apimlDiscoveryClientFactory;


### PR DESCRIPTION
# Description

This PR is a fix to be able to start GW with the argument `apiml.caching.enabled=false` . The previous PR (#3276) contains a wrong bean name.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
