### PR TITLE
fix: use zowe provided java location if available

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -193,9 +193,13 @@ fi
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 #    -Dapiml.service.preferIpAddress=false \
 
+if [ -n "${ZWE_java_home}" ]; then
+    JAVA_BIN_DIR=${ZWE_java_home}/bin/
+fi
+
 CATALOG_CODE=AC
 _BPXK_AUTOCVT=OFF
-_BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
+_BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} ${JAVA_BIN_DIR}java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -174,9 +174,13 @@ if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true
   keystore_location=
 fi
 
+if [ -n "${ZWE_java_home}" ]; then
+    JAVA_BIN_DIR=${ZWE_java_home}/bin/
+fi
+
 CACHING_CODE=CS
 _BPXK_AUTOCVT=OFF
-_BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java \
+_BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} ${JAVA_BIN_DIR}java \
   -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
   -XX:+ExitOnOutOfMemoryError \
   ${QUICK_START} \

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -182,9 +182,13 @@ if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true
   keystore_location=
 fi
 
+if [ -n "${ZWE_java_home}" ]; then
+    JAVA_BIN_DIR=${ZWE_java_home}/bin/
+fi
+
 DISCOVERY_CODE=AD
 _BPXK_AUTOCVT=OFF
-_BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java \
+_BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} ${JAVA_BIN_DIR}java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -169,9 +169,13 @@ if [ "${ATTLS_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" = "true
   keystore_location=
 fi
 
+if [ -n "${ZWE_java_home}" ]; then
+    JAVA_BIN_DIR=${ZWE_java_home}/bin/
+fi
+
 GATEWAY_CODE=AG
 _BPXK_AUTOCVT=OFF
-_BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
+_BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} ${JAVA_BIN_DIR}java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -229,8 +229,12 @@ fi
 #    -Dapiml.service.ipAddress=${ZOWE_IP_ADDRESS:-127.0.0.1} \
 #    -Dapiml.security.auth.jwtKeyAlias=${PKCS11_TOKEN_LABEL:-jwtsecret} \
 
+if [ -n "${ZWE_java_home}" ]; then
+    JAVA_BIN_DIR=${ZWE_java_home}/bin/
+fi
+
 ZAAS_CODE=AZ
-_BPX_JOBNAME=${ZWE_zowe_job_prefix}${ZAAS_CODE} java \
+_BPX_JOBNAME=${ZWE_zowe_job_prefix}${ZAAS_CODE} ${JAVA_BIN_DIR}java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
     ${ADD_OPENS} \


### PR DESCRIPTION
# Description

This PR updates the start.sh scripts for API ML components to use the Java binary from the location provided via zowe.yaml file if it is available. Otherwise it should use the first java available according to `PATH

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
