### PR TITLE
fix: change scheme of service homepage when AT-TLS is enabled and fix bug in UI

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -63,7 +63,7 @@ public class CachedProductFamilyService {
     @Value("${apiml.catalog.hide.serviceInfo:false}")
     private boolean hideServiceInfo;
 
-    @Value("${spring.profiles.active:}")
+    @Value("${spring.profiles.active:''}")
     private String springProfile;
 
     public CachedProductFamilyService(CachedServicesService cachedServicesService,

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -31,22 +31,11 @@ import org.zowe.apiml.product.routing.ServiceType;
 import org.zowe.apiml.product.routing.transform.TransformService;
 import org.zowe.apiml.product.routing.transform.URLTransformationException;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.stream.Collectors.toList;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.AUTHENTICATION_SCHEME;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.AUTHENTICATION_SSO;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.CATALOG_DESCRIPTION;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.CATALOG_TITLE;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.CATALOG_VERSION;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_DESCRIPTION;
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.SERVICE_TITLE;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
 
 /**
  * Caching service for eureka services
@@ -73,6 +62,9 @@ public class CachedProductFamilyService {
 
     @Value("${apiml.catalog.hide.serviceInfo:false}")
     private boolean hideServiceInfo;
+
+    @Value("${spring.profiles.active}")
+    private String springProfile;
 
     public CachedProductFamilyService(CachedServicesService cachedServicesService,
                                       TransformService transformService,
@@ -286,13 +278,14 @@ public class CachedProductFamilyService {
         if (hasHomePage(instanceInfo)) {
             instanceHomePage = instanceHomePage.trim();
             RoutedServices routes = metadataParser.parseRoutes(instanceInfo.getMetadata());
-
+            boolean isAttlsEnabled = springProfile.equalsIgnoreCase("attls");
             try {
                 instanceHomePage = transformService.transformURL(
                     ServiceType.UI,
                     instanceInfo.getVIPAddress(),
                     instanceHomePage,
-                    routes);
+                    routes,
+                    isAttlsEnabled);
             } catch (URLTransformationException | IllegalArgumentException e) {
                 apimlLog.log("org.zowe.apiml.apicatalog.homePageTransformFailed", instanceInfo.getAppName(), e.getMessage());
             }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -63,7 +63,7 @@ public class CachedProductFamilyService {
     @Value("${apiml.catalog.hide.serviceInfo:false}")
     private boolean hideServiceInfo;
 
-    @Value("${spring.profiles.active}")
+    @Value("${spring.profiles.active:}")
     private String springProfile;
 
     public CachedProductFamilyService(CachedServicesService cachedServicesService,
@@ -278,7 +278,7 @@ public class CachedProductFamilyService {
         if (hasHomePage(instanceInfo)) {
             instanceHomePage = instanceHomePage.trim();
             RoutedServices routes = metadataParser.parseRoutes(instanceInfo.getMetadata());
-            boolean isAttlsEnabled = springProfile.equalsIgnoreCase("attls");
+            boolean isAttlsEnabled = springProfile != null && springProfile.equalsIgnoreCase("attls");
             try {
                 instanceHomePage = transformService.transformURL(
                     ServiceType.UI,

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -63,8 +63,8 @@ public class CachedProductFamilyService {
     @Value("${apiml.catalog.hide.serviceInfo:false}")
     private boolean hideServiceInfo;
 
-    @Value("${spring.profiles.active:''}")
-    private String springProfile;
+    @Value("${server.attls.enabled:false}")
+    private boolean isAttlsEnabled;
 
     public CachedProductFamilyService(CachedServicesService cachedServicesService,
                                       TransformService transformService,
@@ -278,7 +278,6 @@ public class CachedProductFamilyService {
         if (hasHomePage(instanceInfo)) {
             instanceHomePage = instanceHomePage.trim();
             RoutedServices routes = metadataParser.parseRoutes(instanceInfo.getMetadata());
-            boolean isAttlsEnabled = springProfile != null && springProfile.equalsIgnoreCase("attls");
             try {
                 instanceHomePage = transformService.transformURL(
                     ServiceType.UI,

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
@@ -99,7 +99,7 @@ class CachedProductFamilyServiceTest {
                         updatedMetadata);
 
                 when(transformService.transformURL(
-                        any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class)))
+                        any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), false))
                                 .thenReturn(instance.getHomePageUrl());
             }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
@@ -30,6 +30,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,7 +100,7 @@ class CachedProductFamilyServiceTest {
                         updatedMetadata);
 
                 when(transformService.transformURL(
-                        any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), false))
+                        any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), eq(false)))
                                 .thenReturn(instance.getHomePageUrl());
             }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
@@ -29,8 +29,7 @@ import org.zowe.apiml.product.routing.transform.URLTransformationException;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -108,6 +107,31 @@ class CachedProductFamilyServiceTest {
             class GivenInstanceIsNotInCache {
                 @Test
                 void createNew() {
+                    APIContainer originalContainer = underTest.saveContainerFromInstance("demoapp", instance);
+
+                    List<APIContainer> lsContainer = underTest.getRecentlyUpdatedContainers();
+                    assertThatContainerIsCorrect(lsContainer, originalContainer, instance);
+                }
+
+                @Nested
+                class WhenCheckingAttlsProfile {
+                    @Test
+                    void givenNoProfile_thenGetInstanceHomePageUrl() throws URLTransformationException {
+                        when(transformService.transformURL(
+                            any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), eq(true)))
+                            .thenReturn(instance.getHomePageUrl());
+                        APIContainer originalContainer = underTest.saveContainerFromInstance("demoapp", instance);
+
+                        List<APIContainer> lsContainer = underTest.getRecentlyUpdatedContainers();
+                        assertThatContainerIsCorrect(lsContainer, originalContainer, instance);
+                    }
+                }
+                @Test
+                void givenAttlsProfile_thenGetInstanceHomePageUrl() throws URLTransformationException {
+                    ReflectionTestUtils.setField(underTest, "springProfile", "attls");
+                    when(transformService.transformURL(
+                        any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), eq(true)))
+                        .thenReturn(instance.getHomePageUrl());
                     APIContainer originalContainer = underTest.saveContainerFromInstance("demoapp", instance);
 
                     List<APIContainer> lsContainer = underTest.getRecentlyUpdatedContainers();

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyServiceTest.java
@@ -114,9 +114,9 @@ class CachedProductFamilyServiceTest {
                 }
 
                 @Nested
-                class WhenCheckingAttlsProfile {
+                class WhenCheckingIfAttlsEnabled {
                     @Test
-                    void givenNoProfile_thenGetInstanceHomePageUrl() throws URLTransformationException {
+                    void givenNoAttls_thenGetInstanceHomePageUrl() throws URLTransformationException {
                         when(transformService.transformURL(
                             any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), eq(true)))
                             .thenReturn(instance.getHomePageUrl());
@@ -127,8 +127,8 @@ class CachedProductFamilyServiceTest {
                     }
                 }
                 @Test
-                void givenAttlsProfile_thenGetInstanceHomePageUrl() throws URLTransformationException {
-                    ReflectionTestUtils.setField(underTest, "springProfile", "attls");
+                void givenAttlsEnabled_thenGetInstanceHomePageUrl() throws URLTransformationException {
+                    ReflectionTestUtils.setField(underTest, "isAttlsEnabled", true);
                     when(transformService.transformURL(
                         any(ServiceType.class), any(String.class), any(String.class), any(RoutedServices.class), eq(true)))
                         .thenReturn(instance.getHomePageUrl());

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -132,7 +132,7 @@ export default class DetailPage extends Component {
         } = countAdditionalContents(selectedService);
         const onlySwaggerPresent = tutorialsCounter === 0 && videosCounter === 0 && useCasesCounter === 0;
         const showSideBar = false;
-        if (hasTiles && tiles[0]?.customStyleConfig) {
+        if (hasTiles && tiles[0]?.customStyleConfig && Object.keys(tiles[0].customStyleConfig).length > 0) {
             customUIStyle(tiles[0].customStyleConfig);
         }
 

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -343,6 +343,7 @@ DetailPage.propTypes = {
     tiles: PropTypes.arrayOf(
         PropTypes.shape({
             title: PropTypes.string.isRequired,
+            customStyleConfig: PropTypes.object.isRequired,
         })
     ).isRequired,
 };

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -132,12 +132,7 @@ export default class DetailPage extends Component {
         } = countAdditionalContents(selectedService);
         const onlySwaggerPresent = tutorialsCounter === 0 && videosCounter === 0 && useCasesCounter === 0;
         const showSideBar = false;
-        if (
-            hasTiles &&
-            'customStyleConfig' in tiles[0] &&
-            tiles[0].customStyleConfig &&
-            Object.keys(tiles[0].customStyleConfig).length > 0
-        ) {
+        if (hasTiles && tiles[0]?.customStyleConfig) {
             customUIStyle(tiles[0].customStyleConfig);
         }
 
@@ -209,7 +204,7 @@ export default class DetailPage extends Component {
                                 )}
                             </div>
                             {/* Extra Zowe information */}
-                            {apiPortalEnabled && tiles[0].title.toLowerCase().indexOf('zowe') >= 0 && (
+                            {apiPortalEnabled && hasTiles && tiles[0].title?.toLowerCase().indexOf('zowe') >= 0 && (
                                 <div style={{ display: 'flex', flexDirection: 'column', width: '80%' }}>
                                     <div>
                                         <img id="zowe" alt="Zowe" src={zoweImage} className="hover" />

--- a/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
+++ b/api-catalog-ui/frontend/src/components/DetailPage/DetailPage.jsx
@@ -340,4 +340,9 @@ DetailPage.propTypes = {
     }).isRequired,
     selectedService: PropTypes.object.isRequired,
     selectedContentAnchor: PropTypes.string.isRequired,
+    tiles: PropTypes.arrayOf(
+        PropTypes.shape({
+            title: PropTypes.string.isRequired,
+        })
+    ).isRequired,
 };

--- a/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
@@ -43,7 +43,7 @@ public class TransformService {
      * @param serviceId  the service id
      * @param serviceUrl the service URL
      * @param routes     the routes
-     * @param isAttlsEnabled attls flag
+     * @param httpsScheme https scheme flag
      * @return the new URL
      * @throws URLTransformationException if the path of the service URL is not valid
      */
@@ -51,7 +51,7 @@ public class TransformService {
                                String serviceId,
                                String serviceUrl,
                                RoutedServices routes,
-                               boolean isAttlsEnabled) throws URLTransformationException {
+                               boolean httpsScheme) throws URLTransformationException {
 
         if (!gatewayClient.isInitialized()) {
             apimlLog.log("org.zowe.apiml.common.gatewayNotFoundForTransformRequest");
@@ -83,7 +83,7 @@ public class TransformService {
 
         GatewayConfigProperties gatewayConfigProperties = gatewayClient.getGatewayConfigProperties();
         String scheme = gatewayConfigProperties.getScheme();
-        if (isAttlsEnabled) {
+        if (httpsScheme) {
             scheme = "https";
         }
         return String.format("%s://%s/%s/%s%s",

--- a/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
@@ -43,13 +43,15 @@ public class TransformService {
      * @param serviceId  the service id
      * @param serviceUrl the service URL
      * @param routes     the routes
+     * @param isAttlsEnabled attls flag
      * @return the new URL
      * @throws URLTransformationException if the path of the service URL is not valid
      */
     public String transformURL(ServiceType type,
                                String serviceId,
                                String serviceUrl,
-                               RoutedServices routes) throws URLTransformationException {
+                               RoutedServices routes,
+                               boolean isAttlsEnabled) throws URLTransformationException {
 
         if (!gatewayClient.isInitialized()) {
             apimlLog.log("org.zowe.apiml.common.gatewayNotFoundForTransformRequest");
@@ -80,9 +82,12 @@ public class TransformService {
         }
 
         GatewayConfigProperties gatewayConfigProperties = gatewayClient.getGatewayConfigProperties();
-
+        String scheme = gatewayConfigProperties.getScheme();
+        if (isAttlsEnabled) {
+            scheme = "https";
+        }
         return String.format("%s://%s/%s/%s%s",
-            gatewayConfigProperties.getScheme(),
+            scheme,
             gatewayConfigProperties.getHostname(),
             serviceId,
             route.getGatewayUrl(),

--- a/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/routing/transform/TransformService.java
@@ -82,10 +82,8 @@ public class TransformService {
         }
 
         GatewayConfigProperties gatewayConfigProperties = gatewayClient.getGatewayConfigProperties();
-        String scheme = gatewayConfigProperties.getScheme();
-        if (httpsScheme) {
-            scheme = "https";
-        }
+
+        String scheme = httpsScheme ? "https" : gatewayConfigProperties.getScheme();
         return String.format("%s://%s/%s/%s%s",
             scheme,
             gatewayConfigProperties.getHostname(),

--- a/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/routing/transform/TransformServiceTest.java
@@ -53,10 +53,30 @@ class TransformServiceTest {
         routedServices.addRoutedService(routedService2);
 
         TransformService transformService = new TransformService(gatewayClient);
-        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices, false);
 
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
+            gatewayClient.getGatewayConfigProperties().getHostname(),
+            SERVICE_ID,
+            UI_PREFIX);
+        assertEquals(expectedUrl, actualUrl);
+    }
+
+    @Test
+    void givenHomePageWithAttlsEnabled_whenTransform_thenUseNewUrlWithHttps() throws URLTransformationException {
+        String url = "http://localhost:8080/ui";
+        RoutedServices routedServices = new RoutedServices();
+        RoutedService routedService1 = new RoutedService(SERVICE_ID, UI_PREFIX, "/ui");
+        RoutedService routedService2 = new RoutedService(SERVICE_ID, "api/v1", "/");
+        routedServices.addRoutedService(routedService1);
+        routedServices.addRoutedService(routedService2);
+
+        TransformService transformService = new TransformService(gatewayClient);
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices, true);
+
+        String expectedUrl = String.format("%s://%s/%s/%s",
+            "https",
             gatewayClient.getGatewayConfigProperties().getHostname(),
             SERVICE_ID,
             UI_PREFIX);
@@ -76,7 +96,7 @@ class TransformServiceTest {
         TransformService transformService = new TransformService(gatewayClient);
 
         Exception exception = assertThrows(URLTransformationException.class, () -> {
-            transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+            transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices, false);
         });
         assertEquals("Not able to select route for url https://localhost:8080/u of the service service. Original url used.", exception.getMessage());
     }
@@ -92,7 +112,7 @@ class TransformServiceTest {
         routedServices.addRoutedService(routedService2);
 
         TransformService transformService = new TransformService(gatewayClient);
-        String actualUrl = transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices, false);
 
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
@@ -113,7 +133,7 @@ class TransformServiceTest {
         routedServices.addRoutedService(routedService2);
 
         TransformService transformService = new TransformService(gatewayClient);
-        String actualUrl = transformService.transformURL(ServiceType.API, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.API, SERVICE_ID, url, routedServices, false);
 
         String expectedUrl = String.format("%s://%s/%s/%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
@@ -131,7 +151,7 @@ class TransformServiceTest {
         TransformService transformService = new TransformService(gatewayClient);
 
         Exception exception = assertThrows(URLTransformationException.class, () -> {
-            transformService.transformURL(null, null, url, null);
+            transformService.transformURL(null, null, url, null, false);
         });
         assertEquals("The URI " + url + " is not valid.", exception.getMessage());
     }
@@ -144,7 +164,7 @@ class TransformServiceTest {
         TransformService transformService = new TransformService(emptyGatewayClient);
 
         Exception exception = assertThrows(URLTransformationException.class, () -> {
-            transformService.transformURL(null, null, url, null);
+            transformService.transformURL(null, null, url, null, false);
         });
         assertEquals("Gateway not found yet, transform service cannot perform the request", exception.getMessage());
     }
@@ -163,7 +183,7 @@ class TransformServiceTest {
         TransformService transformService = new TransformService(gatewayClient);
 
         Exception exception = assertThrows(URLTransformationException.class, () -> {
-            transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices);
+            transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices, false);
         });
         assertEquals("The path /wss of the service URL https://localhost:8080/wss is not valid.", exception.getMessage());
     }
@@ -180,7 +200,7 @@ class TransformServiceTest {
 
         TransformService transformService = new TransformService(gatewayClient);
 
-        String actualUrl = transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.WS, SERVICE_ID, url, routedServices, false);
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
@@ -201,7 +221,7 @@ class TransformServiceTest {
 
         TransformService transformService = new TransformService(gatewayClient);
 
-        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices, false);
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),
@@ -223,7 +243,7 @@ class TransformServiceTest {
 
         TransformService transformService = new TransformService(gatewayClient);
 
-        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices);
+        String actualUrl = transformService.transformURL(ServiceType.UI, SERVICE_ID, url, routedServices, false);
         String expectedUrl = String.format("%s://%s/%s/%s%s",
             gatewayClient.getGatewayConfigProperties().getScheme(),
             gatewayClient.getGatewayConfigProperties().getHostname(),

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PageRedirectionFilter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/post/PageRedirectionFilter.java
@@ -177,7 +177,7 @@ public class PageRedirectionFilter extends PostZuulFilter implements RoutedServi
             String host = instance.getHost() + ":" + instance.getPort();
             if (location.contains(host)) {
                 try {
-                    String transformedUrl = transformService.transformURL(ServiceType.ALL, serviceId, location, routedServicesMap.get(serviceId));
+                    String transformedUrl = transformService.transformURL(ServiceType.ALL, serviceId, location, routedServicesMap.get(serviceId), false);
                     return Optional.of(transformedUrl);
                 } catch (URLTransformationException e) {
                     //do nothing if no matched url is found

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/services/ServicesInfoService.java
@@ -193,7 +193,8 @@ public class ServicesInfoService {
                     type,
                     serviceId,
                     url,
-                    routes);
+                    routes,
+                    false);
         } catch (URLTransformationException e) {
             return url;
         }


### PR DESCRIPTION
# Description

When ATTLS is enabled, the service homepage transformation uses the Gateway base path to construct the URL, but set the wrong scheme ( HTTP), retrieved from the discovery client.  Now it's forced to use https.
Also fix a bug on UI which was breaking react component

Linked to #3335 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
