### PR TITLE
fix: Fix base path in API Catalog

### DIFF
--- a/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
@@ -12,6 +12,8 @@ package org.zowe.apiml.product.routing.transform;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.zowe.apiml.product.gateway.GatewayClient;
 import org.zowe.apiml.product.gateway.GatewayConfigProperties;
 import org.zowe.apiml.product.routing.RoutedService;
@@ -293,6 +295,30 @@ class TransformServiceTest {
             transformService.retrieveApiBasePath(SERVICE_ID, url, routedServices);
         });
         assertEquals("Not able to select API base path for the service " + SERVICE_ID + ". Original url used.", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "service,api/v1,api/v1,api/v1,/service/api/{api-version}",
+        "srv,api/v1/home/page.html,api/v1,api/v1,/srv/api/{api-version}",
+        "srv,wrong/url,api/v1,api/v1,",
+        "srv,apiV1/home/page.html,api/v1,apiV1,/srv/api/{api-version}"
+    })
+    void testRetrieveApiBasePath(String serviceId, String url, String gatewayUrl, String serviceUrl, String expectedBasePath) {
+        RoutedService route = new RoutedService("api", gatewayUrl, serviceUrl);
+
+        RoutedServices routedServices = new RoutedServices();
+        routedServices.addRoutedService(route);
+
+        TransformService transformService = new TransformService(null);
+        String basePath;
+        try {
+            basePath = transformService.retrieveApiBasePath(serviceId, url, routedServices);
+        } catch (URLTransformationException e) {
+            basePath = null;
+        }
+
+        assertEquals(expectedBasePath, basePath);
     }
 
 }

--- a/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
@@ -235,7 +235,7 @@ class TransformServiceTest {
 
     @Test
     void givenServiceAndApiRoute_whenGetApiBasePath_thenReturnApiPath() throws URLTransformationException {
-        String url = "https://localhost:8080/" + SERVICE_ID;
+        String url = "https://localhost:8080/" + SERVICE_ID + "/" + API_PREFIX + "/v1";
 
         String serviceUrl = String.format("/%s/%s", SERVICE_ID, API_PREFIX);
         RoutedServices routedServices = new RoutedServices();
@@ -253,7 +253,7 @@ class TransformServiceTest {
 
     @Test
     void givenServiceAndApiRouteWithVersion_whenGetApiBasePath_thenReturnApiPath() throws URLTransformationException {
-        String url = "https://localhost:8080/" + SERVICE_ID;
+        String url = "https://localhost:8080/" + SERVICE_ID + "/" + API_PREFIX + "/v1";
 
         String serviceUrl = String.format("/%s/%s/%s", SERVICE_ID, API_PREFIX, "v1");
         RoutedServices routedServices = new RoutedServices();

--- a/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/product/routing/RoutedServices.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.product.routing;
 
+import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.util.UrlUtils;
 
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class RoutedServices {
     }
 
     private boolean isMatchingApiRoute(String serviceUrl, String routeServiceUrl) {
-        return routeServiceUrl.startsWith(serviceUrl.toLowerCase());
+        return StringUtils.startsWithIgnoreCase(serviceUrl, routeServiceUrl);
     }
 
     @Override

--- a/common-service-core/src/test/java/org/zowe/apiml/product/routing/RoutedServicesTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/product/routing/RoutedServicesTest.java
@@ -112,13 +112,11 @@ class RoutedServicesTest {
         routedServices.addRoutedService(routedService1);
         routedServices.addRoutedService(routedService2);
 
-        routedService = routedServices.getBestMatchingApiUrl("/test");
+        routedService = routedServices.getBestMatchingApiUrl("/test2/api/v2");
 
         assertEquals("api_v2", routedService.getSubServiceId());
         assertEquals("api/v2", routedService.getGatewayUrl());
         assertEquals("/test2/api/v2", routedService.getServiceUrl());
-
-
     }
 
     @Test

--- a/config/local/api-defs-http/staticclient.yml
+++ b/config/local/api-defs-http/staticclient.yml
@@ -11,7 +11,7 @@ services:
       description: Sample to demonstrate how to add an API service with Swagger to API Catalog using a static YAML definition  # Description of the service in the API catalog
       instanceBaseUrls:  # list of base URLs for each instance
         - http://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl: / # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -36,7 +36,7 @@ services:
       description: Sample to demonstrate how to add an API service without Swagger documentation to API Catalog using a static YAML definition  # Description of the service in the API catalog
       instanceBaseUrls:  # list of base URLs for each instance
         - http://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -61,7 +61,7 @@ services:
       description: Define service to test by pass authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - http://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -80,7 +80,7 @@ services:
       description: Define service to test passTicket authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - http://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -100,7 +100,7 @@ services:
       description: Define service to test safIdt authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - http://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -120,7 +120,7 @@ services:
       description: Define service to test zosmf authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:

--- a/config/local/api-defs/staticclient.yml
+++ b/config/local/api-defs/staticclient.yml
@@ -11,7 +11,7 @@ services:
       description: Sample to demonstrate how to add an API service with Swagger to API Catalog using a static YAML definition  # Description of the service in the API catalog
       instanceBaseUrls:  # list of base URLs for each instance
         - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl: / # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -36,7 +36,7 @@ services:
       description: Sample to demonstrate how to add an API service without Swagger documentation to API Catalog using a static YAML definition  # Description of the service in the API catalog
       instanceBaseUrls:  # list of base URLs for each instance
         - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -61,7 +61,7 @@ services:
       description: Sample to demonstrate how to add an API service without Swagger documentation to API Catalog using a static YAML definition  # Description of the service in the API catalog
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -84,7 +84,7 @@ services:
       description: Define service to test by pass authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -103,7 +103,7 @@ services:
       description: Define service to test passTicket authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -123,7 +123,7 @@ services:
       description: Define service to test safIdt authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:
@@ -143,7 +143,7 @@ services:
       description: Define service to test zosmf authentication schema for integration tests.
       instanceBaseUrls:  # list of base URLs for each instance
           - https://localhost:10012/discoverableclient  # scheme://hostname:port/contextPath
-      homePageRelativeUrl:  # Normally used for informational purposes for other services to use it as a landing page
+      homePageRelativeUrl: /api/v1 # Normally used for informational purposes for other services to use it as a landing page
       statusPageRelativeUrl: /application/info  # Appended to the instanceBaseUrl
       healthCheckRelativeUrl: /application/health  # Appended to the instanceBaseUrl
       routes:


### PR DESCRIPTION
# Description

The API Catalog tries to calculate the base path (prefix) of a service. However, the evaluation uses the opposite condition. The homepage URL could be longer than a routing rule - it is not necessary to be the homepage same as the root URL.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
