### PR TITLE
fix: quotes in zosmf static definition

### DIFF
--- a/discovery-package/src/main/resources/zosmf-static-definition.yaml.template
+++ b/discovery-package/src/main/resources/zosmf-static-definition.yaml.template
@@ -9,7 +9,7 @@ services:
       description: 'IBM z/OS Management Facility REST API service. Once configured you can access z/OSMF via the API gateway: https://${ZOWE_EXPLORER_HOST}:${GATEWAY_PORT}/ibmzosmf/api/v1/info'
       catalogUiTileId: zosmf
       instanceBaseUrls:
-        - %ZOSMF_SCHEME%://${ZOSMF_HOST}:${ZOSMF_PORT}/"
+        - %ZOSMF_SCHEME%://${ZOSMF_HOST}:${ZOSMF_PORT}/
       homePageRelativeUrl:  # Home page is at the same URL
       routedServices:
         - gatewayUrl: api/v1
@@ -20,7 +20,7 @@ services:
         - apiId: ibm.zosmf
           gatewayUrl: api/v1
           documentationUrl: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.izua700/IZUHPINFO_RESTServices.htm
-          swaggerUrl: %ZOSMF_SCHEME%://${ZOSMF_HOST}:${ZOSMF_PORT}/zosmf/api/docs"
+          swaggerUrl: %ZOSMF_SCHEME%://${ZOSMF_HOST}:${ZOSMF_PORT}/zosmf/api/docs
       customMetadata:
           apiml:
               enableUrlEncodedCharacters: true


### PR DESCRIPTION
# Description

Fix trailing quotes not having matching initial ones.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
