### PR TITLE
fix: tls minimum setting (v3)

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -175,13 +175,12 @@ fi
 get_enabled_protocol_limit() {
     target=$1
     type=$2
+    default=$3
     key_component="ZWE_configs_zowe_network_${target}_tls_${type}Tls"
     value_component=$(eval echo \$$key_component)
-    key_gateway="ZWE_components_gateway_zowe_network_${target}_tls_${type}Tls"
-    value_gateway=$(eval echo \$$key_gateway)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_gateway:-${value_zowe:-}}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
 }
 
 extract_between() {
@@ -190,9 +189,9 @@ extract_between() {
 
 get_enabled_protocol() {
     target=$1
-    get_enabled_protocol_limit "${target}" "min"
+    get_enabled_protocol_limit "${target}" "min" "TLSv1.2"
     enabled_protocols_min=${enabled_protocol_limit}
-    get_enabled_protocol_limit "${target}" "max"
+    get_enabled_protocol_limit "${target}" "max" "TLSv1.3"
     enabled_protocols_max=${enabled_protocol_limit}
 
     if [ "${enabled_protocols_min:-}" = "${enabled_protocols_max:-}" ]; then
@@ -208,8 +207,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.3"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_gateway_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -180,7 +180,7 @@ get_enabled_protocol_limit() {
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-${default}}}
 }
 
 extract_between() {

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -143,7 +143,7 @@ get_enabled_protocol_limit() {
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-${default}}}
 }
 
 extract_between() {

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -138,13 +138,12 @@ fi
 get_enabled_protocol_limit() {
     target=$1
     type=$2
+    default=$3
     key_component="ZWE_configs_zowe_network_${target}_tls_${type}Tls"
     value_component=$(eval echo \$$key_component)
-    key_gateway="ZWE_components_gateway_zowe_network_${target}_tls_${type}Tls"
-    value_gateway=$(eval echo \$$key_gateway)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_gateway:-${value_zowe:-}}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
 }
 
 extract_between() {
@@ -153,9 +152,9 @@ extract_between() {
 
 get_enabled_protocol() {
     target=$1
-    get_enabled_protocol_limit "${target}" "min"
+    get_enabled_protocol_limit "${target}" "min" "TLSv1.2"
     enabled_protocols_min=${enabled_protocol_limit}
-    get_enabled_protocol_limit "${target}" "max"
+    get_enabled_protocol_limit "${target}" "max" "TLSv1.3"
     enabled_protocols_max=${enabled_protocol_limit}
 
     if [ "${enabled_protocols_min:-}" = "${enabled_protocols_max:-}" ]; then
@@ -171,8 +170,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.3"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_gateway_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -169,7 +169,7 @@ get_enabled_protocol_limit() {
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-${default}}}
 }
 
 extract_between() {

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -164,13 +164,12 @@ ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
 get_enabled_protocol_limit() {
     target=$1
     type=$2
+    default=$3
     key_component="ZWE_configs_zowe_network_${target}_tls_${type}Tls"
     value_component=$(eval echo \$$key_component)
-    key_gateway="ZWE_components_gateway_zowe_network_${target}_tls_${type}Tls"
-    value_gateway=$(eval echo \$$key_gateway)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_gateway:-${value_zowe:-}}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
 }
 
 extract_between() {
@@ -179,9 +178,9 @@ extract_between() {
 
 get_enabled_protocol() {
     target=$1
-    get_enabled_protocol_limit "${target}" "min"
+    get_enabled_protocol_limit "${target}" "min" "TLSv1.2"
     enabled_protocols_min=${enabled_protocol_limit}
-    get_enabled_protocol_limit "${target}" "max"
+    get_enabled_protocol_limit "${target}" "max" "TLSv1.3"
     enabled_protocols_max=${enabled_protocol_limit}
 
     if [ "${enabled_protocols_min:-}" = "${enabled_protocols_max:-}" ]; then
@@ -197,8 +196,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.3"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_gateway_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -95,6 +95,18 @@ bootRun {
         args project.args.split(',')
     }
 
+    jvmArgs([
+        '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+        '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
+        '--add-opens=java.base/java.net=ALL-UNNAMED'
+    ])
+
     debugOptions {
         port = 5011
         suspend = false

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -205,11 +205,12 @@ ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
 get_enabled_protocol_limit() {
     target=$1
     type=$2
+    default=$3
     key_component="ZWE_configs_zowe_network_${target}_tls_${type}Tls"
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
 }
 
 extract_between() {
@@ -218,9 +219,9 @@ extract_between() {
 
 get_enabled_protocol() {
     target=$1
-    get_enabled_protocol_limit "${target}" "min"
+    get_enabled_protocol_limit "${target}" "min" "TLSv1.2"
     enabled_protocols_min=${enabled_protocol_limit}
-    get_enabled_protocol_limit "${target}" "max"
+    get_enabled_protocol_limit "${target}" "max" "TLSv1.3"
     enabled_protocols_max=${enabled_protocol_limit}
 
     if [ "${enabled_protocols_min:-}" = "${enabled_protocols_max:-}" ]; then
@@ -236,8 +237,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.3"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_gateway_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -210,7 +210,7 @@ get_enabled_protocol_limit() {
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-${default}}}
 }
 
 extract_between() {

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -210,13 +210,12 @@ ADD_OPENS="--add-opens=java.base/java.lang=ALL-UNNAMED
 get_enabled_protocol_limit() {
     target=$1
     type=$2
+    default=$3
     key_component="ZWE_configs_zowe_network_${target}_tls_${type}Tls"
     value_component=$(eval echo \$$key_component)
-    key_gateway="ZWE_components_gateway_zowe_network_${target}_tls_${type}Tls"
-    value_gateway=$(eval echo \$$key_gateway)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_gateway:-${value_zowe:-}}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
 }
 
 extract_between() {
@@ -225,9 +224,9 @@ extract_between() {
 
 get_enabled_protocol() {
     target=$1
-    get_enabled_protocol_limit "${target}" "min"
+    get_enabled_protocol_limit "${target}" "min" "TLSv1.2"
     enabled_protocols_min=${enabled_protocol_limit}
-    get_enabled_protocol_limit "${target}" "max"
+    get_enabled_protocol_limit "${target}" "max" "TLSv1.3"
     enabled_protocols_max=${enabled_protocol_limit}
 
     if [ "${enabled_protocols_min:-}" = "${enabled_protocols_max:-}" ]; then
@@ -243,8 +242,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.3"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_gateway_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -215,7 +215,7 @@ get_enabled_protocol_limit() {
     value_component=$(eval echo \$$key_component)
     key_zowe="ZWE_zowe_network_${target}_tls_${type}Tls"
     value_zowe=$(eval echo \$$key_zowe)
-    enabled_protocol_limit=${value_component:-${value_zowe:-default}}
+    enabled_protocol_limit=${value_component:-${value_zowe:-${default}}}
 }
 
 extract_between() {


### PR DESCRIPTION
# Description

In v3, default minimum was changed if none is specified in zowe.yaml, making it TLSv1.3 only.
The default suggested in the example zowe.yaml file is TLSv1.2 as minimum with TLSv1.3 supported by default: https://github.com/zowe/zowe-install-packaging/blob/v3.x/staging/example-zowe.yaml#L351

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
