### PR TITLE
fix: Renovate adding HostRule

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -3,6 +3,12 @@ module.exports = {
     repositories: ['zowe/api-layer'],
     baseBranches: ["v2.x.x","v3.x.x"],
     dependencyDashboard: true,
+    hostRules: [
+      {
+      hostType: 'npm',
+      matchHost: 'https://zowe.jfrog.io/artifactory/api/npm/',
+      }
+    ],
     packageRules: [
         {
             //for v2.x.x branch ignore grouping from extends preset, find all packages which are patches,


### PR DESCRIPTION
Adding Host rules for host type npm to reach correct adress

# Description

To the .js file of renovate I added HostRules for npm to reach correct address.

# Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
