### PR TITLE
fix: throw insecureHttpWarning message only when attls is not enabled

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -45,6 +45,8 @@ public class HttpConfig {
 
     private static final char[] KEYRING_PASSWORD = "password".toCharArray();
 
+    @Value("${server.attls.enabled:false}")
+    private boolean attlsEnabled;
     @Value("${server.ssl.protocol:TLSv1.2}")
     private String protocol;
     @Value("${apiml.httpclient.ssl.enabled-protocols:TLSv1.2,TLSv1.3}")
@@ -285,7 +287,7 @@ public class HttpConfig {
 
     @Bean
     public Supplier<EurekaJerseyClientBuilder> eurekaJerseyClientBuilder() {
-        return () -> factory.createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId);
+        return () -> factory.createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId, attlsEnabled);
     }
 
 }

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -123,6 +123,9 @@ public class ConnectionsConfig {
     @Value("${spring.application.name}")
     private String serviceId;
 
+    @Value("${server.attls.enabled:false}")
+    private boolean attlsEnabled;
+
     @Value("${server.ssl.trustStoreRequired:false}")
     private boolean trustStoreRequired;
 
@@ -234,7 +237,7 @@ public class ConnectionsConfig {
 
     @Bean("primaryApimlEurekaJerseyClient")
     EurekaJerseyClient getEurekaJerseyClient() {
-        return factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId).build();
+        return factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId, attlsEnabled).build();
     }
 
     @Bean(destroyMethod = "shutdown")
@@ -292,7 +295,7 @@ public class ConnectionsConfig {
         BeanUtils.copyProperties(config, configBean);
         configBean.setServiceUrl(urls);
 
-        EurekaJerseyClient jerseyClient = factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId).build();
+        EurekaJerseyClient jerseyClient = factory().createEurekaJerseyClientBuilder(eurekaServerUrl, serviceId, attlsEnabled).build();
         MutableDiscoveryClientOptionalArgs args = new MutableDiscoveryClientOptionalArgs();
         args.setEurekaJerseyClient(jerseyClient);
 

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/AdditionalRegistrationTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/config/AdditionalRegistrationTest.java
@@ -37,6 +37,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -83,7 +84,7 @@ public class AdditionalRegistrationTest {
         public void setUp() {
             configSpy = Mockito.spy(connectionsConfig);
             lenient().doReturn(httpsFactory).when(configSpy).factory();
-            lenient().when(httpsFactory.createEurekaJerseyClientBuilder(any(), any())).thenReturn(mock(EurekaJerseyClientImpl.EurekaJerseyClientBuilder.class));
+            lenient().when(httpsFactory.createEurekaJerseyClientBuilder(any(), any(), anyBoolean())).thenReturn(mock(EurekaJerseyClientImpl.EurekaJerseyClientBuilder.class));
 
             lenient().when(eurekaFactory.createCloudEurekaClient(any(), any(), clientConfigCaptor.capture(), any(), any())).thenReturn(additionalClientOne, additionalClientTwo);
         }

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -237,7 +237,7 @@ public class HttpsFactory {
         }
     }
 
