### PR TITLE
chore: Change log levels for WS and Identity Mapper and add service info

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/mapping/ExternalMapper.java
@@ -24,6 +24,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.zowe.apiml.gateway.security.mapping.model.MapperResponse;
 import org.zowe.apiml.gateway.security.service.TokenCreationService;
+import org.zowe.apiml.message.log.ApimlLogger;
+import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
 
 import javax.validation.constraints.NotNull;
@@ -44,8 +46,10 @@ public abstract class ExternalMapper {
     private final CloseableHttpClient httpClientProxy;
     private final TokenCreationService tokenCreationService;
     private final AuthConfigurationProperties authConfigurationProperties;
-
     protected static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectApimlLogger
+    protected ApimlLogger apimlLog = ApimlLogger.empty();
 
     MapperResponse callExternalMapper(@NotNull HttpEntity payload) {
         if (StringUtils.isBlank(mapperUrl)) {
@@ -77,7 +81,7 @@ public abstract class ExternalMapper {
             }
             if (!org.springframework.http.HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
                 if (org.springframework.http.HttpStatus.valueOf(statusCode).is5xxServerError()) {
-                    log.error("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
+                    apimlLog.log("org.zowe.apiml.gateway.security.unexpectedMappingResponse", statusCode, response);
                 } else {
                     log.debug("Unexpected response from the external identity mapper. Status: {} body: {}", statusCode, response);
                 }
@@ -88,9 +92,9 @@ public abstract class ExternalMapper {
                 return objectMapper.readValue(response, MapperResponse.class);
             }
         } catch (IOException e) {
-            log.error("Error occurred while communicating with external identity mapper", e);
+            apimlLog.log("org.zowe.apiml.gateway.security.InvalidMappingResponse", e);
         } catch (URISyntaxException e) {
-            log.error("Configuration error: Failed to construct the external identity mapper URI.", e);
+            apimlLog.log("org.zowe.apiml.gateway.security.InvalidMapperUrl", e);
         }
 
         return null;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/source/DefaultAuthSourceService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/source/DefaultAuthSourceService.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.security.service.schema.source;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,6 +41,7 @@ import java.util.Optional;
 @Primary
 @Scope(proxyMode = ScopedProxyMode.TARGET_CLASS)
 @EnableAspectJAutoProxy(proxyTargetClass = true)
+@Slf4j
 public class DefaultAuthSourceService implements AuthSourceService {
     private final Map<AuthSourceType, AuthSourceService> map = new EnumMap<>(AuthSourceType.class);
 
@@ -94,6 +96,7 @@ public class DefaultAuthSourceService implements AuthSourceService {
     public Optional<AuthSource> getAuthSourceFromRequest(HttpServletRequest request) {
         AuthSourceService service = getService(AuthSourceType.JWT);
         Optional<AuthSource> authSource = service.getAuthSourceFromRequest(request);
+        String logMessage = "Authentication request towards the southbound service {} using the auth source {}";
         if (!authSource.isPresent() && isPATEnabled) {
             service = getService(AuthSourceType.PAT);
             authSource = service.getAuthSourceFromRequest(request);
@@ -106,6 +109,7 @@ public class DefaultAuthSourceService implements AuthSourceService {
             service = getService(AuthSourceType.CLIENT_CERT);
             authSource = service.getAuthSourceFromRequest(request);
         }
+        authSource.ifPresent(source -> log.debug(logMessage, request.getRequestURI(), source.getType().toString()));
         return authSource;
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/source/DefaultAuthSourceService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/schema/source/DefaultAuthSourceService.java
@@ -48,7 +48,7 @@ public class DefaultAuthSourceService implements AuthSourceService {
     private final boolean isX509Enabled;
     private final boolean isPATEnabled;
     private final boolean isOIDCEnabled;
-
+    private static final String LOG_MESSAGE = "Authentication request towards the southbound service {} using the auth source {}";
     /**
      * Build the map of the specific implementations of {@link AuthSourceService} for processing of different type of authentications
      *
@@ -96,7 +96,6 @@ public class DefaultAuthSourceService implements AuthSourceService {
     public Optional<AuthSource> getAuthSourceFromRequest(HttpServletRequest request) {
         AuthSourceService service = getService(AuthSourceType.JWT);
         Optional<AuthSource> authSource = service.getAuthSourceFromRequest(request);
-        String logMessage = "Authentication request towards the southbound service {} using the auth source {}";
         if (!authSource.isPresent() && isPATEnabled) {
             service = getService(AuthSourceType.PAT);
             authSource = service.getAuthSourceFromRequest(request);
@@ -109,7 +108,7 @@ public class DefaultAuthSourceService implements AuthSourceService {
             service = getService(AuthSourceType.CLIENT_CERT);
             authSource = service.getAuthSourceFromRequest(request);
         }
-        authSource.ifPresent(source -> log.debug(logMessage, request.getRequestURI(), source.getType().toString()));
+        authSource.ifPresent(source -> log.debug(LOG_MESSAGE, request.getRequestURI(), source.getType()));
         return authSource;
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyClientHandler.java
@@ -80,7 +80,7 @@ public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
 
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-        log.warn("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
+        log.debug("WebSocket transport error in session {}: {}", session.getId(), exception.getMessage());
 
         if (webSocketServerSession.isOpen()) {
             webSocketServerSession.close(getCloseStatusByError(exception));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -137,6 +137,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
         }
 
         try {
+            log.debug("Trying to open a WebSocket connection and route to the {} service", serviceId);
             meAsProxy.openConn(serviceId, service, webSocketSession, path);
         } catch (WebSocketProxyError e) {
             log.debug("Error opening WebSocket connection to: {}, {}", service.getServiceUrl(), e.getMessage());

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -370,6 +370,27 @@ messages:
       reason: "The JWT token or client certificate is not valid"
       action: "Configure your client to provide valid authentication."
 
+    - key: org.zowe.apiml.gateway.security.unexpectedMappingResponse
+      number: ZWEAG169
+      type: ERROR
+      text: "Unexpected response from the external identity mapper. Status: %s body: %s"
+      reason: "The external identity mapper request failed with Internal Error"
+      action: "Verify that ZSS is responding."
+
+    - key: org.zowe.apiml.gateway.security.InvalidMappingResponse
+      number: ZWEAG170
+      type: ERROR
+      text: "Error occurred while trying to parse the response from the external identity mapper. Reason: %s"
+      reason: "The external identity mapper failed when trying to parse the response"
+      action: "Verify that the response is valid."
+
+    - key: org.zowe.apiml.gateway.security.InvalidMapperUrl
+      number: ZWEAG171
+      type: ERROR
+      text: "Configuration error. Failed to construct the external identity mapper URI. Reason: %s"
+      reason: "Failed to construct the external identity mapper URI"
+      action: "Verify that the external identity mapper URL specified in the configuration is valid."
+
     # Revoke personal access token
     - key: org.zowe.apiml.security.query.invalidRevokeRequestBody
       number: ZWEAT607


### PR DESCRIPTION
# Description

1. This [fix](https://github.com/zowe/api-layer/pull/3271) fixed the issue of keeping open websockets even in case of failure, that was causing crash of GW due to heap out of memory. However a log message is still being spammed constantly in case the websocket communication failed, before closing the session.
2. Similarly, in case of failure when calling the external identity mapper, the WARN message is spammed. 
Both messages are now changed to debug to make them less intrusive, and a msg with information about the southbound service request's been created.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
