### PR TITLE
fix: Provide the correct external URL in the ZUUL Gateway if AT-TLS is enabled

### DIFF
--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -31,6 +31,7 @@
 # - ZWE_configs_heap_init
 # - ZWE_configs_apiml_catalog_serviceId
 # - ZWE_configs_apiml_gateway_timeoutMillis
+# - ZWE_configs_apiml_gateway_externalProtocol
 # - ZWE_configs_apiml_security_auth_provider
 # - ZWE_configs_apiml_security_allowtokenrefresh
 # - ZWE_configs_apiml_security_auth_zosmf_jwtAutoconfiguration
@@ -254,7 +255,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
     -Dapiml.service.allowEncodedSlashes=${ZWE_configs_apiml_service_allowEncodedSlashes:-true} \
     -Dapiml.service.corsEnabled=${ZWE_configs_apiml_service_corsEnabled:-false} \
-    -Dapiml.service.externalUrl="${externalProtocol}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}" \
+    -Dapiml.service.externalUrl="${ZWE_configs_apiml_gateway_externalProtocol:-${externalProtocol}}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}" \
     -Dapiml.service.apimlId=${ZWE_configs_apimlId:-} \
     -Dapiml.catalog.serviceId=${APIML_GATEWAY_CATALOG_ID:-apicatalog} \
     -Dapiml.cache.storage.location=${ZWE_zowe_workspaceDirectory}/api-mediation/${ZWE_haInstance_id:-localhost} \

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
@@ -87,7 +87,7 @@ public class GatewayConfig {
             .parseInt(getEnabledPort(env));
 
         boolean isSecurePortEnabled = Boolean.parseBoolean(getProperty("server.ssl.enabled"));
-        boolean attls = Boolean.valueOf(getProperty("server.attls.enabled"));
+        boolean attls = Boolean.parseBoolean(getProperty("server.attls.enabled"));
         instance.setNonSecurePort(isSecurePortEnabled ? 0 : serverPort);
         instance.setNonSecurePortEnabled(!isSecurePortEnabled);
         instance.setSecurePort(isSecurePortEnabled ? serverPort : 0);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayConfig.java
@@ -87,6 +87,7 @@ public class GatewayConfig {
             .parseInt(getEnabledPort(env));
 
         boolean isSecurePortEnabled = Boolean.parseBoolean(getProperty("server.ssl.enabled"));
+        boolean attls = Boolean.valueOf(getProperty("server.attls.enabled"));
         instance.setNonSecurePort(isSecurePortEnabled ? 0 : serverPort);
         instance.setNonSecurePortEnabled(!isSecurePortEnabled);
         instance.setSecurePort(isSecurePortEnabled ? serverPort : 0);
@@ -105,7 +106,7 @@ public class GatewayConfig {
 
         String externalUrl = getProperty("apiml.service.external-url");
         if (!StringUtils.hasText(externalUrl)) {
-            externalUrl = (isSecurePortEnabled ? "https" : "http") + "://" + hostname + ":" + serverPort;
+            externalUrl = (isSecurePortEnabled || attls ? "https" : "http") + "://" + hostname + ":" + serverPort;
         }
         instance.getMetadataMap().put(SERVICE_EXTERNAL_URL, externalUrl);
 


### PR DESCRIPTION
# Description

In the case there is enabled AT-TLS for the ZUUL Gateway, it provides the external URL with HTTP protocol, which is wrong one. This fix change the schema to https instead.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
