### PR TITLE
fix: Remove global setup of keystores

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -901,6 +901,7 @@ jobs:
                 run: >
                     ./gradlew runHATests --info -Denvironment.config=-ha -Denvironment.offPlatform=true
                     -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
+                    -DcloudGateway.enabled=false
                 env:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
                     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -1064,7 +1065,7 @@ jobs:
             -   name: Run Discovery Service Chaotic HA Tests
                 run: >
                     ./gradlew :integration-tests:runChaoticHATests --tests org.zowe.apiml.integration.ha.DiscoveryChaoticTest
-                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true
+                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true -DcloudGateway.enabled=false
                     -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
                 env:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,10 +26,6 @@ jobs:
             -   name: Build with Gradle
                 run: >
                     ./gradlew clean jib -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }} -Pzowe.docker.password=${{ secrets.PERSONAL_JB_TOKEN }} -Pzowe.docker.username=balhar-jakub -Pzowe.docker.container=ghcr.io/balhar-jakub/ -Pzowe.docker.tag=${{ env.JOB_ID }}
-            -   name: Publish latest v2 Gateway
-                if: ${{ github.ref_name == 'v2.x.x' }}
-                run: >
-                    ./gradlew :gateway-service:jib -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }} -Pzowe.docker.password=${{ secrets.PERSONAL_JB_TOKEN }} -Pzowe.docker.username=balhar-jakub -Pzowe.docker.container=ghcr.io/balhar-jakub/ -Pzowe.docker.tag=latest-v2
             -   name: Standalone Catalog
                 run: >
                     ./gradlew :api-catalog-services:jib -Pzowe.jib.image.suffix=standalone -Pzowe.jib.image.javaAgentPort=6305 -Pzowe.jib.image.debugPort=5125 -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }} -Pzowe.docker.password=${{ secrets.PERSONAL_JB_TOKEN }} -Pzowe.docker.username=balhar-jakub -Pzowe.docker.container=ghcr.io/balhar-jakub/ -Pzowe.docker.tag=${{ env.JOB_ID }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1131,7 +1131,7 @@ jobs:
             -   name: Run Gateway Service Chaotic HA Tests
                 run: >
                     ./gradlew :integration-tests:runChaoticHATests --tests org.zowe.apiml.integration.ha.GatewayChaoticTest
-                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true
+                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true -DcloudGateway.enabled=false
                     -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
                 env:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -1151,7 +1151,7 @@ jobs:
 
             -   uses: ./.github/actions/teardown
 
-    CITestsDicoverableClientChaoticHA:
+    CITestsDiscoverableClientChaoticHA:
         needs: PublishJibContainers
         container: ubuntu:latest
         runs-on: ubuntu-latest
@@ -1205,7 +1205,7 @@ jobs:
             -   name: Run Discoverable Client Chaotic HA Tests
                 run: >
                     ./gradlew :integration-tests:runChaoticHATests --tests org.zowe.apiml.integration.ha.SouthboundServiceChaoticTest
-                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true
+                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true -DcloudGateway.enabled=false
                     -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
                 env:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -1219,7 +1219,7 @@ jobs:
                 uses: actions/upload-artifact@v2
                 if: always()
                 with:
-                    name: CITestsDicoverableClientChaoticHA-${{ env.JOB_ID }}
+                    name: CITestsDiscoverableClientChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -1279,7 +1279,7 @@ jobs:
             -   name: Run WebSocket Chaotic HA Tests
                 run: >
                     ./gradlew :integration-tests:runChaoticHATests --tests org.zowe.apiml.integration.ha.WebSocketChaoticTest
-                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true
+                    --info -Denvironment.config=-ha -Denvironment.offPlatform=true -DcloudGateway.enabled=false
                     -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
                 env:
                     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -9,6 +9,7 @@ jobs:
         name: Identify security related PR
         runs-on: ubuntu-latest
         timeout-minutes: 20
+        permissions: write-all
 
         steps:
             - uses: actions/github-script@v6

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/functional/ApiCatalogFunctionalTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/functional/ApiCatalogFunctionalTest.java
@@ -34,6 +34,7 @@ public abstract class ApiCatalogFunctionalTest {
     @BeforeEach
     void setUp() {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured.useRelaxedHTTPSValidation();
     }
 
     protected String getCatalogUriWithPath(String path) {

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -172,10 +172,7 @@ public class HttpConfig {
             ApimlPoolingHttpClientConnectionManager connectionManagerWithoutKeystore = getConnectionManager(factoryWithoutKeystore);
             secureHttpClientWithoutKeystore = factoryWithoutKeystore.createSecureHttpClient(connectionManagerWithoutKeystore);
 
-            factory.setSystemSslProperties();
-
             publicKeyCertificatesBase64 = SecurityUtils.loadCertificateChainBase64(httpsConfig);
-
         } catch (HttpsConfigError e) {
             log.error("Invalid configuration of HTTPs: {}", e.getMessage());
             System.exit(1);

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -153,7 +153,6 @@ public class ConnectionsConfig {
             serverProperties.getSsl().setTrustStore(trustStorePath);
             if (trustStorePassword == null) trustStorePassword = KEYRING_PASSWORD;
         }
-        factory().setSystemSslProperties();
     }
 
     public HttpsFactory factory() {

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/acceptance/common/AcceptanceTestWithBasePath.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/acceptance/common/AcceptanceTestWithBasePath.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.cloudgatewayservice.acceptance.common;
 
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
@@ -23,6 +24,7 @@ public class AcceptanceTestWithBasePath {
     @BeforeEach
     void setBasePath() {
         basePath = String.format("https://localhost:%d", port);
+        RestAssured.useRelaxedHTTPSValidation();
     }
 
 

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -229,26 +229,6 @@ public class HttpsFactory {
         }
     }
 
-    private void setSystemProperty(String key, String value) {
-        if (value == null) {
-            System.clearProperty(key);
-        } else {
-            System.setProperty(key, value);
-        }
-    }
-
-    public void setSystemSslProperties() {
-        setSystemProperty("javax.net.ssl.keyStore", SecurityUtils.formatKeyringUrl(config.getKeyStore()));
-        setSystemProperty("javax.net.ssl.keyStorePassword",
-            config.getKeyStorePassword() == null ? null : String.valueOf(config.getKeyStorePassword()));
-        setSystemProperty("javax.net.ssl.keyStoreType", config.getKeyStoreType());
-
-        setSystemProperty("javax.net.ssl.trustStore", SecurityUtils.formatKeyringUrl(config.getTrustStore()));
-        setSystemProperty("javax.net.ssl.trustStorePassword",
-            config.getTrustStorePassword() == null ? null : String.valueOf(config.getTrustStorePassword()));
-        setSystemProperty("javax.net.ssl.trustStoreType", config.getTrustStoreType());
-    }
-
     public HostnameVerifier getHostnameVerifier() {
         if (config.isVerifySslCertificatesOfServices() && !config.isNonStrictVerifySslCertificatesOfServices()) {
             return SSLConnectionSocketFactory.getDefaultHostnameVerifier();

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -250,8 +250,6 @@ public class HttpsFactory {
         if (eurekaServerUrl.startsWith("http://")) {
             apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
         } else {
-            System.setProperty("com.netflix.eureka.shouldSSLConnectionsUseSystemSocketFactory", "true");
-
             builder.withCustomSSL(getSslContext());
 
             builder.withHostnameVerifier(getHostnameVerifier());

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -272,9 +272,6 @@ public class HttpsFactory {
         } else {
             System.setProperty("com.netflix.eureka.shouldSSLConnectionsUseSystemSocketFactory", "true");
 
-            if (config.isVerifySslCertificatesOfServices()) {
-                setSystemSslProperties();
-            }
             builder.withCustomSSL(getSslContext());
 
             builder.withHostnameVerifier(getHostnameVerifier());

--- a/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
@@ -116,21 +116,6 @@ class HttpsFactoryTest {
     }
 
     @Test
-    void shouldSetSystemSslProperties() {
-        HttpsConfig httpsConfig = httpsConfigBuilder.build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
-        httpsFactory.setSystemSslProperties();
-
-        assertEquals(SecurityUtils.formatKeyringUrl(httpsConfig.getKeyStore()), System.getProperty("javax.net.ssl.keyStore"));
-        assertEquals(String.valueOf(httpsConfig.getKeyStorePassword()), System.getProperty("javax.net.ssl.keyStorePassword"));
-        assertEquals(httpsConfig.getKeyStoreType(), System.getProperty("javax.net.ssl.keyStoreType"));
-
-        assertEquals(SecurityUtils.formatKeyringUrl(httpsConfig.getTrustStore()), System.getProperty("javax.net.ssl.trustStore"));
-        assertEquals(String.valueOf(httpsConfig.getTrustStorePassword()), System.getProperty("javax.net.ssl.trustStorePassword"));
-        assertEquals(httpsConfig.getTrustStoreType(), System.getProperty("javax.net.ssl.trustStoreType"));
-    }
-
-    @Test
     void shouldCreateDefaultHostnameVerifier() {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
         HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);

--- a/config/local/metrics-service.yml
+++ b/config/local/metrics-service.yml
@@ -1,0 +1,10 @@
+server:
+    ssl:
+        keyAlias: localhost
+        keyPassword: password
+        keyStore: keystore/localhost/localhost.keystore.p12
+        keyStorePassword: password
+        keyStoreType: PKCS12
+        trustStore: keystore/localhost/localhost.truststore.p12
+        trustStorePassword: password
+        trustStoreType: PKCS12

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/EurekaConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/EurekaConfig.java
@@ -13,6 +13,7 @@ package org.zowe.apiml.discovery.config;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.cluster.PeerEurekaNodes;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
@@ -27,6 +28,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.zowe.apiml.discovery.ApimlInstanceRegistry;
 import org.zowe.apiml.discovery.eureka.RefreshablePeerEurekaNodes;
+
+import java.util.function.Supplier;
 
 /**
  * Configuration to rewrite default Eureka's implementation with custom one
@@ -55,10 +58,11 @@ public class EurekaConfig {
 
     @Bean
     @Primary
-    public PeerEurekaNodes peerEurekaNodes(PeerAwareInstanceRegistry registry,
+    public PeerEurekaNodes peerEurekaNodes(Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder> eurekaJerseyClientBuilder,
+                                           PeerAwareInstanceRegistry registry,
                                            ServerCodecs serverCodecs,
                                            ReplicationClientAdditionalFilters replicationClientAdditionalFilters, ApplicationInfoManager applicationInfoManager, EurekaServerConfig eurekaServerConfig, EurekaClientConfig eurekaClientConfig) {
-        return new RefreshablePeerEurekaNodes(registry, eurekaServerConfig,
+        return new RefreshablePeerEurekaNodes(eurekaJerseyClientBuilder, registry, eurekaServerConfig,
             eurekaClientConfig, serverCodecs, applicationInfoManager,
             replicationClientAdditionalFilters, maxPeerRetries);
     }

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/eureka/RefreshablePeerEurekaNodesTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/eureka/RefreshablePeerEurekaNodesTest.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.discovery.eureka;
 
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.cluster.PeerEurekaNode;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -70,7 +72,8 @@ class RefreshablePeerEurekaNodesTest {
 
     @BeforeEach
     void setUp() {
-        eurekaNodes = new RefreshablePeerEurekaNodes(registry, serverConfig, clientConfig, serverCodecs, applicationInfoManager, replicationClientAdditionalFilters, DEFAULT_MAX_RETRIES);
+        Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder> eurekaJerseyClientBuilder = () -> new EurekaJerseyClientImpl.EurekaJerseyClientBuilder();
+        eurekaNodes = new RefreshablePeerEurekaNodes(eurekaJerseyClientBuilder, registry, serverConfig, clientConfig, serverCodecs, applicationInfoManager, replicationClientAdditionalFilters, DEFAULT_MAX_RETRIES);
     }
 
     @Test

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.springframework.cloud.netflix.eureka.EurekaClientConfigBean.DEFAULT_ZONE;
@@ -65,7 +66,7 @@ public class DiscoveryClientConfig {
     private final AbstractDiscoveryClientOptionalArgs<?> optionalArgs;
     private final ApimlDiscoveryClientFactory apimlDiscoveryClientFactory;
     private final ApplicationContext context;
-    private final EurekaJerseyClientImpl.EurekaJerseyClientBuilder eurekaJerseyClientBuilder;
+    private final Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder> eurekaJerseyClientBuilder;
 
     @Bean
     public List<AdditionalRegistration> additionalRegistration(StandardEnvironment environment) {
@@ -118,7 +119,7 @@ public class DiscoveryClientConfig {
         configBean.setServiceUrl(urls);
 
         MutableDiscoveryClientOptionalArgs args = new MutableDiscoveryClientOptionalArgs();
-        args.setEurekaJerseyClient(eurekaJerseyClientBuilder.build());
+        args.setEurekaJerseyClient(eurekaJerseyClientBuilder.get().build());
 
         InstanceInfo newInfo = apimlDiscoveryClientFactory.createInstanceInfo(appManager.getEurekaInstanceConfig());
         InstanceInfo ii = rewriteInstanceInfoRoutes(apimlRegistration, newInfo);

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
@@ -74,7 +74,7 @@ public class ServerSentEventProxyHandler implements RoutedServicesUser {
     private WebClient webClient;
 
     @PostConstruct
-    void initWeClient() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
+    void initWebClient() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
         webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(
             HttpClient.create().secure(SslProvider.builder().sslContext(getSslContext()).build())
         )).build();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
@@ -10,11 +10,16 @@
 
 package org.zowe.apiml.gateway.sse;
 
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
@@ -28,10 +33,17 @@ import org.zowe.apiml.product.routing.RoutedServices;
 import org.zowe.apiml.product.routing.RoutedServicesUser;
 import org.zowe.apiml.util.UrlUtils;
 import reactor.core.publisher.Flux;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.SslProvider;
 
+import javax.annotation.PostConstruct;
+import javax.net.ssl.TrustManagerFactory;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,18 +51,43 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import static org.zowe.apiml.security.SecurityUtils.loadKeyStore;
+
 @Slf4j
 @Controller
+@RequiredArgsConstructor
 @Component("ServerSentEventProxyHandler")
 public class ServerSentEventProxyHandler implements RoutedServicesUser {
+
+    @Value("${server.ssl.trustStore:#{null}}")
+    private String trustStore;
+
+    @Value("${server.ssl.trustStorePassword:#{null}}")
+    private char[] trustStorePassword;
+
+    @Value("${server.ssl.trustStoreType:PKCS12}")
+    private String trustStoreType;
+
     private final DiscoveryClient discovery;
     private final MessageService messageService;
     private final Map<String, RoutedServices> routedServicesMap = new ConcurrentHashMap<>();
+    private WebClient webClient;
 
-    @Autowired
-    public ServerSentEventProxyHandler(DiscoveryClient discovery, MessageService messageService) {
-        this.discovery = discovery;
-        this.messageService = messageService;
+    @PostConstruct
+    void initWeClient() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
+        webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(
+            HttpClient.create().secure(SslProvider.builder().sslContext(getSslContext()).build())
+        )).build();
+    }
+
+    private SslContext getSslContext() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forClient().clientAuth(ClientAuth.NONE);
+        if (trustStore != null) {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(loadKeyStore(trustStoreType, trustStore, trustStorePassword));
+            sslContextBuilder.trustManager(tmf);
+        }
+        return sslContextBuilder.build();
     }
 
     @GetMapping({"/sse/**","/*/sse/**"})
@@ -106,11 +143,12 @@ public class ServerSentEventProxyHandler implements RoutedServicesUser {
 
     // package protected for unit testing
     Flux<ServerSentEvent<String>> getSseStream(String sseStreamUrl) {
-        WebClient client = WebClient.create(sseStreamUrl);
         ParameterizedTypeReference<ServerSentEvent<String>> type
             = new ParameterizedTypeReference<ServerSentEvent<String>>() {
         };
-        return client.get()
+        return webClient
+            .get()
+            .uri(sseStreamUrl)
             .retrieve()
             .bodyToFlux(type);
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithBasePath.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/acceptance/common/AcceptanceTestWithBasePath.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.acceptance.common;
 
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.zowe.apiml.acceptance.requests.SecurityRequests;
@@ -26,5 +27,6 @@ public class AcceptanceTestWithBasePath {
     public void setBasePath() {
         basePath = String.format("https://localhost:%d", port);
         securityRequests = new SecurityRequests(basePath);
+        RestAssured.useRelaxedHTTPSValidation();
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientBeanTest.java
@@ -10,12 +10,7 @@
 
 package org.zowe.apiml.gateway.config;
 
-import com.netflix.appinfo.ApplicationInfoManager;
-import com.netflix.appinfo.DataCenterInfo;
-import com.netflix.appinfo.EurekaInstanceConfig;
-import com.netflix.appinfo.InstanceInfo;
-import com.netflix.appinfo.LeaseInfo;
-import com.netflix.appinfo.MyDataCenterInfo;
+import com.netflix.appinfo.*;
 import com.netflix.discovery.shared.transport.jersey.EurekaJerseyClientImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,12 +24,11 @@ import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,7 +40,7 @@ class DiscoveryClientBeanTest {
     @BeforeEach
     void setup() {
         ApplicationContext context = mock(ApplicationContext.class);
-        EurekaJerseyClientImpl.EurekaJerseyClientBuilder builder = mock(EurekaJerseyClientImpl.EurekaJerseyClientBuilder.class);
+        Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder> builder = () -> mock(EurekaJerseyClientImpl.EurekaJerseyClientBuilder.class);
         dcConfig = new DiscoveryClientConfig(null, apimlDiscoveryClientFactory, context, builder);
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/DiscoveryClientConfigTest.java
@@ -24,19 +24,19 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.config.AdditionalRegistration;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClient;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 
 import java.util.ArrayList;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,6 +74,7 @@ class DiscoveryClientConfigTest {
             lenient().when(appManager.getInfo()).thenReturn(instanceInfo);
             lenient().when(apimlDiscoveryClientFactory.buildApimlDiscoveryClient(any(), any(), any(), any())).thenReturn(discoveryClientClient);
             lenient().when(apimlDiscoveryClientFactory.createInstanceInfo(any())).thenReturn(instanceInfo);
+            ReflectionTestUtils.setField(discoveryClientConfig, "eurekaJerseyClientBuilder", (Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder>) () -> eurekaJerseyClientBuilder);
         }
 
         @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
@@ -34,6 +34,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -63,12 +66,13 @@ class ServerSentEventProxyHandlerTest {
     private final MessageService messageService = new YamlMessageService("/gateway-messages.yml");
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
         mockHttpServletRequest = mock(HttpServletRequest.class);
         mockHttpServletResponse = mock(HttpServletResponse.class);
 
         mockDiscoveryClient = mock(DiscoveryClient.class);
         underTest = Mockito.spy(new ServerSentEventProxyHandler(mockDiscoveryClient, messageService));
+        underTest.initWebClient();
     }
 
     @Nested

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -501,6 +501,7 @@ task runHATests(type: Test) {
     outputs.cacheIf { false }
 
     systemProperty "environment.ha", true
+    systemProperty "cloudGateway.enabled", false
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(
@@ -534,6 +535,7 @@ task runChaoticHATests(type: Test) {
     outputs.cacheIf { false }
 
     systemProperty "environment.ha", true
+    systemProperty "cloudGateway.enabled", false
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -496,6 +496,7 @@ task runBaseTestsInternalPort(type: Test) {
 task runHATests(type: Test) {
     group "Integration tests"
     description "Run tests verifying High Availability"
+    dependsOn startUpCheck
 
     outputs.cacheIf { false }
 
@@ -528,6 +529,7 @@ task runLbHaTests(type: Test) {
 task runChaoticHATests(type: Test) {
     group "Integration tests"
     description "Run Chaotic tests verifying High Availability"
+    dependsOn startUpCheck
 
     outputs.cacheIf { false }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -501,7 +501,6 @@ task runHATests(type: Test) {
     outputs.cacheIf { false }
 
     systemProperty "environment.ha", true
-    systemProperty "cloudGateway.enabled", false
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(
@@ -535,7 +534,6 @@ task runChaoticHATests(type: Test) {
     outputs.cacheIf { false }
 
     systemProperty "environment.ha", true
-    systemProperty "cloudGateway.enabled", false
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/external/MetricServiceTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/external/MetricServiceTest.java
@@ -39,7 +39,7 @@ class MetricServiceTest {
     }
 
     @Test
-    void allClustersAraAvailable() {
+    void allClustersAreAvailable() {
         String jwt = gatewayToken();
         given().header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
             .get(METRICS_PATH)

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/ha/ApiCatalogMultipleInstancesTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/ha/ApiCatalogMultipleInstancesTest.java
@@ -33,7 +33,7 @@ public class ApiCatalogMultipleInstancesTest {
     private final HADiscoveryRequests haDiscoveryRequests = new HADiscoveryRequests();
     @BeforeEach
     void setUp() {
-        RestAssured.config = RestAssured.config().sslConfig(getConfiguredSslConfig());
+        RestAssured.config = RestAssured.config().sslConfig(getConfiguredSslConfig().relaxedHTTPSValidation());
     }
 
     @Nested

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -84,6 +84,8 @@ public class ApiMediationLayerStartupChecker {
                 return false;
             }
 
+            boolean cloudGatewayEnabled = Boolean.parseBoolean(System.getProperty("cloudGateway.enabled", "true"));
+
             boolean areAllServicesUp = true;
             for (Service toCheck : servicesToCheck) {
                 boolean isUp = isServiceUp(context, toCheck.path);
@@ -97,7 +99,9 @@ public class ApiMediationLayerStartupChecker {
             boolean isTestApplicationUp = allComponents.contains("discoverableclient");
             boolean isCloudGatewayUp = allComponents.contains("cloud-gateway");
             log.debug("Discoverable Client is {}", isTestApplicationUp);
-            log.debug("Cloud gateway is {}", isCloudGatewayUp);
+            if (cloudGatewayEnabled) {
+                log.debug("Cloud gateway is {}", isCloudGatewayUp);
+            }
 
             Integer amountOfActiveGateways = context.read("$.components.gateway.details.gatewayCount");
             boolean isValidAmountOfGatewaysUp = amountOfActiveGateways != null &&
@@ -116,8 +120,7 @@ public class ApiMediationLayerStartupChecker {
                 }
             }
 
-            return areAllServicesUp &&
-                isTestApplicationUp && isCloudGatewayUp;
+            return areAllServicesUp && isTestApplicationUp && (isCloudGatewayUp || !cloudGatewayEnabled);
         } catch (PathNotFoundException | IOException e) {
             log.warn("Check failed on retrieving the information from document: {}", e.getMessage());
             return false;

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -109,9 +109,10 @@ public class ApiMediationLayerStartupChecker {
             // Consider properly the case with multiple gateway services running on different ports.
             if (gatewayConfiguration.getInternalPorts() != null && !gatewayConfiguration.getInternalPorts().isEmpty()) {
                 String[] internalPorts = gatewayConfiguration.getInternalPorts().split(",");
-                for (String port : internalPorts) {
-                    log.debug("Trying to access the Gateway at port {}", port);
-                    HttpRequestUtils.getResponse(healthEndpoint, HttpStatus.SC_OK, Integer.parseInt(port), gatewayConfiguration.getHost());
+                String[] hosts = gatewayConfiguration.getHost().split(",");
+                for (int i = 0; i < Math.min(internalPorts.length, hosts.length); i++) {
+                    log.debug("Trying to access the Gateway at port {}", internalPorts[i]);
+                    HttpRequestUtils.getResponse(healthEndpoint, HttpStatus.SC_OK, Integer.parseInt(internalPorts[i]), hosts[i]);
                 }
             }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/util/requests/Requests.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/requests/Requests.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.util.requests;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -24,11 +25,13 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.Is.is;
 import static org.zowe.apiml.util.SecurityUtils.COOKIE_NAME;
+import static org.zowe.apiml.util.SecurityUtils.getConfiguredSslConfig;
 
 @Slf4j
 public class Requests {
     public ReadContext getJson(URI uri) {
         String apps = given()
+            .config(RestAssuredConfig.config().sslConfig(getConfiguredSslConfig()))
             .accept(ContentType.JSON)
         .when()
             .get(uri)

--- a/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SslConfig.java
+++ b/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SslConfig.java
@@ -1,0 +1,58 @@
+package org.zowe.apiml.metrics.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.zowe.apiml.security.SecurityUtils;
+
+import javax.annotation.PostConstruct;
+
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+
+@Configuration
+public class SslConfig {
+
+    private static final char[] KEYRING_PASSWORD = "password".toCharArray();
+
+    @Value("${server.ssl.trustStoreType:#{null}}")
+    protected String trustStoreType;
+
+    @Value("${server.ssl.trustStore:#{null}}")
+    protected String trustStore;
+
+    @Value("${server.ssl.trustStorePassword:#{null}}")
+    protected char[] trustStorePassword;
+
+    @Value("${server.ssl.keyStoreType:#{null}}")
+    protected String keyStoreType;
+
+    @Value("${server.ssl.keyStore:#{null}}")
+    protected String keyStore;
+
+    @Value("${server.ssl.keyStorePassword:#{null}}")
+    protected char[] keyStorePassword;
+
+    private void setSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    private void initStore(String javaxPrefix, String name, String type, char[] password) {
+        char[] storePassword = password;
+        if (isEmpty(storePassword) && SecurityUtils.isKeyring(name)) {
+            storePassword = KEYRING_PASSWORD;
+        }
+        setSystemProperty(javaxPrefix + "Store", SecurityUtils.formatKeyringUrl(name));
+        setSystemProperty(javaxPrefix + "StorePassword", storePassword == null ? null : String.valueOf(storePassword));
+        setSystemProperty(javaxPrefix + "StoreType", type);
+    }
+
+    @PostConstruct
+    void init() {
+        initStore("javax.net.ssl.trust", trustStore, trustStoreType, trustStorePassword);
+        initStore("javax.net.ssl.key", keyStore, keyStoreType, keyStorePassword);
+    }
+
+}

--- a/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SslConfig.java
+++ b/metrics-service/src/main/java/org/zowe/apiml/metrics/config/SslConfig.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml.metrics.config;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImplTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImplTest.java
@@ -41,6 +41,15 @@ class ApiMediationClientImplTest {
 
     private EurekaClientConfigProvider eurekaClientConfigProvider;
 
+    private static final String[] SSL_SYSTEM_ENVIRONMENT_VALUES = {
+        "javax.net.ssl.keyStore",
+        "javax.net.ssl.keyStorePassword",
+        "javax.net.ssl.keyStoreType",
+        "javax.net.ssl.trustStore",
+        "javax.net.ssl.trustStorePassword",
+        "javax.net.ssl.trustStoreType"
+    };
+
     ApiMediationServiceConfig getValidConfiguration() {
         ApiInfo apiInfo = new ApiInfo("org.zowe.enabler.java", "api/v1", "1.0.0", "https://localhost:10014/apicatalog/api-doc", null);
         Catalog catalogUiTile = new Catalog(new Catalog.Tile("cademoapps", "Sample API Mediation Layer Applications", "Applications which demonstrate how to make a service integrated to the API Mediation Layer ecosystem", "1.0.0"));
@@ -84,6 +93,11 @@ class ApiMediationClientImplTest {
         assertEquals(InstanceInfo.InstanceStatus.UP, client.getEurekaClient().getApplicationInfoManager().getInfo().getStatus());
         assertTrue(client.getEurekaClient().getApplicationInfoManager().getInfo().getMetadata().containsKey("apiml.authentication.scheme"));
         assertFalse(client.getEurekaClient().getApplicationInfoManager().getInfo().getMetadata().containsKey("apiml.authentication.applid"));
+
+        for (String env : SSL_SYSTEM_ENVIRONMENT_VALUES) {
+            assertNull(System.getProperty(env));
+        }
+
         // ...
         client.unregister();
     }

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.zaasclient.service.internal;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,12 +47,28 @@ class ZaasClientTest {
     private static final String VALID_APPLICATION_ID = "APPLID";
     private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
+    private static final String[] SSL_SYSTEM_ENVIRONMENT_VALUES = {
+        "javax.net.ssl.keyStore",
+        "javax.net.ssl.keyStorePassword",
+        "javax.net.ssl.keyStoreType",
+        "javax.net.ssl.trustStore",
+        "javax.net.ssl.trustStorePassword",
+        "javax.net.ssl.trustStoreType"
+    };
+
     @BeforeEach
     void setUp() {
         tokens = mock(TokenService.class);
         passTickets = mock(PassTicketService.class);
 
         underTest = new ZaasClientImpl(tokens, passTickets);
+    }
+
+    @AfterEach
+    void assertSystemEnvironmentValues() {
+        for (String env : SSL_SYSTEM_ENVIRONMENT_VALUES) {
+            assertNull(System.getProperty(env));
+        }
     }
 
     private void assertThatExceptionContainValidCode(ZaasClientException zce, ZaasClientErrorCodes code) {


### PR DESCRIPTION
# Description

This PR removes setting keystore and trust store via the system environment. It is not the best practice because all applications inside one JVM are influenced.

Another application could use Zaas client and Enabler. They could be deployed on an application server (standalone Tomcat). It could lead to the usage of these features could damage another service.

Only metrics-service uses this approach because the turbine implementation does not allow configuring trust stores differently. But metrics-service is not deployable on any server, so there is a low risk.

Equivalent implementation in v3: #3742

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
