### PR TITLE
fix: z/osmf serviceID in manifest

### DIFF
--- a/gateway-package/src/main/resources/manifest.yaml
+++ b/gateway-package/src/main/resources/manifest.yaml
@@ -40,7 +40,7 @@ configs:
         provider: zosmf
         zosmf:
           jwtAutoconfiguration: auto
-          serviceId: zosmf
+          serviceId: ibmzosmf
       authorization:
         endpoint:
           enabled: false


### PR DESCRIPTION
# Description

v3 removes the unused `zosmf` serviceId from the static definition file for discovery service. This fixes which serviceId Gateway will look for.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules