### PR TITLE
chore: remove cli-plugin status badge

### DIFF
--- a/WORKFLOWS_STATUS_OVERVIEW.MD
+++ b/WORKFLOWS_STATUS_OVERVIEW.MD
@@ -19,7 +19,6 @@
 [![Verify that all services can register](https://github.com/zowe/api-layer/actions/workflows/service-registration.yml/badge.svg?branch=v3.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/service-registration.yml)
 [![Binary snapshot release](https://github.com/zowe/api-layer/actions/workflows/binary-snapshot-release.yml/badge.svg?branch=v3.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/binary-snapshot-release.yml)
 [![Image snapshot release](https://github.com/zowe/api-layer/actions/workflows/image-snapshot-release.yml/badge.svg?branch=v3.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/image-snapshot-release.yml)
-[![zowe-cli-plugin-deployment](https://github.com/zowe/api-layer/actions/workflows/zowe-cli-plugin.yml/badge.svg?branch=v3.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/zowe-cli-plugin.yml)
 
 ## v2.x.x
 
@@ -38,5 +37,4 @@
 [![Verify that all services can register](https://github.com/zowe/api-layer/actions/workflows/service-registration.yml/badge.svg?branch=v2.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/service-registration.yml)
 [![Binary snapshot release](https://github.com/zowe/api-layer/actions/workflows/binary-snapshot-release.yml/badge.svg?branch=v2.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/binary-snapshot-release.yml)
 [![Image snapshot release](https://github.com/zowe/api-layer/actions/workflows/image-snapshot-release.yml/badge.svg?branch=v2.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/image-snapshot-release.yml)
-[![zowe-cli-plugin-deployment](https://github.com/zowe/api-layer/actions/workflows/zowe-cli-plugin.yml/badge.svg?branch=v2.x.x&event=push)](https://github.com/zowe/api-layer/actions/workflows/zowe-cli-plugin.yml)
 


### PR DESCRIPTION
# Description

Remove cli-plugin status badge from the workflows status docs after the workflow was configured for manual trigger only

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
