### PR TITLE
fix: improve websocket message

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/websocket/ApimlWebSocketSession.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/websocket/ApimlWebSocketSession.java
@@ -45,6 +45,6 @@ public class ApimlWebSocketSession extends TomcatWebSocketSession {
         if (ex.getCause() instanceof AuthenticationException) {
             close(new CloseStatus(1003, "Invalid login credentials"));
         }
-        close(CloseStatus.SERVER_ERROR);
+        close(CloseStatus.create(CloseStatus.SERVER_ERROR.getCode(), ex.getMessage()));
     }
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/websocket/ApimlWebSocketSessionTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/websocket/ApimlWebSocketSessionTest.java
@@ -22,6 +22,7 @@ import org.springframework.web.reactive.socket.CloseStatus;
 import reactor.core.publisher.Sinks;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -52,7 +53,7 @@ class ApimlWebSocketSessionTest {
     @Test
     void givenGenericException_WhenError_thenServerError() {
         webSocketSession.onError(new RuntimeException("message"));
-        verify(webSocketSession, times(1)).close(CloseStatus.SERVER_ERROR);
+        verify(webSocketSession, times(1)).close(argThat(status -> status.getCode() == CloseStatus.SERVER_ERROR.getCode() && status.getReason().equals("message")));
     }
 
     @Test


### PR DESCRIPTION
# Description

Fixes issue with ws generic 500 response:
```
 The close message is Some(CloseData { status_code: 1011, reason: null}
```
This issue is happening in some case when performing ws call with invalid Authorization header in the request. This results with a message saying missing  `WWW-Authenticate header` from the service response from Spring Cloud WebSocket implementation.
According to [RFC](https://www.rfc-editor.org/rfc/rfc7235#section-3.1) "The server generating a 401 response MUST send a `WWW-Authenticate` header field ".
Linked to #3995 

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
