### PR TITLE
fix: Proper reading OIDC configuration from system environment

### DIFF
--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfiguration.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfiguration.java
@@ -41,40 +41,42 @@ public class ClientConfiguration {
 
     private static final String SYSTEM_ENV_PREFIX = "ZWE_configs_spring_security_oauth2_client_";
     private static final Pattern REGISTRATION_ID_PATTERN = Pattern.compile(
-        "^" + SYSTEM_ENV_PREFIX + "([^_]+)_.*$"
+        "^" + SYSTEM_ENV_PREFIX + "(registration|provider)_([^_]+)_.*$"
     );
 
     private Map<String, Registration> registration = new HashMap<>();
     private Map<String, Provider> provider = new HashMap<>();
 
-    private String getSystemEnv(String id, String name) {
-        return System.getenv(SYSTEM_ENV_PREFIX + id + "_" + name);
+    private String getSystemEnv(String id, String type, String name) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(SYSTEM_ENV_PREFIX).append(type).append('_').append(id).append('_').append(name);
+        return System.getenv(sb.toString());
     }
 
-    private void update(String id, String base, Consumer<String> setter) {
-        String systemEnv = getSystemEnv(id, base);
+    private void update(String id, String type, String base, Consumer<String> setter) {
+        String systemEnv = getSystemEnv(id, type, base);
         if (systemEnv != null) {
             setter.accept(systemEnv);
         }
     }
 
     private void update(String id, Registration registration) {
-        update(id, "registration_clientId", registration::setClientId);
-        update(id, "registration_clientSecret", registration::setClientSecret);
-        update(id, "registration_redirectUri", registration::setRedirectUri);
+        update(id, "registration", "clientId", registration::setClientId);
+        update(id, "registration", "clientSecret", registration::setClientSecret);
+        update(id, "registration", "redirectUri", registration::setRedirectUri);
 
-        String scope = getSystemEnv(id, "registration_scope");
+        String scope = getSystemEnv(id, "registration", "scope");
         if (scope != null) {
             registration.setScope(Arrays.asList(scope.split("[,]")));
         }
     }
 
     private void update(String id, Provider provider) {
-        update(id, "provider_authorizationUri", provider::setAuthorizationUri);
-        update(id, "provider_tokenUri", provider::setTokenUri);
-        update(id, "provider_userInfoUri", provider::setUserInfoUri);
-        update(id, "provider_userNameAttribute", provider::setUserNameAttribute);
-        update(id, "provider_jwkSetUri", provider::setJwkSetUri);
+        update(id, "provider", "authorizationUri", provider::setAuthorizationUri);
+        update(id, "provider", "tokenUri", provider::setTokenUri);
+        update(id, "provider", "userInfoUri", provider::setUserInfoUri);
+        update(id, "provider", "userNameAttribute", provider::setUserNameAttribute);
+        update(id, "provider", "jwkSetUri", provider::setJwkSetUri);
     }
 
     private Set<String> getRegistrationsIdsFromSystemEnv() {
@@ -82,7 +84,7 @@ public class ClientConfiguration {
             .map(key -> {
                 Matcher matcher = REGISTRATION_ID_PATTERN.matcher(String.valueOf(key));
                 if (matcher.matches()) {
-                    return matcher.group(1);
+                    return matcher.group(2);
                 }
                 return null;
             })

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfigurationTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/oidc/ClientConfigurationTest.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.cloudgatewayservice.config.oidc;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,24 +22,22 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ClientConfigurationTest {
 
     private static final String PROVIDER = "oidcprovider";
     private static final String[] SYSTEM_ENVIRONMENTS = {
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientId",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecret",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUri",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scope",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUri",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUri",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUri",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttribute",
-        "ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUri"
+        "ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_clientId",
+        "ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_clientSecret",
+        "ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_redirectUri",
+        "ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_scope",
+        "ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_authorizationUri",
+        "ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_tokenUri",
+        "ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_userInfoUri",
+        "ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_userNameAttribute",
+        "ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_jwkSetUri"
     };
 
     @Nested
@@ -92,19 +91,19 @@ class ClientConfigurationTest {
     }
 
     void assertSystemEnv(Registration registration) {
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientIdV", registration.getClientId());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_clientSecretV", registration.getClientSecret());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_redirectUriV", registration.getRedirectUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_clientIdV", registration.getClientId());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_clientSecretV", registration.getClientSecret());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_redirectUriV", registration.getRedirectUri());
         assertEquals(1, registration.getScope().size());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_registration_scopeV", registration.getScope().get(0));
+        assertEquals("ZWE_configs_spring_security_oauth2_client_registration_oidcprovider_scopeV", registration.getScope().get(0));
     }
 
     void assertSystemEnv(Provider provider) {
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_authorizationUriV", provider.getAuthorizationUri());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_tokenUriV", provider.getTokenUri());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userInfoUriV", provider.getUserInfoUri());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_userNameAttributeV", provider.getUserNameAttribute());
-        assertEquals("ZWE_configs_spring_security_oauth2_client_oidcprovider_provider_jwkSetUriV", provider.getJwkSetUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_authorizationUriV", provider.getAuthorizationUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_tokenUriV", provider.getTokenUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_userInfoUriV", provider.getUserInfoUri());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_userNameAttributeV", provider.getUserNameAttribute());
+        assertEquals("ZWE_configs_spring_security_oauth2_client_provider_oidcprovider_jwkSetUriV", provider.getJwkSetUri());
     }
 
     void assertSystemEnv(ClientConfiguration clientConfiguration) {
@@ -115,6 +114,8 @@ class ClientConfigurationTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void givenSystemEnvironment_whenCreateClientConfiguration_thenSet(boolean providerSet) throws NoSuchFieldException, IllegalAccessException {
+        assumeFalse(StringUtils.containsIgnoreCase(System.getProperty("os.name"), "win"));
+
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         Class<?> envVarClass = System.getenv().getClass();
         Field mField = envVarClass.getDeclaredField("m");


### PR DESCRIPTION
# Description

This PR fixes the names of configuration values used for OIDC provided by the system environment.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
