### PR TITLE
fix: Improve error handling in case of failure when retrieving API doc

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/api/ApiCatalogController.java
@@ -163,9 +163,8 @@ public class ApiCatalogController {
                 String defaultApiVersion = cachedApiDocService.getDefaultApiVersionForService(serviceId);
                 apiService.setDefaultApiVersion(defaultApiVersion);
             } catch (Exception e) {
-                log.debug("An error occurred when trying to fetch ApiDoc for service: " + serviceId +
-                    ", processing can continue but this service will not be able to display any Api Documentation.\n" +
-                    "Error Message: " + e.getMessage());
+                log.debug("An error occurred when trying to fetch ApiDoc for service: {}, processing can continue but this service will not be able to display any Api Documentation.\nError:", serviceId, e);
+                apiService.setApiDocErrorMessage("Failed to fetch API documentation: " + e.getMessage());
             }
         });
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/model/APIService.java
@@ -57,6 +57,9 @@ public class APIService implements Serializable {
     @Schema(description = "The default API version for this service")
     private String defaultApiVersion = "v1";
 
+    @Schema(description = "The error message occurred when trying to retrieve the API doc")
+    private String apiDocErrorMessage;
+
     @Schema(description = "The available API versions for this service")
     private List<String> apiVersions;
 

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2Service.java
@@ -44,7 +44,7 @@ public class ApiDocV2Service extends AbstractApiDocService<Swagger, Path> {
         Swagger swagger = new SwaggerParser().readWithInfo(apiDocInfo.getApiDocContent()).getSwagger();
         if (swagger == null) {
             log.debug("Could not convert response body to a Swagger object.");
-            throw new UnexpectedTypeException("Response is not a Swagger type object.");
+            throw new UnexpectedTypeException(String.format("The Swagger definition for service '%s' was retrieved but was not a valid JSON document.", serviceId));
         }
 
         boolean hidden = swagger.getTag(HIDDEN_TAG) != null;

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3Service.java
@@ -64,7 +64,8 @@ public class ApiDocV3Service extends AbstractApiDocService<OpenAPI, PathItem> {
             if (parseResult.getMessages() == null) {
                 throw new UnexpectedTypeException("Response is not an OpenAPI type object.");
             } else {
-                throw new UnexpectedTypeException(parseResult.getMessages().toString());
+                throw new UnexpectedTypeException(
+                    String.format("The OpenAPI for service '%s' was retrieved but was not a valid JSON document. '%s'", serviceId, parseResult.getMessages().toString()));
             }
         }
 

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/services/cached/CachedApiDocServiceTest.java
@@ -116,7 +116,7 @@ class CachedApiDocServiceTest {
         Exception exception = assertThrows(ApiDocNotFoundException.class,
             () -> cachedApiDocService.getApiDocForService(serviceId, version),
             "Expected exception is not ApiDocNotFoundException");
-        assertEquals("No API Documentation was retrieved for the service Service.", exception.getMessage());
+        assertEquals("No API Documentation was retrieved for the service Service. Root cause: ", exception.getMessage());
     }
 
     @Nested
@@ -220,7 +220,7 @@ class CachedApiDocServiceTest {
         Exception exception = assertThrows(ApiDocNotFoundException.class,
             () -> cachedApiDocService.getDefaultApiDocForService(serviceId),
             "Expected exception is not ApiDocNotFoundException");
-        assertEquals("No API Documentation was retrieved for the service service.", exception.getMessage());
+        assertEquals("No API Documentation was retrieved for the service service. Root cause: ", exception.getMessage());
     }
 
     @Nested

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV2ServiceTest.java
@@ -80,7 +80,7 @@ class ApiDocV2ServiceTest {
         ApiDocInfo apiDocInfo = new ApiDocInfo(null, apiDocContent, null);
 
         Exception exception = assertThrows(UnexpectedTypeException.class, () -> apiDocV2Service.transformApiDoc(SERVICE_ID, apiDocInfo));
-        assertEquals("Response is not a Swagger type object.", exception.getMessage());
+        assertEquals("The Swagger definition for service 'serviceId' was retrieved but was not a valid JSON document.", exception.getMessage());
     }
 
     @Nested

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/swagger/api/ApiDocV3ServiceTest.java
@@ -179,14 +179,14 @@ class ApiDocV3ServiceTest {
                 ApiDocInfo apiDocInfo = new ApiDocInfo(apiInfo, invalidJson, null);
 
                 Exception exception = assertThrows(UnexpectedTypeException.class, () -> apiDocV3Service.transformApiDoc(SERVICE_ID, apiDocInfo));
-                assertEquals("[Null or empty definition]", exception.getMessage());
+                assertEquals("The OpenAPI for service 'serviceId' was retrieved but was not a valid JSON document. '[Null or empty definition]'", exception.getMessage());
             }
 
             @Test
             void givenInvalidJson() {
                 String invalidJson = "nonsense";
-                String error = "[Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('nonsense')\n" +
-                    " at [Source: UNKNOWN; byte offset: #UNKNOWN]]";
+                String error = "The OpenAPI for service 'serviceId' was retrieved but was not a valid JSON document. '[Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('nonsense')\n" +
+                    " at [Source: UNKNOWN; byte offset: #UNKNOWN]]'";
                 ApiInfo apiInfo = new ApiInfo(API_ID, "api/v1", API_VERSION, "https://localhost:10014/apicatalog/api-doc", "https://www.zowe.org");
                 ApiDocInfo apiDocInfo = new ApiDocInfo(apiInfo, invalidJson, null);
 

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
@@ -123,14 +123,12 @@ describe('>>> Swagger component tests', () => {
             basePath: '/enabler/api/v1',
             defaultApiVersion: 0,
             apiDoc: null,
-            apiDocErrorMessage: "API documentation could not be retrieved. Invalid JSON"
-
+            apiDocErrorMessage: 'API documentation could not be retrieved. Invalid JSON',
         };
 
         const container = document.createElement('div');
         document.body.appendChild(container);
-        const root = createRoot(container);
-        await act(async () => root.render(<SwaggerUI selectedService={service} />));
+        await act(async () => render(<SwaggerUI selectedService={service} />, container));
         expect(container.textContent).toEqual(`API documentation could not be retrieved. Invalid JSON`);
     });
 

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUI.test.jsx
@@ -112,6 +112,28 @@ describe('>>> Swagger component tests', () => {
         expect(container.textContent).toContain(`API documentation could not be retrieved`);
     });
 
+    it('should not render swagger if apiDoc contains error', async () => {
+        const service = {
+            serviceId: 'testservice',
+            title: 'Spring Boot Enabler Service',
+            description: 'Dummy Service for enabling others',
+            status: 'UP',
+            secured: false,
+            homePageUrl: 'http://localhost:10013/enabler/',
+            basePath: '/enabler/api/v1',
+            defaultApiVersion: 0,
+            apiDoc: null,
+            apiDocErrorMessage: "API documentation could not be retrieved. Invalid JSON"
+
+        };
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        await act(async () => root.render(<SwaggerUI selectedService={service} />));
+        expect(container.textContent).toEqual(`API documentation could not be retrieved. Invalid JSON`);
+    });
+
     it('should transform swagger server url', async () => {
         const endpoint = '/enabler/api/v1';
         const service = {

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUIApiml.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUIApiml.jsx
@@ -10,12 +10,12 @@
 import { Component } from 'react';
 import * as React from 'react';
 import SwaggerUi from 'swagger-ui-react';
+import PropTypes from 'prop-types';
 import InstanceInfo from '../ServiceTab/InstanceInfo';
 import getBaseUrl from '../../helpers/urls';
 import { CustomizedSnippedGenerator } from '../../utils/generateSnippets';
 import { AdvancedFilterPlugin } from '../../utils/filterApis';
 import { isAPIPortal } from '../../utils/utilFunctions';
-import PropTypes from "prop-types";
 
 function transformSwaggerToCurrentHost(swagger) {
     swagger.host = window.location.host;

--- a/api-catalog-ui/frontend/src/components/Swagger/SwaggerUIApiml.jsx
+++ b/api-catalog-ui/frontend/src/components/Swagger/SwaggerUIApiml.jsx
@@ -15,6 +15,7 @@ import getBaseUrl from '../../helpers/urls';
 import { CustomizedSnippedGenerator } from '../../utils/generateSnippets';
 import { AdvancedFilterPlugin } from '../../utils/filterApis';
 import { isAPIPortal } from '../../utils/utilFunctions';
+import PropTypes from "prop-types";
 
 function transformSwaggerToCurrentHost(swagger) {
     swagger.host = window.location.host;
@@ -204,8 +205,9 @@ export default class SwaggerUIApiml extends Component {
                 {error && (
                     <div style={{ width: '100%', background: '#ffffff', paddingLeft: 55 }}>
                         <h4 id="no-doc_message">
-                            API documentation could not be retrieved. There may be something wrong in your Swagger
-                            definition. Please review the values of 'schemes', 'host' and 'basePath'.
+                            {selectedService.apiDocErrorMessage
+                                ? selectedService.apiDocErrorMessage
+                                : "API documentation could not be retrieved. There may be something wrong in your Swagger definition. Please review the values of 'schemes', 'host' and 'basePath'."}
                         </h4>
                     </div>
                 )}
@@ -218,6 +220,14 @@ export default class SwaggerUIApiml extends Component {
         );
     }
 }
+
+SwaggerUIApiml.propTypes = {
+    selectedService: PropTypes.shape({
+        apiDoc: PropTypes.string,
+        apiDocErrorMessage: PropTypes.string,
+    }).isRequired,
+    url: PropTypes.string,
+};
 
 SwaggerUIApiml.defaultProps = {
     url: `${getBaseUrl()}/apidoc`,


### PR DESCRIPTION
# Description

(backport from v3)

Propagate exception message to the UI in case of failure of retrieving API doc either from the service or from the cache. It covers the following cases:
1. The Swagger definition was retrieved but was not a valid JSON document. + message from the parser
2. The Swagger definition was retrieved but it was not a valid Swagger JSON document according to the schema + message from parser
3. The Swagger URL is not valid

Linked to #2315

## Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
