### PR TITLE
fix: auto conversion during zosmf static definition creation

### DIFF
--- a/discovery-package/src/main/resources/bin/configure.sh
+++ b/discovery-package/src/main/resources/bin/configure.sh
@@ -41,7 +41,7 @@ fi
 
 if [ -e "$SOURCE_FILE" ]; then
     # _BPXK_AUTOCVT is set on some systems and resulted in twice-converted files when run through chtag and sed
-    _BPXK_AUTOCVT="OFF" sed -W filecodeset=ISO8859-1 -e "s|%ZOSMF_SCHEME%|${ZOSMF_SCHEME}|g" $SOURCE_FILE >$DEST_FILE # implicit EBCDIC out
+    _BPXK_AUTOCVT="ON" sed -W filecodeset=ISO8859-1 -e "s|%ZOSMF_SCHEME%|${ZOSMF_SCHEME}|g" $SOURCE_FILE >$DEST_FILE # implicit EBCDIC out
     iconv -f IBM-1047 -t ISO8859-1 $DEST_FILE >$SOURCE_FILE
     _BPXK_AUTOCVT="OFF" chtag -tc ISO8859-1 $SOURCE_FILE
     rm -f $DEST_FILE


### PR DESCRIPTION
# Description


## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
