### PR TITLE
chore: Remove build_arg overwriting image versions in workflow

### DIFF
--- a/.github/workflows/build-conformant-images.yml
+++ b/.github/workflows/build-conformant-images.yml
@@ -47,11 +47,6 @@ jobs:
             matrix:
                 service: [ gateway-service, discovery-service, api-catalog-services, caching-service, metrics-service, cloud-gateway-service ]
                 os: [ ubuntu, ubi ]
-                include:
-                    -   os: ubuntu
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubuntu
-                    -   os: ubi
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubi
         runs-on: ubuntu-latest
         if: ${{ inputs.service == 'all' }}
         steps:
@@ -93,11 +88,6 @@ jobs:
             matrix:
                 service: [ gateway-service, discovery-service, api-catalog-services, caching-service, metrics-service, cloud-gateway-service ]
                 os: [ ubuntu, ubi ]
-                include:
-                    -   os: ubuntu
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubuntu
-                    -   os: ubi
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubi
         runs-on: ubuntu-latest
         if: ${{ inputs.service == 'all' }}
         steps:
@@ -185,11 +175,6 @@ jobs:
             matrix:
                 arch: [ amd64, s390x ]
                 os: [ ubuntu, ubi ]
-                include:
-                    -   os: ubuntu
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubuntu
-                    -   os: ubi
-                        BUILD_ARG_LIST: ZOWE_BASE_IMAGE=latest-ubi
         runs-on: ubuntu-latest
         if: ${{ inputs.service != 'all' }}
         steps:


### PR DESCRIPTION
# Description

In the prior container updates https://github.com/zowe/api-layer/pull/3719, I missed an update to the build-image workflow, where the image version is hardcoded in. We could either update or remove this image version, I opted to remove it since it appears redundant with the default image version on the containerfile.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
