### PR TITLE
fix: Use writeble headers on first. Solve the conflict with RequestAttributesProvider

### DIFF
--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/RequestAttributesProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/RequestAttributesProviderTest.java
@@ -61,8 +61,8 @@ class RequestAttributesProviderTest {
     }
 
     @Test
-    void givenRequestAttributesProvider_whenOrder_thenIsTheFirstOne() {
-        assertEquals(Integer.MIN_VALUE, new RequestAttributesProvider().getOrder());
+    void givenRequestAttributesProvider_whenOrder_thenIsTheFirstOneAfterWritableHeaders() {
+        assertEquals(Integer.MIN_VALUE + 1, new RequestAttributesProvider().getOrder());
     }
 
     @ParameterizedTest(name = "givenMockRequest_whenFilter_thenDoNoCrash with {0}")


### PR DESCRIPTION
# Description

There are two filters: RequestAttributesProvider, writeableHeaders. The writeableHeaders should be first, otherwise the second could failed. This PR defines the different order of filters.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
