### PR TITLE
fix: support customized code snippets in case of endpoint with query params

### DIFF
--- a/api-catalog-ui/frontend/src/utils/generateSnippets.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.js
@@ -33,7 +33,9 @@ export function getSnippetContent(req, target, codeSnippet) {
     const { spec, oasPathMethod } = req.toJS();
     const { path, method } = oasPathMethod;
     // Include query parameters in the path for comparison
-    const fullPath = `${path}${req?.get('query') ? `?${new URLSearchParams(req?.get('query')).toString()}` : ''}`;
+    const query = req?.get('query');
+    const queryString = query ? `?${new URLSearchParams(query).toString()}` : '';
+    const fullPath = path + queryString;
     let snippet;
     try {
         // set request snippet content

--- a/api-catalog-ui/frontend/src/utils/generateSnippets.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.js
@@ -32,8 +32,8 @@ export function getSnippetContent(req, target, codeSnippet) {
     // get extended info about request
     const { spec, oasPathMethod } = req.toJS();
     const { path, method } = oasPathMethod;
-    // run OpenAPISnippet for target node
-    const targets = [target];
+    // Include query parameters in the path for comparison
+    const fullPath = `${path}${req.get('query') ? `?${new URLSearchParams(req.get('query')).toString()}` : ''}`;
     let snippet;
     try {
         // set request snippet content
@@ -43,13 +43,13 @@ export function getSnippetContent(req, target, codeSnippet) {
             codeSnippet.codeBlock !== undefined &&
             codeSnippet.codeBlock !== null
         ) {
-            if (codeSnippet.endpoint === path) {
+            if (codeSnippet.endpoint === fullPath) {
                 snippet = codeSnippet.codeBlock;
             } else {
                 snippet = null;
             }
         } else {
-            snippet = OpenAPISnippet.getEndpointSnippets(spec, path, method, targets).snippets[0].content;
+            snippet = OpenAPISnippet.getEndpointSnippets(spec, path, method, [target]).snippets[0].content;
         }
     } catch (err) {
         snippet = JSON.stringify(snippet);

--- a/api-catalog-ui/frontend/src/utils/generateSnippets.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.js
@@ -33,7 +33,7 @@ export function getSnippetContent(req, target, codeSnippet) {
     const { spec, oasPathMethod } = req.toJS();
     const { path, method } = oasPathMethod;
     // Include query parameters in the path for comparison
-    const fullPath = `${path}${req.get('query') ? `?${new URLSearchParams(req.get('query')).toString()}` : ''}`;
+    const fullPath = `${path}${req?.get('query') ? `?${new URLSearchParams(req?.get('query')).toString()}` : ''}`;
     let snippet;
     try {
         // set request snippet content

--- a/api-catalog-ui/frontend/src/utils/generateSnippets.test.js
+++ b/api-catalog-ui/frontend/src/utils/generateSnippets.test.js
@@ -66,6 +66,7 @@ describe('>>> Code snippet generator', () => {
         };
 
         const req = {
+            get: jest.fn(),
             toJS: () => ({
                 spec,
                 oasPathMethod,
@@ -76,6 +77,73 @@ describe('>>> Code snippet generator', () => {
         const expectedResult =
             // eslint-disable-next-line no-useless-concat
             'HttpResponse<String> response = Unirest.get("http://undefinedundefined/path/to/api")\n' + '  .asString();';
+
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('generate a snippet for endpoint with query parameter', () => {
+        const system = {
+            Im: {
+                fromJS: (obj) => obj,
+            },
+        };
+        const title = 'Java Unirest';
+        const syntax = 'java';
+        const target = 'java_unirest';
+
+        const spec = {
+            paths: {
+                '/path/to/api': {
+                    get: {
+                        parameters: [
+                            {
+                                name: 'parameter',
+                                in: 'query',
+                                required: true,
+                                type: 'string',
+                            },
+                        ],
+                        responses: {
+                            200: {
+                                description: 'Response description',
+                                schema: {
+                                    $ref: '#/definitions/SomeSchema',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const oasPathMethod = {
+            path: '/path/to/api',
+            method: 'get',
+        };
+
+        const query = { parameter: 'value' };
+
+        const req = {
+            get: jest.fn((key) => {
+                if (key === 'query') {
+                    return query;
+                }
+                return undefined;
+            }),
+            toJS: () => ({
+                spec,
+                oasPathMethod,
+            }),
+        };
+
+        const codeSnippet = {
+            endpoint: '/path/to/api?parameter=value',
+            language: 'java',
+            codeBlock: 'Some java code;',
+        };
+
+        const result = generateSnippet(system, title, syntax, target, codeSnippet).fn(req);
+        const expectedResult = 'Some java code;';
 
         expect(result).toEqual(expectedResult);
     });
@@ -176,6 +244,7 @@ describe('>>> Code snippet generator', () => {
         };
 
         const req = {
+            get: jest.fn(),
             toJS: () => ({
                 spec,
                 oasPathMethod,
@@ -210,6 +279,7 @@ describe('>>> Code snippet generator', () => {
         };
 
         const req = {
+            get: jest.fn(),
             toJS: () => ({
                 spec,
                 oasPathMethod,
@@ -245,6 +315,7 @@ describe('>>> Code snippet generator', () => {
         };
 
         const req = {
+            get: jest.fn(),
             toJS: () => ({
                 spec,
                 oasPathMethod,
@@ -276,7 +347,9 @@ describe('>>> Code snippet generator', () => {
             path: '/path/to/api',
             method: 'get',
         };
+
         const req = {
+            get: jest.fn(),
             toJS: () => ({
                 spec,
                 oasPathMethod,


### PR DESCRIPTION
# Description

Customized snippet generator was not able to render the snippet in the UI for endpoints containing query parameters. 
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
