### PR TITLE
chore: GH action to check PR title (V2)

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -27,4 +27,4 @@ jobs:
                     done
                     echo "PR title doesn't start with any of allowed prefixes"
                     gh pr edit $PR --add-label 'invalid'
-                    gh pr comment $PR --body 'It looks like PR tile does not contain one of the required prefixes: `fix:`, `feat:`, `docs:`, `refactor:`, `chore:`. Please add one of the prefixes based on the type of your changes by following our [contributing guidelines](https://github.com/zowe/api-layer/blob/v3.x.x/CONTRIBUTING.md#type)'
+                    gh pr comment $PR --body 'It looks like PR title does not contain one of the required prefixes: `fix:`, `feat:`, `docs:`, `refactor:`, `chore:`. Please add one of the prefixes based on the type of your changes by following our [contributing guidelines](https://github.com/zowe/api-layer/blob/v3.x.x/CONTRIBUTING.md#type)'

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,0 +1,30 @@
+name: PR Checker
+
+on:
+    pull_request_target:
+        branches: [ v2.x.x, v3.x.x ]
+        types: [opened, reopened, edited]
+
+jobs:
+    PRInstructions:
+        name: PR Instructions
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.user.login != 'zowe-robot'
+
+        steps:
+            -   name: Check PR title
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    TITLE: ${{ github.event.pull_request.title }}
+                    PR: ${{ github.event.pull_request.html_url }}
+                run: |
+                    for prefix in 'fix:' 'feat:' 'docs:' 'refactor:' 'chore:'; do
+                        case $TITLE in
+                            "$prefix"*)
+                                echo "PR title starts with '$prefix'"
+                                exit 0
+                        esac
+                    done
+                    echo "PR title doesn't start with any of allowed prefixes"
+                    gh pr edit $PR --add-label 'invalid'
+                    gh pr comment $PR --body 'It looks like PR tile does not contain one of the required prefixes: `fix:`, `feat:`, `docs:`, `refactor:`, `chore:`. Please add one of the prefixes based on the type of your changes by following our [contributing guidelines](https://github.com/zowe/api-layer/blob/v3.x.x/CONTRIBUTING.md#type)'


### PR DESCRIPTION
# Description

GH action to check PR title. It won't be trigered until it's in target branch. I tested on fork.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
