### PR TITLE
fix: upgrade spring boot with http headers workaround

### DIFF
--- a/config/docker/api-defs/staticclient.yml
+++ b/config/docker/api-defs/staticclient.yml
@@ -111,6 +111,7 @@ services:
                 serviceRelativeUrl: /api/v3 # relativePath that is added to baseUrl of an instance
         authentication:
             scheme: httpBasicPassTicket
+            applid: ZOWEAPPL
         apiInfo:
             -   apiId: zowe.apiml.discoverableclient
                 gatewayUrl: api/v3

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
             version('projectNode', '20.14.0')
             version('projectNpm', '10.7.0')
 
-            version('springBoot', '3.3.4')
+            version('springBoot', '3.3.5')
             version('springBootGraphQl', '3.3.4')
             version('springCloudNetflix', '4.1.3')
             version('springCloudCommons', '4.1.4')


### PR DESCRIPTION
# Description

Spring security update breaks gateway filters https://github.com/spring-cloud/spring-cloud-gateway/issues/3568 . This change introduces workaround and updates spring boot to the latest version.
Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
