### PR TITLE
fix: Fix SSL Context switching

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReaderZaasClient.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReaderZaasClient.java
@@ -18,21 +18,19 @@ import static org.zowe.apiml.util.requests.Endpoints.ROUTED_AUTH;
 public class ConfigReaderZaasClient {
 
         public static ConfigProperties getConfigProperties() {
-
-            ConfigProperties configProperties = new ConfigProperties();
-
-
-            configProperties.setApimlHost(environmentConfiguration().getGatewayServiceConfiguration().getHost());
-            configProperties.setApimlPort(environmentConfiguration().getGatewayServiceConfiguration().getPort() + "");
-            configProperties.setApimlBaseUrl(ROUTED_AUTH);
-            configProperties.setKeyStorePath(environmentConfiguration().getTlsConfiguration().getKeyStore());
-            configProperties.setKeyStorePassword(environmentConfiguration().getTlsConfiguration().getKeyStorePassword());
-            configProperties.setKeyStoreType(environmentConfiguration().getTlsConfiguration().getKeyStoreType());
-            configProperties.setTrustStorePath(environmentConfiguration().getTlsConfiguration().getTrustStore());
-            configProperties.setTrustStorePassword(environmentConfiguration().getTlsConfiguration().getTrustStorePassword());
-            configProperties.setTrustStoreType(environmentConfiguration().getTlsConfiguration().getTrustStoreType());
-            configProperties.setNonStrictVerifySslCertificatesOfServices(environmentConfiguration().getTlsConfiguration().isNonStrictVerifySslCertificatesOfServices());
-            return configProperties;
+            return ConfigProperties.builder()
+                .apimlHost(environmentConfiguration().getGatewayServiceConfiguration().getHost())
+                .apimlPort(environmentConfiguration().getGatewayServiceConfiguration().getPort() + "")
+                .apimlBaseUrl(ROUTED_AUTH)
+                .keyStorePath(environmentConfiguration().getTlsConfiguration().getKeyStore())
+                .keyStorePassword(environmentConfiguration().getTlsConfiguration().getKeyStorePassword())
+                .keyStoreType(environmentConfiguration().getTlsConfiguration().getKeyStoreType())
+                .trustStorePath(environmentConfiguration().getTlsConfiguration().getTrustStore())
+                .trustStorePassword(environmentConfiguration().getTlsConfiguration().getTrustStorePassword())
+                .trustStoreType(environmentConfiguration().getTlsConfiguration().getTrustStoreType())
+                .nonStrictVerifySslCertificatesOfServices(environmentConfiguration().getTlsConfiguration().isNonStrictVerifySslCertificatesOfServices())
+                .build();
         }
+
 }
 

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
@@ -43,6 +43,7 @@ public class ConfigProperties {
     @Tolerate
     public ConfigProperties() {
         // lombok Builder.Default bug workaround
+        this.protocol = "TLS";
         this.tokenPrefix = "apimlAuthenticationToken";
     }
 
@@ -56,6 +57,7 @@ public class ConfigProperties {
             .trustStorePassword(trustStorePassword)
             .httpOnly(httpOnly)
             .nonStrictVerifySslCertificatesOfServices(nonStrictVerifySslCertificatesOfServices)
+            .protocol(protocol)
             .tokenPrefix(tokenPrefix)
             .build();
     }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/config/ConfigProperties.java
@@ -29,6 +29,8 @@ public class ConfigProperties {
     private char[] trustStorePassword;
     private boolean httpOnly;
     private boolean nonStrictVerifySslCertificatesOfServices;
+    @Builder.Default
+    private String protocol = "TLS";
 
     @SuppressWarnings("squid:S1075")
     private static final String OLD_PATH_FORMAT = "/api/v1/gateway";

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -27,7 +27,6 @@ import org.zowe.apiml.zaasclient.config.ConfigProperties;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;


### PR DESCRIPTION
# Description

There is a use case when a service uses a ZAAS client and onboarding enabler together. The setup of the default SSL context factory could lead to a failing onboarding enabler.

step to reproduce:
1. onboard by enabler (the connection fetched the default SSL context - using to detect if the SSL should be set - see the issue in Jersey)
2. wait for at least 30 seconds - onboarding is working
3. create a ZAAS client and try to call any endpoint (ie. login)
4. onboarding started failing with 403 (default SSL context changed, ZAAS client stopped using client certificate)

The issue happened because of implementation in Jersey, see issue https://github.com/eclipse-ee4j/jersey/issues/5637
- It has started because of PR https://github.com/eclipse-ee4j/jersey/pull/4764 (since 2.34)
- The APIML has upgraded Jersey from version 2.26 at https://github.com/zowe/api-layer/pull/2923


Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
