### PR TITLE
chore: add request with http client for jwt from zosmf

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
@@ -170,7 +170,7 @@ class PassTicketTest implements TestWithStartedInstances {
     @Nested
     class WhenGeneratingPassTicket_returnBadRequest {
 
-        private String jwt = getZosmfJwtToken();
+        private final String jwt = getZosmfJwtToken();
 
         @Test
         void givenNoApplicationName() {

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
@@ -33,14 +33,24 @@ import java.util.Collections;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.XML;
-import static org.apache.http.HttpStatus.*;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.*;
-import static org.zowe.apiml.util.SecurityUtils.*;
+import static org.zowe.apiml.integration.zaas.ZaasTestUtil.COOKIE;
+import static org.zowe.apiml.integration.zaas.ZaasTestUtil.LTPA_COOKIE;
+import static org.zowe.apiml.integration.zaas.ZaasTestUtil.ZAAS_TICKET_URI;
+import static org.zowe.apiml.util.SecurityUtils.USERNAME;
+import static org.zowe.apiml.util.SecurityUtils.generateZoweJwtWithLtpa;
+import static org.zowe.apiml.util.SecurityUtils.getConfiguredSslConfig;
+import static org.zowe.apiml.util.SecurityUtils.getZosmfJwtToken;
+import static org.zowe.apiml.util.SecurityUtils.getZosmfToken;
+import static org.zowe.apiml.util.SecurityUtils.personalAccessToken;
+import static org.zowe.apiml.util.SecurityUtils.validOktaAccessToken;
 
 /**
  * Verify integration of the API ML PassTicket support with the zOS provider of the PassTicket.
@@ -161,7 +171,7 @@ class PassTicketTest implements TestWithStartedInstances {
     @Nested
     class WhenGeneratingPassTicket_returnBadRequest {
 
-        private final String jwt = getZosmfJwtToken();
+        private String jwt = getZosmfJwtToken();
 
         @Test
         void givenNoApplicationName() {

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/PassTicketTest.java
@@ -42,13 +42,12 @@ import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.zowe.apiml.integration.zaas.ZaasTestUtil.COOKIE;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.LTPA_COOKIE;
 import static org.zowe.apiml.integration.zaas.ZaasTestUtil.ZAAS_TICKET_URI;
 import static org.zowe.apiml.util.SecurityUtils.USERNAME;
 import static org.zowe.apiml.util.SecurityUtils.generateZoweJwtWithLtpa;
 import static org.zowe.apiml.util.SecurityUtils.getConfiguredSslConfig;
 import static org.zowe.apiml.util.SecurityUtils.getZosmfJwtToken;
-import static org.zowe.apiml.util.SecurityUtils.getZosmfToken;
+import static org.zowe.apiml.util.SecurityUtils.getZosmfLtpaToken;
 import static org.zowe.apiml.util.SecurityUtils.personalAccessToken;
 import static org.zowe.apiml.util.SecurityUtils.validOktaAccessToken;
 
@@ -91,7 +90,7 @@ class PassTicketTest implements TestWithStartedInstances {
 
         @Test
         void givenValidZoweTokenWithLtpa() throws UnrecoverableKeyException, CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
-            String ltpaToken = getZosmfToken(LTPA_COOKIE);
+            String ltpaToken = getZosmfLtpaToken();
             String zoweToken = generateZoweJwtWithLtpa(ltpaToken);
 
             //@formatter:off

--- a/integration-tests/src/test/java/org/zowe/apiml/util/SecurityUtils.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/SecurityUtils.java
@@ -181,6 +181,10 @@ public class SecurityUtils {
         return getZosmfTokenWebClient("jwtToken");
     }
 
+    public static String getZosmfLtpaToken() {
+        return getZosmfTokenWebClient("LtpaToken2");
+    }
+
     public static String getZosmfTokenWebClient(String cookie) {
         try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
             HttpClientContext context = HttpClientContext.create();

--- a/integration-tests/src/test/java/org/zowe/apiml/util/SecurityUtils.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/SecurityUtils.java
@@ -199,9 +199,9 @@ public class SecurityUtils {
                     .filter(c -> cookie.equals(c.getName()))
                     .findFirst()
                     .map(c -> c.getValue())
-                    .orElseThrow(RuntimeException::new);
+                    .orElseThrow(() -> new RuntimeException("Cookie " + cookie + " not found in z/OSMF response"));
             } else {
-                throw new RuntimeException("");
+                throw new RuntimeException("Request to z/OSMF failed with status code " + response.getStatusLine().getStatusCode() + ": " + response.getStatusLine().getReasonPhrase());
             }
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
# Description

Requests to real z/OSMF instances can fail if the z/OSMF server doesn't complete the response completely as RestAssured expects, leading to integration tests hanging. Replacing this call with http client which handles this situation gracefully.

## Type of change

Please delete options that are not relevant.

- [ ] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
