### PR TITLE
fix: WebSocket non-blocking session opening

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ClientSessionFailureCallback.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ClientSessionFailureCallback.java
@@ -1,0 +1,19 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import org.springframework.web.socket.WebSocketSession;
+
+public interface ClientSessionFailureCallback {
+
+    void onClientSessionFailure(WebSocketRoutedSession webSocketRoutedSession, WebSocketSession serverSession, Throwable throwable);
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ClientSessionSuccessCallback.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ClientSessionSuccessCallback.java
@@ -1,0 +1,19 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import org.springframework.web.socket.WebSocketSession;
+
+public interface ClientSessionSuccessCallback {
+
+    void onClientSessionSuccess(WebSocketRoutedSession webSocketRoutedSession, WebSocketSession serverSession, WebSocketSession clientSession);
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ServerNotYetAvailableException.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/ServerNotYetAvailableException.java
@@ -1,0 +1,15 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+public class ServerNotYetAvailableException extends RuntimeException {
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -281,12 +281,12 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
     }
 
     private boolean isClientConnectionClosed(WebSocketRoutedSession session) {
-        return session != null && session.isClientConnected();
+        WebSocketSession clientSession = session.getClientSession();
+        return session != null && session.getWebSocketClientSession().isDone() && clientSession != null && !clientSession.isOpen();
     }
 
     private boolean isClientConnectionReady(WebSocketRoutedSession session) {
-        WebSocketSession clientSession = session.getClientSession();
-        return session != null && session.getWebSocketClientSession().isDone() && clientSession != null && !clientSession.isOpen();
+        return session != null && session.isClientConnected();
     }
 
     private WebSocketRoutedSession getRoutedSession(WebSocketSession webSocketSession) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -192,7 +192,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         // if the browser closes the session, close the GWs client one as well.
         Optional.ofNullable(routedSessions.get(session.getId()))
-            .filter(routedSession -> routedSession.isClientConnected())
+            .filter(WebSocketRoutedSession::isClientConnected)
             .map(WebSocketRoutedSession::getClientSession)
             .ifPresent(clientSession -> {
                 try {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -296,10 +296,15 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
         log.debug("Failed opening client web socket session against {}. Server WebSocket session is {}", routedSession.getTargetUrl(), serverSession.getId(), throwable);
         try {
             routedSession.getClientHandler().handleMessage(serverSession, new TextMessage("Failed opening a session against " + routedSession.getTargetUrl() + ": " + throwable.getMessage()));
-            serverSession.close(CloseStatus.SERVER_ERROR);
             routedSessions.remove(serverSession.getId());
         } catch (Exception e) {
-            log.debug("Failed sending / closing WebSocket session", e);
+            log.debug("Failed sending server error WebSocket message to client: {}", e.getMessage());
+        } finally {
+            try {
+                serverSession.close(CloseStatus.SERVER_ERROR);
+            } catch (IOException e) {
+                log.debug("Failed closing server WebSocket session: {}", e.getMessage());
+            }
         }
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -264,6 +264,8 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
                 closeServerSession(null, webSocketSession, webSocketMessage);
             }
             session.sendMessageToServer(webSocketMessage);
+        } catch (ServerNotYetAvailableException e) {
+            throw e;
         } catch (Exception ex) {
             log.debug("Error sending WebSocket message. Closing session due to exception:", ex);
             close(webSocketSession, CloseStatus.SESSION_NOT_RELIABLE);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -195,7 +195,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
                     session.getClientHandler().handleMessage(webSocketSession, new TextMessage("Failed opening a session against " + targetUrl + ": " + failure.getMessage()));
                     webSocketSession.close(CloseStatus.SERVER_ERROR);
                 } catch (Exception e) {
-                    log.debug("Failed seding / closing WebSocket session", e);
+                    log.debug("Failed sending / closing WebSocket session", e);
                 }
             });
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -195,6 +195,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         // if the browser closes the session, close the GWs client one as well.
+        log.debug("Server session closed from client with status {}", status);
         Optional.ofNullable(routedSessions.get(session.getId()))
             .filter(WebSocketRoutedSession::isClientConnected)
             .map(WebSocketRoutedSession::getClientSession)

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandler.java
@@ -274,7 +274,7 @@ public class WebSocketProxyServerHandler extends AbstractWebSocketHandler implem
 
     private boolean isClientConnectionClosed(WebSocketRoutedSession session) {
         WebSocketSession clientSession = session.getClientSession();
-        return session != null && clientSession != null && !clientSession.isOpen();
+        return clientSession != null && !clientSession.isOpen();
     }
 
     private boolean isClientConnectionReady(WebSocketRoutedSession session) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class WebSocketRoutedSession {
 
-    private AtomicReference<WebSocketSession> clientSession;
+    private AtomicReference<WebSocketSession> clientSession = new AtomicReference<>();
     private final WebSocketSession webSocketServerSession;
     private final WebSocketProxyClientHandler clientHandler;
     private final String targetUrl;
@@ -94,7 +94,7 @@ public class WebSocketRoutedSession {
         return targetUrl;
     }
 
-    private void onSuccess(WebSocketSession serverSession, WebSocketSession clientSession) {
+    private synchronized void onSuccess(WebSocketSession serverSession, WebSocketSession clientSession) {
         this.clientSession.set(clientSession);
         this.successCallbacks.forEach(callback -> callback.onClientSessionSuccess(this, serverSession, clientSession));
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -79,7 +79,7 @@ public class WebSocketRoutedSession {
 
     private ListenableFuture<WebSocketSession> createWebSocketClientSession(WebSocketSession webSocketServerSession, String targetUrl, WebSocketClientFactory webSocketClientFactory) {
         try {
-            JettyWebSocketClient client = webSocketClientFactory.getClientInstance();
+            JettyWebSocketClient client = webSocketClientFactory.getClientInstance(targetUrl);
             URI targetURI = new URI(targetUrl);
             WebSocketHttpHeaders headers = getWebSocketHttpHeaders(webSocketServerSession);
             return client.doHandshake(clientHandler, headers, targetURI);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -132,9 +132,11 @@ public class WebSocketRoutedSession {
                 clientSession.get().sendMessage(webSocketMessage);
             } catch (IOException e) {
                 log.debug("Failed sending message: {}", webSocketMessage, e);
+                throw e;
             }
         } else {
             log.debug("Tried to send a WebSocket message in a non-established client session.");
+            throw new ServerNotYetAvailableException();
         }
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -94,6 +94,7 @@ public class WebSocketRoutedSession {
     }
 
     private void onSuccess(WebSocketSession serverSession, WebSocketSession clientSession) {
+        this.clientSession = clientSession;
         this.successCallbacks.forEach(callback -> callback.onClientSessionSuccess(this, serverSession, clientSession));
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -139,7 +139,7 @@ public class WebSocketRoutedSession {
     }
 
     public boolean isClientConnected() {
-        return clientSession != null && clientSession.get().isOpen();
+        return clientSession.get() != null && clientSession.get().isOpen();
     }
 
     public void close(CloseStatus status) throws IOException {
@@ -182,7 +182,7 @@ public class WebSocketRoutedSession {
      * @throws ServerNotYetAvailableException If a client session is not established
      */
     public String getClientId() {
-        if (clientSession == null) {
+        if (clientSession.get() == null) {
             throw new ServerNotYetAvailableException();
         }
         if (isClientConnected()) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -61,7 +61,7 @@ public class WebSocketRoutedSession {
 
     @VisibleForTesting
     WebSocketRoutedSession(WebSocketSession webSocketServerSession, WebSocketSession webSocketClientSession, WebSocketProxyClientHandler clientHandler, String targetUrl) {
-        this.clientSession = webSocketClientSession;
+        this.clientSession.set(webSocketClientSession);
         this.webSocketServerSession = webSocketServerSession;
         this.clientHandler = clientHandler;
         this.targetUrl = targetUrl;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.ws;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.concurrent.ListenableFuture;
@@ -45,7 +46,8 @@ public class WebSocketRoutedSession {
         this.webSocketClientSession = createWebSocketClientSession(webSocketServerSession, targetUrl, webSocketClientFactory);
     }
 
-    public WebSocketRoutedSession(WebSocketSession webSocketServerSession, ListenableFuture<WebSocketSession> webSocketClientSession, WebSocketProxyClientHandler clientHandler, String targetUrl) {
+    @VisibleForTesting
+    WebSocketRoutedSession(WebSocketSession webSocketServerSession, ListenableFuture<WebSocketSession> webSocketClientSession, WebSocketProxyClientHandler clientHandler, String targetUrl) {
         this.webSocketClientSession = webSocketClientSession;
         this.webSocketServerSession = webSocketServerSession;
         this.clientHandler = clientHandler;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSession.java
@@ -109,7 +109,7 @@ public class WebSocketRoutedSession {
             URI targetURI = new URI(targetUrl);
             WebSocketHttpHeaders headers = getWebSocketHttpHeaders(webSocketServerSession);
             client.doHandshake(clientHandler, headers, targetURI)
-                .addCallback(clientSession -> this.onSuccess(webSocketServerSession, clientSession), e -> this.onFailure(webSocketServerSession, e));
+                .addCallback(obtainedSession -> this.onSuccess(webSocketServerSession, obtainedSession), e -> this.onFailure(webSocketServerSession, e));
         } catch (IllegalStateException e) {
             throw webSocketProxyException(targetUrl, e, webSocketServerSession, true);
         } catch (Exception e) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactory.java
@@ -18,7 +18,13 @@ public interface WebSocketRoutedSessionFactory {
      * @param webSocketSession Valid Server side WebSocket Session.
      * @param targetUrl Full websocket URL towards the server
      * @param webSocketClientFactory Factory producing the current SSL Context.
-     * @return Valid routed session handling the client session
+     * @param successCallback callback to be called if the session is established successfully
+     * @param failureCallback callback to be called if the session fails to be established
      */
-    WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory);
+    WebSocketRoutedSession session(
+        WebSocketSession webSocketSession,
+        String targetUrl,
+        WebSocketClientFactory webSocketClientFactory,
+        ClientSessionSuccessCallback successCallback,
+        ClientSessionFailureCallback failureCallback);
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
@@ -18,8 +18,13 @@ import org.springframework.web.socket.WebSocketSession;
 public class WebSocketRoutedSessionFactoryImpl implements WebSocketRoutedSessionFactory {
 
     @Override
-    public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory) {
-        return new WebSocketRoutedSession(webSocketSession, targetUrl, webSocketClientFactory);
+    public WebSocketRoutedSession session(
+            WebSocketSession webSocketSession,
+            String targetUrl,
+            WebSocketClientFactory webSocketClientFactory,
+            ClientSessionSuccessCallback successCallback,
+            ClientSessionFailureCallback failureCallback) {
+        return new WebSocketRoutedSession(webSocketSession, targetUrl, webSocketClientFactory, successCallback, failureCallback);
     }
 
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImpl.java
@@ -16,8 +16,10 @@ import org.springframework.web.socket.WebSocketSession;
  * Default implementation. Provides the WebSocketRoutedSession the same way as before.
  */
 public class WebSocketRoutedSessionFactoryImpl implements WebSocketRoutedSessionFactory {
+
     @Override
     public WebSocketRoutedSession session(WebSocketSession webSocketSession, String targetUrl, WebSocketClientFactory webSocketClientFactory) {
         return new WebSocketRoutedSession(webSocketSession, targetUrl, webSocketClientFactory);
     }
+
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
     level:
-        ROOT: DEBUG
+        ROOT: INFO
         org.zowe.apiml: INFO
         org.springframework: WARN
         com.netflix: WARN
@@ -9,8 +9,8 @@ logging:
         com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient: OFF
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
-        org.springframework.web.socket: DEBUG
-        org.zowe.apiml.gateway.ws: DEBUG
+        org.springframework.web.socket: WARN
+        org.zowe.apiml.gateway.ws: INFO
         org.zowe.apiml.gateway.error: INFO
         org.eclipse.jetty: WARN
         org.springframework.web.servlet.PageNotFound: ERROR

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ logging:
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.springframework.web.socket: WARN
-        org.zowe.apiml.gateway.ws: INFO
+        org.zowe.apiml.gateway.ws: DEBUG
         org.zowe.apiml.gateway.error: INFO
         org.eclipse.jetty: WARN
         org.springframework.web.servlet.PageNotFound: ERROR

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
     level:
-        ROOT: INFO
+        ROOT: DEBUG
         org.zowe.apiml: INFO
         org.springframework: WARN
         com.netflix: WARN

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -9,7 +9,7 @@ logging:
         com.netflix.discovery.shared.transport.decorator.RedirectingEurekaHttpClient: OFF
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
-        org.springframework.web.socket: WARN
+        org.springframework.web.socket: DEBUG
         org.zowe.apiml.gateway.ws: DEBUG
         org.zowe.apiml.gateway.error: INFO
         org.eclipse.jetty: WARN
@@ -307,6 +307,7 @@ logging:
         org.ehcache: INFO
         org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter: INFO
         com.netflix.discovery.shared.transport.decorator: DEBUG
+        org.springframework.web.socket: DEBUG
         org.zowe.apiml.gateway.ws: DEBUG
 
 ---

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryContextTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryContextTest.java
@@ -70,18 +70,18 @@ public class WebSocketClientFactoryContextTest {
     class GivenFactory {
 
         private JettyWebSocketClient client = mock(JettyWebSocketClient.class);
-        private WebSocketClientFactory factory = new WebSocketClientFactory(client);
+        private WebSocketClientFactory factory = new WebSocketClientFactory(null, 0, 0, 0, 0, 0);
 
         @Test
         void whenIsRunning_thenStop() {
             doReturn(true).when(client).isRunning();
-            factory.closeClient();
+            factory.closeClients();
             verify(client).stop();
         }
 
         @Test
         void whenIsNotRunning_thenDontStop() {
-            factory.closeClient();
+            factory.closeClients();
             verify(client, never()).stop();
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
@@ -34,25 +34,25 @@ class WebSocketClientFactoryTest {
         @BeforeEach
         void setUp() {
             this.client = mock(JettyWebSocketClient.class);
-            this.webSocketClientFactory = new WebSocketClientFactory(this.client);
+            this.webSocketClientFactory = new WebSocketClientFactory(null, 0, 0, 0, 0, 0);
         }
 
         @Test
         void givenRunningClient_whenClose_thenStopClient() {
             doReturn(true).when(client).isRunning();
-            webSocketClientFactory.closeClient();
+            webSocketClientFactory.closeClients();
             verify(client).stop();
         }
 
         @Test
         void givenStoppedClient_whenClose_thenDoNothing() {
-            webSocketClientFactory.closeClient();
+            webSocketClientFactory.closeClients();
             verify(client, never()).stop();
         }
 
         @Test
         void whenGetClient_thenReturnInstance() {
-            assertSame(client, webSocketClientFactory.getClientInstance());
+            assertSame(client, webSocketClientFactory.getClientInstance("key"));
         }
 
     }
@@ -70,7 +70,7 @@ class WebSocketClientFactoryTest {
 
         @Test
         void givenInitilizedClient_thenHasNonDefaultIdleConfig() {
-            WebSocketClient wsClient = (WebSocketClient) ReflectionTestUtils.getField(webSocketClientFactory.getClientInstance(), "client");
+            WebSocketClient wsClient = (WebSocketClient) ReflectionTestUtils.getField(webSocketClientFactory.getClientInstance("key"), "client");
             assertEquals(1234, wsClient.getMaxIdleTimeout());
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketClientFactoryTest.java
@@ -10,31 +10,44 @@
 
 package org.zowe.apiml.gateway.ws;
 
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
-
+@ExtendWith(MockitoExtension.class)
 class WebSocketClientFactoryTest {
 
     @Nested
     class CreatedInstance {
 
-        private WebSocketClientFactory webSocketClientFactory;
+        @Mock
         private JettyWebSocketClient client;
+
+        private WebSocketClientFactory webSocketClientFactory;
 
         @BeforeEach
         void setUp() {
-            this.client = mock(JettyWebSocketClient.class);
             this.webSocketClientFactory = new WebSocketClientFactory(null, 0, 0, 0, 0, 0);
+            ConcurrentMap<String, JettyWebSocketClient> clients = new ConcurrentHashMap<>();
+            clients.put("key", client);
+            ReflectionTestUtils.setField(webSocketClientFactory, "clientsMap", clients);
         }
 
         @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
@@ -33,10 +34,16 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class WebSocketProxyServerHandlerTest {
     private WebSocketProxyServerHandler underTest;
@@ -223,7 +230,7 @@ class WebSocketProxyServerHandlerTest {
         void whenTheConnectionIsClosed_thenClientSessionIsAlsoClosed() throws IOException {
             CloseStatus normalClose = CloseStatus.NORMAL;
             WebSocketSession clientSession = mock(WebSocketSession.class);
-            when(internallyStoredSession.getWebSocketClientSession()).thenReturn(clientSession);
+            when(internallyStoredSession.getWebSocketClientSession()).thenReturn(AsyncResult.forValue(clientSession));
 
             underTest.afterConnectionClosed(establishedSession, normalClose);
             verify(clientSession, times(1)).close(normalClose);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -271,7 +271,7 @@ class WebSocketProxyServerHandlerTest {
         /**
          * This scenario is now handled by Spring Retry
          */
-        void whenSessionIsNull_thenCloseAndReturn() throws IOException {
+        void whenSessionIsNull_thenCloseAndReturn() {
             routedSessions.replace("123", null);
 
             assertThrows(ServerNotYetAvailableException.class, () -> underTest.handleMessage(establishedSession, passedMessage));

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -238,9 +238,11 @@ class WebSocketProxyServerHandlerTest {
         void whenTheConnectionIsClosed_thenClientSessionIsAlsoClosed() throws IOException {
             CloseStatus normalClose = CloseStatus.NORMAL;
             WebSocketSession clientSession = mock(WebSocketSession.class);
-            when(internallyStoredSession.getWebSocketClientSession()).thenReturn(AsyncResult.forValue(clientSession));
+            when(internallyStoredSession.isClientConnected()).thenReturn(true);
+            when(internallyStoredSession.getClientSession()).thenReturn(clientSession);
 
             underTest.afterConnectionClosed(establishedSession, normalClose);
+
             verify(clientSession, times(1)).close(normalClose);
             assertThat(routedSessions.entrySet(), hasSize(0));
         }
@@ -249,7 +251,9 @@ class WebSocketProxyServerHandlerTest {
         void whenTheMessageIsReceived_thenTheMessageIsPassedToTheSession() throws Exception {
             WebSocketSession clientSession = mock(WebSocketSession.class);
             when(clientSession.isOpen()).thenReturn(true);
+            when(internallyStoredSession.isClientConnected()).thenReturn(true);
             when(internallyStoredSession.getWebSocketClientSession()).thenReturn(AsyncResult.forValue(clientSession));
+            when(internallyStoredSession.getClientSession()).thenReturn(clientSession);
 
             underTest.handleMessage(establishedSession, passedMessage);
 
@@ -281,7 +285,8 @@ class WebSocketProxyServerHandlerTest {
         void whenClosingSessionThrowException_thenCatchIt() throws IOException {
             CloseStatus status = CloseStatus.SESSION_NOT_RELIABLE;
             doThrow(new IOException()).when(establishedSession).close(status);
-            when(internallyStoredSession.getWebSocketClientSession()).thenReturn(AsyncResult.forValue(establishedSession));
+            when(internallyStoredSession.isClientConnected()).thenReturn(true);
+            when(internallyStoredSession.getClientSession()).thenReturn(establishedSession);
 
             underTest.afterConnectionClosed(establishedSession, status);
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -316,11 +316,28 @@ class WebSocketProxyServerHandlerTest {
             when(clientSession.isOpen()).thenReturn(true);
             when(internallyStoredSession.isClientConnected()).thenReturn(true);
             when(internallyStoredSession.getClientSession()).thenReturn(clientSession);
-            when(internallyStoredSession.getClientSession()).thenReturn(clientSession);
 
             underTest.handleMessage(establishedSession, passedMessage);
 
             verify(internallyStoredSession).sendMessageToServer(passedMessage);
+        }
+
+        @Test
+        void givenClientNotConnected_whenHandleMessage_thenThrowException() {            when(internallyStoredSession.isClientConnected()).thenReturn(false);
+            assertThrows(ServerNotYetAvailableException.class, () -> underTest.handleMessage(establishedSession, passedMessage));
+        }
+
+        @Test
+        void givenClientConnectionClosed_whenHandleMessage_thenCloseServerSession() throws IOException {
+            WebSocketSession clientSession = mock(WebSocketSession.class);
+
+            when(clientSession.isOpen()).thenReturn(false);
+            when(internallyStoredSession.isClientConnected()).thenReturn(true);
+            when(internallyStoredSession.getClientSession()).thenReturn(clientSession);
+
+            underTest.handleMessage(establishedSession, passedMessage);
+
+            verify(establishedSession, times(1)).close(CloseStatus.SESSION_NOT_RELIABLE);
         }
 
         @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -264,6 +264,8 @@ class WebSocketProxyServerHandlerTest {
         void whenExceptionIsThrown_thenRemoveRoutedSession() throws Exception {
             doThrow(new WebSocketException("error")).when(routedSessions.get("123")).sendMessageToServer(passedMessage);
             when(internallyStoredSession.getWebSocketClientSession()).thenReturn(AsyncResult.forValue(establishedSession));
+            when(internallyStoredSession.getClientSession()).thenReturn(establishedSession);
+            when(internallyStoredSession.isClientConnected()).thenReturn(true);
             when(establishedSession.isOpen()).thenReturn(true);
 
             underTest.handleMessage(establishedSession, passedMessage);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketProxyServerHandlerTest.java
@@ -234,7 +234,8 @@ class WebSocketProxyServerHandlerTest {
         @Test
         void whenHandleMessage_thenThrowNotAvailable() {
             assumeTrue(underTest.getRoutedSessions().isEmpty());
-            assertThrows(ServerNotYetAvailableException.class, () -> underTest.handleMessage(session, new TextMessage("null")));
+            WebSocketMessage<String> message = new TextMessage("null");
+            assertThrows(ServerNotYetAvailableException.class, () -> underTest.handleMessage(session, message));
         }
 
         @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImplTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionFactoryImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.ws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.jetty.JettyWebSocketClient;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketRoutedSessionFactoryImplTest {
+
+    private static final String WSS_URI = "wss://service";
+
+    @Mock
+    private WebSocketClientFactory factory;
+    @Mock
+    private WebSocketSession webSocketSession;
+    @Mock
+    private JettyWebSocketClient jettyWebSocketClient;
+
+    private WebSocketRoutedSessionFactoryImpl underTest = new WebSocketRoutedSessionFactoryImpl();
+
+    @BeforeEach
+    void setUp() {
+        when(webSocketSession.getHandshakeHeaders()).thenReturn(HttpHeaders.EMPTY);
+    }
+
+    @Test
+    void testSession() {
+        when(factory.getClientInstance(WSS_URI)).thenReturn(jettyWebSocketClient);
+        when(jettyWebSocketClient.doHandshake(any(), any(WebSocketHttpHeaders.class), any(URI.class))).thenReturn(AsyncResult.forValue(null));
+
+        WebSocketRoutedSession generated = underTest.session(webSocketSession, WSS_URI, factory, null, null);
+
+        assertNotNull(generated);
+    }
+}

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
@@ -42,7 +42,8 @@ class WebSocketRoutedSessionTest {
         clientSession = mock(WebSocketSession.class);
         serverSession = mock(WebSocketSession.class);
 
-        underTest = new WebSocketRoutedSession(serverSession, clientSession);
+        // underTest = new WebSocketRoutedSession(serverSession, clientSession, null, null);
+        underTest = null;
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
@@ -54,6 +54,7 @@ class WebSocketRoutedSessionTest {
     @BeforeEach
     void prepareSessionUnderTest() {
         underTest = new WebSocketRoutedSession(serverSession, new AsyncResult<>(clientSession), clientHandler, "ws://localhost:8080/petstore");
+        underTest.setClientSession(clientSession);
     }
 
     @Test
@@ -62,6 +63,7 @@ class WebSocketRoutedSessionTest {
         String clientUriPath = "ws://localhost:8080/petstore";
         String serverUriPath = "ws://gateway:8080/petstore";
 
+        when(clientSession.isOpen()).thenReturn(true);
         when(clientSession.getId()).thenReturn(sessionId);
         when(serverSession.getRemoteAddress()).thenReturn(new InetSocketAddress("gateway",  8080));
         when(serverSession.getUri()).thenReturn(new URI(serverUriPath));
@@ -105,7 +107,10 @@ class WebSocketRoutedSessionTest {
     class GivenWSMessage {
         @Test
         void whenAddressNotNull_thenSendMessage() throws IOException {
+            when(clientSession.isOpen()).thenReturn(true);
+
             underTest.sendMessageToServer(mock(WebSocketMessage.class));
+
             verify(clientSession, times(1)).sendMessage(any());
         }
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
@@ -82,7 +82,7 @@ class WebSocketRoutedSessionTest {
         void whenFailingToCreateSession_thenThrowException() {
             WebSocketClientFactory webSocketClientFactory = mock(WebSocketClientFactory.class);
             JettyWebSocketClient jettyWebSocketClient = mock(JettyWebSocketClient.class);
-            when(webSocketClientFactory.getClientInstance()).thenReturn(jettyWebSocketClient);
+            when(webSocketClientFactory.getClientInstance("key")).thenReturn(jettyWebSocketClient);
             HttpHeaders headers = new WebSocketHttpHeaders();
             headers.add("header", "someHeader");
             when(serverSession.getHandshakeHeaders()).thenReturn(headers);
@@ -93,7 +93,7 @@ class WebSocketRoutedSessionTest {
         @Test
         void whenFailingOnHandshake_thenThrowException() {
             WebSocketClientFactory webSocketClientFactory = mock(WebSocketClientFactory.class);
-            when(webSocketClientFactory.getClientInstance()).thenThrow(new IllegalStateException());
+            when(webSocketClientFactory.getClientInstance("key")).thenThrow(new IllegalStateException());
             assertThrows(WebSocketProxyError.class, () -> new WebSocketRoutedSession(serverSession, "", webSocketClientFactory));
         }
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/ws/WebSocketRoutedSessionTest.java
@@ -135,7 +135,7 @@ class WebSocketRoutedSessionTest {
         }
 
         @Test
-        void whenClientNotConnected_throwNotAvailable() throws IOException {
+        void whenClientNotConnected_throwNotAvailable() {
             when(clientSession.isOpen()).thenReturn(false);
 
             assertThrows(ServerNotYetAvailableException.class, () -> underTest.sendMessageToServer(mock(WebSocketMessage.class)));

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -156,7 +156,7 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
 
                     @Test
                     @Timeout(value = 30, unit = TimeUnit.SECONDS)
-                    void newSessionCanBeCreated() throws Exception {
+                    void newSessionCanBeCreated() {
                         final StringBuilder response = new StringBuilder();
                         HAGatewayRequests haGatewayRequests = new HAGatewayRequests("https");
                         // take off an instance of Gateway
@@ -164,7 +164,7 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
 
                         await("Gateway Shutdown")
                             .atMost(20, TimeUnit.SECONDS)
-                            .untilAsserted(() -> {
+                            .until(() -> {
                                 // create websocket session using the second alive instance of Gateway
                                 session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);
 
@@ -173,7 +173,7 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                                     response.wait(WAIT_TIMEOUT_MS);
                                 }
 
-                                assertEquals("HELLO WORLD 2!", response.toString());
+                                return response.toString().equals("HELLO WORLD 2!");
                             });
                     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -26,11 +26,13 @@ import org.zowe.apiml.util.requests.ha.HAGatewayRequests;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.tomcat.websocket.Constants.SSL_CONTEXT_PROPERTY;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.zowe.apiml.util.requests.Endpoints.*;
 
@@ -154,6 +156,8 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                         HAGatewayRequests haGatewayRequests = new HAGatewayRequests("https");
                         // take off an instance of Gateway
                         haGatewayRequests.shutdown(0);
+
+                        await().during(Duration.ofSeconds(5));
 
                         // create websocket session using the second alive instance of Gateway
                         session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -148,11 +148,14 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                 class WhenAGatewayInstanceIsOff {
 
                     @Test
+                    @Timeout(value = 30, unit = TimeUnit.SECONDS)
                     void newSessionCanBeCreated() throws Exception {
                         final StringBuilder response = new StringBuilder();
                         HAGatewayRequests haGatewayRequests = new HAGatewayRequests("https");
                         // take off an instance of Gateway
                         haGatewayRequests.shutdown(0);
+
+                        Thread.sleep(10 * 1000);
 
                         // create websocket session using the second alive instance of Gateway
                         session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -33,6 +33,7 @@ import org.zowe.apiml.util.requests.ha.HAGatewayRequests;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -166,6 +167,7 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
 
                         await("Gateway Shutdown")
                             .atMost(20, TimeUnit.SECONDS)
+                            .pollInterval(Duration.ofSeconds(2))
                             .until(() -> {
                                 // create websocket session using the second alive instance of Gateway
                                 URI gatewayUrl = gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -10,7 +10,6 @@
 
 package org.zowe.apiml.integration.ha;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -48,7 +47,6 @@ import static org.zowe.apiml.util.requests.Endpoints.DISCOVERABLE_WS_UPPERCASE;
  */
 @ChaoticHATest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Slf4j
 class WebSocketChaoticTest implements TestWithStartedInstances {
     private final HAGatewayRequests gatewaysWsRequests = new HAGatewayRequests("wss");
     private final HADiscoverableClientRequests haDiscoverableClientRequests = new HADiscoverableClientRequests();
@@ -167,12 +165,11 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
 
                         await("Gateway Shutdown")
                             .atMost(20, TimeUnit.SECONDS)
+                            .pollDelay(Duration.ofSeconds(5))
                             .pollInterval(Duration.ofSeconds(2))
                             .until(() -> {
                                 // create websocket session using the second alive instance of Gateway
                                 URI gatewayUrl = gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE);
-
-                                log.error("trying with gatewayUrl: {}", gatewayUrl);
 
                                 session = appendingWebSocketSession(gatewayUrl, VALID_AUTH_HEADERS, response, 1);
 
@@ -180,8 +177,6 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                                 synchronized (response) {
                                     response.wait(WAIT_TIMEOUT_MS);
                                 }
-
-                                log.error("Obtained response from {}: {}", gatewayUrl, response.toString());
 
                                 if (response.toString().equals("HELLO WORLD 2!")) {
                                     return true;

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -155,8 +155,6 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                         // take off an instance of Gateway
                         haGatewayRequests.shutdown(0);
 
-                        Thread.sleep(10 * 1000);
-
                         // create websocket session using the second alive instance of Gateway
                         session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -173,7 +173,12 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                                     response.wait(WAIT_TIMEOUT_MS);
                                 }
 
-                                return response.toString().equals("HELLO WORLD 2!");
+                                if (response.toString().equals("HELLO WORLD 2!")) {
+                                    return true;
+                                } else {
+                                    session.close();
+                                    return false;
+                                }
                             });
                     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.integration.ha;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -46,6 +47,7 @@ import static org.zowe.apiml.util.requests.Endpoints.DISCOVERABLE_WS_UPPERCASE;
  */
 @ChaoticHATest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Slf4j
 class WebSocketChaoticTest implements TestWithStartedInstances {
     private final HAGatewayRequests gatewaysWsRequests = new HAGatewayRequests("wss");
     private final HADiscoverableClientRequests haDiscoverableClientRequests = new HADiscoverableClientRequests();
@@ -166,12 +168,18 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                             .atMost(20, TimeUnit.SECONDS)
                             .until(() -> {
                                 // create websocket session using the second alive instance of Gateway
-                                session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);
+                                URI gatewayUrl = gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE);
+
+                                log.error("trying with gatewayUrl: {}", gatewayUrl);
+
+                                session = appendingWebSocketSession(gatewayUrl, VALID_AUTH_HEADERS, response, 1);
 
                                 session.sendMessage(new TextMessage("hello world 2!"));
                                 synchronized (response) {
                                     response.wait(WAIT_TIMEOUT_MS);
                                 }
+
+                                log.error("Obtained response from {}: {}", gatewayUrl, response.toString());
 
                                 if (response.toString().equals("HELLO WORLD 2!")) {
                                     return true;

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -155,6 +155,8 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                         // take off an instance of Gateway
                         haGatewayRequests.shutdown(0);
 
+                        Thread.sleep(10 * 1000);
+
                         // create websocket session using the second alive instance of Gateway
                         session = appendingWebSocketSession(gatewaysWsRequests.getGatewayUrl( 1, DISCOVERABLE_WS_UPPERCASE), VALID_AUTH_HEADERS, response, 1);
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/WebSocketChaoticTest.java
@@ -91,11 +91,6 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
 
         private WebSocketSession session;
 
-        @BeforeEach
-        void setUp() {
-
-        }
-
         @AfterEach
         void tearDown() throws IOException {
             if (session != null) {
@@ -149,6 +144,7 @@ class WebSocketChaoticTest implements TestWithStartedInstances {
                  * TODO: Introduce HA capabailities for the WebSocket connections.
                  */
                 @Nested
+                @Order(3)
                 class WhenAGatewayInstanceIsOff {
 
                     @Test


### PR DESCRIPTION
# Description

This PR refactors the code in the WebSocket client / server to be non-blocking and callback-based.
Retries are set in place now instead of holding on the thread for a determined amount of time.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
