### PR TITLE
chore: fix IT to not depend on OIDC token

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasNegativeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasNegativeTest.java
@@ -48,8 +48,6 @@ public class ZaasNegativeTest {
 
     private final static String APPLICATION_NAME = ConfigReader.environmentConfiguration().getDiscoverableClientConfiguration().getApplId();
 
-    private static final String OKTA_TOKEN_NO_MAPPING = SecurityUtils.validOktaAccessToken(false);
-
     private static final Set<URI> tokenEndpoints = new HashSet<URI>() {{
         add(ZAAS_ZOWE_URI);
         add(ZAAS_ZOSMF_URI);
@@ -68,6 +66,7 @@ public class ZaasNegativeTest {
         add(generateJwtWithRandomSignature("https://localhost:10010"));
     }};
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> provideZaasEndpointsWithAllTokens() {
         List<Arguments> argumentsList = new ArrayList<>();
         for (URI uri : endpoints) {
@@ -83,6 +82,7 @@ public class ZaasNegativeTest {
         return argumentsList.stream();
     }
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> provideZaasEndpoints() {
         List<Arguments> argumentsList = new ArrayList<>();
         for (URI uri : endpoints) {
@@ -95,6 +95,7 @@ public class ZaasNegativeTest {
         return argumentsList.stream();
     }
 
+    @SuppressWarnings("unused")
     private static Stream<Arguments> provideZaasTokenEndpoints() {
         List<Arguments> argumentsList = new ArrayList<>();
         for (URI uri : tokenEndpoints) {
@@ -143,9 +144,10 @@ public class ZaasNegativeTest {
         @ParameterizedTest
         @MethodSource("org.zowe.apiml.integration.zaas.ZaasNegativeTest#provideZaasEndpoints")
         void givenOKTATokenWithNoMapping(URI uri, RequestSpecification requestSpecification) {
+            String oktaTokenNoMapping = SecurityUtils.validOktaAccessToken(false);
             //@formatter:off
             requestSpecification
-                .header("Authorization", "Bearer " + OKTA_TOKEN_NO_MAPPING)
+                .header("Authorization", "Bearer " + oktaTokenNoMapping)
             .when()
                 .post(uri)
             .then()


### PR DESCRIPTION
# Description

This integration test does not need to depend on obtaining OIDC token, as if it fails it leads to difficult to debug messages. Besides the token is used in one test only.

## Type of change

- [ ] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules