### PR TITLE
fix: javax.net.ssl default log levels

### DIFF
--- a/api-catalog-services/src/main/resources/application.yml
+++ b/api-catalog-services/src/main/resources/application.yml
@@ -40,6 +40,7 @@ logging:
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR # For running with java 17
 
 ##############################################################################################
 # APIML configuration section

--- a/caching-service/src/main/resources/application.yml
+++ b/caching-service/src/main/resources/application.yml
@@ -38,6 +38,7 @@ logging:
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
         org.springframework.security.config.annotation.web.builders.WebSecurity: ERROR
+        javax.net.ssl: ERROR # For running with java 17
 eureka:
     client:
         initialInstanceInfoReplicationIntervalSeconds: 1

--- a/cloud-gateway-service/src/main/resources/application.yml
+++ b/cloud-gateway-service/src/main/resources/application.yml
@@ -86,6 +86,7 @@ logging:
         org.springframework.context.support: WARN
         reactor.netty.http.client: INFO
         reactor.netty.http.client.HttpClientConnect: OFF
+        javax.net.ssl: ERROR # For running with java 17
 
 management:
     endpoint:

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -12,6 +12,7 @@ logging:
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR # For running with java 17
 
 spring:
     config:

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -18,6 +18,7 @@ logging:
         org.apache: WARN #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         org.eclipse.jetty: WARN
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR # For running with java 17
     #    com.netflix.eureka.resources: WARN
 
 apiml:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -22,6 +22,7 @@ logging:
         # New Config
         org.apache: WARN  #org.apache.catalina, org.apache.coyote, org.apache.tomcat
         javax.servlet: INFO
+        javax.net.ssl: ERROR # For running with java 17
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
         org.eclipse.jetty.util.ssl: ERROR
         org.apache.tomcat.util.net.SSLUtilBase: ERROR

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -13,6 +13,7 @@ logging:
         com.netflix.discovery.DiscoveryClient: OFF
         org.springframework.boot.web.embedded.tomcat.TomcatWebServer: INFO
         org.apache.http.conn.ssl.DefaultHostnameVerifier: DEBUG #logs only SSLException
+        javax.net.ssl: ERROR # For running with java 17
 
 eureka:
     client:


### PR DESCRIPTION
# Description

Running Zowe v2 with Java 17 works but floods the logs with info and warn messages coming from javax.net.ssl. This is changed in v3 but was not done for v2.

## Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
