### PR TITLE
chore: Upgrade library javax.servlet-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,12 @@ allprojects {
         }
     }
 
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module('javax.servlet:servlet-api')).using(module('javax.servlet:javax.servlet-api:4.0.1'))
+        }
+    }
+
 }
 
 configure(subprojects.findAll { it.name in [


### PR DESCRIPTION
# Description

This PR replaces the old legacy library `javax.servlet:servlet-api:2.5` with the newer one `javax.servlet:javax.servlet-api:4.0.1`. It is not possible to replace it with Jakarta one (conflict with a different package name).

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
