### PR TITLE
fix: read from env instead of properties

### DIFF
--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfiguration.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfiguration.java
@@ -19,16 +19,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
-* Reads OIDC Client configuration from environment variables or application configuration file.
-*/
+ * Reads OIDC Client configuration from environment variables or application configuration file.
+ */
 @Data
 @Component
 @Slf4j
@@ -37,14 +41,14 @@ public class ClientConfiguration {
 
     private static final String SYSTEM_ENV_PREFIX = "ZWE_configs_spring_security_oauth2_client_";
     private static final Pattern REGISTRATION_ID_PATTERN = Pattern.compile(
-    "^" + SYSTEM_ENV_PREFIX + "([^_]+)_.*$"
+        "^" + SYSTEM_ENV_PREFIX + "([^_]+)_.*$"
     );
 
     private Map<String, Registration> registration = new HashMap<>();
     private Map<String, Provider> provider = new HashMap<>();
 
     private String getSystemEnv(String id, String name) {
-        return System.getProperty(SYSTEM_ENV_PREFIX + id + "_" + name);
+        return System.getenv(SYSTEM_ENV_PREFIX + id + "_" + name);
     }
 
     private void update(String id, String base, Consumer<String> setter) {
@@ -74,16 +78,16 @@ public class ClientConfiguration {
     }
 
     private Set<String> getRegistrationsIdsFromSystemEnv() {
-        return System.getProperties().keySet().stream()
-        .map(key -> {
-            Matcher matcher = REGISTRATION_ID_PATTERN.matcher(String.valueOf(key));
-            if (matcher.matches()) {
-                return matcher.group(1);
-            }
-            return null;
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toSet());
+        return System.getenv().keySet().stream()
+            .map(key -> {
+                Matcher matcher = REGISTRATION_ID_PATTERN.matcher(String.valueOf(key));
+                if (matcher.matches()) {
+                    return matcher.group(1);
+                }
+                return null;
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
     }
 
     @PostConstruct
@@ -101,10 +105,10 @@ public class ClientConfiguration {
             Provider providerConfig = provider.get(id);
             if (providerConfig != null) {
                 map.put(id, Config.builder()
-                .id(id)
-                .registration(registrationEntry.getValue())
-                .provider(providerConfig)
-                .build()
+                    .id(id)
+                    .registration(registrationEntry.getValue())
+                    .provider(providerConfig)
+                    .build()
                 );
             }
         }

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfigurationTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfigurationTest.java
@@ -8,126 +8,134 @@
  * Copyright Contributors to the Zowe Project.
  */
 
- package org.zowe.apiml.cloudgatewayservice.config.oidc;
+package org.zowe.apiml.cloudgatewayservice.config.oidc;
 
- import org.junit.jupiter.api.Nested;
- import org.junit.jupiter.api.Test;
- import org.junit.jupiter.params.ParameterizedTest;
- import org.junit.jupiter.params.provider.ValueSource;
- import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
- import java.util.Arrays;
- import java.util.Collections;
- import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
- import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
- class ClientConfigurationTest {
+class ClientConfigurationTest {
 
-     private static final String PROVIDER = "oidcprovider";
-     private static final String[] SYSTEM_ENVIRONMENTS = {
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientId",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecret",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUri",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scope",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUri",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUri",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUri",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttribute",
-         "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUri"
-     };
+    private static final String PROVIDER = "oidcprovider";
+    private static final String[] SYSTEM_ENVIRONMENTS = {
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientId",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecret",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUri",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scope",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUri",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUri",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUri",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttribute",
+        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUri"
+    };
 
-     @Nested
-     class WhenCreatingConfiguration {
+    @Nested
+    class WhenCreatingConfiguration {
 
-         @Test
-         void givenNoConfiguration_thenReturnNoProvider() {
-             ClientConfiguration clientConfiguration = new ClientConfiguration();
-             assertTrue(clientConfiguration.getConfigurations().isEmpty());
-             assertFalse(clientConfiguration.isConfigured());
-         }
+        @Test
+        void givenNoConfiguration_thenReturnNoProvider() {
+            ClientConfiguration clientConfiguration = new ClientConfiguration();
+            assertTrue(clientConfiguration.getConfigurations().isEmpty());
+            assertFalse(clientConfiguration.isConfigured());
+        }
 
-         @Test
-         void givenOnlyProvider_thenReturnNoProvider() {
-             ClientConfiguration clientConfiguration = new ClientConfiguration();
-             ReflectionTestUtils.setField(clientConfiguration, "provider", Collections.singletonMap("id", new Provider()));
-             assertTrue(clientConfiguration.getConfigurations().isEmpty());
-             assertFalse(clientConfiguration.isConfigured());
-         }
+        @Test
+        void givenOnlyProvider_thenReturnNoProvider() {
+            ClientConfiguration clientConfiguration = new ClientConfiguration();
+            ReflectionTestUtils.setField(clientConfiguration, "provider", Collections.singletonMap("id", new Provider()));
+            assertTrue(clientConfiguration.getConfigurations().isEmpty());
+            assertFalse(clientConfiguration.isConfigured());
+        }
 
-         @Test
-         void givenOnlyRegistration_thenReturnNoProvider() {
-             ClientConfiguration clientConfiguration = new ClientConfiguration();
-             ReflectionTestUtils.setField(clientConfiguration, "registration", Collections.singletonMap("id", new Registration()));
-             assertTrue(clientConfiguration.getConfigurations().isEmpty());
-             assertFalse(clientConfiguration.isConfigured());
-         }
-     }
+        @Test
+        void givenOnlyRegistration_thenReturnNoProvider() {
+            ClientConfiguration clientConfiguration = new ClientConfiguration();
+            ReflectionTestUtils.setField(clientConfiguration, "registration", Collections.singletonMap("id", new Registration()));
+            assertTrue(clientConfiguration.getConfigurations().isEmpty());
+            assertFalse(clientConfiguration.isConfigured());
+        }
+    }
 
-     @Test
-     void givenConfiguration_whenGetConfiguration_thenReturnJustFullProviders() {
-         ClientConfiguration clientConfiguration = new ClientConfiguration();
-         Map<String, Registration> registration = clientConfiguration.getRegistration();
-         Map<String, Provider> provider = clientConfiguration.getProvider();
+    @Test
+    void givenConfiguration_whenGetConfiguration_thenReturnJustFullProviders() {
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        Map<String, Registration> registration = clientConfiguration.getRegistration();
+        Map<String, Provider> provider = clientConfiguration.getProvider();
 
-         registration.put("id1", new Registration());
-         registration.put("id2", new Registration());
-         registration.put("id3", new Registration());
+        registration.put("id1", new Registration());
+        registration.put("id2", new Registration());
+        registration.put("id3", new Registration());
 
-         provider.put("id2", new Provider());
-         provider.put("id3", new Provider());
-         provider.put("id4", new Provider());
+        provider.put("id2", new Provider());
+        provider.put("id3", new Provider());
+        provider.put("id4", new Provider());
 
-         Map<String, ClientConfiguration.Config> configMap = clientConfiguration.getConfigurations();
-         assertTrue(clientConfiguration.isConfigured());
-         assertEquals(2, configMap.size());
-         assertSame(registration.get("id2"), configMap.get("id2").getRegistration());
-         assertSame(provider.get("id2"), configMap.get("id2").getProvider());
-         assertSame(registration.get("id3"), configMap.get("id3").getRegistration());
-         assertSame(provider.get("id3"), configMap.get("id3").getProvider());
-     }
+        Map<String, ClientConfiguration.Config> configMap = clientConfiguration.getConfigurations();
+        assertTrue(clientConfiguration.isConfigured());
+        assertEquals(2, configMap.size());
+        assertSame(registration.get("id2"), configMap.get("id2").getRegistration());
+        assertSame(provider.get("id2"), configMap.get("id2").getProvider());
+        assertSame(registration.get("id3"), configMap.get("id3").getRegistration());
+        assertSame(provider.get("id3"), configMap.get("id3").getProvider());
+    }
 
-     void assertSystemEnv(Registration registration) {
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientIdV", registration.getClientId());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecretV", registration.getClientSecret());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUriV", registration.getRedirectUri());
-         assertEquals(1, registration.getScope().size());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scopeV", registration.getScope().get(0));
-     }
+    void assertSystemEnv(Registration registration) {
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientIdV", registration.getClientId());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecretV", registration.getClientSecret());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUriV", registration.getRedirectUri());
+        assertEquals(1, registration.getScope().size());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scopeV", registration.getScope().get(0));
+    }
 
-     void assertSystemEnv(Provider provider) {
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUriV", provider.getAuthorizationUri());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUriV", provider.getTokenUri());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUriV", provider.getUserInfoUri());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttributeV", provider.getUserNameAttribute());
-         assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUriV", provider.getJwkSetUri());
-     }
+    void assertSystemEnv(Provider provider) {
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUriV", provider.getAuthorizationUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUriV", provider.getTokenUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUriV", provider.getUserInfoUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttributeV", provider.getUserNameAttribute());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUriV", provider.getJwkSetUri());
+    }
 
-     void assertSystemEnv(ClientConfiguration clientConfiguration) {
-         assertSystemEnv(clientConfiguration.getProvider().get(PROVIDER));
-         assertSystemEnv(clientConfiguration.getRegistration().get(PROVIDER));
-     }
+    void assertSystemEnv(ClientConfiguration clientConfiguration) {
+        assertSystemEnv(clientConfiguration.getProvider().get(PROVIDER));
+        assertSystemEnv(clientConfiguration.getRegistration().get(PROVIDER));
+    }
 
-     @ParameterizedTest
-     @ValueSource(booleans = {false, true})
-     void givenSystemEnvironment_whenCreateClientConfiguration_thenSet(boolean providerSet) {
-         ClientConfiguration clientConfiguration = new ClientConfiguration();
-         try {
-             Arrays.asList(SYSTEM_ENVIRONMENTS).forEach(s -> System.setProperty(s, s + "V"));
-             if (providerSet) {
-                 clientConfiguration.getProvider().put(PROVIDER, new Provider());
-                 clientConfiguration.getRegistration().put(PROVIDER, new Registration());
-             }
-             clientConfiguration.updateWithSystemEnvironment();
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void givenSystemEnvironment_whenCreateClientConfiguration_thenSet(boolean providerSet) throws NoSuchFieldException, IllegalAccessException {
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        Class<?> envVarClass = System.getenv().getClass();
+        Field mField = envVarClass.getDeclaredField("m");
+        mField.setAccessible(true);
+        Map<String, String> writeableEnvVars = (Map<String, String>) mField.get(System.getenv());
+        try {
+            Arrays.asList(SYSTEM_ENVIRONMENTS).forEach(s -> writeableEnvVars.put(s, s + "V"));
+            if (providerSet) {
+                clientConfiguration.getProvider().put(PROVIDER, new Provider());
+                clientConfiguration.getRegistration().put(PROVIDER, new Registration());
+            }
+            clientConfiguration.updateWithSystemEnvironment();
 
-             assertSystemEnv(clientConfiguration);
-         } finally {
-             Arrays.asList(SYSTEM_ENVIRONMENTS).forEach(s -> System.getProperties().remove(s));
-         }
+            assertSystemEnv(clientConfiguration);
+        } finally {
+            Arrays.asList(SYSTEM_ENVIRONMENTS).forEach(s -> writeableEnvVars.remove(s));
+        }
 
-         // test if missing system environment will be skipped
-         clientConfiguration.updateWithSystemEnvironment();
-         assertSystemEnv(clientConfiguration);
-     }
+        // test if missing system environment will be skipped
+        clientConfiguration.updateWithSystemEnvironment();
+        assertSystemEnv(clientConfiguration);
+    }
 
- }
+}


### PR DESCRIPTION
# Description

ClientConfiguration needs to read environment variables from System.getenv() instead of getProperties().

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
