### PR TITLE
fix: authentication header for routed requests

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/AbstractTokenFilterFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/AbstractTokenFilterFactory.java
@@ -30,6 +30,8 @@ import reactor.core.publisher.Mono;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.zowe.apiml.constants.ApimlConstants.BEARER_AUTHENTICATION_PREFIX;
+
 public abstract class AbstractTokenFilterFactory<T extends AbstractTokenFilterFactory.Config, D> extends AbstractAuthSchemeFactory<T, ZaasTokenResponse, D> {
 
     protected AbstractTokenFilterFactory(Class<T> configClazz, WebClient webClient, InstanceInfoService instanceInfoService, MessageService messageService) {
@@ -90,6 +92,7 @@ public abstract class AbstractTokenFilterFactory<T extends AbstractTokenFilterFa
                         response.get().getToken()
                     );
                     headers.set(HttpHeaders.COOKIE, cookieHeader);
+                    headers.set(HttpHeaders.AUTHORIZATION, BEARER_AUTHENTICATION_PREFIX + " "  + response.get().getToken());
                 }).build();
                 exchange = exchange.mutate().request(request).build();
             }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/acceptance/TokenSchemeTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/acceptance/TokenSchemeTest.java
@@ -12,10 +12,7 @@ package org.zowe.apiml.gateway.acceptance;
 
 import com.sun.net.httpserver.HttpExchange;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.http.HttpHeaders;
 import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.gateway.acceptance.common.AcceptanceTest;
@@ -262,7 +259,7 @@ public abstract class TokenSchemeTest {
         private MockService service;
 
         @BeforeAll
-        void initService() throws IOException {
+        void initService() {
             service = createService();
         }
 
@@ -303,8 +300,9 @@ public abstract class TokenSchemeTest {
                 .authenticationScheme(getAuthenticationScheme())
                 .addEndpoint("/service/test/success")
                     .assertion(he -> assertEquals(JWT, getCookie(he, COOKIE_NAME)))
+                    .assertion(he -> assertEquals(1, he.getRequestHeaders().get(HttpHeaders.AUTHORIZATION).size()))
+                    .assertion(he -> assertEquals("Bearer " + JWT, he.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION)))
 
-                    .assertion(he -> assertNull(he.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION)))
                     .assertion(he -> assertNull(he.getRequestHeaders().getFirst("x-service-id")))
                     .assertion(he -> assertNull(he.getRequestHeaders().getFirst("X-SAF-Token")))
                     .assertion(he -> assertNull(he.getRequestHeaders().getFirst("X-Certificate-Public")))
@@ -323,7 +321,8 @@ public abstract class TokenSchemeTest {
                 .addEndpoint("/service/test/fail")
                     .assertion(he -> assertNull(getCookie(he, COOKIE_NAME)))
 
-                    .assertion(he -> assertNotNull(he.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION)))
+                    .assertion(he -> assertEquals(1, he.getRequestHeaders().get(HttpHeaders.AUTHORIZATION).size()))
+                    .assertion(he -> assertNotEquals("Bearer " + JWT, he.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION)))
                     .assertion(he -> assertNull(he.getRequestHeaders().getFirst("x-service-id")))
                     .assertion(he -> assertNotNull(he.getRequestHeaders().getFirst("X-SAF-Token")))
                     .assertion(he -> assertNull(he.getRequestHeaders().getFirst("X-Certificate-Public")))

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/AbstractTokenFilterFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/AbstractTokenFilterFactoryTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -79,6 +80,7 @@ class AbstractTokenFilterFactoryTest {
                     .build()
                 ));
                 assertEquals("cookieName=cookieValue", request.getHeaders().getFirst("cookie"));
+                assertEquals("Bearer cookieValue" , request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
             }
 
         }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/PATWithAllSchemesTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/PATWithAllSchemesTest.java
