### PR TITLE
feat: java sample to authenticate with client certificate

### DIFF
--- a/api-catalog-ui/frontend/package-lock.json
+++ b/api-catalog-ui/frontend/package-lock.json
@@ -115,6 +115,7 @@
                 "source-map-explorer": "2.5.3",
                 "start-server-and-test": "2.0.8",
                 "tmpl": "1.0.5",
+                "undici": "6.19.8",
                 "yaml": "2.6.0"
             },
             "engines": {
@@ -29531,10 +29532,11 @@
             "dev": true
         },
         "node_modules/undici": {
-            "version": "6.20.1",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/undici/-/undici-6.20.1.tgz",
-            "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+            "version": "6.19.8",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/undici/-/undici-6.19.8.tgz",
+            "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18.17"
             }

--- a/api-catalog-ui/frontend/package.json
+++ b/api-catalog-ui/frontend/package.json
@@ -135,7 +135,8 @@
         "source-map-explorer": "2.5.3",
         "start-server-and-test": "2.0.8",
         "tmpl": "1.0.5",
-        "yaml": "2.6.0"
+        "yaml": "2.6.0",
+        "undici": "6.19.8"
     },
     "overrides": {
         "nth-check": "2.1.1",

--- a/client-cert-auth-sample/build.gradle
+++ b/client-cert-auth-sample/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.zowe.apiml'
+version = '3.0.39-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation libs.http.client5
+    implementation libs.http
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/client-cert-auth-sample/build.gradle
+++ b/client-cert-auth-sample/build.gradle
@@ -11,9 +11,6 @@ repositories {
 
 dependencies {
     implementation libs.http.client5
-    implementation libs.http
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 test {

--- a/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
+++ b/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
@@ -1,0 +1,111 @@
+package org.zowe.apiml;
+
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+
+
+import javax.net.ssl.SSLContext;
+
+import java.awt.desktop.ScreenSleepEvent;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+
+public class Main {
+    //private static final String API_URL = "https://hostname:port/bcmdbmdsh/api/v1/gen/agents?flattenResults=false"; // Replace with your API URL
+    private static final String API_URL = "https://hostname:port/gateway/api/v1/auth/login"; // Replace with your API URL
+    private static final String CLIENT_CERT_PATH = "/path/to/keystore.p12"; // Replace with your client cert path
+    private static final String CLIENT_CERT_PASSWORD = "password"; // Replace with your cert password
+    private static final String CLIENT_CERT_ALIAS = "mycert"; // Replace with your signed client cert alias
+    private static final String PRIVATE_KEY_ALIAS = "server"; // Replace with your private key alias
+
+
+    public static void main(String[] args) {
+        try {
+            // Load the keystore containing the client certificate
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            try (FileInputStream keyStoreStream = new FileInputStream(new File(CLIENT_CERT_PATH))) {
+                keyStore.load(keyStoreStream, CLIENT_CERT_PASSWORD.toCharArray());
+            }
+
+            Key key = keyStore.getKey(PRIVATE_KEY_ALIAS, CLIENT_CERT_PASSWORD.toCharArray()); // Load private key from original keystore
+            Certificate cert = keyStore.getCertificate(CLIENT_CERT_ALIAS); // Load signed certificate from original keystore
+
+            // Create new keystore
+            KeyStore newKeyStore = KeyStore.getInstance("PKCS12");
+            newKeyStore.load(null);
+            newKeyStore.setKeyEntry(PRIVATE_KEY_ALIAS, key, CLIENT_CERT_PASSWORD.toCharArray(), new Certificate[]{ cert }); // Create an entry with private key + signed certificate
+
+            // Create SSL context with the client certificate
+//            SSLContext sslContext = SSLContexts.custom()
+//                .loadKeyMaterial(newKeyStore, CLIENT_CERT_PASSWORD.toCharArray())
+//                .build();
+            var sslContext = new SSLContextBuilder()
+                .loadKeyMaterial(newKeyStore, CLIENT_CERT_PASSWORD.toCharArray()).build();
+
+            // Create an HTTP client with the SSL context
+            HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+
+            var sslsf = new DefaultClientTlsStrategy(sslContext);
+//            var socketFactoryRegistry =
+//                RegistryBuilder.<DefaultClientTlsStrategy> create()
+//                    .register("https", sslsf)
+//                    .build();
+
+            var connectionManager = BasicHttpClientConnectionManager.create((s)->sslsf);
+            var clientBuilder1 = clientBuilder.setConnectionManager(connectionManager);
+
+
+            try (CloseableHttpClient httpClient = clientBuilder1.build()) {
+
+//                // Create a GET request
+//                HttpGet httpGet = new HttpGet(API_URL);
+
+                // Create a POST request
+                HttpPost httpPost = new HttpPost(API_URL);
+
+                // Execute the request
+                HttpResponse response = httpClient.execute(httpPost, res -> res);
+
+                // Print the response status
+                System.out.println("Response Code: " + response.getCode());
+
+                // Print headers
+                Header[] headers = response.getHeaders();
+                for (Header header : headers) {
+                    System.out.println("Key : " + header.getName()
+                        + " ,Value : " + header.getValue());
+                }
+
+                // You can read the response body if needed
+//                HttpEntity entity = response.getEntity();
+//                StringBuilder builder = new StringBuilder();
+//                try (BufferedInputStream is = new BufferedInputStream(entity.getContent())) {
+//                    byte[] contents = new byte[1024];
+//                    int bytesRead = 0;
+//                    while ((bytesRead = is.read(contents)) != -1) {
+//                        builder.append(new String(contents, 0, bytesRead));
+//                    }
+//                }
+//                System.out.println("Response Body: " + builder.toString());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
+++ b/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
@@ -44,15 +44,15 @@ public class Main {
             // Create new keystore
             var newKeyStore = KeyStore.getInstance("PKCS12");
             newKeyStore.load(null);
-            newKeyStore.setKeyEntry(PRIVATE_KEY_ALIAS, key, CLIENT_CERT_PASSWORD.toCharArray(), new Certificate[]{ cert }); // Create an entry with private key + signed certificate
+            newKeyStore.setKeyEntry(PRIVATE_KEY_ALIAS, key, CLIENT_CERT_PASSWORD.toCharArray(), new Certificate[]{cert}); // Create an entry with private key + signed certificate
 
             // Create SSL context with the client certificate
-            var sslContext = new SSLContextBuilder().loadTrustMaterial((chain,type)->true)
+            var sslContext = new SSLContextBuilder().loadTrustMaterial((chain, type) -> true)
                 .loadKeyMaterial(newKeyStore, CLIENT_CERT_PASSWORD.toCharArray()).build();
             var sslsf = new DefaultClientTlsStrategy(sslContext);
 
 
-            var connectionManager = BasicHttpClientConnectionManager.create((s)->sslsf);
+            var connectionManager = BasicHttpClientConnectionManager.create((s) -> sslsf);
 
             var clientBuilder = HttpClientBuilder.create().setConnectionManager(connectionManager);
 

--- a/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
+++ b/client-cert-auth-sample/src/main/java/org/zowe/apiml/Main.java
@@ -1,38 +1,33 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
-import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
-import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
-import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.config.Registry;
-import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 
-
-import javax.net.ssl.SSLContext;
-
-import java.awt.desktop.ScreenSleepEvent;
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 
 public class Main {
-    //private static final String API_URL = "https://hostname:port/bcmdbmdsh/api/v1/gen/agents?flattenResults=false"; // Replace with your API URL
-    private static final String API_URL = "https://hostname:port/gateway/api/v1/auth/login"; // Replace with your API URL
-    private static final String CLIENT_CERT_PATH = "/path/to/keystore.p12"; // Replace with your client cert path
+
+    private static final String API_URL = "https://localhost:8080/gateway/api/v1/auth/login"; // Replace with your API URL
+    private static final String CLIENT_CERT_PATH = "../keystore/client_cert/client-certs.p12"; // Replace with your client cert path
     private static final String CLIENT_CERT_PASSWORD = "password"; // Replace with your cert password
-    private static final String CLIENT_CERT_ALIAS = "mycert"; // Replace with your signed client cert alias
-    private static final String PRIVATE_KEY_ALIAS = "server"; // Replace with your private key alias
+    private static final String CLIENT_CERT_ALIAS = "apimtst"; // Replace with your signed client cert alias
+    private static final String PRIVATE_KEY_ALIAS = "apimtst"; // Replace with your private key alias
 
 
     public static void main(String[] args) {
@@ -43,66 +38,41 @@ public class Main {
                 keyStore.load(keyStoreStream, CLIENT_CERT_PASSWORD.toCharArray());
             }
 
-            Key key = keyStore.getKey(PRIVATE_KEY_ALIAS, CLIENT_CERT_PASSWORD.toCharArray()); // Load private key from original keystore
-            Certificate cert = keyStore.getCertificate(CLIENT_CERT_ALIAS); // Load signed certificate from original keystore
+            var key = keyStore.getKey(PRIVATE_KEY_ALIAS, CLIENT_CERT_PASSWORD.toCharArray()); // Load private key from original keystore
+            var cert = keyStore.getCertificate(CLIENT_CERT_ALIAS); // Load signed certificate from original keystore
 
             // Create new keystore
-            KeyStore newKeyStore = KeyStore.getInstance("PKCS12");
+            var newKeyStore = KeyStore.getInstance("PKCS12");
             newKeyStore.load(null);
             newKeyStore.setKeyEntry(PRIVATE_KEY_ALIAS, key, CLIENT_CERT_PASSWORD.toCharArray(), new Certificate[]{ cert }); // Create an entry with private key + signed certificate
 
             // Create SSL context with the client certificate
-//            SSLContext sslContext = SSLContexts.custom()
-//                .loadKeyMaterial(newKeyStore, CLIENT_CERT_PASSWORD.toCharArray())
-//                .build();
-            var sslContext = new SSLContextBuilder()
+            var sslContext = new SSLContextBuilder().loadTrustMaterial((chain,type)->true)
                 .loadKeyMaterial(newKeyStore, CLIENT_CERT_PASSWORD.toCharArray()).build();
-
-            // Create an HTTP client with the SSL context
-            HttpClientBuilder clientBuilder = HttpClientBuilder.create();
-
             var sslsf = new DefaultClientTlsStrategy(sslContext);
-//            var socketFactoryRegistry =
-//                RegistryBuilder.<DefaultClientTlsStrategy> create()
-//                    .register("https", sslsf)
-//                    .build();
+
 
             var connectionManager = BasicHttpClientConnectionManager.create((s)->sslsf);
-            var clientBuilder1 = clientBuilder.setConnectionManager(connectionManager);
 
+            var clientBuilder = HttpClientBuilder.create().setConnectionManager(connectionManager);
 
-            try (CloseableHttpClient httpClient = clientBuilder1.build()) {
-
-//                // Create a GET request
-//                HttpGet httpGet = new HttpGet(API_URL);
+            try (var httpClient = clientBuilder.build()) {
 
                 // Create a POST request
-                HttpPost httpPost = new HttpPost(API_URL);
+                var httpPost = new HttpPost(API_URL);
 
                 // Execute the request
-                HttpResponse response = httpClient.execute(httpPost, res -> res);
+                var response = httpClient.execute(httpPost, res -> res);
 
                 // Print the response status
                 System.out.println("Response Code: " + response.getCode());
 
                 // Print headers
-                Header[] headers = response.getHeaders();
-                for (Header header : headers) {
+                var headers = response.getHeaders();
+                for (var header : headers) {
                     System.out.println("Key : " + header.getName()
                         + " ,Value : " + header.getValue());
                 }
-
-                // You can read the response body if needed
-//                HttpEntity entity = response.getEntity();
-//                StringBuilder builder = new StringBuilder();
-//                try (BufferedInputStream is = new BufferedInputStream(entity.getContent())) {
-//                    byte[] contents = new byte[1024];
-//                    int bytesRead = 0;
-//                    while ((bytesRead = is.read(contents)) != -1) {
-//                        builder.append(new String(contents, 0, bytesRead));
-//                    }
-//                }
-//                System.out.println("Response Body: " + builder.toString());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
+++ b/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
@@ -42,9 +42,6 @@ class MainTest {
         tm.init(ts);
 
         sslContext.init(km.getKeyManagers(), tm.getTrustManagers(), null);
-        sslContext.getDefaultSSLParameters().setNeedClientAuth(true);
-        sslContext.getDefaultSSLParameters().setWantClientAuth(true);
-
 
         var httpsConfigurator = new TestHttpsConfigurator(sslContext);
         httpServer.setHttpsConfigurator(httpsConfigurator);

--- a/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
+++ b/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
@@ -1,0 +1,103 @@
+package org.zowe.apiml;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsExchange;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.net.InetSocketAddress;
+import java.security.KeyStore;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MainTest {
+
+    static HttpsServer httpServer;
+    static AssertionError error;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        var inetAddress = new InetSocketAddress("127.0.0.1", 8080);
+        httpServer = HttpsServer.create(inetAddress, 0);
+
+        var sslContext = SSLContext.getInstance("TLS");
+        var ks = KeyStore.getInstance("PKCS12");
+        try (var fis = new FileInputStream("../keystore/localhost/localhost.keystore.p12")) {
+            ks.load(fis, "password".toCharArray());
+        }
+        var km = KeyManagerFactory.getInstance("SunX509");
+        km.init(ks, "password".toCharArray());
+        var ts = KeyStore.getInstance("PKCS12");
+        try (var fis = new FileInputStream("../keystore/localhost/localhost.truststore.p12")) {
+            ts.load(fis, "password".toCharArray());
+        }
+        var tm = TrustManagerFactory.getInstance("SunX509");
+        tm.init(ts);
+
+        sslContext.init(km.getKeyManagers(), tm.getTrustManagers(), null);
+        sslContext.getDefaultSSLParameters().setNeedClientAuth(true);
+        sslContext.getDefaultSSLParameters().setWantClientAuth(true);
+
+
+        var httpsConfigurator = new TestHttpsConfigurator(sslContext);
+        httpServer.setHttpsConfigurator(httpsConfigurator);
+        httpServer.createContext("/gateway/api/v1/auth/login", exchange -> {
+
+            exchange.sendResponseHeaders(204, 0);
+            var clientCert = ((HttpsExchange) exchange).getSSLSession().getPeerCertificates();
+            try {
+                // client certificate must be present at this stage
+                assertNotNull(clientCert);
+            } catch (AssertionError e) {
+                error = e;
+            }
+            exchange.close();
+        });
+        httpServer.start();
+
+    }
+
+    @AfterAll
+    static void tearDown() {
+
+        httpServer.stop(0);
+        if (error != null) {
+            throw error;
+        }
+    }
+
+    @Test
+    void givenHttpsRequestWithClientCertificate_thenPeerCertificateMustBeAvailable() {
+        // Assertion is done on the server to make sure that client certificate was delivered.
+        // Assertion error is then rethrown in the tear down method in case certificate was not present.
+        Main.main(null);
+    }
+
+    static class TestHttpsConfigurator extends HttpsConfigurator {
+        /**
+         * Creates a Https configuration, with the given {@link SSLContext}.
+         *
+         * @param context the {@code SSLContext} to use for this configurator
+         * @throws NullPointerException if no {@code SSLContext} supplied
+         */
+        public TestHttpsConfigurator(SSLContext context) {
+            super(context);
+        }
+
+        @Override
+        public void configure(HttpsParameters params) {
+            var parms = getSSLContext().getDefaultSSLParameters();
+            parms.setNeedClientAuth(true);
+            params.setWantClientAuth(true);
+            params.setSSLParameters(parms);
+        }
+    }
+
+}

--- a/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
+++ b/client-cert-auth-sample/src/test/java/org/zowe/apiml/MainTest.java
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 package org.zowe.apiml;
 
 import com.sun.net.httpserver.HttpsConfigurator;

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,4 +55,5 @@ include 'apiml-sample-extension'
 include 'apiml-sample-extension-package'
 include 'apiml-extension-loader'
 include 'zowe-cli-id-federation-plugin'
+include 'client-cert-auth-sample'
 


### PR DESCRIPTION
# Description

Provides a sample java code to help users to start with client certificate authentication. This sample app uses client-cert keystore to construct SSL context and then execute a request against auth/login endpoint on the gateway service.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [x] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
