### PR TITLE
fix: Add missing OIDC documentation to OpenAPI

### DIFF
--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -639,6 +639,33 @@
                 }
             }
         },
+
+        "/auth/oidc-token/validate": {
+            "post": {
+                "tags": ["OIDC"],
+                "summary": "Validate OIDC token",
+                "description": "Use the /oidc-token/validate API to validate token against configured OIDC provider. The Gateway can verify token locally or remotely depends on API Mediation Layer configuration.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OIDCValidationRequest"
+                            }
+                        }
+                    },
+                    "description": "Specifies the OIDC token for validation without scopes (serviceId will be ignored)."
+                },
+                "responses": {
+                    "204": {
+                        "description": "Valid token"
+                    },
+                    "401": {
+                        "description": "Invalid token or OIDC provider is not defined"
+                    }
+                }
+            }
+        },
+
         "/services": {
             "get": {
                 "tags": ["Services"],
@@ -963,6 +990,23 @@
                 "required": ["applicationName"],
                 "example": {
                     "applicationName": "ZOWEAPPL"
+                }
+            },
+            "OIDCValidationRequest": {
+                "type": "object",
+                "properties": {
+                    "token": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "serviceId": {
+                        "type": "string",
+                        "description": ""
+                    }
+                },
+                "example": {
+                    "serviceId": "string",
+                    "token": "string"
                 }
             },
             "TicketResponse": {

--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -997,7 +997,7 @@
                 "properties": {
                     "token": {
                         "type": "string",
-                        "description": ""
+                        "description": "OIDC token to be validated"
                     },
                     "serviceId": {
                         "type": "string",

--- a/gateway-service/src/main/resources/gateway-api-doc.json
+++ b/gateway-service/src/main/resources/gateway-api-doc.json
@@ -1001,7 +1001,7 @@
                     },
                     "serviceId": {
                         "type": "string",
-                        "description": ""
+                        "description": "Service ID to be validated as required scope in the token"
                     }
                 },
                 "example": {


### PR DESCRIPTION
# Description

The OIDC validate documentation was missing in 2.18 OpenAPI for Gateway. This PR adds the documentation that is now in V3. 

Linked to #3885

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
