### PR TITLE
fix: use default jdk dns resolver

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
@@ -20,6 +20,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.support.AopUtils;
@@ -345,7 +346,9 @@ public class ConnectionsConfig {
         return new HttpClientFactory(properties, serverProperties, sslConfigurer, customizers) {
             @Override
             protected HttpClient createInstance() {
-                return super.createInstance().secure(sslContextSpec -> sslContextSpec.sslContext(sslContext));
+                return super.createInstance()
+                    .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
+                    .resolver(DefaultAddressResolverGroup.INSTANCE);
             }
         };
     }
@@ -353,12 +356,16 @@ public class ConnectionsConfig {
     @Bean
     @Primary
     public WebClient webClient(HttpClient httpClient) {
-        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(getHttpClient(httpClient, false))).build();
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(getHttpClient(httpClient, false)))
+            .build();
     }
 
     @Bean
     public WebClient webClientClientCert(HttpClient httpClient) {
-        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(getHttpClient(httpClient, true))).build();
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(getHttpClient(httpClient, true)))
+            .build();
     }
 
     @Bean


### PR DESCRIPTION
# Description

Use default JDK DNS resolver. Netty one seems to have issues in z/OS.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
