### PR TITLE
fix: update attls icsf condition

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -190,7 +190,7 @@ fi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -188,7 +188,9 @@ if [ $JAVA_VERSION -ge 61 ]; then
     fi
 fi
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -176,7 +176,7 @@ fi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -174,7 +174,9 @@ if [ $JAVA_VERSION -ge 61 ]; then
     fi
 fi
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -136,7 +136,7 @@ fi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -134,7 +134,9 @@ if [ $JAVA_VERSION -ge 61 ]; then
     fi
 fi
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -183,7 +183,9 @@ if [ $JAVA_VERSION -ge 61 ]; then
     fi
 fi
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -185,7 +185,7 @@ fi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -254,7 +254,7 @@ fi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -252,7 +252,9 @@ if [ $JAVA_VERSION -ge 61 ]; then
     fi
 fi
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -107,14 +107,15 @@ truststore_pass="${ZWE_configs_certificate_truststore_password:-${ZWE_zowe_certi
 keystore_location="${ZWE_configs_certificate_keystore_file:-${ZWE_zowe_certificate_keystore_file}}"
 truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certificate_truststore_file}}"
 
-if [ "${ATTLS_ENABLED}" = "true" ]; then
+# Disable Java keyring loading for ICSF hardware private key storage.
+# Only z/OSMF JWT authentication provider is supported with this type of keyrings.
+if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=
   key_alias=
   keystore_location=
 fi
-
 
 # NOTE: these are moved from below
 # -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -109,7 +109,7 @@ truststore_location="${ZWE_configs_certificate_truststore_file:-${ZWE_zowe_certi
 
 # Disable Java keyring loading for ICSF hardware private key storage.
 # Only z/OSMF JWT authentication provider is supported with this type of keyrings.
-if [ "${ATTLS_ENABLED}" = "true" -a "${ZWE_zowe_certificate_keystore_icsfHwKey:-false}" = "true" ]; then
+if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true" ]; then
   keystore_type=
   keystore_pass=
   key_pass=


### PR DESCRIPTION
# Description

The current condition means that if AT-TLS is enabled then the keyring will not be loaded from Java code.
This is valid for ICSF but not in other scenarios:

If AT-TLS is enabled and ICSF hardware storage:

- With z/OSMF JWT provider: Ok not to read keyring (z/OSMF signs the JWT)
- With z/OSMF LTPA. Can't work with ICSF currently. Needs private key to sign JWT.
- With SAF provider. Can't work with ICSF currenty. Needs private key to sign JWT.

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
