### PR TITLE
fix: do not leak 'exampleSetFlag' in api doc (v2.x.x)

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -10,12 +10,13 @@
 
 package org.zowe.apiml.apicatalog.swagger.api;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
@@ -47,11 +48,8 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
     @Value("${gateway.scheme.external:https}")
     private String scheme;
 
-    private final ObjectMapper mapper;
-
     public ApiDocV3Service(GatewayClient gatewayClient) {
         super(gatewayClient);
-        mapper = initializeObjectMapper();
     }
 
     public String transformApiDoc(String serviceId, ApiDocInfo apiDocInfo) {
@@ -75,7 +73,7 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
         updateExternalDoc(openAPI, apiDocInfo);
 
         try {
-            return mapper.writeValueAsString(openAPI);
+            return objectMapper().writeValueAsString(openAPI);
         } catch (JsonProcessingException e) {
             log.debug("Could not convert OpenAPI to JSON", e);
             throw new ApiDocTransformationException("Could not convert Swagger to JSON");
@@ -189,17 +187,12 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
         return tags != null && tags.stream().anyMatch(tag -> tag.getName().equals(HIDDEN_TAG));
     }
 
-    private ObjectMapper initializeObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
-        SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addSerializer(SecurityScheme.class, new SecuritySchemeSerializer());
-
-        objectMapper.registerModule(simpleModule);
-        objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-
-        objectMapper.registerModule(new JavaTimeModule());
-        return objectMapper;
+    private ObjectMapper objectMapper() {
+        return Json.mapper()
+            .registerModule(new SimpleModule().addSerializer(SecurityScheme.class, new SecuritySchemeSerializer()))
+            .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -10,17 +10,20 @@
 
 package org.zowe.apiml.apicatalog.swagger.api;
 
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.swagger.v3.core.util.Json;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.swagger.v3.core.jackson.mixin.MediaTypeMixin;
+import io.swagger.v3.core.jackson.mixin.SchemaMixin;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
@@ -188,11 +191,12 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
     }
 
     private ObjectMapper objectMapper() {
-        return Json.mapper()
+        return new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(new SimpleModule().addSerializer(SecurityScheme.class, new SecuritySchemeSerializer()))
-            .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-            .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
-            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            .registerModule(new JavaTimeModule())
+            .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+            .addMixIn(Schema.class, SchemaMixin.class)
+            .addMixIn(MediaType.class, MediaTypeMixin.class);
     }
 }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiTransformationConfig.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiTransformationConfig.java
@@ -42,8 +42,8 @@ public class ApiTransformationConfig {
     @Bean
     @Scope(value = "prototype")
     public AbstractApiDocService<?, ?> abstractApiDocService(String content) {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
         try {
             ObjectNode objectNode = mapper.readValue(content, ObjectNode.class);
             JsonNode openApiNode = objectNode.get("openapi");

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -239,14 +239,28 @@ class ApiDocV3ServiceTest {
                 }
             };
             String transformed = apiDocV3Service.transformApiDoc("serviceId", new ApiDocInfo(
-                    mock(ApiInfo.class),
-                    IOUtils.toString(new ClassPathResource("swagger/openapi3.json").getInputStream(), StandardCharsets.UTF_8),
-                    mock(RoutedServices.class)
+                mock(ApiInfo.class),
+                IOUtils.toString(new ClassPathResource("swagger/openapi3.json").getInputStream(), StandardCharsets.UTF_8),
+                mock(RoutedServices.class)
             ));
             assertNotNull(transformed);
             verifyOpenApi3(openApiHolder.get());
         }
 
+        @Test
+        void givenValidApiDoc_thenDoNotLeakExampleSetFlag() throws IOException {
+            ApiInfo apiInfo = new ApiInfo("zowe.apiml.apicatalog", "api/v1", API_VERSION, "https://localhost:10014/apicatalog/v3/api-docs", "https://www.zowe.org");
+            String content = IOUtils.toString(new ClassPathResource("swagger/openapi3.json").getInputStream(), StandardCharsets.UTF_8);
+
+            RoutedServices routedServices = new RoutedServices();
+            routedServices.addRoutedService(new RoutedService("api-v1", "api/v1", "/apicatalog"));
+
+            ApiDocInfo info = new ApiDocInfo(apiInfo, content, routedServices);
+            assertThat(content, containsString("\"exampleSetFlag\":"));
+
+            String actualContent = apiDocV3Service.transformApiDoc(SERVICE_ID, info);
+            assertThat(actualContent, not(containsString("\"exampleSetFlag\":")));
+        }
     }
 
     private String convertOpenApiToJson(OpenAPI openApi) {


### PR DESCRIPTION
# Description

'exampleSetFlag' property is leaking in OpenApi doc. Fix is done to use the correctly configured ObjectMapper for serialization.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
