### PR TITLE
fix: update default javax.net.ssl log levels

### DIFF
--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -41,6 +41,7 @@ logging:
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR
 
 ##############################################################################################
 # APIML configuration section
@@ -208,6 +209,7 @@ logging:
         com.netflix: INFO
         org.ehcache: INFO
         com.netflix.discovery.shared.transport.decorator: DEBUG
+        javax.net.ssl: INFO
 
 ---
 spring.config.activate.on-profile: diag

--- a/caching-service/src/main/resources/application.yml
+++ b/caching-service/src/main/resources/application.yml
@@ -38,6 +38,7 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
         org.springframework.security.config.annotation.web.builders.WebSecurity: ERROR
+        javax.net.ssl: ERROR
 
 eureka:
     client:
@@ -170,6 +171,7 @@ logging:
         org.ehcache: INFO
         com.netflix.discovery.shared.transport.decorator: DEBUG
         org.springframework.security.web: INFO
+        javax.net.ssl: INFO
 
 spring.config.activate.on-profile: dev
 

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -13,6 +13,7 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
         org.springframework.web.socket.adapter: DEBUG
+        javax.net.ssl: ERROR
 
 spring:
     cloud:
@@ -205,6 +206,7 @@ logging:
         org.springframework: INFO
         org.apache.catalina: INFO
         com.netflix: INFO
+        javax.net.ssl: INFO
 
 logbackServiceName: ZWEADC1
 

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -17,6 +17,7 @@ logging:
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR
     #    com.netflix.eureka.resources: WARN
 
 apiml:
@@ -164,6 +165,7 @@ logging:
         com.sun.jersey.server.impl.application.WebApplicationImpl: INFO
         org.ehcache: INFO
         com.netflix.discovery.shared.transport.decorator: DEBUG
+        javax.net.ssl: INFO
 
 ---
 spring.config.activate.on-profile: diag

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -130,6 +130,7 @@ logging:
         org.springframework.context.support: WARN
         reactor.netty.http.client: INFO
         reactor.netty.http.client.HttpClientConnect: OFF
+        javax.net.ssl: ERROR
 
 management:
     endpoint:
@@ -159,6 +160,7 @@ logging:
         reactor.netty.http.client.HttpClientConnect: DEBUG
         com.netflix: DEBUG
         org.apache.tomcat.util.net: DEBUG
+        javax.net.ssl: INFO
 
 ---
 spring.config.activate.on-profile: attls

--- a/zaas-service/src/main/resources/application.yml
+++ b/zaas-service/src/main/resources/application.yml
@@ -20,6 +20,7 @@ logging:
         # New Config
         org.apache: WARN  #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         javax.servlet: INFO
+        javax.net.ssl: ERROR
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
         org.eclipse.jetty.util.ssl: ERROR
         org.apache.tomcat.util.net.SSLUtilBase: ERROR
@@ -220,6 +221,7 @@ logging:
         org.ehcache: DEBUG
         org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter: INFO
         com.netflix.discovery.shared.transport.decorator: DEBUG
+        javax.net.ssl: INFO
 
 ---
 spring.config.activate.on-profile: diag


### PR DESCRIPTION
# Description

This PR updates the default log level of `javax.net.ssl` messages to avoid flooding the logs with messages related to specifics of the TLS configuration. 
From Java 11, messages from `javax.net.ssl` are coming to the console from INFO level and up.

Default log level is `ERROR`, in debug mode all INFO and up messages will be shown.

Zowe configuration supports enabling javax.net.ssl debug messages from zowe.yaml.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
