### PR TITLE
chore: add add-opens options in start scripts

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -151,6 +151,23 @@ truststore_pass="${ZWE_configs_certificate_truststore_password:-${ZWE_zowe_certi
 keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}"
 truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
 
+# Check for Java version and set --add-opens Java option in case the version is 17 or later
+java_home="${1:-${JAVA_HOME}}"
+java_version=$("${java_home}/bin/java" -version 2>&1)
+java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
+if [[ $java_version_short == "" ]]; then
+    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
+fi
+java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+ADD_OPENS=""
+if [[ java_major_version -ge 17 ]]; then
+    ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+fi
 # NOTE: these are moved from below
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 #    -Dapiml.service.preferIpAddress=false \
@@ -159,6 +176,7 @@ CATALOG_CODE=AC
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
+    ${ADD_OPENS} \
     -Dibm.serversocket.recover=true \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -152,21 +152,17 @@ keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certifica
 truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 # NOTE: these are moved from below
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -138,21 +138,17 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 #   -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 
 CACHING_CODE=CS

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -97,11 +97,29 @@ truststore_pass="${ZWE_configs_certificate_truststore_password:-${ZWE_zowe_certi
 keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}"
 truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
 
+# Check for Java version and set --add-opens Java option in case the version is 17 or later
+java_home="${1:-${JAVA_HOME}}"
+java_version=$("${java_home}/bin/java" -version 2>&1)
+java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
+if [[ $java_version_short == "" ]]; then
+    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
+fi
+java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+ADD_OPENS=""
+if [[ java_major_version -ge 17 ]]; then
+    ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+fi
 
 CLOUD_GATEWAY_CODE=CG
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
+    ${ADD_OPENS} \
     -Dibm.serversocket.recover=true \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -98,21 +98,17 @@ keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certifica
 truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 
 CLOUD_GATEWAY_CODE=CG

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -147,21 +147,17 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 # -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 
 DISCOVERY_CODE=AD

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -146,10 +146,29 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 # -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \
 
+# Check for Java version and set --add-opens Java option in case the version is 17 or later
+java_home="${1:-${JAVA_HOME}}"
+java_version=$("${java_home}/bin/java" -version 2>&1)
+java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
+if [[ $java_version_short == "" ]]; then
+    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
+fi
+java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+ADD_OPENS=""
+if [[ java_major_version -ge 17 ]]; then
+    ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+fi
+
 DISCOVERY_CODE=AD
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
+    ${ADD_OPENS} \
     -Dibm.serversocket.recover=true \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -212,21 +212,17 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 #    -Dapiml.security.auth.jwtKeyAlias=${PKCS11_TOKEN_LABEL:-jwtsecret} \
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 
 GATEWAY_CODE=AG

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -211,10 +211,29 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 #    -Dapiml.security.auth.jwtKeyAlias=${PKCS11_TOKEN_LABEL:-jwtsecret} \
 
+# Check for Java version and set --add-opens Java option in case the version is 17 or later
+java_home="${1:-${JAVA_HOME}}"
+java_version=$("${java_home}/bin/java" -version 2>&1)
+java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
+if [[ $java_version_short == "" ]]; then
+    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
+fi
+java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+ADD_OPENS=""
+if [[ java_major_version -ge 17 ]]; then
+    ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+fi
+
 GATEWAY_CODE=AG
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
+    ${ADD_OPENS} \
     -Dibm.serversocket.recover=true \
     -Dfile.encoding=UTF-8 \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -110,21 +110,17 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 # -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \
 
 # Check for Java version and set --add-opens Java option in case the version is 17 or later
-java_home="${1:-${JAVA_HOME}}"
-java_version=$("${java_home}/bin/java" -version 2>&1)
-java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
-if [[ $java_version_short == "" ]]; then
-    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
-fi
-java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+JAVA_VERSION=$(${JAVA_HOME}/bin/javap -verbose java.lang.String \
+    | grep "major version" \
+    | cut -d " " -f5)
 ADD_OPENS=""
-if [[ java_major_version -ge 17 ]]; then
+if [ $JAVA_VERSION -ge 61 ]; then
     ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+                --add-opens=java.base/java.util=ALL-UNNAMED
+                --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
 fi
 
 METRICS_CODE=MS

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -109,10 +109,29 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 # -Dapiml.service.preferIpAddress=${APIML_PREFER_IP_ADDRESS:-false} \
 
+# Check for Java version and set --add-opens Java option in case the version is 17 or later
+java_home="${1:-${JAVA_HOME}}"
+java_version=$("${java_home}/bin/java" -version 2>&1)
+java_version_short=$(echo "${java_version}" | grep ^"java version" | sed -e "s/java version //g"| sed -e "s/\"//g")
+if [[ $java_version_short == "" ]]; then
+    java_version_short=$(echo "${java_version}" | grep ^"openjdk version" | sed -e "s/openjdk version //g"| sed -e "s/\"//g")
+fi
+java_major_version=$(echo "${java_version_short}" | cut -d '.' -f 1)
+ADD_OPENS=""
+if [[ java_major_version -ge 17 ]]; then
+    ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/javax.net.ssl=ALL-UNNAMED"
+fi
+
 METRICS_CODE=MS
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java \
   -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
    ${QUICK_START} \
+   ${ADD_OPENS} \
   -Dibm.serversocket.recover=true \
   -Dfile.encoding=UTF-8 \
   -Djava.io.tmpdir=${TMPDIR:-/tmp} \


### PR DESCRIPTION
# Description

Add Java option `--add-opens` in v2 start.sh scripts necessary to run API ML with Java 17

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
