### PR TITLE
chore: update working dir in bootrun task

### DIFF
--- a/api-catalog-services/build.gradle
+++ b/api-catalog-services/build.gradle
@@ -176,6 +176,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/api-catalog-ui/build.gradle
+++ b/api-catalog-ui/build.gradle
@@ -104,8 +104,6 @@ task npmBuild(type: NpmTask) {
 
 }
 
-
-
 npmBuild.dependsOn npmInstall
 npmBuild.dependsOn npmLint
 build.dependsOn npmBuild

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -120,4 +120,20 @@ jar {
     archiveClassifier = ""
 }
 
+bootRun {
+    if (project.hasProperty('args')) {
+        args project.args.split(',')
+    }
+
+    debugOptions {
+        port = 5016
+        suspend = false
+        server = true
+    }
+
+    workingDir = project.rootDir
+
+    systemProperties = System.properties
+}
+
 bootJar.archiveFileName = bootJar.archiveBaseName.get() + ".jar"

--- a/cloud-gateway-service/build.gradle
+++ b/cloud-gateway-service/build.gradle
@@ -128,6 +128,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -55,6 +55,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -141,6 +141,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -173,6 +173,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/metrics-service/build.gradle
+++ b/metrics-service/build.gradle
@@ -134,6 +134,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/mock-services/build.gradle
+++ b/mock-services/build.gradle
@@ -55,6 +55,8 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }
 

--- a/onboarding-enabler-spring-sample-app/build.gradle
+++ b/onboarding-enabler-spring-sample-app/build.gradle
@@ -55,5 +55,7 @@ bootRun {
         server = true
     }
 
+    workingDir = project.rootDir
+
     systemProperties = System.properties
 }


### PR DESCRIPTION
# Description

When using gradle bootRun task, uses the same working dir as other ways of running the services (npm, intellij, etc)

## Type of change

- [ ] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