@@ -62,7 +62,7 @@ class PATWithAllSchemesTest {
         var schemasTest = new ArrayList<Arguments>();
         schemasTest.add(Arguments.of("zowejwt", HttpRequestUtils.getUriFromGateway(ZOWE_JWT_REQUEST), (Consumer<Response>) r -> {
             assertEquals(HttpStatus.SC_OK, r.getStatusCode());
-            assertNull(r.getBody().path("headers.authorization"));
+            assertNotNull(r.getBody().path("headers.authorization"));
             assertThat(r.getBody().path("headers.cookie"), containsString(COOKIE_NAME));
             String jwt = r.getBody().path("headers.cookie").toString();
             try {

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/GatewayAuthTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/GatewayAuthTest.java
@@ -49,12 +49,12 @@ public class GatewayAuthTest implements TestWithStartedInstances {
         List<Arguments> arguments = new ArrayList<>(Arrays.asList(
             Arguments.of("Zowe auth scheme", ZOWE_JWT_REQUEST, (Consumer<Response>) response -> {
                 assertNotNull(response.jsonPath().getString("cookies.apimlAuthenticationToken"), "Expected not null apimlAuthenticationToken. Response was: " + response.asPrettyString());
-                assertNull(response.jsonPath().getString("headers.authorization"), "Expected null Authorization header. Response was: " + response.asPrettyString());
+                assertNotNull(response.jsonPath().getString("headers.authorization"), "Expected not null Authorization header. Response was: " + response.asPrettyString());
                 assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")), "Expected empty certs list. Response was: " + response.asPrettyString());
             }),
             Arguments.of("z/OSMF auth scheme", ZOSMF_REQUEST, (Consumer<Response>) response -> {
                 assertNotNull(response.jsonPath().getString("cookies.jwtToken"), "Expected not null jwtToken cookie. Response was: " + response.asPrettyString());
-                assertNull(response.jsonPath().getString("headers.authorization"), "Expected null Authorization header. Response was: " + response.asPrettyString());
+                assertNotNull(response.jsonPath().getString("headers.authorization"), "Expected not null Authorization header. Response was: " + response.asPrettyString());
                 assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")), "Expected empty certs list. Response was: " + response.asPrettyString());
             }),
             Arguments.of("PassTicket auth scheme", REQUEST_INFO_ENDPOINT, (Consumer<Response>) response -> {

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/ZoweJwtSchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/ZoweJwtSchemeTest.java
@@ -21,6 +21,7 @@ import org.zowe.apiml.util.TestWithStartedInstances;
 import org.zowe.apiml.util.categories.DiscoverableClientDependentTest;
 import org.zowe.apiml.util.categories.InfinispanStorageTest;
 import org.zowe.apiml.util.categories.zOSMFAuthTest;
+import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.config.ItSslConfigFactory;
 import org.zowe.apiml.util.config.SslContext;
 import org.zowe.apiml.util.http.HttpRequestUtils;
@@ -41,6 +42,9 @@ import static org.zowe.apiml.util.requests.Endpoints.ZOWE_JWT_REQUEST;
 class ZoweJwtSchemeTest implements TestWithStartedInstances {
 
     private static URI URL;
+    private static final String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
+    private static final String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
+
 
     @BeforeAll
     static void init() throws Exception {
@@ -69,6 +73,20 @@ class ZoweJwtSchemeTest implements TestWithStartedInstances {
             .then()
             .body("headers.x-zowe-auth-failure", is("ZWEAG160E No authentication provided in the request"))
             .header("x-zowe-auth-failure", is("ZWEAG160E No authentication provided in the request"))
+            .statusCode(200);
+    }
+
+    @Test
+    void givenBasicAuthHeader_authenticationIsPassedUnchanged() {
+        given()
+            .config(SslContext.tlsWithoutCert)
+            .auth().preemptive().basic(USERNAME, PASSWORD)
+            .when()
+            .get(URL)
+            .then()
+            .log().all()
+            .body("headers.cookie", nullValue())
+            .body("headers.authorization", startsWith("Basic"))
             .statusCode(200);
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/ZoweJwtSchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/ZoweJwtSchemeTest.java
@@ -56,6 +56,7 @@ class ZoweJwtSchemeTest implements TestWithStartedInstances {
             .get(URL)
             .then()
             .body("headers.cookie", startsWith("apimlAuthenticationToken"))
+            .body("headers.authorization", startsWith("Bearer"))
             .statusCode(200);
     }
 
@@ -100,6 +101,7 @@ class ZoweJwtSchemeTest implements TestWithStartedInstances {
                 .get(URL)
                 .then()
                 .body("headers.cookie", is("apimlAuthenticationToken=" + jwt))
+                .body("headers.authorization", is("Bearer " + jwt))
                 .statusCode(200);
         }
 
@@ -117,6 +119,7 @@ class ZoweJwtSchemeTest implements TestWithStartedInstances {
                 .then()
                 .body("cookies.apimlAuthenticationToken", is(jwt))
                 .body("cookies.XSRF-TOKEN", is("another-token-in-cookies"))
+                .body("headers.authorization", is("Bearer " + jwt))
                 .statusCode(200);
         }
 
@@ -151,6 +154,7 @@ class ZoweJwtSchemeTest implements TestWithStartedInstances {
                 .get(URL)
                 .then()
                 .body("headers.cookie", startsWith("apimlAuthenticationToken="))
+                .body("headers.authorization", startsWith("Bearer "))
                 .statusCode(200);
         }
     }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ServiceProtectedEndpointIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/services/ServiceProtectedEndpointIntegrationTest.java
@@ -112,7 +112,7 @@ class ServiceProtectedEndpointIntegrationTest implements TestWithStartedInstance
                 URI uri = HttpRequestUtils.getUriFromGateway(ZOSMF_ENDPOINT, ARGUMENT);
 
                 given()
-                    .auth().preemptive().basic(USERNAME, new String(PASSWORD))
+                    .auth().preemptive().basic(USERNAME, PASSWORD)
                     .header("X-CSRF-ZOSMF-HEADER", "zosmf")
                 .when()
                     .get(uri)

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -13,6 +13,7 @@ package org.zowe.apiml.client.services.apars;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.zowe.apiml.client.model.LoginBody;
 import org.zowe.apiml.client.services.JwtTokenService;
 
@@ -216,6 +217,19 @@ public class FunctionalApar implements Apar {
         String jwtToken = jwtTokenService.extractToken(headers);
         return jwtTokenService.validateJwtToken(jwtToken);
 
+    }
+
+    protected boolean isValidAuthHeader(String authHeader) {
+        if (!StringUtils.hasText(authHeader)) {
+            return false;
+        }
+
+        if (authHeader.startsWith("Bearer")) {
+            var jwtToken = authHeader.length() > 8 ? authHeader.substring(7) : "";
+            return jwtTokenService.validateJwtToken(jwtToken);
+        }
+
+        return true;
     }
 
     private String getAuthCookie(Map<String, String> headers) {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -229,7 +229,7 @@ public class FunctionalApar implements Apar {
             return jwtTokenService.validateJwtToken(jwtToken);
         }
 
-        return true;
+        return false;
     }
 
     private String getAuthCookie(Map<String, String> headers) {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -229,7 +229,7 @@ public class FunctionalApar implements Apar {
             return jwtTokenService.validateJwtToken(jwtToken);
         }
 
-        return false;
+        return true;
     }
 
     private String getAuthCookie(Map<String, String> headers) {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
@@ -70,7 +70,7 @@ public class PHBase extends FunctionalApar {
         String authorization = headers.get(AUTHORIZATION_HEADER);
 
         if (authorization != null) {
-            if (!isValidAuthHeader(authorization)) {
+            if (!isValidAuthHeader(authorization) && !ltpaIsPresent(headers)) {
                 return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
             }
         } else {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
@@ -70,7 +70,7 @@ public class PHBase extends FunctionalApar {
         String authorization = headers.get(AUTHORIZATION_HEADER);
 
         if (authorization != null) {
-            if (authorization.startsWith("Bearer")) {
+            if (!isValidAuthHeader(authorization)) {
                 return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
             }
         } else {


### PR DESCRIPTION
# Description

Add authorization header for routed requests, ensure backwards compatibility with v2.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
