### PR TITLE
fix: fix four slashes support in SSE class

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandler.java
@@ -31,6 +31,7 @@ import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.product.routing.RoutedService;
 import org.zowe.apiml.product.routing.RoutedServices;
 import org.zowe.apiml.product.routing.RoutedServicesUser;
+import org.zowe.apiml.security.SecurityUtils;
 import org.zowe.apiml.util.UrlUtils;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
@@ -75,9 +76,19 @@ public class ServerSentEventProxyHandler implements RoutedServicesUser {
 
     @PostConstruct
     void initWebClient() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
+        updateStorePaths();
         webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(
             HttpClient.create().secure(SslProvider.builder().sslContext(getSslContext()).build())
         )).build();
+    }
+
+    void updateStorePaths() {
+        if (SecurityUtils.isKeyring(trustStore)) {
+            trustStore = SecurityUtils.formatKeyringUrl(trustStore);
+            if (trustStorePassword == null || trustStorePassword.length == 0) {
+                trustStorePassword = "password".toCharArray();
+            }
+        }
     }
 
     private SslContext getSslContext() throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/sse/ServerSentEventProxyHandlerTest.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.message.yaml.YamlMessageService;
@@ -44,11 +45,14 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ServerSentEventProxyHandlerTest {
+
     private static final String HOST = "host.com";
     private static final int PORT = 10010;
     private static final String SERVICE_URL = "/service";
@@ -73,6 +77,20 @@ class ServerSentEventProxyHandlerTest {
         mockDiscoveryClient = mock(DiscoveryClient.class);
         underTest = Mockito.spy(new ServerSentEventProxyHandler(mockDiscoveryClient, messageService));
         underTest.initWebClient();
+    }
+
+    @Test
+    void givenFourSlashesKeyring_thenFixFormat() {
+        ReflectionTestUtils.setField(underTest, "trustStorePassword", new char[]{});
+        ReflectionTestUtils.setField(underTest, "trustStore", "safkeyring:////USER/KEYRING");
+
+        try {
+            underTest.initWebClient();
+        } catch (Exception e) {
+            // ignore
+        }
+        assertArrayEquals(new char[]{'p','a','s','s','w','o','r','d'}, (char[]) ReflectionTestUtils.getField(underTest, "trustStorePassword"));
+        assertEquals("safkeyring://USER/KEYRING", ReflectionTestUtils.getField(underTest, "trustStore"));
     }
 
     @Nested
@@ -253,6 +271,7 @@ class ServerSentEventProxyHandlerTest {
         }
     }
 
+    @SuppressWarnings("unused") // parameterized test
     private static Stream<Arguments> endpoints() {
         return Stream.of(
             Arguments.of(GATEWAY_PATH, ENDPOINT),


### PR DESCRIPTION
# Description

Changes in #3702 made the class `ServerSentEventProxyHandler` not support safkeyring URLs with four slashes, which are kept to avoid the breaking change in version 2.

This PR fixes it.

Linked to #3702 

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
