### PR TITLE
feat: customizable request buffer size for websocket connections

### DIFF
--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -290,6 +290,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dserver.webSocket.connectTimeout=${ZWE_configs_server_webSocket_connectTimeout:-15000} \
     -Dserver.webSocket.stopTimeout=${ZWE_configs_server_webSocket_stopTimeout:-30000} \
     -Dserver.webSocket.asyncWriteTimeout=${ZWE_configs_server_webSocket_asyncWriteTimeout:-60000} \
+    -Dserver.webSocket.requestBufferSize=${ZWE_configs_server_webSocket_requestBufferSize:-8192} \
     -Dserver.ssl.enabled=${ZWE_configs_server_ssl_enabled:-true} \
     -Dserver.ssl.protocol=${ZWE_configs_server_ssl_protocol:-"TLSv1.2"}  \
     -Dserver.ssl.keyStore="${keystore_location}" \

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -10,19 +10,17 @@
 
 package org.zowe.apiml.gateway.ws;
 
-import javax.annotation.PreDestroy;
-
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import javax.annotation.PreDestroy;
 
 /**
  * Factory for provisioning web socket client
@@ -36,17 +34,20 @@ public class WebSocketClientFactory {
 
     private final JettyWebSocketClient client;
 
-    @Autowired
     public WebSocketClientFactory(
             SslContextFactory.Client jettyClientSslContextFactory,
             @Value("${server.webSocket.maxIdleTimeout:3600000}") int maxIdleWebSocketTimeout,
             @Value("${server.webSocket.connectTimeout:15000}") long connectTimeout,
             @Value("${server.webSocket.stopTimeout:30000}") long stopTimeout,
-            @Value("${server.webSocket.asyncWriteTimeout:60000}") long asyncWriteTimeout
+            @Value("${server.webSocket.asyncWriteTimeout:60000}") long asyncWriteTimeout,
+            @Value("${server.webSocket.requestBufferSize:8192}") int maxRequestBufferSize
         ) {
-        log.debug("Creating Jetty WebSocket client, with SslFactory: {}",
-            jettyClientSslContextFactory);
-        WebSocketClient wsClient = new WebSocketClient(new HttpClient(jettyClientSslContextFactory));
+        log.debug("Creating Jetty WebSocket client, with SslFactory: {}", jettyClientSslContextFactory);
+
+        HttpClient httpClient = new HttpClient(jettyClientSslContextFactory);
+        httpClient.setRequestBufferSize(maxRequestBufferSize);
+        WebSocketClient wsClient = new WebSocketClient(httpClient);
+
         wsClient.setMaxIdleTimeout(maxIdleWebSocketTimeout);
         wsClient.setConnectTimeout(connectTimeout);
         wsClient.setStopTimeout(stopTimeout);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketClientFactory.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
@@ -34,6 +35,7 @@ public class WebSocketClientFactory {
 
     private final JettyWebSocketClient client;
 
+    @Autowired
     public WebSocketClientFactory(
             SslContextFactory.Client jettyClientSslContextFactory,
             @Value("${server.webSocket.maxIdleTimeout:3600000}") int maxIdleWebSocketTimeout,

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryContextTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryContextTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.*;
         "server.webSocket.connectTimeout=1000",
         "server.webSocket.stopTimeout=500",
         "server.webSocket.asyncWriteTimeout=1500",
+        "server.webSocket.requestBufferSize=9090"
     },
     classes = { WebSocketClientFactory.class }
 )
@@ -60,6 +61,7 @@ public class WebSocketClientFactoryContextTest {
             assertEquals(1000, httpClient.getConnectTimeout());
             assertEquals(500, webSocketClient.getStopTimeout());
             assertEquals(1500, policy.getAsyncWriteTimeout());
+            assertEquals(9090, httpClient.getRequestBufferSize());
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
@@ -65,7 +65,7 @@ class WebSocketClientFactoryTest {
         @BeforeEach
         void setUp() {
             SslContextFactory.Client sslClient = mock(SslContextFactory.Client.class);
-            this.webSocketClientFactory = new WebSocketClientFactory(sslClient, 1234, 0, 0, 0);
+            this.webSocketClientFactory = new WebSocketClientFactory(sslClient, 1234, 0, 0, 0, 0);
         }
 
         @Test

--- a/schemas/gateway-schema.json
+++ b/schemas/gateway-schema.json
@@ -253,23 +253,28 @@
                                                     "properties": {
                                                         "maxIdleTimeout": {
                                                             "type": "integer",
-                                                            "description": "The gateway acts as a server and client. This parameters customizes the default idle timeout for its client role.",
+                                                            "description": "The gateway acts as a server and client. This parameter customizes the default idle timeout for its client role.",
                                                             "default": 3600000
                                                         },
                                                         "connectTimeout": {
                                                             "type": "integer",
-                                                            "description": "The gateway acts as a server and client. This parameters customizes the default connect timeout for its client role.",
+                                                            "description": "The gateway acts as a server and client. This parameter customizes the default connect timeout for its client role.",
                                                             "default": 15000
                                                         },
                                                         "stopTimeout": {
                                                             "type": "integer",
-                                                            "description": "The gateway acts as a server and client. This parameters customizes the default stop timeout for its client role.",
+                                                            "description": "The gateway acts as a server and client. This parameter customizes the default stop timeout for its client role.",
                                                             "default": 30000
                                                         },
                                                         "asyncWriteTimeout": {
                                                             "type": "integer",
-                                                            "description": "The gateway acts as a server and client. This parameters customizes the default async write timeout for its client role.",
+                                                            "description": "The gateway acts as a server and client. This parameter customizes the default async write timeout for its client role.",
                                                             "default": 60000
+                                                        },
+                                                        "requestBufferSize": {
+                                                            "type": "integer",
+                                                            "description": "The gateway acts as a server and client. This parameter customizes the default max size of the request",
+                                                            "default": 8192
                                                         }
                                                     }
                                                 },


### PR DESCRIPTION
# Description

Web Socket connections from API ML have a default fixed request size of 4K.
This PR doubles the default to 8K and creates a custom property to customize this value.

## Type of change

- [ ] feat: New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
