### PR TITLE
chore: Remove WebJar dependency

### DIFF
--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -92,7 +92,6 @@ dependencies {
     implementation libs.tomcat.embed.core
     implementation libs.jackson.core
     implementation libs.jackson.databind
-    implementation libs.bootstrap
     implementation libs.jquery
 
     implementation libs.gson

--- a/discoverable-client/src/main/resources/static/index.html
+++ b/discoverable-client/src/main/resources/static/index.html
@@ -7,7 +7,7 @@
     <title>Discoverable Client Hello World!</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" type="text/css" href="webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
 
     <!-- Custom styles for this template -->
     <link href="css/hello.css" rel="stylesheet">
@@ -82,8 +82,8 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script type="text/javascript" src="webjars/jquery/3.6.0/jquery.min.js"></script>
-<script type="text/javascript" src="webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/hello.js"></script>
 </body>
 </html>

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -28,7 +28,6 @@ dependencyResolutionManagement {
             version('awaitility', '4.2.2')
             version('awsJavaSdk', '1.12.770')
             version('bouncyCastle', '1.78.1')
-            version('bootstrap', '4.3.1')
             // forced version in root gradle.build file. Version 3.x requieres Java 11
             version('caffeine', '2.9.3')
             version('commonsCodec', '1.17.1')
@@ -239,7 +238,6 @@ dependencyResolutionManagement {
             library('awaitility', 'org.awaitility', 'awaitility').versionRef('awaitility')
             library('bcprov', 'org.bouncycastle', 'bcprov-jdk18on').versionRef('bouncyCastle')
             library('bcpkix', 'org.bouncycastle', 'bcpkix-jdk18on').versionRef('bouncyCastle')
-            library('bootstrap', 'org.webjars', 'bootstrap').versionRef('bootstrap')
             library('caffeine', 'com.github.ben-manes.caffeine', 'caffeine').versionRef('caffeine')
             library('commons_io', 'commons-io', 'commons-io').versionRef('commonsIo')
             library('eh_cache', 'org.ehcache', 'ehcache').versionRef('ehCache')

--- a/mock-services/build.gradle
+++ b/mock-services/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     implementation libs.spring.messaging
     implementation libs.spring.webmvc
 
-    implementation libs.bootstrap
     implementation libs.jquery
 
     implementation libs.gson


### PR DESCRIPTION
# Description

Discoverable Client and Mock Service has a dependency WebJar Bootstrap. The specific version contained a security vulnerability. The Mock didn't use it at all and the code in the Discoverable client was changed to use Bootstrap in a different way. It prevents our code from vulnerability and cleans up the dependencies.

It was not exploitable (it was used just for testing purposes.)

It was implemented in v3 as part of https://github.com/zowe/api-layer/pull/3467

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
