### PR TITLE
fix: Login into API Catalog fix 

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/login/LoginFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/login/LoginFilter.java
@@ -11,6 +11,10 @@
 package org.zowe.apiml.security.common.login;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
@@ -28,10 +32,7 @@ import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.security.common.error.AuthMethodNotSupportedException;
 import org.zowe.apiml.security.common.error.ResourceAccessExceptionHandler;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -198,11 +199,16 @@ public class LoginFilter extends NonCompulsoryAuthenticationProcessingFilter {
      * @throws AuthenticationCredentialsNotFoundException if the login object has wrong format
      */
     private Optional<LoginRequest> getCredentialsFromBody(HttpServletRequest request) {
-        try {
-            if (request.getInputStream().available() == 0) {
+        // method available could return 0 even there are some data, depends on the implementation
+        try (var is = new BufferedInputStream(request.getInputStream())) {
+            is.mark(1);
+            if (is.read() < 0) {
+                // no data available
                 return Optional.empty();
             }
-            return Optional.of(mapper.readValue(request.getInputStream(), LoginRequest.class));
+            // return to the beginning (to do not skip first character: '{')
+            is.reset();
+            return Optional.of(mapper.readValue(is, LoginRequest.class));
         } catch (IOException e) {
             logger.debug("Authentication problem: login object has wrong format");
             throw new AuthenticationCredentialsNotFoundException("Login object has wrong format.");

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayHomepageController.java
@@ -161,7 +161,11 @@ public class GatewayHomepageController {
     private String getCatalogLink(ServiceInstance catalogInstance) {
         String gatewayUrl = catalogInstance.getMetadata().get(String.format(UI_V1_ROUTE, ROUTES, ROUTES_GATEWAY_URL));
         String serviceUrl = catalogInstance.getMetadata().get(String.format(UI_V1_ROUTE, ROUTES, ROUTES_SERVICE_URL));
-        return serviceUrl + gatewayUrl;
+        String catalogLink = serviceUrl + gatewayUrl;
+        if (catalogLink.endsWith("/")) {
+            return catalogLink;
+        }
+        return catalogLink + "/";
     }
 
 }


### PR DESCRIPTION
# Description

There were two issues with the login in the API Catalog:
- access (the link on the homepage did not contain a leading slash)
- verification if the body of the login request was not written well
  - it was based on the calling method available() on the input stream
  - the method by the documentation could return the length of unread bytes, but it could also return 0 as not implemented

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
