### PR TITLE
fix: Improve untrusted certificate message when certificate is not forwarded

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -129,7 +129,7 @@ jobs:
                     ./gradlew :integration-tests:runOidcTests --info -Denvironment.config=-docker -Denvironment.offPlatform=true -Dokta.client.id=${{ secrets.OKTA_CLIENT_ID }}
                     -Doidc.test.user=${{ secrets.OIDC_TEST_USER }} -Doidc.test.pass=${{ secrets.OIDC_TEST_PASS }}
                     -Doidc.test.alt_user=${{ secrets.OKTA_WINNIE_USER }} -Doidc.test.alt_pass=${{ secrets.OKTA_WINNIE_PASS }}
-                    -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
+                    -DidpConfiguration.host=${{secrets.OKTA_HOST}}
 
             -   uses: ./.github/actions/teardown
 
@@ -419,7 +419,7 @@ jobs:
                     -Partifactory_user=${{ secrets.ARTIFACTORY_USERNAME }} -Partifactory_password=${{ secrets.ARTIFACTORY_PASSWORD }}
                     -Dokta.client.id=${{ secrets.OKTA_CLIENT_ID }} -Doidc.test.user=${{ secrets.OIDC_TEST_USER }}
                     -Doidc.test.pass=${{ secrets.OIDC_TEST_PASS }} -Doidc.test.alt_user=${{ secrets.OKTA_WINNIE_USER }}
-                    -Doidc.test.alt_pass=${{ secrets.OKTA_WINNIE_PASS }}
+                    -Doidc.test.alt_pass=${{ secrets.OKTA_WINNIE_PASS }} -DidpConfiguration.host=${{secrets.OKTA_HOST}}
 
             -   name: Dump DC jacoco data
                 run: >