-    public EurekaJerseyClientBuilder createEurekaJerseyClientBuilder(String eurekaServerUrl, String serviceId, boolean isAttlsEnabled) {
+    public EurekaJerseyClientBuilder createEurekaJerseyClientBuilder(String eurekaServerUrl, String serviceId, boolean attlsEnabled) {
         EurekaJerseyClientBuilder builder = new EurekaJerseyClientBuilder();
         builder.withClientName(serviceId);
         builder.withMaxTotalConnections(10);
@@ -248,7 +248,7 @@ public class HttpsFactory {
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {
-                if (!isAttlsEnabled) {
+                if (!attlsEnabled) {
                     apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
             }
         } else {

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -247,31 +247,12 @@ public class HttpsFactory {
         builder.withReadTimeout(5000);
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
-        if (eurekaServerUrl.startsWith("http://") && !isAttlsEnabled) {
-            apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
-        } else {
-            builder.withCustomSSL(getSslContext());
-
-            builder.withHostnameVerifier(getHostnameVerifier());
-        }
-        return builder;
-    }
-
-    public EurekaJerseyClientBuilder createEurekaJerseyClientBuilder(String eurekaServerUrl, String serviceId) {
-        EurekaJerseyClientBuilder builder = new EurekaJerseyClientBuilder();
-        builder.withClientName(serviceId);
-        builder.withMaxTotalConnections(10);
-        builder.withMaxConnectionsPerHost(10);
-        builder.withConnectionIdleTimeout(10);
-        builder.withConnectionTimeout(5000);
-        builder.withReadTimeout(5000);
-        // See:
-        // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {
-            apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
+                if (!isAttlsEnabled) {
+                    apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
+            }
         } else {
             builder.withCustomSSL(getSslContext());
-
             builder.withHostnameVerifier(getHostnameVerifier());
         }
         return builder;

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -248,8 +248,8 @@ public class HttpsFactory {
         // See:
         // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
         if (eurekaServerUrl.startsWith("http://")) {
-                if (!attlsEnabled) {
-                    apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
+            if (!attlsEnabled) {
+                apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
             }
         } else {
             builder.withCustomSSL(getSslContext());

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -237,6 +237,26 @@ public class HttpsFactory {
         }
     }
 
+    public EurekaJerseyClientBuilder createEurekaJerseyClientBuilder(String eurekaServerUrl, String serviceId, boolean isAttlsEnabled) {
+        EurekaJerseyClientBuilder builder = new EurekaJerseyClientBuilder();
+        builder.withClientName(serviceId);
+        builder.withMaxTotalConnections(10);
+        builder.withMaxConnectionsPerHost(10);
+        builder.withConnectionIdleTimeout(10);
+        builder.withConnectionTimeout(5000);
+        builder.withReadTimeout(5000);
+        // See:
+        // https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyReplicationClient.java#L160
+        if (eurekaServerUrl.startsWith("http://") && !isAttlsEnabled) {
+            apimlLog.log("org.zowe.apiml.common.insecureHttpWarning");
+        } else {
+            builder.withCustomSSL(getSslContext());
+
+            builder.withHostnameVerifier(getHostnameVerifier());
+        }
+        return builder;
+    }
+
     public EurekaJerseyClientBuilder createEurekaJerseyClientBuilder(String eurekaServerUrl, String serviceId) {
         EurekaJerseyClientBuilder builder = new EurekaJerseyClientBuilder();
         builder.withClientName(serviceId);

--- a/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 class HttpsFactoryTest {
     private static final String EUREKA_URL_NO_SCHEME = "://localhost:10011/eureka/";
     private static final String TEST_SERVICE_ID = "service1";
+    private static final boolean ATTLS = false;
     private static final String INCORRECT_PARAMETER_VALUE = "WRONG";
 
     private HttpsConfig.HttpsConfigBuilder httpsConfigBuilder;
@@ -136,7 +137,7 @@ class HttpsFactoryTest {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
         HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
         EurekaJerseyClientImpl.EurekaJerseyClientBuilder clientBuilder =
-            httpsFactory.createEurekaJerseyClientBuilder("https" + EUREKA_URL_NO_SCHEME, TEST_SERVICE_ID);
+            httpsFactory.createEurekaJerseyClientBuilder("https" + EUREKA_URL_NO_SCHEME, TEST_SERVICE_ID, ATTLS);
         assertNotNull(clientBuilder);
     }
 
@@ -145,7 +146,7 @@ class HttpsFactoryTest {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
         HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
         EurekaJerseyClientImpl.EurekaJerseyClientBuilder clientBuilder =
-            httpsFactory.createEurekaJerseyClientBuilder("http" + EUREKA_URL_NO_SCHEME, TEST_SERVICE_ID);
+            httpsFactory.createEurekaJerseyClientBuilder("http" + EUREKA_URL_NO_SCHEME, TEST_SERVICE_ID, ATTLS);
         assertNotNull(clientBuilder);
     }
 }

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
@@ -67,6 +67,10 @@ public class ApiMediationServiceConfig {
      *    XML Path: /instance/app
      */
     private String serviceId;
+    /**
+     * to verify if Attls is enabled for the service
+     */
+    private boolean attlsEnabled;
 
     /**
      * * **title** (XML Path: /instance/metadata/apiml.service.title)

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
@@ -156,7 +156,7 @@ public class ApiMediationClientImpl implements ApiMediationClient {
         HttpsFactory factory = new HttpsFactory(httpsConfig);
 
         EurekaJerseyClient eurekaJerseyClient = factory.createEurekaJerseyClientBuilder(
-            config.getDiscoveryServiceUrls().get(0), config.getServiceId()).build();
+            config.getDiscoveryServiceUrls().get(0), config.getServiceId(), config.isAttlsEnabled()).build();
 
         AbstractDiscoveryClientOptionalArgs<?> args = new DiscoveryClient.DiscoveryClientOptionalArgs();
         args.setEurekaJerseyClient(eurekaJerseyClient);


### PR DESCRIPTION
# Description

This is to fix the insecureHttpWarning error message to be thrown only when its http and attls disabled  

Linked to  #2378 

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
