### PR TITLE
fix: Add newPassword to Open API Documentation of the login endpoint.

### DIFF
--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -38,7 +38,7 @@
                             }
                         }
                     },
-                    "description": "Specifies the user credentials to be authenticated."
+                    "description": "Specifies the user credentials to be authenticated. If newPassword is provided and the password is valid, the password is changed to newPassword"
                 },
                 "security": [
                     {
@@ -910,6 +910,9 @@
                         "type": "string"
                     },
                     "password": {
+                        "type": "string"
+                    },
+                    "newPassword": {
                         "type": "string"
                     }
                 },


### PR DESCRIPTION
# Description

The Open API documentation for login was missing information on how to change the password. 

<img width="580" alt="Screenshot 2025-02-21 at 12 53 04" src="https://github.com/user-attachments/assets/672d5114-b16c-4a24-8a39-a60b220fb66e" />

Linked to #3886 

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
