### PR TITLE
fix: allow special characters in url

### DIFF
--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SecurityConfiguration.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/SecurityConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.zowe.apiml.filter.AttlsFilter;
 
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -63,7 +64,16 @@ public class SecurityConfiguration {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return web ->
+        StrictHttpFirewall firewall = new StrictHttpFirewall();
+        firewall.setAllowUrlEncodedSlash(true);
+        firewall.setAllowBackSlash(true);
+        firewall.setAllowUrlEncodedPercent(true);
+        firewall.setAllowUrlEncodedPeriod(true);
+        firewall.setAllowSemicolon(true);
+
+        return web -> {
+            web.httpFirewall(firewall);
             web.ignoring().requestMatchers("/api/v1/**");
+        };
     }
 }

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/TomcatConfiguration.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/configuration/TomcatConfiguration.java
@@ -10,6 +10,8 @@
 
 package org.zowe.apiml.client.configuration;
 
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
@@ -23,13 +25,23 @@ import java.util.List;
  */
 @Configuration
 public class TomcatConfiguration {
+
     @Bean
     public ServletWebServerFactory servletContainer(List<TomcatConnectorCustomizer> connectorCustomizers) {
-        System.setProperty("org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH", "true");
-        System.setProperty("org.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH", "true");
+        connectorCustomizers.add(new UrlTomcatCustomizer());
         TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
         tomcat.setProtocol(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
         tomcat.addConnectorCustomizers(connectorCustomizers.toArray(new TomcatConnectorCustomizer[0]));
         return tomcat;
+    }
+
+    static class UrlTomcatCustomizer implements TomcatConnectorCustomizer {
+
+        @Override
+        public void customize(Connector connector) {
+            connector.setAllowBackslash(true);
+            connector.setEncodedSolidusHandling(EncodedSolidusHandling.PASS_THROUGH.getValue());
+        }
+
     }
 }

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -197,6 +197,13 @@ management:
             enabled: true
 
 ---
+spring.config.activate.on-profile: debug
+
+logging:
+    level:
+        ROOT: DEBUG
+
+---
 spring.config.activate.on-profile: dev
 
 logging:

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -50,6 +50,7 @@ import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.security.web.server.firewall.StrictServerWebExchangeFirewall;
 import org.springframework.security.web.server.savedrequest.CookieServerRequestCache;
 import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
@@ -113,6 +114,9 @@ public class WebSecurity {
 
     @Value("${apiml.health.protected:true}")
     private boolean isHealthEndpointProtected;
+
+    @Value("${apiml.security.enableStrictUrlValidation:false}")
+    private boolean isStrictUrlValidationEnabled;
 
     private final ClientConfiguration clientConfiguration;
 
@@ -485,6 +489,22 @@ public class WebSecurity {
                 .build();
             return chain.filter(writeableExchange);
         };
+    }
+
+    @Bean
+    public StrictServerWebExchangeFirewall httpFirewall() {
+        StrictServerWebExchangeFirewall firewall = new StrictServerWebExchangeFirewall();
+
+        if (isStrictUrlValidationEnabled) {
+            return firewall;
+        }
+
+        firewall.setAllowUrlEncodedSlash(true);
+        firewall.setAllowBackSlash(true);
+        firewall.setAllowUrlEncodedPercent(true);
+        firewall.setAllowUrlEncodedPeriod(true);
+        firewall.setAllowSemicolon(true);
+        return firewall;
     }
 
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/GatewayRoutingTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/GatewayRoutingTest.java
@@ -110,4 +110,13 @@ class GatewayRoutingTest implements TestWithStartedInstances {
         String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), "/dcpassticket/api/v1/unknown");
         given().get(new URI(scgUrl)).then().statusCode(404);
     }
+
+    @Test
+    void testRoutingWithSpecialCharacters() throws URISyntaxException {
+        String scgUrl = String.format("%s://%s:%s%s", conf.getScheme(), conf.getHost(), conf.getPort(), "/discoverableclient/api/v1/%5C%2F%25%2E%3B/greeting");
+        given()
+            .urlEncodingEnabled(false)
+            .get(new URI(scgUrl)).then().statusCode(200);
+    }
+
 }


### PR DESCRIPTION
# Description

This was default behavior in v2 and v3, got broken during update to spring boot 3.3.5. This fix enables the support for special characters again.

Linked to #4012 
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
