### PR TITLE
fix: change refill strategy for API rate limiting

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/InMemoryRateLimiter.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/InMemoryRateLimiter.java
@@ -48,7 +48,7 @@ public class InMemoryRateLimiter implements RateLimiter<InMemoryRateLimiter.Conf
     }
 
     private Bucket newBucket(String id) {
-        Bandwidth limit = Bandwidth.builder().capacity(capacity).refillGreedy(tokens, Duration.ofMinutes(refillDuration)).build();
+        Bandwidth limit = Bandwidth.builder().capacity(capacity).refillIntervally(tokens, Duration.ofMinutes(refillDuration)).build();
         return Bucket.builder().addLimit(limit).build();
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/InMemoryRateLimiterFilterFactoryIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/InMemoryRateLimiterFilterFactoryIntegrationTest.java
@@ -19,11 +19,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.zowe.apiml.util.categories.RateLimitTest;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 import reactor.netty.http.client.HttpClient;
 
 import javax.net.ssl.SSLException;
 
+@RateLimitTest
 public class InMemoryRateLimiterFilterFactoryIntegrationTest {
 
     private static WebTestClient client;
@@ -33,7 +35,7 @@ public class InMemoryRateLimiterFilterFactoryIntegrationTest {
     @BeforeAll
     static void setUpTester() {
         String baseUrl = HttpRequestUtils.getUriFromGateway("/discoverableclient/api/v1/greeting").toString();
-        SslContext sslContext = null;
+        SslContext sslContext;
         try {
             sslContext = SslContextBuilder
                 .forClient()

--- a/integration-tests/src/test/java/org/zowe/apiml/util/categories/RateLimitTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/categories/RateLimitTest.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.util.categories;
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Test that makes sense only in AT-TLS context.
+ */
+@Tag("RateLimitTest")
+@Target({ TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimitTest {
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/util/categories/RateLimitTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/categories/RateLimitTest.java
@@ -17,7 +17,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 
 /**
- * Test that makes sense only in AT-TLS context.
+ * Test related to the API Rate limiting.
  */
 @Tag("RateLimitTest")
 @Target({ TYPE, METHOD })


### PR DESCRIPTION
# Description

1. Change the refill strategy from greedy to intervally. Greedy Refill refills tokens as quickly as possible, which could potentially lead to sudden bursts of traffic when the bucket refills, causing unpredictable traffic patterns. Intervally Refill, on the other hand, refills tokens at regular intervals, which provides more controlled and predictable rate limiting. 
2. Include the related ITs in the GH pipeline as the tests were not ran. 

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
