### PR TITLE
fix: allow key exchange port configuration

### DIFF
--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -160,6 +160,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java \
   -Dcaching.storage.vsam.name=${VSAM_FILE_NAME} \
   -Djgroups.bind.address=${ZWE_haInstance_hostname:-localhost} \
   -Djgroups.bind.port=${ZWE_configs_storage_infinispan_jgroups_port:-7098} \
+  -Djgroups.keyExchange.port=${ZWE_configs_storage_infinispan_jgroups_keyExchange_port:-7118} \
   -Dcaching.storage.infinispan.persistence.dataLocation=${ZWE_configs_storage_infinispan_persistence_dataLocation:-data} \
   -Dcaching.storage.infinispan.persistence.indexLocation=${ZWE_configs_storage_infinispan_persistence_indexLocation:-index} \
   -Dcaching.storage.infinispan.initialHosts=${ZWE_configs_storage_infinispan_initialHosts:-localhost[7098]} \

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -60,6 +60,8 @@ public class InfinispanConfig {
     private String port;
     @Value("${jgroups.bind.address}")
     private String address;
+    @Value("${jgroups.keyExchange.port:2157}")
+    private String keyExchangePort;
 
     @PostConstruct
     void updateKeyring() {
@@ -74,6 +76,7 @@ public class InfinispanConfig {
         System.setProperty("jgroups.tcpping.initial_hosts", initialHosts);
         System.setProperty("jgroups.bind.port", port);
         System.setProperty("jgroups.bind.address", address);
+        System.setProperty("jgroups.keyExchange.port", keyExchangePort);
         System.setProperty("server.ssl.keyStoreType", keyStoreType);
         System.setProperty("server.ssl.keyStore", keyStore);
         System.setProperty("server.ssl.keyStorePassword", keyStorePass);

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -60,6 +60,7 @@ public class InfinispanConfig {
     private String port;
     @Value("${jgroups.bind.address}")
     private String address;
+// 2157 is default from jgroups, Zowe default should be within the range of Zowe ports, e.g. 7xxx
     @Value("${jgroups.keyExchange.port:2157}")
     private String keyExchangePort;
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -60,8 +60,7 @@ public class InfinispanConfig {
     private String port;
     @Value("${jgroups.bind.address}")
     private String address;
-// 2157 is default from jgroups, Zowe default should be within the range of Zowe ports, e.g. 7xxx
-    @Value("${jgroups.keyExchange.port:2157}")
+    @Value("${jgroups.keyExchange.port:7118}")
     private String keyExchangePort;
 
     @PostConstruct

--- a/caching-service/src/main/resources/infinispan.xml
+++ b/caching-service/src/main/resources/infinispan.xml
@@ -26,9 +26,9 @@
                               keystore_type="${server.ssl.keyStoreType}"
                               keystore_password="${server.ssl.keyStorePassword}"
                               secret_key_algorithm="RSA"
+                              port="${jgroups.keyExchange.port}"
             />
             <!-- Configures ASYM_ENCRYPT -->
-            <!-- Uses the stack.combine and stack.position attributes to insert ASYM_ENCRYPT into the default TCP stack before pbcast.NAKACK2. -->
             <!-- The use_external_key_exchange = "true" attribute configures nodes to use the `SSL_KEY_EXCHANGE` protocol for certificate authentication. -->
             <ASYM_ENCRYPT asym_keylength="2048"
                           asym_algorithm="RSA"


### PR DESCRIPTION
# Description

Allow users to configure Infinispan SSL key exchange port from external configuration, e.g. zowe.yaml.

Linked to #3450 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
