### PR TITLE
fix: Semantic of onboarded Gateways in the multitenancy deployment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -307,8 +307,8 @@ jobs:
                     APIML_SERVICE_PORT: 10037
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
                     ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka
-                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_GATEWAYURL: /
-                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_SERVICEURL: /
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_GATEWAYURL: /
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_SERVICEURL: /
             zaas-service-2:
                 image: ghcr.io/balhar-jakub/zaas-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -325,8 +325,8 @@ jobs:
                     APIML_SECURITY_X509_REGISTRY_ALLOWEDUSERS: USER,UNKNOWNUSER
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
                     ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka
-                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_GATEWAYURL: /
-                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_SERVICEURL: /
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_GATEWAYURL: /
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_SERVICEURL: /
 
         steps:
             -   uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1398,6 +1398,7 @@ jobs:
                     APIML_SECURITY_X509_CERTIFICATESURL: https://gateway-service-2:10010/gateway/certificates
                     APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10011/eureka/
                     APIML_HEALTH_PROTECTED: false
+                    APIML_SERVICE_HOSTNAME: zaas-service-2
 
         steps:
             -   uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1366,8 +1366,11 @@ jobs:
                     SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OKTA_USERNAMEATTRIBUTE: sub
                     SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OKTA_JWKSETURI: ${{ secrets.OKTA_JWKSET_URI }}
                     APIML_SECURITY_OIDC_COOKIE_SAMESITE: None
+                    APIML_HEALTH_PROTECTED: false
             zaas-service:
                 image: ghcr.io/balhar-jakub/zaas-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_HEALTH_PROTECTED: false
             mock-services:
                 image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
 
@@ -1377,14 +1380,13 @@ jobs:
                     - /api-defs:/api-defs
                 env:
                     APIML_SERVICE_HOSTNAME: discovery-service-2
-                    APIML_SERVICE_PORT: 10031
             gateway-service-2:
                 image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SERVICE_APIMLID: apiml2
                     APIML_SERVICE_HOSTNAME: gateway-service-2
-                    APIML_SERVICE_PORT: 10037
-                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
+                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10011/eureka/
+                    APIML_HEALTH_PROTECTED: false
                     ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka
                     ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_GATEWAYURL: /
                     ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_SERVICEURL: /
@@ -1393,8 +1395,9 @@ jobs:
                 env:
                     APIML_SECURITY_X509_ENABLED: true
                     APIML_SECURITY_X509_ACCEPTFORWARDEDCERT: true
-                    APIML_SECURITY_X509_CERTIFICATESURL: https://gateway-service:10010/gateway/certificates
-                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
+                    APIML_SECURITY_X509_CERTIFICATESURL: https://gateway-service-2:10010/gateway/certificates
+                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10011/eureka/
+                    APIML_HEALTH_PROTECTED: false
 
         steps:
             -   uses: actions/checkout@v4
@@ -1413,6 +1416,9 @@ jobs:
                         ~/.cache/Cypress
                         api-catalog-ui/frontend/node_modules
                     key: my-cache-${{ runner.os }}-${{ hashFiles('api-catalog-ui/frontend/*.json') }}
+            -   name: Run startup check
+                run: >
+                    ./gradlew runStartUpCheck --info --scan -Denvironment.config=-ha -Ddiscoverableclient.instances=1
             -   name: Cypress run API Catalog
                 run: |
                     cd api-catalog-ui/frontend

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1098,7 +1098,7 @@ jobs:
 
             -   uses: ./.github/actions/teardown
 
-    CITestsDicoverableClientChaoticHA:
+    CITestsDiscoverableClientChaoticHA:
         needs: PublishJibContainers
         container: ubuntu:latest
         runs-on: ubuntu-latest
@@ -1169,7 +1169,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: always()
                 with:
-                    name: CITestsDicoverableClientChaoticHA-${{ env.JOB_ID }}
+                    name: CITestsDiscoverableClientChaoticHA-${{ env.JOB_ID }}
                     path: |
                         integration-tests/build/reports/**
 
@@ -1370,6 +1370,31 @@ jobs:
                 image: ghcr.io/balhar-jakub/zaas-service:${{ github.run_id }}-${{ github.run_number }}
             mock-services:
                 image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
+
+            discovery-service-2:
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
+                volumes:
+                    - /api-defs:/api-defs
+                env:
+                    APIML_SERVICE_HOSTNAME: discovery-service-2
+                    APIML_SERVICE_PORT: 10031
+            gateway-service-2:
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SERVICE_APIMLID: apiml2
+                    APIML_SERVICE_HOSTNAME: gateway-service-2
+                    APIML_SERVICE_PORT: 10037
+                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_DISCOVERYSERVICEURLS: https://discovery-service:10011/eureka
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_GATEWAYURL: /
+                    ZWE_CONFIGS_APIML_SERVICE_ADDITIONALREGISTRATION_0_ROUTES_0_SERVICEURL: /
+            zaas-service-2:
+                image: ghcr.io/balhar-jakub/zaas-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_X509_ENABLED: true
+                    APIML_SECURITY_X509_ACCEPTFORWARDEDCERT: true
+                    APIML_SECURITY_X509_CERTIFICATESURL: https://gateway-service:10010/gateway/certificates
+                    APIML_SERVICE_DISCOVERYSERVICEURLS: https://discovery-service-2:10031/eureka/
 
         steps:
             -   uses: actions/checkout@v4

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
@@ -44,7 +44,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
-import static org.zowe.apiml.constants.EurekaMetadataDefinition.REGISTRATION_TYPE;
 import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
 /**
@@ -106,12 +105,12 @@ public class InstanceRetrievalService {
         // identification if there was no instance or any error happened during fetching
         AtomicBoolean instanceFound = new AtomicBoolean(false);
         InstanceInfo instanceInfo = getInstanceInfo(serviceId, instanceFound,
-            ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata().get(REGISTRATION_TYPE)).isPrimary()
+            ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata()).isPrimary()
         );
         if (instanceInfo == null) {
             // maybe the input is apimlId, try to find the matching Gateway (multi-tenancy use case)
             instanceInfo = getInstanceInfo(GATEWAY.getServiceId(), instanceFound,
-                ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata().get(REGISTRATION_TYPE)).isAdditional()
+                ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata()).isAdditional()
             );
         }
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
@@ -19,6 +19,7 @@ import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.Header;
@@ -40,6 +41,7 @@ import org.zowe.apiml.product.registry.ApplicationWrapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.REGISTRATION_TYPE;
@@ -62,6 +64,8 @@ public class InstanceRetrievalService {
     @InjectApimlLogger
     private final ApimlLogger apimlLog = ApimlLogger.empty();
 
+    private ObjectMapper mapper = new ObjectMapper();
+
     @Autowired
     public InstanceRetrievalService(DiscoveryConfigProperties discoveryConfigProperties,
                                     CloseableHttpClient httpClient) {
@@ -69,14 +73,15 @@ public class InstanceRetrievalService {
         this.httpClient = httpClient;
     }
 
-    private InstanceInfo getInstanceInfo(String serviceId, boolean delta, Predicate<InstanceInfo> selector) {
-        List<EurekaServiceInstanceRequest> eurekaServiceInstanceRequests = constructServiceInfoQueryRequest(serviceId, delta);
+    private InstanceInfo getInstanceInfo(String serviceId, AtomicBoolean instanceFound, Predicate<InstanceInfo> selector) {
+        List<EurekaServiceInstanceRequest> eurekaServiceInstanceRequests = constructServiceInfoQueryRequest(serviceId, false);
         // iterate over list of discovery services, return at first success
         for (EurekaServiceInstanceRequest eurekaServiceInstanceRequest : eurekaServiceInstanceRequests) {
             // call Eureka REST endpoint to fetch single or all Instances
             try {
                 String responseBody = queryDiscoveryForInstances(eurekaServiceInstanceRequest);
                 if (responseBody != null) {
+                    instanceFound.set(true);
                     return extractSingleInstanceFromApplication(serviceId, responseBody, selector);
                 }
             } catch (Exception e) {
@@ -98,13 +103,19 @@ public class InstanceRetrievalService {
             return null;
         }
 
-        InstanceInfo instanceInfo = getInstanceInfo(serviceId, false, ii -> true);
+        // identification if there was no instance or any error happened during fetching
+        AtomicBoolean instanceFound = new AtomicBoolean(false);
+        InstanceInfo instanceInfo = getInstanceInfo(serviceId, instanceFound,
+            ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata().get(REGISTRATION_TYPE)).isPrimary()
+        );
         if (instanceInfo == null) {
-            instanceInfo = getInstanceInfo(GATEWAY.getServiceId(), false,
+            // maybe the input is apimlId, try to find the matching Gateway (multi-tenancy use case)
+            instanceInfo = getInstanceInfo(GATEWAY.getServiceId(), instanceFound,
                 ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata().get(REGISTRATION_TYPE)).isAdditional()
             );
         }
-        if (instanceInfo == null) {
+
+        if (!instanceFound.get()) {
             String msg = "An error occurred when trying to get instance info for:  " + serviceId;
             throw new InstanceInitializationException(msg);
         }
@@ -159,7 +170,7 @@ public class InstanceRetrievalService {
      * @param eurekaServiceInstanceRequest information used to query the discovery service
      * @return ResponseEntity<String> query response
      */
