### PR TITLE
fix: Use HA instance ID in path to infinispan storage location (v2)

### DIFF
--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -92,12 +92,12 @@ fi
 
 if [ -z "${ZWE_configs_storage_infinispan_persistence_dataLocation}" ]; then
   if [ -n "${ZWE_zowe_workspaceDirectory}" ]; then
-    ZWE_configs_storage_infinispan_persistence_dataLocation="${ZWE_zowe_workspaceDirectory}/caching-service/data"
+    ZWE_configs_storage_infinispan_persistence_dataLocation="${ZWE_zowe_workspaceDirectory}/caching-service/${ZWE_haInstance_id:-localhost}/data"
   fi
 fi
 if [ -z "${ZWE_configs_storage_infinispan_persistence_indexLocation}" ]; then
   if [ -n "${ZWE_zowe_workspaceDirectory}" ]; then
-    ZWE_configs_storage_infinispan_persistence_indexLocation="${ZWE_zowe_workspaceDirectory}/caching-service/index"
+    ZWE_configs_storage_infinispan_persistence_indexLocation="${ZWE_zowe_workspaceDirectory}/caching-service/${ZWE_haInstance_id:-localhost}/index"
   fi
 fi
 if [ -z "${ZWE_configs_storage_infinispan_initialHosts}" ]; then


### PR DESCRIPTION
# Description

The all instances of infinityspan uses the same location of storage. It could lead to unexpected behaviour if the storage is not define for each instance. This PR make path different by adding HA instance ID in the path.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
