### PR TITLE
chore: Allow manual trigger for Error Messages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: "Flag the error message changes and label the PR"
 
 on:
+    workflow_dispatch:
     schedule:
         # * is a special character in YAML so you have to quote this string
         - cron:  '0 0 * * 5'


### PR DESCRIPTION
# Description

Allow manual trigger for Error Messages

## Type of change

- [x] chore: Chore, repository cleanup, updates the dependencies.
