### PR TITLE
fix: Add newPassword to the Swagger

### DIFF
--- a/zaas-service/src/main/resources/zaas-api-doc.json
+++ b/zaas-service/src/main/resources/zaas-api-doc.json
@@ -26,7 +26,7 @@
                             }
                         }
                     },
-                    "description": "Specifies the user credentials to be authenticated."
+                    "description": "Specifies the user credentials to be authenticated. If newPassword is provided and the password is valid, the password is changed to newPassword"
                 },
                 "security": [
                     {
@@ -259,6 +259,9 @@
                         "type": "string"
                     },
                     "password": {
+                        "type": "string"
+                    },
+                    "newPassword": {
                         "type": "string"
                     }
                 },


### PR DESCRIPTION
# Description

The API Mediation Layer support password change. The implementation is on the POST to the login endpoint. 

This functionality wasn't documented in the OpenAPI Documentation. This PR adds the documentation. 

<img width="583" alt="Screenshot 2025-02-20 at 13 55 05" src="https://github.com/user-attachments/assets/e070f7f3-1b9f-4171-88f1-171e8614a8e8" />

Linked to #3886

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