--- a/api-catalog-ui/frontend/cypress/e2e/login/login-oauth.cy.js
+++ b/api-catalog-ui/frontend/cypress/e2e/login/login-oauth.cy.js
@@ -26,13 +26,12 @@ describe('>>> Login through Okta OK', () => {
             cy.log("System env CYPRESS_OKTA_PASSWORD is not set");
         }
 
-        cy.get('form span.o-form-input-name-identifier input').type(username);
+        cy.get('form span.o-form-input-name-username input').type(username);
         cy.get('form input[type="password"]').type(password);
 
         cy.get('form input.button-primary').should('not.be.disabled');
         cy.get('form input.button-primary').click();
 
-        cy.location('href').should('contain', '/oauth2/v1/authorize')
 
         cy.url().should('contain', '/application');
 

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -16,8 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.zowe.apiml.message.log.ApimlLogger;
-import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -33,9 +31,6 @@ import java.util.Set;
 public class CertificateValidator {
 
     final TrustedCertificatesProvider trustedCertificatesProvider;
-
-    @InjectApimlLogger
-    private final ApimlLogger apimlLog = ApimlLogger.empty();
 
     @Getter
     @Value("${apiml.security.x509.acceptForwardedCert:false}")
@@ -63,8 +58,7 @@ public class CertificateValidator {
         List<Certificate> trustedCerts = trustedCertificatesProvider.getTrustedCerts(proxyCertificatesEndpoint);
         for (X509Certificate cert : certs) {
             if (!trustedCerts.contains(cert)) {
-                apimlLog.log("org.zowe.apiml.security.common.verify.untrustedCert");
-                log.debug("Untrusted certificate is {}", cert);
+                log.debug("Certificate is not trusted by endpoint {}. Untrusted certificate is {}", proxyCertificatesEndpoint, cert);
                 return false;
             }
         }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -55,6 +56,11 @@ public class CertificateValidator {
      * @return true if all given certificates are known false otherwise
      */
     public boolean isTrusted(X509Certificate[] certs) {
+        if (ObjectUtils.isEmpty(proxyCertificatesEndpoint)) {
+            log.debug("No endpoint configured to retrieve trusted certificates. Provide URL via apiml.security.x509.certificatesUrls");
+            return false;
+        }
+
         List<Certificate> trustedCerts = trustedCertificatesProvider.getTrustedCerts(proxyCertificatesEndpoint);
         for (X509Certificate cert : certs) {
             if (!trustedCerts.contains(cert)) {

--- a/apiml-security-common/src/main/resources/security-common-log-messages.yml
+++ b/apiml-security-common/src/main/resources/security-common-log-messages.yml
@@ -123,13 +123,6 @@ messages:
       reason: "The string sent by the central Gateway was not recognized as valid DER-encoded certificates in the Base64 printable form."
       action: "Check that the URL configured in apiml.security.x509.certificatesUrl responds with valid DER-encoded certificates in the Base64 printable form."
 
-    - key: org.zowe.apiml.security.common.verify.untrustedCert
-      number: ZWEAT505
-      type: ERROR
-      text: "Incoming request certificate is not one of the trusted certificates provided by the central Gateway."
-      reason: "The Gateway performs additional check of request certificates when the central Gateway forwards incoming client certificate to the domain Gateway. This check may fail when the certificatesUrl parameter does not point to proper central Gateway certificates endpoint."
-      action: "Check that the URL configured in apiml.security.x509.certificatesUrl points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form."
-
     # Various messages
     # 600-699
 

--- a/apiml-security-common/src/test/resources/security-service-messages.yml
+++ b/apiml-security-common/src/test/resources/security-service-messages.yml
@@ -93,13 +93,6 @@ messages:
       reason: "The string sent by the central Gateway was not recognized as valid DER-encoded certificates in the Base64 printable form."
       action: "Check that the URL configured in apiml.security.x509.certificatesUrl responds with valid DER-encoded certificates in the Base64 printable form."
 
-    - key: org.zowe.apiml.security.common.verify.untrustedCert
-      number: ZWEAT505
-      type: ERROR
-      text: "Incoming request certificate is not one of the trusted certificates provided by the central Gateway."
-      reason: "The Gateway performs additional check of request certificates when the central Gateway forwards incoming client certificate to the domain Gateway. This check may fail when the certificatesUrl parameter does not point to proper central Gateway certificates endpoint."
-      action: "Check that the URL configured in apiml.security.x509.certificatesUrl points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form."
-
     # Personal access token messages
     - key: org.zowe.apiml.security.query.invalidAccessTokenBody
       number: ZWEAT605

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderEndpoint.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/token/OIDCTokenProviderEndpoint.java
@@ -39,12 +39,14 @@ public class OIDCTokenProviderEndpoint implements OIDCProvider {
     @Override
     public boolean isValid(String token) {
         try {
+            log.debug("Validating the token against URL: {}", endpointUrl);
             HttpGet httpGet = new HttpGet(endpointUrl);
             httpGet.addHeader(HttpHeaders.AUTHORIZATION, ApimlConstants.BEARER_AUTHENTICATION_PREFIX + " " + token);
 
             HttpResponse httpResponse = secureHttpClientWithKeystore.execute(httpGet);
 
             int responseCode = httpResponse.getStatusLine().getStatusCode();
+            log.debug("Response code: {}", responseCode);
             return HttpStatus.valueOf(responseCode).is2xxSuccessful();
         } catch (IOException e) {
             log.error("error validating token using userInfo URI {} message: {}", endpointUrl, e.getMessage());

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
@@ -133,6 +133,7 @@ public class ConfigReader {
                     configuration.getIdpConfiguration().setPassword(System.getProperty("oidc.test.pass", configuration.getIdpConfiguration().getPassword()));
                     configuration.getIdpConfiguration().setAlternateUser(System.getProperty("oidc.test.alt_user", configuration.getIdpConfiguration().getAlternateUser()));
                     configuration.getIdpConfiguration().setAlternatePassword(System.getProperty("oidc.test.alt_pass", configuration.getIdpConfiguration().getAlternatePassword()));
+                    configuration.getIdpConfiguration().setHost(System.getProperty("idpConfiguration.host", configuration.getIdpConfiguration().getHost()));
 
                     configuration.getSafIdtConfiguration().setEnabled(Boolean.parseBoolean(System.getProperty("safidt.enabled", String.valueOf(configuration.getSafIdtConfiguration().isEnabled()))));
 


### PR DESCRIPTION
# Description

fix: Improve untrusted certificate message when certificate is not forwarded

Linked to # (3321)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