-    private String queryDiscoveryForInstances(EurekaServiceInstanceRequest eurekaServiceInstanceRequest) throws IOException {
+    String queryDiscoveryForInstances(EurekaServiceInstanceRequest eurekaServiceInstanceRequest) throws IOException {
         HttpGet httpGet = new HttpGet(eurekaServiceInstanceRequest.getEurekaRequestUrl());
         for (Header header : createRequestHeader(eurekaServiceInstanceRequest)) {
             httpGet.setHeader(header);
@@ -194,9 +205,8 @@ public class InstanceRetrievalService {
      * @param responseBody the fetch attempt response body
      * @return service instance
      */
-    private InstanceInfo extractSingleInstanceFromApplication(String serviceId, String responseBody, Predicate<InstanceInfo> selector) {
+    InstanceInfo extractSingleInstanceFromApplication(String serviceId, String responseBody, Predicate<InstanceInfo> selector) {
         ApplicationWrapper application = null;
-        ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         try {
             application = mapper.readValue(responseBody, ApplicationWrapper.class);
@@ -237,7 +247,7 @@ public class InstanceRetrievalService {
 
             log.debug("Querying instance information of the service {} from the URL {} with the user {} and password {}",
                 serviceId, discoveryServiceLocatorUrl, eurekaUsername,
-                eurekaUserPassword.isEmpty() ? "NO PASSWORD" : "*******");
+                StringUtils.isEmpty(eurekaUserPassword) ? "NO PASSWORD" : "*******");
 
             EurekaServiceInstanceRequest eurekaServiceInstanceRequest = EurekaServiceInstanceRequest.builder()
                 .serviceId(serviceId)

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.converters.jackson.EurekaJsonJacksonCodec;
+import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
+import org.zowe.apiml.constants.EurekaMetadataDefinition;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.product.instance.InstanceInitializationException;
 import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
@@ -37,9 +39,11 @@ import org.zowe.apiml.product.registry.ApplicationWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
+import java.util.*;
+import java.util.function.Predicate;
+
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.REGISTRATION_TYPE;
+import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
 /**
  * Service for instance retrieval from Eureka
@@ -65,6 +69,24 @@ public class InstanceRetrievalService {
         this.httpClient = httpClient;
     }
 
+    private InstanceInfo getInstanceInfo(String serviceId, boolean delta, Predicate<InstanceInfo> selector) {
+        List<EurekaServiceInstanceRequest> eurekaServiceInstanceRequests = constructServiceInfoQueryRequest(serviceId, delta);
+        // iterate over list of discovery services, return at first success
+        for (EurekaServiceInstanceRequest eurekaServiceInstanceRequest : eurekaServiceInstanceRequests) {
+            // call Eureka REST endpoint to fetch single or all Instances
+            try {
+                String responseBody = queryDiscoveryForInstances(eurekaServiceInstanceRequest);
+                if (responseBody != null) {
+                    return extractSingleInstanceFromApplication(serviceId, responseBody, selector);
+                }
+            } catch (Exception e) {
+                log.debug("Error obtaining instance information from {}, error message: {}",
+                    eurekaServiceInstanceRequest.getEurekaRequestUrl(), e.getMessage());
+            }
+        }
+        return null;
+    }
+
     /**
      * Retrieves {@link InstanceInfo} of particular service
      *
@@ -76,22 +98,18 @@ public class InstanceRetrievalService {
             return null;
         }
 
-        List<EurekaServiceInstanceRequest> eurekaServiceInstanceRequests = constructServiceInfoQueryRequest(serviceId, false);
-        // iterate over list of discovery services, return at first success
-        for (EurekaServiceInstanceRequest eurekaServiceInstanceRequest : eurekaServiceInstanceRequests) {
-            // call Eureka REST endpoint to fetch single or all Instances
-            try {
-                String responseBody = queryDiscoveryForInstances(eurekaServiceInstanceRequest);
-                if (responseBody != null) {
-                    return extractSingleInstanceFromApplication(serviceId, responseBody);
-                }
-            } catch (Exception e) {
-                log.debug("Error obtaining instance information from {}, error message: {}",
-                    eurekaServiceInstanceRequest.getEurekaRequestUrl(), e.getMessage());
-            }
+        InstanceInfo instanceInfo = getInstanceInfo(serviceId, false, ii -> true);
+        if (instanceInfo == null) {
+            instanceInfo = getInstanceInfo(GATEWAY.getServiceId(), false,
+                ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata().get(REGISTRATION_TYPE)).isAdditional()
+            );
         }
-        String msg = "An error occurred when trying to get instance info for:  " + serviceId;
-        throw new InstanceInitializationException(msg);
+        if (instanceInfo == null) {
+            String msg = "An error occurred when trying to get instance info for:  " + serviceId;
+            throw new InstanceInitializationException(msg);
+        }
+
+        return instanceInfo;
     }
 
     /**
@@ -176,7 +194,7 @@ public class InstanceRetrievalService {
      * @param responseBody the fetch attempt response body
      * @return service instance
      */
-    private InstanceInfo extractSingleInstanceFromApplication(String serviceId, String responseBody) {
+    private InstanceInfo extractSingleInstanceFromApplication(String serviceId, String responseBody, Predicate<InstanceInfo> selector) {
         ApplicationWrapper application = null;
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -186,15 +204,13 @@ public class InstanceRetrievalService {
             log.debug("Could not extract service: {} info from discovery --{}", serviceId, e.getMessage(), e);
         }
 
-
-        if (application != null
-            && application.getApplication() != null
-            && application.getApplication().getInstances() != null
-            && !application.getApplication().getInstances().isEmpty()) {
-            return application.getApplication().getInstances().get(0);
-        } else {
-            return null;
-        }
+        return Optional.ofNullable(application)
+            .map(ApplicationWrapper::getApplication)
+            .map(Application::getInstances)
+            .orElse(Collections.emptyList())
+            .stream().filter(selector)
+            .findFirst()
+            .orElse(null);
     }
 
     /**

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -68,8 +68,7 @@ public class CachedProductFamilyService {
 
     public CachedProductFamilyService(CachedServicesService cachedServicesService,
                                       TransformService transformService,
-                                      @Value("${apiml.service-registry.cacheRefreshUpdateThresholdInMillis}")
-                                          Integer cacheRefreshUpdateThresholdInMillis,
+                                      @Value("${apiml.service-registry.cacheRefreshUpdateThresholdInMillis}") Integer cacheRefreshUpdateThresholdInMillis,
                                       CustomStyleConfig customStyleConfig) {
         this.cachedServicesService = cachedServicesService;
         this.transformService = transformService;
@@ -359,7 +358,7 @@ public class CachedProductFamilyService {
      * @param instanceInfo the service instance
      * @return a APIService object
      */
-    private APIService createAPIServiceFromInstance(InstanceInfo instanceInfo) {
+    APIService createAPIServiceFromInstance(InstanceInfo instanceInfo) {
         boolean secureEnabled = instanceInfo.isPortEnabled(InstanceInfo.PortType.SECURE);
 
         String instanceHomePage = getInstanceHomePageUrl(instanceInfo);

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -14,6 +14,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.shared.Application;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.zowe.apiml.apicatalog.model.APIContainer;
@@ -24,7 +25,6 @@ import org.zowe.apiml.auth.AuthenticationSchemes;
 import org.zowe.apiml.config.ApiInfo;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
 import org.zowe.apiml.message.log.ApimlLogger;
-import org.zowe.apiml.product.constants.CoreService;
 import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 import org.zowe.apiml.product.routing.RoutedServices;
 import org.zowe.apiml.product.routing.ServiceType;
@@ -35,6 +35,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.zowe.apiml.constants.EurekaMetadataDefinition.*;
+import static org.zowe.apiml.product.constants.CoreService.GATEWAY;
 
 /**
  * Caching service for eureka services
@@ -275,7 +276,7 @@ public class CachedProductFamilyService {
         String instanceHomePage = instanceInfo.getHomePageUrl();
 
         //Gateway homePage is used to hold DVIPA address and must not be modified
-        if (hasHomePage(instanceInfo) && !isGateway(instanceInfo)) {
+        if (hasHomePage(instanceInfo) && !StringUtils.equalsIgnoreCase(GATEWAY.getServiceId(), instanceInfo.getAppName())) {
             instanceHomePage = instanceHomePage.trim();
             RoutedServices routes = metadataParser.parseRoutes(instanceInfo.getMetadata());
             try {
@@ -324,10 +325,6 @@ public class CachedProductFamilyService {
         String instanceHomePage = instanceInfo.getHomePageUrl();
         return instanceHomePage != null
             && !instanceHomePage.isEmpty();
-    }
-
-    private boolean isGateway(InstanceInfo instanceInfo) {
-        return instanceInfo.getAppName().equalsIgnoreCase(CoreService.GATEWAY.getServiceId());
     }
 
     /**
@@ -384,8 +381,21 @@ public class CachedProductFamilyService {
             log.info("createApiServiceFromInstance#incorrectVersions {}", ex.getMessage());
         }
 
-        return new APIService.Builder(instanceInfo.getAppName().toLowerCase())
-            .title(instanceInfo.getMetadata().get(SERVICE_TITLE))
+        String serviceId = instanceInfo.getAppName();
+        String title = instanceInfo.getMetadata().get(SERVICE_TITLE);
+        if (StringUtils.equalsIgnoreCase(GATEWAY.getServiceId(), serviceId)) {
+            if (RegistrationType.of(instanceInfo.getMetadata().get(REGISTRATION_TYPE)).isAdditional()) {
+                // additional registration for GW means domain one, update serviceId with the ApimlId
+                String apimlId = instanceInfo.getMetadata().get(APIML_ID);
+                if (apimlId != null) {
+                    serviceId = apimlId;
+                    title += " (" + apimlId + ")";
+                }
+            }
+        }
+
+        return new APIService.Builder(StringUtils.lowerCase(serviceId))
+            .title(title)
             .description(instanceInfo.getMetadata().get(SERVICE_DESCRIPTION))
             .secured(secureEnabled)
             .baseUrl(instanceInfo.getHomePageUrl())

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/cached/CachedProductFamilyService.java
@@ -383,7 +383,7 @@ public class CachedProductFamilyService {
         String serviceId = instanceInfo.getAppName();
         String title = instanceInfo.getMetadata().get(SERVICE_TITLE);
         if (StringUtils.equalsIgnoreCase(GATEWAY.getServiceId(), serviceId)) {
-            if (RegistrationType.of(instanceInfo.getMetadata().get(REGISTRATION_TYPE)).isAdditional()) {
+            if (RegistrationType.of(instanceInfo.getMetadata()).isAdditional()) {
                 // additional registration for GW means domain one, update serviceId with the ApimlId
                 String apimlId = instanceInfo.getMetadata().get(APIML_ID);
                 if (apimlId != null) {

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -30,8 +31,10 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
 import org.zowe.apiml.apicatalog.util.ApplicationsWrapper;
+import org.zowe.apiml.constants.EurekaMetadataDefinition;
 import org.zowe.apiml.product.constants.CoreService;
 import org.zowe.apiml.product.instance.InstanceInitializationException;
 import org.zowe.apiml.product.registry.ApplicationWrapper;
@@ -47,199 +50,267 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.APIML_ID;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.REGISTRATION_TYPE;
 
-@ExtendWith(SpringExtension.class)
-@TestPropertySource(locations = "/application.yml")
-@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class, classes = InstanceServicesContextConfiguration.class)
 class InstanceRetrievalServiceTest {
 
     private static final String UNKNOWN = "unknown";
 
-    private InstanceRetrievalService instanceRetrievalService;
-
-    @Autowired
-    private DiscoveryConfigProperties discoveryConfigProperties;
-
-    @Mock
-    private CloseableHttpClient httpClient;
-
-    @Mock
-    private CloseableHttpResponse response;
-
-    @BeforeEach
-    void setup() {
-        HttpClientMockHelper.mockExecuteWithResponse(httpClient, response);
-        HttpClientMockHelper.mockResponse(response, HttpStatus.SC_OK);
-
-        instanceRetrievalService = new InstanceRetrievalService(discoveryConfigProperties, httpClient);
-    }
-
-    @Test
-    void whenDiscoveryServiceIsNotAvailable_thenTryOthersFromTheList() throws IOException {
-        when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN).thenReturn(HttpStatus.SC_OK);
-
-        instanceRetrievalService.getAllInstancesFromDiscovery(false);
-        verify(httpClient, times(2)).execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class));
-    }
-
-    @Test
-    void testGetInstanceInfo_whenServiceIdIsUNKNOWN() {
-        InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(UNKNOWN);
-        assertNull(instanceInfo);
-    }
-
-    @Test
-    void providedNoInstanceInfoIsReturned_thenInstanceInitializationExceptionIsThrown() {
-        String serviceId = CoreService.API_CATALOG.getServiceId();
-        when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
-
-        assertThrows(InstanceInitializationException.class, () -> instanceRetrievalService.getInstanceInfo(serviceId));
-    }
-
-    @Test
-    void testGetInstanceInfo_whenResponseHasEmptyBody() {
-        HttpClientMockHelper.mockResponse(response, "");
-        InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
-        assertNull(instanceInfo);
-    }
-
-    @Test
-    void testGetInstanceInfo_whenResponseCodeIsSuccessWithUnParsedJsonText() {
-        HttpClientMockHelper.mockResponse(response, "UNPARSABLE_JSON");
-        InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
-        assertNull(instanceInfo);
-    }
-
-    @Test
-    void testGetInstanceInfo() throws IOException {
-        InstanceInfo expectedInstanceInfo = getStandardInstance(
-            CoreService.API_CATALOG.getServiceId(),
-            InstanceInfo.InstanceStatus.UP
-        );
-
-        ObjectMapper mapper = new ObjectMapper();
-        String bodyCatalog = mapper.writeValueAsString(
-            new ApplicationWrapper(new Application(
-                CoreService.API_CATALOG.getServiceId(),
-                Collections.singletonList(expectedInstanceInfo)
-            )));
-        BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyCatalog, StandardCharsets.UTF_8), APPLICATION_JSON);
-        when(response.getEntity()).thenReturn(responseEntity);
-
-        InstanceInfo actualInstanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
-
-        assertNotNull(actualInstanceInfo);
-        assertThat(actualInstanceInfo, hasProperty("instanceId", equalTo(expectedInstanceInfo.getInstanceId())));
-        assertThat(actualInstanceInfo, hasProperty("appName", equalTo(expectedInstanceInfo.getAppName())));
-        assertThat(actualInstanceInfo, hasProperty("status", equalTo(expectedInstanceInfo.getStatus())));
-    }
-
-    @Test
-    void testGetAllInstancesFromDiscovery_whenResponseCodeIsNotSuccess() {
-        when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
-
-        Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
-        assertNull(actualApplications);
-    }
-
-    @Test
-    void testGetAllInstancesFromDiscovery_whenResponseCodeIsSuccessWithUnParsedJsonText() {
-        Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
-        assertNull(actualApplications);
-    }
-
-    @Test
-    void testGetAllInstancesFromDiscovery_whenNeedApplicationsWithoutFilter() throws IOException {
-        Map<String, InstanceInfo> instanceInfoMap = createInstances();
-
-
-        Applications expectedApplications = new Applications();
-        instanceInfoMap.forEach((key, value) -> expectedApplications.addApplication(new Application(value.getAppName(), Collections.singletonList(value))));
-
-        ObjectMapper mapper = new ObjectMapper();
-        String bodyAll = mapper.writeValueAsString(new ApplicationsWrapper(expectedApplications));
-        BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyAll, StandardCharsets.UTF_8), APPLICATION_JSON);
-        when(response.getEntity()).thenReturn(responseEntity);
-
-        Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
-
-        assertEquals(expectedApplications.size(), actualApplications.size());
-
-        List<Application> actualApplicationList =
-            new ArrayList<>(actualApplications.getRegisteredApplications());
-
-
-        expectedApplications
-            .getRegisteredApplications()
-            .forEach(expectedApplication ->
-                assertThat(actualApplicationList, hasItem(hasProperty("name", equalTo(expectedApplication.getName()))))
-            );
-    }
-
-    @Test
-    void testGetAllInstancesFromDiscovery_whenNeedApplicationsWithDeltaFilter() throws IOException {
-        Map<String, InstanceInfo> instanceInfoMap = createInstances();
-
-        Applications expectedApplications = new Applications();
-        instanceInfoMap.forEach((key, value) -> expectedApplications.addApplication(new Application(value.getAppName(), Collections.singletonList(value))));
-
-        ObjectMapper mapper = new ObjectMapper();
-        String bodyAll = mapper.writeValueAsString(new ApplicationsWrapper(expectedApplications));
-        BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyAll, StandardCharsets.UTF_8), APPLICATION_JSON);
-        when(response.getEntity()).thenReturn(responseEntity);
-
-        Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(true);
-
-        assertEquals(expectedApplications.size(), actualApplications.size());
-
-        List<Application> actualApplicationList =
-            new ArrayList<>(actualApplications.getRegisteredApplications());
-
-
-        expectedApplications
-            .getRegisteredApplications()
-            .forEach(expectedApplication ->
-                assertThat(actualApplicationList, hasItem(hasProperty("name", equalTo(expectedApplication.getName()))))
-            );
-    }
-
-    private Map<String, InstanceInfo> createInstances() {
-        Map<String, InstanceInfo> instanceInfoMap = new HashMap<>();
-
-        InstanceInfo instanceInfo = getStandardInstance(CoreService.GATEWAY.getServiceId(), InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-        instanceInfo = getStandardInstance(CoreService.ZAAS.getServiceId(), InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-        instanceInfo = getStandardInstance(CoreService.API_CATALOG.getServiceId(), InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-
-        instanceInfo = getStandardInstance("STATICCLIENT", InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-
-        instanceInfo = getStandardInstance("STATICCLIENT2", InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-
-        instanceInfo = getStandardInstance("ZOSMF1", InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-        instanceInfo = getStandardInstance("ZOSMF2", InstanceInfo.InstanceStatus.UP);
-        instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
-
-        return instanceInfoMap;
-    }
-
-    private InstanceInfo getStandardInstance(String serviceId,
-                                             InstanceInfo.InstanceStatus status) {
-
+    private InstanceInfo getStandardInstance(String serviceId, InstanceInfo.InstanceStatus status) {
         return InstanceInfo.Builder.newBuilder()
             .setInstanceId(serviceId)
             .setAppName(serviceId)
             .setStatus(status)
             .build();
     }
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @TestPropertySource(locations = "/application.yml")
+    @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class, classes = InstanceServicesContextConfiguration.class)
+    class SingleDomain {
+
+        private InstanceRetrievalService instanceRetrievalService;
+
+        @Autowired
+        private DiscoveryConfigProperties discoveryConfigProperties;
+
+        @Mock
+        private CloseableHttpClient httpClient;
+
+        @Mock
+        private CloseableHttpResponse response;
+
+        @BeforeEach
+        void setup() {
+            HttpClientMockHelper.mockExecuteWithResponse(httpClient, response);
+            HttpClientMockHelper.mockResponse(response, HttpStatus.SC_OK);
+
+            instanceRetrievalService = new InstanceRetrievalService(discoveryConfigProperties, httpClient);
+        }
+
+        @Test
+        void whenDiscoveryServiceIsNotAvailable_thenTryOthersFromTheList() throws IOException {
+            when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN).thenReturn(HttpStatus.SC_OK);
+
+            instanceRetrievalService.getAllInstancesFromDiscovery(false);
+            verify(httpClient, times(2)).execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class));
+        }
+
+        @Test
+        void testGetInstanceInfo_whenServiceIdIsUNKNOWN() {
+            InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(UNKNOWN);
+            assertNull(instanceInfo);
+        }
+
+        @Test
+        void providedNoInstanceInfoIsReturned_thenInstanceInitializationExceptionIsThrown() {
+            String serviceId = CoreService.API_CATALOG.getServiceId();
+            when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
+
+            assertThrows(InstanceInitializationException.class, () -> instanceRetrievalService.getInstanceInfo(serviceId));
+        }
+
+        @Test
+        void testGetInstanceInfo_whenResponseHasEmptyBody() {
+            HttpClientMockHelper.mockResponse(response, "");
+            InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
+            assertNull(instanceInfo);
+        }
+
+        @Test
+        void testGetInstanceInfo_whenResponseCodeIsSuccessWithUnParsedJsonText() {
+            HttpClientMockHelper.mockResponse(response, "UNPARSABLE_JSON");
+            InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
+            assertNull(instanceInfo);
+        }
+
+        @Test
+        void testGetInstanceInfo() throws IOException {
+            InstanceInfo expectedInstanceInfo = getStandardInstance(
+                CoreService.API_CATALOG.getServiceId(),
+                InstanceInfo.InstanceStatus.UP
+            );
+
+            ObjectMapper mapper = new ObjectMapper();
+            String bodyCatalog = mapper.writeValueAsString(
+                new ApplicationWrapper(new Application(
+                    CoreService.API_CATALOG.getServiceId(),
+                    Collections.singletonList(expectedInstanceInfo)
+                )));
+            BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyCatalog, StandardCharsets.UTF_8), APPLICATION_JSON);
+            when(response.getEntity()).thenReturn(responseEntity);
+
+            InstanceInfo actualInstanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.API_CATALOG.getServiceId());
+
+            assertNotNull(actualInstanceInfo);
+            assertThat(actualInstanceInfo, hasProperty("instanceId", equalTo(expectedInstanceInfo.getInstanceId())));
+            assertThat(actualInstanceInfo, hasProperty("appName", equalTo(expectedInstanceInfo.getAppName())));
+            assertThat(actualInstanceInfo, hasProperty("status", equalTo(expectedInstanceInfo.getStatus())));
+        }
+
+        @Test
+        void testGetAllInstancesFromDiscovery_whenResponseCodeIsNotSuccess() {
+            when(response.getCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
+
+            Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
+            assertNull(actualApplications);
+        }
+
+        @Test
+        void testGetAllInstancesFromDiscovery_whenResponseCodeIsSuccessWithUnParsedJsonText() {
+            Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
+            assertNull(actualApplications);
+        }
+
+        @Test
+        void testGetAllInstancesFromDiscovery_whenNeedApplicationsWithoutFilter() throws IOException {
+            Map<String, InstanceInfo> instanceInfoMap = createInstances();
+
+
+            Applications expectedApplications = new Applications();
+            instanceInfoMap.forEach((key, value) -> expectedApplications.addApplication(new Application(value.getAppName(), Collections.singletonList(value))));
+
+            ObjectMapper mapper = new ObjectMapper();
+            String bodyAll = mapper.writeValueAsString(new ApplicationsWrapper(expectedApplications));
+            BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyAll, StandardCharsets.UTF_8), APPLICATION_JSON);
+            when(response.getEntity()).thenReturn(responseEntity);
+
+            Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(false);
+
+            assertEquals(expectedApplications.size(), actualApplications.size());
+
+            List<Application> actualApplicationList =
+                new ArrayList<>(actualApplications.getRegisteredApplications());
+
+
+            expectedApplications
+                .getRegisteredApplications()
+                .forEach(expectedApplication ->
+                    assertThat(actualApplicationList, hasItem(hasProperty("name", equalTo(expectedApplication.getName()))))
+                );
+        }
+
+        @Test
+        void testGetAllInstancesFromDiscovery_whenNeedApplicationsWithDeltaFilter() throws IOException {
+            Map<String, InstanceInfo> instanceInfoMap = createInstances();
+
+            Applications expectedApplications = new Applications();
+            instanceInfoMap.forEach((key, value) -> expectedApplications.addApplication(new Application(value.getAppName(), Collections.singletonList(value))));
+
+            ObjectMapper mapper = new ObjectMapper();
+            String bodyAll = mapper.writeValueAsString(new ApplicationsWrapper(expectedApplications));
+            BasicHttpEntity responseEntity = new BasicHttpEntity(IOUtils.toInputStream(bodyAll, StandardCharsets.UTF_8), APPLICATION_JSON);
+            when(response.getEntity()).thenReturn(responseEntity);
+
+            Applications actualApplications = instanceRetrievalService.getAllInstancesFromDiscovery(true);
+
+            assertEquals(expectedApplications.size(), actualApplications.size());
+
+            List<Application> actualApplicationList =
+                new ArrayList<>(actualApplications.getRegisteredApplications());
+
+
+            expectedApplications
+                .getRegisteredApplications()
+                .forEach(expectedApplication ->
+                    assertThat(actualApplicationList, hasItem(hasProperty("name", equalTo(expectedApplication.getName()))))
+                );
+        }
+
+        private Map<String, InstanceInfo> createInstances() {
+            Map<String, InstanceInfo> instanceInfoMap = new HashMap<>();
+
+            InstanceInfo instanceInfo = getStandardInstance(CoreService.GATEWAY.getServiceId(), InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+            instanceInfo = getStandardInstance(CoreService.ZAAS.getServiceId(), InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+            instanceInfo = getStandardInstance(CoreService.API_CATALOG.getServiceId(), InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+
+            instanceInfo = getStandardInstance("STATICCLIENT", InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+
+            instanceInfo = getStandardInstance("STATICCLIENT2", InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+
+            instanceInfo = getStandardInstance("ZOSMF1", InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+            instanceInfo = getStandardInstance("ZOSMF2", InstanceInfo.InstanceStatus.UP);
+            instanceInfoMap.put(instanceInfo.getAppName(), instanceInfo);
+
+            return instanceInfoMap;
+        }
+
+    }
+
+    @Nested
+    class MultiDomain {
+
+        private static final String APIML_CENTRAL = "apimlidcentral";
+        private static final String APIML_ID_1 = "apimlid1";
+
+        private InstanceRetrievalService instanceRetrievalService;
+        private ObjectMapper mapper = mock(ObjectMapper.class);
+
+        @BeforeEach
+        void init() throws IOException {
+            DiscoveryConfigProperties discoveryConfig = new DiscoveryConfigProperties();
+            ReflectionTestUtils.setField(discoveryConfig, "locations", new String[] { "https://ds:10011/eureka" });
+
+            instanceRetrievalService = spy(new InstanceRetrievalService(discoveryConfig, null));
+            ReflectionTestUtils.setField(instanceRetrievalService, "mapper", mapper);
+
+            // construct Eureka representation of Gateway instances
+            InstanceInfo centralApiml = getStandardInstance(CoreService.GATEWAY.getServiceId(), InstanceInfo.InstanceStatus.UP);
+            ReflectionTestUtils.setField(centralApiml, "instanceId", "centralApiml:instance:1");
+            centralApiml.getMetadata().put(APIML_ID, APIML_CENTRAL);
+            centralApiml.getMetadata().put(REGISTRATION_TYPE, EurekaMetadataDefinition.RegistrationType.PRIMARY.getValue());
+            InstanceInfo apiml1 = getStandardInstance(CoreService.GATEWAY.getServiceId(), InstanceInfo.InstanceStatus.UP);
+            ReflectionTestUtils.setField(apiml1, "instanceId", "domainApiml:instance:1");
+            apiml1.getMetadata().put(APIML_ID, APIML_ID_1);
+            apiml1.getMetadata().put(REGISTRATION_TYPE, EurekaMetadataDefinition.RegistrationType.ADDITIONAL.getValue());
+            Application application = new Application(CoreService.GATEWAY.getServiceId());
+            application.addInstance(centralApiml);
+            application.addInstance(apiml1);
+            ApplicationWrapper applications = new ApplicationWrapper(application);
+
+            // mock obtaining and mapping of APIML instance
+            doReturn("gatewayJson").when(instanceRetrievalService).queryDiscoveryForInstances(argThat(request ->
+                CoreService.GATEWAY.getServiceId().equalsIgnoreCase(request.getServiceId())
+            ));
+            doReturn(applications).when(mapper).readValue("gatewayJson", ApplicationWrapper.class);
+        }
+
+        @Test
+        void givenAdditionalRegistrationOfGateway_whenAskWithApimlId_thenFindIt() {
+            InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(APIML_ID_1);
+            assertEquals(CoreService.GATEWAY.getServiceId(), instanceInfo.getAppName().toLowerCase(Locale.ROOT));
+            assertEquals(APIML_ID_1, instanceInfo.getMetadata().get(APIML_ID));
+            assertEquals(EurekaMetadataDefinition.RegistrationType.ADDITIONAL.getValue(), instanceInfo.getMetadata().get(REGISTRATION_TYPE));
+        }
+
+        @Test
+        void givenUnknownServiceId_whenGetInstanceInfo_thenMakeTwoQueries() throws IOException {
+            instanceRetrievalService.getInstanceInfo("unknown-service");
+            verify(instanceRetrievalService, times(2)).queryDiscoveryForInstances(any());
+        }
+
+        @Test
+        void givenMultipleGateways_whenAskForGatewayService_thenReturnThePrimaryOne() {
+            InstanceInfo instanceInfo = instanceRetrievalService.getInstanceInfo(CoreService.GATEWAY.getServiceId());
+            assertEquals(CoreService.GATEWAY.getServiceId(), instanceInfo.getAppName().toLowerCase(Locale.ROOT));
+            assertEquals(APIML_CENTRAL, instanceInfo.getMetadata().get(APIML_ID));
+            assertEquals(EurekaMetadataDefinition.RegistrationType.PRIMARY.getValue(), instanceInfo.getMetadata().get(REGISTRATION_TYPE));
+        }
+
+    }
+
 }

--- a/api-catalog-ui/frontend/cypress/e2e/dashboard/dashboard.cy.js
+++ b/api-catalog-ui/frontend/cypress/e2e/dashboard/dashboard.cy.js
@@ -46,11 +46,11 @@ describe('>>> Dashboard test', () => {
 
         cy.get('#search > div > div > input').as('search').type('API Gateway');
 
-        cy.get('.grid-tile').should('have.length', 1);
+        cy.get('.grid-tile').should('have.length', 2);
 
         cy.get('.clear-text-search').click();
 
-        cy.get('.grid-tile').should('have.length.gte', 1);
+        cy.get('.grid-tile').should('have.length.gte', 2);
         cy.get('@search').should('have.text', '');
 
         cy.contains('API Catalog').click();

--- a/api-catalog-ui/frontend/cypress/e2e/detail-page/detail-page.cy.js
+++ b/api-catalog-ui/frontend/cypress/e2e/detail-page/detail-page.cy.js
@@ -116,6 +116,6 @@ describe('>>> Detail page test', () => {
 
         cy.get('#search > div > div > input').as('search').type('API Gateway');
 
-        cy.get('.grid-tile').should('have.length', 1).should('contain', 'API Gateway');
+        cy.get('.grid-tile').should('have.length', 2).should('contain', 'API Gateway');
     });
 });

--- a/api-catalog-ui/frontend/cypress/e2e/detail-page/multiple-gateway-services.cy.js
+++ b/api-catalog-ui/frontend/cypress/e2e/detail-page/multiple-gateway-services.cy.js
@@ -1,0 +1,112 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+/// <reference types="Cypress" />
+
+
+describe('>>> Multi-tenancy deployment test', () => {
+    it('Detail page test', () => {
+        cy.login(Cypress.env('username'), Cypress.env('password'));
+
+        cy.get('#grid-container').contains('API Gateway (apiml2)').click();
+
+        cy.url().should('contain', '/service/apiml2');
+
+        cy.get('#go-back-button').should('exist');
+
+        cy.get('.api-description-container').should('exist');
+
+        cy.contains(
+            'The API Mediation Layer for z/OS internal API services. The API Mediation Layer provides a single point of access to mainframe REST APIs and offers enterprise cloud-like features such as high-availability, scalability, dynamic API discovery, and documentation.'
+        );
+
+        cy.contains('Version: ');
+    });
+
+    it('Should display the additional API Gateway (apiml2) service title, URL and description in Swagger', () => {
+        cy.login(Cypress.env('username'), Cypress.env('password'));
+
+        cy.contains('Version: ');
+        cy.get('#grid-container').contains('API Gateway (apiml2)').click();
+
+        cy.visit(`${Cypress.env('catalogHomePage')}/#/service/apiml2`);
+
+        const baseUrl = `${Cypress.env('catalogHomePage')}`;
+
+        cy.get(
+            '#swaggerContainer > div > div:nth-child(2) > div.scheme-container > section > div:nth-child(1) > div > div > label > select > option'
+        )
+            .should('exist')
+            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/gateway/api/v1`);
+
+        cy.get('.tabs-container').should('not.exist');
+        cy.get('.serviceTab').should('exist').and('contain', 'API Gateway');
+
+        cy.contains('Service Homepage').should('exist');
+
+        cy.contains('Swagger/OpenAPI JSON Document').should('exist');
+
+        cy.get('.opblock-tag-section').should('have.length.gte', 1);
+    });
+
+    it('Should display the API Gateway service title, URL and description in Swagger', () => {
+        cy.login(Cypress.env('username'), Cypress.env('password'));
+
+        cy.contains('Version: ');
+        cy.contains('API Gateway').click();
+
+        cy.visit(`${Cypress.env('catalogHomePage')}/#/service/gateway`);
+
+        const baseUrl = `${Cypress.env('catalogHomePage')}`;
+
+        cy.get(
+            '#swaggerContainer > div > div:nth-child(2) > div.scheme-container > section > div:nth-child(1) > div > div > label > select > option'
+        )
+            .should('exist')
+            .should('contain', `${baseUrl.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1]}/`);
+
+        cy.get('.tabs-container').should('not.exist');
+        cy.get('.serviceTab').should('exist').and('contain', 'API Gateway');
+
+        cy.contains('Service Homepage').should('exist');
+
+        cy.get('pre.version').should('contain', 'OAS');
+
+        cy.contains('Swagger/OpenAPI JSON Document').should('exist');
+
+        cy.get('.opblock-tag-section').should('have.length.gte', 1);
+
+        cy.get(
+            '#root > div > div.content > div.main > div.main-content2.detail-content > div.content-description-container > div > div > div.header > h6:nth-child(4)'
+        )
+            .should('exist')
+            .should(
+                'contain',
+                'API Gateway service to route requests to services registered in the API Mediation Layer and provides an API for mainframe security.'
+            );
+    });
+
+    it('Should go to the detail page, go back to the dashboard page and check if the search bar works', () => {
+        cy.login(Cypress.env('username'), Cypress.env('password'));
+
+        cy.contains('Version: ');
+        cy.contains('API Gateway').click();
+
+        cy.url().should('contain', '/service/gateway');
+
+        cy.get('#go-back-button').should('exist').click();
+
+        cy.get('#search > div > div > input').should('exist');
+        cy.should('not.contain', 'Available API Services'); // Removed in last version
+
+        cy.get('#search > div > div > input').as('search').type('API Gateway');
+
+        cy.get('.grid-tile').should('have.length', 2).should('contain', 'API Gateway');
+    });
+});

--- a/api-catalog-ui/frontend/cypress/e2e/detail-page/service-version-compare.cy.js
+++ b/api-catalog-ui/frontend/cypress/e2e/detail-page/service-version-compare.cy.js
@@ -36,7 +36,7 @@ describe('>>> Service version compare Test', () => {
         );
         cy.get('div.MuiTabs-flexContainer.MuiTabs-flexContainerVertical') // Select the parent div
             .find('a.MuiTab-root') // Find all the anchor elements within the div
-            .should('have.length', 15); // Check if there are 15 anchor elements within the div
+            .should('have.length', 16); // Check if there are 15 anchor elements within the div
         cy.get('.version-text').should('exist');
         cy.get('.version-text').should('contain.text', 'Compare');
     });

--- a/apiml-common/src/main/java/org/zowe/apiml/product/instance/lookup/InstanceLookupExecutor.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/instance/lookup/InstanceLookupExecutor.java
@@ -15,9 +15,9 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.shared.Application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.zowe.apiml.constants.EurekaMetadataDefinition;
 import org.zowe.apiml.product.instance.InstanceNotFoundException;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -36,12 +36,10 @@ public class InstanceLookupExecutor {
             throw new InstanceNotFoundException("Service '" + serviceId + "' is not registered to Discovery Service");
         }
 
-        List<InstanceInfo> appInstances = application.getInstances();
-        if (appInstances.isEmpty()) {
-            throw new InstanceNotFoundException("'" + serviceId + "' has no running instances registered to Discovery Service");
-        }
-
-        return appInstances.get(0);
+        return application.getInstances().stream()
+            .filter(ii -> EurekaMetadataDefinition.RegistrationType.of(ii.getMetadata()).isPrimary())
+            .findFirst()
+            .orElseThrow(() -> new InstanceNotFoundException("'" + serviceId + "' has no running instances registered to Discovery Service"));
     }
 
     /**

--- a/apiml-common/src/test/java/org/zowe/apiml/product/instance/lookup/InstanceLookupExecutorTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/instance/lookup/InstanceLookupExecutorTest.java
@@ -14,174 +14,231 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.shared.Application;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.zowe.apiml.constants.EurekaMetadataDefinition;
 import org.zowe.apiml.product.constants.CoreService;
 import org.zowe.apiml.product.instance.InstanceInitializationException;
 import org.zowe.apiml.product.instance.InstanceNotFoundException;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static java.time.Duration.ofMillis;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.REGISTRATION_TYPE;
 
-@ExtendWith(MockitoExtension.class)
 class InstanceLookupExecutorTest {
 
-    private static final String SERVICE_ID = CoreService.API_CATALOG.getServiceId();
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class UsageInApiCatalog {
 
-    @Mock
-    private EurekaClient eurekaClient;
+        private static final String SERVICE_ID = CoreService.API_CATALOG.getServiceId();
 
-    private InstanceLookupExecutor instanceLookupExecutor;
-    private List<InstanceInfo> instances;
+        @Mock
+        private EurekaClient eurekaClient;
 
-    private Exception lastException;
-    private InstanceInfo lastInstanceInfo;
-    private CountDownLatch latch;
+        private InstanceLookupExecutor instanceLookupExecutor;
+        private List<InstanceInfo> instances;
 
-    @BeforeEach
-    void setUp() {
-        instanceLookupExecutor = new InstanceLookupExecutor(eurekaClient);
-        instances = Collections.singletonList(
-            getInstance(SERVICE_ID));
-        latch = new CountDownLatch(1);
+        private Exception lastException;
+        private InstanceInfo lastInstanceInfo;
+        private CountDownLatch latch;
+
+        private InstanceInfo getInstance(String serviceId) {
+            return createInstance(
+                serviceId,
+                serviceId,
+                InstanceInfo.InstanceStatus.UP,
+                InstanceInfo.ActionType.ADDED,
+                new HashMap<>());
+        }
+
+        InstanceInfo createInstance(String serviceId, String instanceId,
+                                    InstanceInfo.InstanceStatus status,
+                                    InstanceInfo.ActionType actionType,
+                                    HashMap<String, String> metadata) {
+            return InstanceInfo.Builder.newBuilder()
+                .setInstanceId(instanceId)
+                .setAppName(serviceId.toUpperCase())
+                .setIPAddr("192.168.0.1")
+                .setSecurePort(9090)
+                .setHostName("hostname")
+                .setStatus(status)
+                .setMetadata(metadata)
+                .setActionType(actionType)
+                .build();
+        }
+
+        @BeforeEach
+        void setUp() {
+            instanceLookupExecutor = new InstanceLookupExecutor(eurekaClient);
+            instances = Collections.singletonList(
+                getInstance(SERVICE_ID));
+            latch = new CountDownLatch(1);
+        }
+
+        @Test
+        void testRun_whenNoApplicationRegisteredInDiscovery() {
+            assertTimeout(ofMillis(2000), () -> {
+                instanceLookupExecutor.run(
+                    SERVICE_ID, null,
+                    (exception, isStopped) -> {
+                        lastException = exception;
+                        latch.countDown();
+                    }
+                );
+
+                latch.await();
+            });
+
+            assertNotNull(lastException);
+            assertInstanceOf(InstanceNotFoundException.class, lastException);
+            assertEquals("Service '" + SERVICE_ID + "' is not registered to Discovery Service",
+                lastException.getMessage());
+        }
+
+        @Test
+        void testRun_whenNoInstancesExistInDiscovery() {
+            assertTimeout(ofMillis(2000), () -> {
+                when(eurekaClient.getApplication(SERVICE_ID))
+                    .thenReturn(new Application(SERVICE_ID, Collections.emptyList()));
+
+                instanceLookupExecutor.run(
+                    SERVICE_ID, null,
+                    (exception, isStopped) -> {
+                        lastException = exception;
+                        latch.countDown();
+                    }
+                );
+
+                latch.await();
+            });
+
+            assertNotNull(lastException);
+            assertInstanceOf(InstanceNotFoundException.class, lastException);
+            assertEquals("'" + SERVICE_ID + "' has no running instances registered to Discovery Service",
+                lastException.getMessage());
+        }
+
+        @Test
+        void testRun_whenUnexpectedExceptionHappened() {
+            assertTimeout(ofMillis(2000), () -> {
+                when(eurekaClient.getApplication(SERVICE_ID))
+                    .thenThrow(new InstanceInitializationException("Unexpected Exception"));
+
+                instanceLookupExecutor.run(
+                    SERVICE_ID, null,
+                    (exception, isStopped) -> {
+                        lastException = exception;
+                        latch.countDown();
+                    }
+                );
+
+                latch.await();
+            });
+
+            assertNotNull(lastException);
+            assertInstanceOf(InstanceInitializationException.class, lastException);
+        }
+
+        @Test
+        void testRun_whenInstanceExistInDiscovery() {
+            assertTimeout(ofMillis(2000), () -> {
+                when(eurekaClient.getApplication(SERVICE_ID))
+                    .thenReturn(new Application(SERVICE_ID, instances));
+
+                instanceLookupExecutor.run(
+                    SERVICE_ID,
+                    instanceInfo -> {
+                        lastInstanceInfo = instanceInfo;
+                        latch.countDown();
+                    }, null
+                );
+
+                latch.await();
+            });
+
+            assertNull(lastException);
+            assertNotNull(lastInstanceInfo);
+            assertEquals(instances.get(0), lastInstanceInfo);
+        }
+
     }
 
+    @Nested
+    class MultiTenancy {
 
-    @Test
-    void testRun_whenNoApplicationRegisteredInDiscovery() throws InterruptedException {
-        assertTimeout(ofMillis(2000), () -> {
-            instanceLookupExecutor.run(
-                SERVICE_ID, null,
-                (exception, isStopped) -> {
-                    lastException = exception;
-                    latch.countDown();
-                }
-            );
+        private final EurekaClient eurekaClient = mock(EurekaClient.class);
+        private final InstanceLookupExecutor instanceLookupExecutor = new InstanceLookupExecutor(eurekaClient);
 
-            latch.await();
-        });
+        private final Consumer<InstanceInfo> successHandler = mock(Consumer.class);
+        private final BiConsumer<Exception, Boolean> failureHandler = mock(BiConsumer.class);
 
-        assertNotNull(lastException);
-        assertTrue(lastException instanceof InstanceNotFoundException);
-        assertEquals("Service '" + SERVICE_ID + "' is not registered to Discovery Service",
-            lastException.getMessage());
+        private final Application application = new Application(CoreService.GATEWAY.getServiceId());
+
+        InstanceInfo mockGateway(EurekaMetadataDefinition.RegistrationType registrationType) {
+            Map<String, String> metadata = new HashMap<>();
+            if (registrationType != null) {
+                metadata.put(REGISTRATION_TYPE, registrationType.getValue());
+            }
+            InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder()
+                .setAppName(CoreService.GATEWAY.getServiceId())
+                .setInstanceId(CoreService.GATEWAY.getServiceId() + ":localhost:" + (1 + new Random().nextInt() % 65535))
+                .setMetadata(metadata)
+                .build();
+            application.addInstance(instanceInfo);
+            return instanceInfo;
+        }
+
+        private void invokeRun() {
+            instanceLookupExecutor.run(CoreService.GATEWAY.getServiceId(), successHandler, failureHandler);
+        }
+
+        @BeforeEach
+        void setUp() {
+            doReturn(application).when(eurekaClient).getApplication(CoreService.GATEWAY.getServiceId());
+        }
+
+        @Test
+        void givenNoInstance_whenRun_thenInvokeFailureHandler() {
+            invokeRun();
+            verify(successHandler, never()).accept(any());
+            verify(failureHandler).accept(any(), eq(false));
+        }
+
+        @Test
+        void givenOnlyAdditionalInstances_whenRun_thenInvokeFailureHandler() {
+            mockGateway(EurekaMetadataDefinition.RegistrationType.ADDITIONAL);
+            invokeRun();
+            verify(successHandler, never()).accept(any());
+            verify(failureHandler).accept(any(), eq(false));
+        }
+
+        @Test
+        void givenOnlyPrimaryInstances_whenRun_thenInvokeSuccessHandler() {
+            var primary = mockGateway(EurekaMetadataDefinition.RegistrationType.PRIMARY);
+            invokeRun();
+            verify(successHandler).accept(primary);
+            verify(failureHandler, never()).accept(any(), anyBoolean());
+        }
+
+        @Test
+        void givenMultipleInstances_whenRun_thenInvokeSuccessHandler() {
+            var primary = mockGateway(EurekaMetadataDefinition.RegistrationType.PRIMARY);
+            mockGateway(EurekaMetadataDefinition.RegistrationType.ADDITIONAL);
+            invokeRun();
+            verify(successHandler).accept(primary);
+            verify(failureHandler, never()).accept(any(), anyBoolean());
+        }
+
     }
 
-
-    @Test
-    void testRun_whenNoInstancesExistInDiscovery() throws InterruptedException {
-        assertTimeout(ofMillis(2000), () -> {
-            when(eurekaClient.getApplication(SERVICE_ID))
-                .thenReturn(new Application(SERVICE_ID, Collections.emptyList()));
-
-            instanceLookupExecutor.run(
-                SERVICE_ID, null,
-                (exception, isStopped) -> {
-                    lastException = exception;
-                    latch.countDown();
-                }
-            );
-
-            latch.await();
-        });
-
-        assertNotNull(lastException);
-        assertTrue(lastException instanceof InstanceNotFoundException);
-        assertEquals("'" + SERVICE_ID + "' has no running instances registered to Discovery Service",
-            lastException.getMessage());
-    }
-
-    @Test
-    void testRun_whenUnexpectedExceptionHappened() throws InterruptedException {
-        assertTimeout(ofMillis(2000), () -> {
-            when(eurekaClient.getApplication(SERVICE_ID))
-                .thenThrow(new InstanceInitializationException("Unexpected Exception"));
-
-            instanceLookupExecutor.run(
-                SERVICE_ID, null,
-                (exception, isStopped) -> {
-                    lastException = exception;
-                    latch.countDown();
-                }
-            );
-
-            latch.await();
-        });
-
-        assertNotNull(lastException);
-        assertTrue(lastException instanceof InstanceInitializationException);
-    }
-
-    @Test
-    void testRun_whenInstanceExistInDiscovery() throws InterruptedException {
-        assertTimeout(ofMillis(2000), () -> {
-            when(eurekaClient.getApplication(SERVICE_ID))
-                .thenReturn(new Application(SERVICE_ID, instances));
-
-            instanceLookupExecutor.run(
-                SERVICE_ID,
-                instanceInfo -> {
-                    lastInstanceInfo = instanceInfo;
-                    latch.countDown();
-                }, null
-            );
-
-            latch.await();
-        });
-
-        assertNull(lastException);
-        assertNotNull(lastInstanceInfo);
-        assertEquals(instances.get(0), lastInstanceInfo);
-    }
-
-
-    private InstanceInfo getInstance(String serviceId) {
-        return createInstance(
-            serviceId,
-            serviceId,
-            InstanceInfo.InstanceStatus.UP,
-            InstanceInfo.ActionType.ADDED,
-            new HashMap<>());
-    }
-
-    InstanceInfo createInstance(String serviceId, String instanceId,
-                                InstanceInfo.InstanceStatus status,
-                                InstanceInfo.ActionType actionType,
-                                HashMap<String, String> metadata) {
-        return new InstanceInfo(
-            instanceId,
-            serviceId.toUpperCase(),
-            null,
-            "192.168.0.1",
-            null,
-            new InstanceInfo.PortWrapper(true, 9090),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            0,
-            null,
-            "hostname",
-            status,
-            null,
-            null,
-            null,
-            null,
-            metadata,
-            null,
-            null,
-            actionType,
-            null);
-    }
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Map;
+import java.util.Optional;
+
 public final class EurekaMetadataDefinition {
 
     private EurekaMetadataDefinition() {
@@ -78,8 +81,20 @@ public final class EurekaMetadataDefinition {
     public static final String API_VERSION_PROPERTIES_VERSION_V1 = "mfaas.api-info.apiVersionProperties.v1.version";
     public static final String API_VERSION_PROPERTIES_DESCRIPTION_V1 = "mfaas.api-info.apiVersionProperties.v1.description";
 
+    public interface BasicRegistrationType {
+
+        default boolean isAdditional() {
+            return false;
+        }
+
+        default boolean isPrimary() {
+            return false;
+        }
+
+    }
+
     @RequiredArgsConstructor
-    public enum RegistrationType {
+    public enum RegistrationType implements BasicRegistrationType {
             PRIMARY("primary"),
             ADDITIONAL("additional")
         ;
@@ -97,6 +112,13 @@ public final class EurekaMetadataDefinition {
                 return PRIMARY;
             }
             return null;
+        }
+
+        public static BasicRegistrationType of(Map<String, String> metadata) {
+            return Optional.ofNullable(metadata)
+                .map(m -> of(m.get(REGISTRATION_TYPE)))
+                .map(BasicRegistrationType.class::cast)
+                .orElse(new BasicRegistrationType() {});
         }
 
         public boolean isAdditional() {

--- a/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
@@ -103,6 +103,10 @@ public final class EurekaMetadataDefinition {
             return this == ADDITIONAL;
         }
 
+        public boolean isPrimary() {
+            return this == PRIMARY;
+        }
+
     }
 
 }

--- a/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
@@ -10,6 +10,10 @@
 
 package org.zowe.apiml.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
 public final class EurekaMetadataDefinition {
 
     private EurekaMetadataDefinition() {
@@ -35,6 +39,7 @@ public final class EurekaMetadataDefinition {
     public static final String SERVICE_SUPPORTING_CLIENT_CERT_FORWARDING = "apiml.service.supportClientCertForwarding";
     public static final String ENABLE_URL_ENCODED_CHARACTERS = "apiml.enableUrlEncodedCharacters";
     public static final String APIML_ID = "apiml.service.apimlId";
+    public static final String REGISTRATION_TYPE = "apiml.registrationType";
 
     public static final String API_INFO = "apiml.apiInfo";
     public static final String API_INFO_API_ID = "apiId";
@@ -72,4 +77,32 @@ public final class EurekaMetadataDefinition {
     public static final String API_VERSION_PROPERTIES_TITLE_V1 = "mfaas.api-info.apiVersionProperties.v1.title";
     public static final String API_VERSION_PROPERTIES_VERSION_V1 = "mfaas.api-info.apiVersionProperties.v1.version";
     public static final String API_VERSION_PROPERTIES_DESCRIPTION_V1 = "mfaas.api-info.apiVersionProperties.v1.description";
+
+    @RequiredArgsConstructor
+    public enum RegistrationType {
+            PRIMARY("primary"),
+            ADDITIONAL("additional")
+        ;
+
+        @Getter
+        private final String value;
+
+        public static RegistrationType of(String value) {
+            for (RegistrationType registrationType : RegistrationType.values()) {
+                if (StringUtils.equals(value, registrationType.getValue())) {
+                    return registrationType;
+                }
+            }
+            if (value == null) {
+                return PRIMARY;
+            }
+            return null;
+        }
+
+        public boolean isAdditional() {
+            return this == ADDITIONAL;
+        }
+
+    }
+
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
@@ -163,7 +163,7 @@ public class GatewayExceptionHandler {
     @ExceptionHandler({ServiceNotAccessibleException.class, WebClientResponseException.ServiceUnavailable.class})
     public Mono<Void> handleServiceNotAccessibleException(ServerWebExchange exchange, Exception ex) {
         log.debug("A service is not available at the moment to finish request {}: {}", exchange.getRequest().getURI(), ex.getMessage());
-        return setBodyResponse(exchange, SC_SERVICE_UNAVAILABLE, "org.zowe.apiml.common.serviceUnavailable");
+        return setBodyResponse(exchange, SC_SERVICE_UNAVAILABLE, "org.zowe.apiml.common.serviceUnavailable", exchange.getRequest().getURI());
     }
 
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -11,6 +11,7 @@ eureka:
         securePortEnabled: ${apiml.service.securePortEnabled}
         metadata-map:
             apiml:
+                registrationType: primary
                 apiBasePath: /gateway/api/v1
                 catalog:
                     tile:

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/AdditionalRegistrationTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/AdditionalRegistrationTest.java
@@ -35,6 +35,7 @@ import org.zowe.apiml.security.HttpsFactory;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -93,7 +94,10 @@ public class AdditionalRegistrationTest {
             lenient().when(httpsFactory.getHostnameVerifier()).thenReturn(new NoopHostnameVerifier());
             lenient().when(eurekaFactory.createCloudEurekaClient(any(), any(), clientConfigCaptor.capture(), any(), any(), any())).thenReturn(additionalClientOne, additionalClientTwo);
 
-            instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("service1").build();
+            var metadata = new HashMap<String, String>();
+            metadata.put("apiml.routes.0.gatewayUrl", "/api/v1");
+            metadata.put("apiml.routes.0.serviceUrl", "/service/api/v1");
+            instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("service1").setMetadata(metadata).build();
             lenient().when(eurekaFactory.createInstanceInfo(any())).thenReturn(instanceInfo);
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/AdditionalRegistrationTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/AdditionalRegistrationTest.java
@@ -34,15 +34,14 @@ import org.zowe.apiml.config.AdditionalRegistration;
 import org.zowe.apiml.security.HttpsFactory;
 
 import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.cloud.netflix.eureka.EurekaClientConfigBean.DEFAULT_ZONE;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,20 +75,26 @@ public class AdditionalRegistrationTest {
         @Mock
         private HttpsFactory httpsFactory;
 
+        private InstanceInfo instanceInfo;
+
         @Captor
         private ArgumentCaptor<EurekaClientConfigBean> clientConfigCaptor;
 
-        private final AdditionalRegistration registration = AdditionalRegistration.builder().discoveryServiceUrls("https://another-eureka-1").build();
+        private List<AdditionalRegistration.Route> routes = Arrays.asList(new AdditionalRegistration.Route("/", "/"));
+        private final AdditionalRegistration registration = AdditionalRegistration.builder().discoveryServiceUrls("https://another-eureka-1").routes(routes).build();
 
         @BeforeEach
         public void setUp() throws Exception {
-            ReflectionTestUtils.setField(connectionsConfig,"eurekaServerUrl","https://host:2222");
-            ReflectionTestUtils.setField(connectionsConfig,"httpsFactory",httpsFactory);
+            ReflectionTestUtils.setField(connectionsConfig, "eurekaServerUrl", "https://host:2222");
+            ReflectionTestUtils.setField(connectionsConfig, "httpsFactory", httpsFactory);
             configSpy = Mockito.spy(connectionsConfig);
             lenient().doReturn(httpsFactory).when(configSpy).factory();
             lenient().when(httpsFactory.getSslContext()).thenReturn(SSLContexts.custom().build());
             lenient().when(httpsFactory.getHostnameVerifier()).thenReturn(new NoopHostnameVerifier());
             lenient().when(eurekaFactory.createCloudEurekaClient(any(), any(), clientConfigCaptor.capture(), any(), any(), any())).thenReturn(additionalClientOne, additionalClientTwo);
+
+            instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("service1").build();
+            lenient().when(eurekaFactory.createInstanceInfo(any())).thenReturn(instanceInfo);
         }
 
         @Test
@@ -110,6 +115,9 @@ public class AdditionalRegistrationTest {
             assertThat(holder.getDiscoveryClients()).hasSize(2);
             verify(additionalClientOne).registerHealthCheck(healthCheckHandler);
             verify(additionalClientTwo).registerHealthCheck(healthCheckHandler);
+
+            assertThat(instanceInfo.getMetadata().get("apiml.routes.0.gatewayUrl")).isEqualTo("/");
+            assertThat(instanceInfo.getMetadata().get("apiml.routes.0.serviceUrl")).isEqualTo("/");
         }
 
         @Test

--- a/integration-tests/src/test/resources/environment-configuration-ha.yml
+++ b/integration-tests/src/test/resources/environment-configuration-ha.yml
@@ -7,7 +7,6 @@ gatewayServiceConfiguration:
     scheme: https
     host: gateway-service,gateway-service-2
     port: 10010
-    internalPorts: 10017,10027
     externalPort: 10010
     instances: 2
     servicesEndpoint: gateway/api/v1/services


### PR DESCRIPTION
# Description

This PR solves registration on multiple Gateways to the central Discovery service. To explain the issue let take a look on the multitenancy deployment. There is one central APIML instance and multiple domain one:

Domain APIML 1:
- Discovery service
- Gateway
  - it is onboarded on local Discovery Service and has an additional registration (to the central Discovery service)
- ZAAS
- API Catalog
- other services

Domain APIML 2+:
- the same structure and the similar configuration as Domain APIML 1

Central APIML:
- Discovery service
- Gateway
- API Catalog
- other services

Note: In version 2 is instead of Gateway used cloud-gateway on level of central APIML instance.

The main issue is that on central level they are registred all gateways (all domain instance and the cetral one as well). There is missing semantic because all those instances have the same serviceId (gateway), In the v2 it was a little bit better, because they were separated from the central one. Anyway merging of Gateways from different domain does not make any sense. They have different purposes, but they looks like HA instances.

There is no way, how to automatically select the Gateway in the central APIML instance. Also API Catalog in the central Gateway merge all Gateways together (it shows one of them - randomly selected instance).

The solution on how to add a (basic) sematic is to use metadata value (`apiml.registrationType=<primary|additional>`). It allows to find the instance from the central APIML. For other is allows to use `apimlId` as serviceId (the same mechanism used in the Gateway).

The PR is mainly about adding the attribute `apiml.registrationType`, but it also contains these fixes:
- API Catalog split Gateway into multiple records (each for any APIML instance)
- Fix overriding routing paths for additional registration
- Fix configuration for multi-tenancy integration tests

Linked to #3873
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
