### PR TITLE
fix: Workaround for api catalog redirect behavior in desktop

### DIFF
--- a/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
+++ b/api-catalog-package/src/main/resources/plugin/pluginDefinition.json
@@ -5,7 +5,7 @@
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",
-    "destination": "https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT}/apicatalog/ui/v1",
+    "destination": "https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT}/apicatalog/ui/v1/",
     "launchDefinition": {
       "pluginShortNameKey": "API Catalog",
       "pluginShortNameDefault": "API Catalog",


### PR DESCRIPTION
I have encountered a symptom of https://github.com/zowe/api-layer/issues/3652 which is breaking using the catalog in the desktop for some, and I am assuming this is also the reason the v3.x/staging builds are failing on zowe-install-packaging right now too.

In short:

In v2, the desktop sends a GET to https://<current url>/apicatalog/ui/v1
It does a 302 redirect to /apicatalog/ui/v1/

In v3, it does a 302 redirect to https://<zowe.externalDomains[0]>:<zowe.externalPort>/apicatalog/ui/v1/

Further, v3 adds the header "X-Frame-Options: sameorigin"

Put together, you can't load the API catalog in the Desktop in v3 unless you use the same hostname as in the first position of zowe.externalDomains, because the redirect the v3 catalog does will change the hostname and then violate its own header.


Example 1:
I have "hostname" in my zowe YAML, but go to "hostname.company.com"
Works in v2, doesnt work in v3. Same with vice-versa.

Example 2:
I have multiple hosts in my zowe YAML. I go to the first one for the Desktop and it works, but if I go to the second one it does not because the api catalog issues a redirect to the first one.


Adding a "/" to the end of the URL, as sugggested in 3652, makes this redirect to a different hostname not happen, so it fixes the problem.