### PR TITLE
fix: check for nullpointer exception when jwk key can't be retrieved

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProvider.java
@@ -14,6 +14,7 @@ package org.zowe.apiml.gateway.security.service.token;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Clock;
 import io.jsonwebtoken.JwtException;
@@ -105,7 +106,10 @@ public class OIDCTokenProvider implements OIDCProvider {
 
     private Map<String, Key> processKeys(JWKSet jwkKeys) {
         return jwkKeys.getKeys().stream()
-            .filter(jwkKey -> "sig".equals(jwkKey.getKeyUse().getValue()) && "RSA".equals(jwkKey.getKeyType().getValue()))
+            .filter(jwkKey -> {
+                KeyUse keyUse = jwkKey.getKeyUse();
+                return keyUse != null && "sig".equals(jwkKey.getKeyUse().getValue()) && "RSA".equals(jwkKey.getKeyType().getValue());
+            })
             .collect(Collectors.toMap(JWK::getKeyID, jwkKey -> {
                 try {
                     return jwkKey.toRSAKey().toRSAPublicKey();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProvider.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProvider.java
@@ -14,6 +14,7 @@ package org.zowe.apiml.gateway.security.service.token;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Clock;
@@ -108,7 +109,8 @@ public class OIDCTokenProvider implements OIDCProvider {
         return jwkKeys.getKeys().stream()
             .filter(jwkKey -> {
                 KeyUse keyUse = jwkKey.getKeyUse();
-                return keyUse != null && "sig".equals(jwkKey.getKeyUse().getValue()) && "RSA".equals(jwkKey.getKeyType().getValue());
+                KeyType keyType = jwkKey.getKeyType();
+                return keyUse != null && keyType != null && "sig".equals(keyUse.getValue()) && "RSA".equals(keyType.getValue());
             })
             .collect(Collectors.toMap(JWK::getKeyID, jwkKey -> {
                 try {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderTest.java
@@ -227,6 +227,28 @@ class OIDCTokenProviderTest {
         }
 
         @Test
+        void shouldHandleNullPointer_whenJWKTypeNull() {
+
+            JWKSet mockedJwtSet = mock(JWKSet.class);
+            List<JWK> mockedKeys = new ArrayList<>();
+            JWK mockedJwk = mock(JWK.class);
+            when(mockedJwk.getKeyType()).thenReturn(null);
+            RSAKey rsaKey = mock(RSAKey.class);
+            mockedKeys.add(mockedJwk);
+            when(mockedJwtSet.getKeys()).thenReturn(mockedKeys);
+
+            try (MockedStatic<JWKSet> mockedStatic = Mockito.mockStatic(JWKSet.class)) {
+                mockedStatic.when(() -> JWKSet.load(any(URL.class))).thenReturn(mockedJwtSet);
+
+                oidcTokenProvider.fetchJWKSet();
+
+                verify(rsaKey, never()).toRSAPublicKey();
+            } catch (JOSEException e) {
+                fail("Exception thrown: " + e.getMessage());
+            }
+        }
+
+        @Test
         void throwsCorrectException() throws JOSEException {
 
             try (MockedStatic<JWKSet> mockedStatic = Mockito.mockStatic(JWKSet.class)) {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderTest.java
@@ -12,11 +12,7 @@ package org.zowe.apiml.gateway.security.service.token;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.Requirement;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.KeyType;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.*;
 import io.jsonwebtoken.impl.DefaultClock;
 import io.jsonwebtoken.impl.FixedClock;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,21 +33,12 @@ import java.net.URL;
 import java.security.Key;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class OIDCTokenProviderTest {
@@ -214,6 +201,28 @@ class OIDCTokenProviderTest {
 
                 oidcTokenProvider.fetchJWKSet();
                 mockedStatic.verify(() -> JWKSet.load(new URL("https://jwksurl")), times(1));
+            }
+        }
+
+        @Test
+        void shouldHandleNullPointer_whenJWKKeyNull() {
+
+            JWKSet mockedJwtSet = mock(JWKSet.class);
+            List<JWK> mockedKeys = new ArrayList<>();
+            JWK mockedJwk = mock(JWK.class);
+            when(mockedJwk.getKeyUse()).thenReturn(null);
+            RSAKey rsaKey = mock(RSAKey.class);
+            mockedKeys.add(mockedJwk);
+            when(mockedJwtSet.getKeys()).thenReturn(mockedKeys);
+
+            try (MockedStatic<JWKSet> mockedStatic = Mockito.mockStatic(JWKSet.class)) {
+                mockedStatic.when(() -> JWKSet.load(any(URL.class))).thenReturn(mockedJwtSet);
+
+                oidcTokenProvider.fetchJWKSet();
+
+                verify(rsaKey, never()).toRSAPublicKey();
+            } catch (JOSEException e) {
+                fail("Exception thrown: " + e.getMessage());
             }
         }
 


### PR DESCRIPTION
# Description

 Nullpointer Exception is thrown when JWK key can't be retrieved.
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
