### PR TITLE
fix: Improve untrusted certificate message when certificate is not forwarded

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/verify/CertificateValidator.java
@@ -16,8 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.zowe.apiml.message.log.ApimlLogger;
-import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -35,9 +33,6 @@ import static org.zowe.apiml.security.common.filter.CategorizeCertsFilter.base64
 public class CertificateValidator {
 
     final TrustedCertificatesProvider trustedCertificatesProvider;
-
-    @InjectApimlLogger
-    private final ApimlLogger apimlLog = ApimlLogger.empty();
 
     @Getter
     @Value("${apiml.security.x509.acceptForwardedCert:false}")
@@ -72,8 +67,7 @@ public class CertificateValidator {
             .toList();
         for (X509Certificate cert : certs) {
             if (!trustedCerts.contains(cert)) {
-                apimlLog.log("org.zowe.apiml.security.common.verify.untrustedCert");
-                log.debug("Untrusted certificate is {}", cert);
+                log.debug("Certificate is not trusted by endpoint {}. Untrusted certificate is {}", proxyCertificatesEndpoints, cert);
                 return false;
             }
         }

--- a/apiml-security-common/src/main/resources/security-common-log-messages.yml
+++ b/apiml-security-common/src/main/resources/security-common-log-messages.yml
@@ -123,13 +123,6 @@ messages:
       reason: "The string sent by the central Gateway was not recognized as valid DER-encoded certificates in the Base64 printable form."
       action: "Check that the URL configured in apiml.security.x509.certificatesUrls responds with valid DER-encoded certificates in the Base64 printable form."
 
-    - key: org.zowe.apiml.security.common.verify.untrustedCert
-      number: ZWEAT505
-      type: ERROR
-      text: "Incoming request certificate is not one of the trusted certificates provided by the central Gateway."
-      reason: "The Gateway performs additional check of request certificates when the central Gateway forwards incoming client certificate to the domain Gateway. This check may fail when the certificatesUrl parameter does not point to proper central Gateway certificates endpoint."
-      action: "Check that the URL configured in apiml.security.x509.certificatesUrls points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form."
-
     # Various messages
     # 600-699
 

--- a/apiml-security-common/src/test/resources/security-service-messages.yml
+++ b/apiml-security-common/src/test/resources/security-service-messages.yml
@@ -93,13 +93,6 @@ messages:
       reason: "The string sent by the central Gateway was not recognized as valid DER-encoded certificates in the Base64 printable form."
       action: "Check that the URL configured in apiml.security.x509.certificatesUrls responds with valid DER-encoded certificates in the Base64 printable form."
 
-    - key: org.zowe.apiml.security.common.verify.untrustedCert
-      number: ZWEAT505
-      type: ERROR
-      text: "Incoming request certificate is not one of the trusted certificates provided by the central Gateway."
-      reason: "The Gateway performs additional check of request certificates when the central Gateway forwards incoming client certificate to the domain Gateway. This check may fail when the certificatesUrl parameter does not point to proper central Gateway certificates endpoint."
-      action: "Check that the URL configured in apiml.security.x509.certificatesUrls points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form."
-
     # Personal access token messages
     - key: org.zowe.apiml.security.query.invalidAccessTokenBody
       number: ZWEAT605


### PR DESCRIPTION
# Description

fix: Improve untrusted certificate message when certificate is not forwarded

Linked to # (3321)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
