### PR TITLE
chore: protect conformance endpoints and add them to Swagger

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/conformance/ValidateAPIController.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/conformance/ValidateAPIController.java
@@ -52,7 +52,8 @@ public class ValidateAPIController {
     private final VerificationOnboardService verificationOnboardService;
     private final DiscoveryClient discoveryClient;
     private final GatewayClient gatewayClient;
-
+    public static final String VALIDATE_CONFORMANCE_URL = "/gateway/conformance";
+    public static final String LEGACY_CONFORMANCE_URL = "/validate";
 
     /**
      * Accepts serviceID and checks conformance criteria
@@ -133,7 +134,7 @@ public class ValidateAPIController {
      * @param serviceId serviceId to check for conformance
      * @return 200 if service is conformant, 400 + JSON explanation if not
      */
-    @PostMapping(value = "/validate", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = LEGACY_CONFORMANCE_URL, produces = MediaType.APPLICATION_JSON_VALUE)
     @HystrixCommand
     public ResponseEntity<String> checkValidateLegacy(@RequestBody String serviceId, @CookieValue(value = "apimlAuthenticationToken", defaultValue = "dummy") String authenticationToken) {
         if (serviceId.startsWith("serviceID")) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.zowe.apiml.filter.AttlsFilter;
 import org.zowe.apiml.filter.SecureConnectionFilter;
+import org.zowe.apiml.gateway.conformance.ValidateAPIController;
 import org.zowe.apiml.gateway.controllers.AuthController;
 import org.zowe.apiml.gateway.controllers.CacheServiceController;
 import org.zowe.apiml.gateway.controllers.SafResourceAccessController;
@@ -66,12 +67,7 @@ import org.zowe.apiml.security.common.error.AuthExceptionHandler;
 import org.zowe.apiml.security.common.filter.CategorizeCertsFilter;
 import org.zowe.apiml.security.common.filter.StoreAccessTokenInfoFilter;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
-import org.zowe.apiml.security.common.login.BasicAuthFilter;
-import org.zowe.apiml.security.common.login.LoginFilter;
-import org.zowe.apiml.security.common.login.NonCompulsoryAuthenticationProcessingFilter;
-import org.zowe.apiml.security.common.login.ShouldBeAlreadyAuthenticatedFilter;
-import org.zowe.apiml.security.common.login.X509AuthAwareFilter;
-import org.zowe.apiml.security.common.login.X509AuthenticationFilter;
+import org.zowe.apiml.security.common.login.*;
 import org.zowe.apiml.security.common.verify.CertificateValidator;
 
 import java.util.Collections;
@@ -503,7 +499,9 @@ public class NewSecurityConfiguration {
             private final String[] protectedEndpoints = {
                 "/application",
                 SafResourceAccessController.FULL_CONTEXT_PATH,
-                ServicesInfoController.SERVICES_URL
+                ServicesInfoController.SERVICES_URL,
+                ValidateAPIController.VALIDATE_CONFORMANCE_URL,
+                ValidateAPIController.LEGACY_CONFORMANCE_URL
             };
 
             @Bean
@@ -511,7 +509,9 @@ public class NewSecurityConfiguration {
                 baseConfigure(http.requestMatchers(matchers -> matchers
                         .antMatchers("/application/**")
                         .antMatchers(HttpMethod.POST, SafResourceAccessController.FULL_CONTEXT_PATH)
-                        .antMatchers(ServicesInfoController.SERVICES_URL + "/**"))
+                        .antMatchers(ServicesInfoController.SERVICES_URL + "/**")
+                        .antMatchers(ValidateAPIController.VALIDATE_CONFORMANCE_URL + "/**")
+                        .antMatchers(ValidateAPIController.LEGACY_CONFORMANCE_URL))
                 ).authorizeRequests(requests -> requests
                         .anyRequest().authenticated())
                         .logout(logout -> logout.disable());  // logout filter in this chain not needed

--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -427,6 +427,137 @@
                     }
                 }
             }
+        },
+        "/gateway/conformance/{serviceId}": {
+            "get": {
+                "tags": ["Services"],
+                "summary": "Checks service conformance",
+                "description": "Accepts serviceID and checks conformance criteria.",
+                "operationId": "checkConformanceUsingGET",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "serviceId",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "description": "Service ID of the service to check"
+                    }
+                ],
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Service conforms to the criteria",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Service {serviceId} fulfills all checked conformance criteria"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Service does not conform to the criteria",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "details": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/validate": {
+            "post": {
+                "tags": ["Services"],
+                "summary": "Legacy endpoint for checking service conformance",
+                "description": "Mapping so the old endpoint keeps working.",
+                "operationId": "checkValidateLegacyUsingPOST",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "string",
+                                "example": "serviceID=serviceId"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Service conforms to the criteria",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Service {serviceId} fulfills all checked conformance criteria"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Service does not conform to the criteria",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "details": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "servers": [

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/ValidateAPITest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/ValidateAPITest.java
@@ -78,11 +78,25 @@ class ValidateAPITest implements TestWithStartedInstances {
     void testGetEndpointNonConformant() {
         given()
             .log().all()
+            .header("Cookie", "apimlAuthenticationToken=" + token)
             .when()
             .get(getEndpointURLGet() + "/nonConformantServiceBecauseNameIsTooLongAndContainsCapitalLettersqwertyuiop")
             .then()
             .assertThat()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+    }
+
+    @Test
+    @TestsNotMeantForZowe
+    void testGetEndpointWithNoAuthentication() {
+        given()
+            .log().all()
+            .when()
+            .get(getEndpointURLGet() + "/discoverableclient")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.SC_UNAUTHORIZED);
 
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/ValidateAPITest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/ValidateAPITest.java
@@ -92,9 +92,23 @@ class ValidateAPITest implements TestWithStartedInstances {
     void testGetEndpointWithNoAuthentication() {
         given()
             .log().all()
-            .when()
+        .when()
             .get(getEndpointURLGet() + "/discoverableclient")
-            .then()
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.SC_UNAUTHORIZED);
+
+    }
+
+    @Test
+    @TestsNotMeantForZowe
+    void testLegacyEndpointWithNoAuthentication() {
+        given()
+            .log().all()
+            .param("serviceID", "discoverableclient")
+        .when()
+            .post(getLegacyEndpointURLPost())
+        .then()
             .assertThat()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
 


### PR DESCRIPTION
# Description

Require authentication for the conformance endpoint `/gateway/conformance/{serviceId}` and the legacy one `/validate` and add them to Swagger.

Linked to #3570 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
