### PR TITLE
fix: specify content type when validating OIDC

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ZaasClientIntegrationTest.java
@@ -14,7 +14,9 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.core.Is;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,12 +28,17 @@ import org.zowe.apiml.util.categories.TestsNotMeantForZowe;
 import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.config.ConfigReaderZaasClient;
 import org.zowe.apiml.zaasclient.config.ConfigProperties;
-import org.zowe.apiml.zaasclient.exception.*;
+import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
+import org.zowe.apiml.zaasclient.exception.ZaasClientException;
+import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.service.ZaasClient;
 import org.zowe.apiml.zaasclient.service.ZaasToken;
 import org.zowe.apiml.zaasclient.service.internal.ZaasClientImpl;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.CertificateException;
@@ -260,12 +267,14 @@ class ZaasClientIntegrationTest implements TestWithStartedInstances {
 
         private static final String VALID_TOKEN_NO_MAPPING = SecurityUtils.validOktaAccessToken(false);
 
+        @Test
         void givenValidOidcToken_thenValidDetailsAreProvided() throws ZaasClientException {
             var validationResult = tokenService.validateOidc(VALID_TOKEN_NO_MAPPING);
             assertNotNull(validationResult);
             assertTrue(validationResult.isValid());
         }
 
+        @Test
         void givenInvalidOidcToken_thenNotValidIsIssued() throws ZaasClientException {
             var validationResult = tokenService.validateOidc("invalidtoken");
             assertNotNull(validationResult);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ZaasClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ZaasClientIntegrationTest.java
@@ -16,6 +16,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -263,6 +264,7 @@ class ZaasClientIntegrationTest implements TestWithStartedInstances {
     }
 
     @Nested
+    @Tag("OktaOauth2Test")
     class WhenOidcQuery {
 
         private static final String VALID_TOKEN_NO_MAPPING = SecurityUtils.validOktaAccessToken(false);

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
@@ -160,6 +160,7 @@ class ZaasJwtService implements TokenService {
         String json = objectMapper.writeValueAsString(new TokenRequest(oidcToken));
         var entity = new StringEntity(json);
         httpPost.setEntity(entity);
+        httpPost.setHeader("Content-Type", "application/json");
         return httpPost;
     }
 


### PR DESCRIPTION
# Description

ZAAS service rejects validation request when content is not specified.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
