### PR TITLE
chore: Change log levels for Websocket and Identity mapper failures

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
@@ -73,8 +72,8 @@ public abstract class ExternalMapper {
             if (httpResponse.getEntity() != null) {
                 response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
             }
-            if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
-                log.warn("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+            if (!org.springframework.http.HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
+                log.debug("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
                 return null;
             }
             log.debug("External identity mapper API returned: {}", response);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
@@ -73,7 +73,11 @@ public abstract class ExternalMapper {
                 response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
             }
             if (!org.springframework.http.HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                log.debug("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+                if (org.springframework.http.HttpStatus.valueOf(statusCode).is5xxServerError()) {
+                    log.error("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+                } else {
+                    log.debug("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+                }
                 return null;
             }
             log.debug("External identity mapper API returned: {}", response);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
@@ -85,9 +85,9 @@ public abstract class ExternalMapper {
                 return objectMapper.readValue(response, MapperResponse.class);
             }
         } catch (IOException e) {
-            log.warn("Error occurred while communicating with external identity mapper", e);
+            log.error("Error occurred while communicating with external identity mapper", e);
         } catch (URISyntaxException e) {
-            log.warn("Configuration error: Failed to construct the external identity mapper URI.", e);
+            log.error("Configuration error: Failed to construct the external identity mapper URI.", e);
         }
 
         return null;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -80,7 +80,7 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
 
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-        log.warn("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
+        log.debug("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
 
         if (webSocketServerSession.isOpen()) {
             webSocketServerSession.close(getCloseStatusByError(exception));


### PR DESCRIPTION
# Description

1. This [fix](https://github.com/zowe/api-layer/pull/3271) fixed the issue of keeping open websockets even in case of failure, that was causing crash of GW due to heap out of memory. However a log message is still being spammed constantly in case the websocket communication failed, before closing the session.
2. Similarly, in case of failure when calling the external identity mapper, the WARN message is spammed. 
Both messages are now changed to debug to make them less intrusive.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
