### PR TITLE
fix: Use writeble headers on first. Solve the conflict with RequestAttributesProvider

### DIFF
--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/RequestAttributesProvider.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/filters/RequestAttributesProvider.java
@@ -67,7 +67,7 @@ public class RequestAttributesProvider implements WebFilter, GlobalFilter, Order
 
     @Override
     public int getOrder() {
-        return Ordered.HIGHEST_PRECEDENCE;
+        return Ordered.HIGHEST_PRECEDENCE + 1;
     }
 
 }

--- a/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/RequestAttributesProviderTest.java
+++ b/cloud-gateway-service/src/test/java/org/zowe/apiml/cloudgatewayservice/filters/RequestAttributesProviderTest.java
@@ -61,8 +61,8 @@ class RequestAttributesProviderTest {
     }
 
     @Test
-    void givenRequestAttributesProvider_whenOrder_thenIsTheFirstOne() {
-        assertEquals(Integer.MIN_VALUE, new RequestAttributesProvider().getOrder());
+    void givenRequestAttributesProvider_whenOrder_thenIsTheFirstOneAfterWritableHeaders() {
+        assertEquals(Integer.MIN_VALUE + 1, new RequestAttributesProvider().getOrder());
     }
 
     @ParameterizedTest(name = "givenMockRequest_whenFilter_thenDoNoCrash with {0}")


### PR DESCRIPTION
# Description

There are two filters: RequestAttributesProvider, writeableHeaders. The writeableHeaders should be first, otherwise the second could failed. This PR defines the different order of filters.

## Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
