### PR TITLE
fix: Fix choosing correct client certificate for outbound communication from the Gateway

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
@@ -74,9 +74,14 @@ import reactor.netty.tcp.SslProvider;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509KeyManager;
 import java.net.MalformedURLException;
+import java.net.Socket;
 import java.net.URL;
 import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -226,6 +231,11 @@ public class ConnectionsConfig {
         };
     }
 
+    // for testing purposes
+    X509KeyManager x509KeyManagerSelectedAlias(KeyManagerFactory keyManagerFactory) {
+        return new X509KeyManagerSelectedAlias(keyManagerFactory, keyAlias);
+    }
+
     /**
      * @return io.netty.handler.ssl.SslContext for http client.
      */
@@ -243,7 +253,7 @@ public class ConnectionsConfig {
                 log.info("Loading keystore: {}: {}", keyStoreType, keyStorePath);
                 KeyStore keyStore = SecurityUtils.loadKeyStore(keyStoreType, keyStorePath, keyStorePassword);
                 keyManagerFactory.init(keyStore, keyStorePassword);
-                builder.keyManager(keyManagerFactory);
+                builder.keyManager(x509KeyManagerSelectedAlias(keyManagerFactory));
             } else {
                 KeyStore emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
                 emptyKeystore.load(null, null);
@@ -536,6 +546,54 @@ public class ConnectionsConfig {
             String getHomePageUrl();
             String getStatusPageUrl();
 
+        }
+
+    }
+
+    static class X509KeyManagerSelectedAlias implements X509KeyManager {
+
+        private final X509KeyManager originalKm;
+        private final String keyAlias;
+
+        X509KeyManagerSelectedAlias(KeyManagerFactory keyManagerFactory, String keyAlias) {
+            this.originalKm = (X509KeyManager) keyManagerFactory.getKeyManagers()[0];
+            this.keyAlias = keyAlias;
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return originalKm.getClientAliases(keyType, issuers);
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            if (keyAlias != null) {
+                return keyAlias;
+            }
+            return originalKm.chooseClientAlias(keyType, issuers, socket);
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return originalKm.getServerAliases(keyType, issuers);
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            if (keyAlias != null) {
+                return keyAlias;
+            }
+            return originalKm.chooseServerAlias(keyType, issuers, socket);
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return originalKm.getCertificateChain(alias);
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return originalKm.getPrivateKey(alias);
         }
 
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.config;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.appinfo.*;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
@@ -231,7 +232,7 @@ public class ConnectionsConfig {
         };
     }
 
-    // for testing purposes
+    @VisibleForTesting
     X509KeyManager x509KeyManagerSelectedAlias(KeyManagerFactory keyManagerFactory) {
         return new X509KeyManagerSelectedAlias(keyManagerFactory, keyAlias);
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
@@ -221,85 +221,85 @@ class ConnectionsConfigTest {
             private static final X509Certificate[] CERTIFICATES = new X509Certificate[0];
             private static final PrivateKey PRIVATE_KEY = mock(PrivateKey.class);
 
-            private final X509KeyManager ORIG_KEY_MANAGER = mock(X509KeyManager.class);
-            private final KeyManagerFactory ORIG_KEY_MANAGER_FACTORY = new KeyManagerFactoryWrapper(ORIG_KEY_MANAGER);
+            private final X509KeyManager origKeyManager = mock(X509KeyManager.class);
+            private final KeyManagerFactory origKeyManagerFactory = new KeyManagerFactoryWrapper(origKeyManager);
 
             @Test
             void whenGetClientAliases_thenRecall() {
-                doReturn(ALIASES).when(ORIG_KEY_MANAGER).getClientAliases(KEY_TYPE, ISSUERS);
+                doReturn(ALIASES).when(origKeyManager).getClientAliases(KEY_TYPE, ISSUERS);
                 assertSame(ALIASES,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .getClientAliases(KEY_TYPE, ISSUERS)
                 );
-                verify(ORIG_KEY_MANAGER).getClientAliases(KEY_TYPE, ISSUERS);
+                verify(origKeyManager).getClientAliases(KEY_TYPE, ISSUERS);
             }
 
             @Test
             void givenNoAlias_whenChooseClientAlias_thenRecall() {
-                doReturn(ALIAS).when(ORIG_KEY_MANAGER).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+                doReturn(ALIAS).when(origKeyManager).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
                 assertSame(ALIAS,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, null)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, null)
                         .chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET)
                 );
-                verify(ORIG_KEY_MANAGER).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+                verify(origKeyManager).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
             }
 
             @Test
             void givenAlias_whenChooseClientAlias_thenReturnAlias() {
                 assertSame(CONFIG_ALIAS,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET)
                 );
-                verify(ORIG_KEY_MANAGER, never()).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+                verify(origKeyManager, never()).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
             }
 
             @Test
             void whenGetServerAliases_thenRecall() {
-                doReturn(ALIASES).when(ORIG_KEY_MANAGER).getServerAliases(KEY_TYPE, ISSUERS);
+                doReturn(ALIASES).when(origKeyManager).getServerAliases(KEY_TYPE, ISSUERS);
                 assertSame(ALIASES,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .getServerAliases(KEY_TYPE, ISSUERS)
                 );
-                verify(ORIG_KEY_MANAGER).getServerAliases(KEY_TYPE, ISSUERS);
+                verify(origKeyManager).getServerAliases(KEY_TYPE, ISSUERS);
             }
 
             @Test
             void givenNoAlias_whenChooseServerAlias_thenRecall() {
-                doReturn(ALIAS).when(ORIG_KEY_MANAGER).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+                doReturn(ALIAS).when(origKeyManager).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
                 assertSame(ALIAS,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, null)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, null)
                         .chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET)
                 );
-                verify(ORIG_KEY_MANAGER).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+                verify(origKeyManager).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
             }
 
             @Test
             void givenAlias_whenChooseServerAlias_thenReturnAlias() {
                 assertSame(CONFIG_ALIAS,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET)
                 );
-                verify(ORIG_KEY_MANAGER, never()).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+                verify(origKeyManager, never()).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
             }
 
             @Test
             void whenGetCertificateChain_thenRecall() {
-                doReturn(CERTIFICATES).when(ORIG_KEY_MANAGER).getCertificateChain(ALIAS);
+                doReturn(CERTIFICATES).when(origKeyManager).getCertificateChain(ALIAS);
                 assertSame(CERTIFICATES,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .getCertificateChain(ALIAS)
                 );
-                verify(ORIG_KEY_MANAGER).getCertificateChain(ALIAS);
+                verify(origKeyManager).getCertificateChain(ALIAS);
             }
 
             @Test
             void whenGetPrivateKey_thenRecall() {
-                doReturn(PRIVATE_KEY).when(ORIG_KEY_MANAGER).getPrivateKey(ALIAS);
+                doReturn(PRIVATE_KEY).when(origKeyManager).getPrivateKey(ALIAS);
                 assertSame(PRIVATE_KEY,
-                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(origKeyManagerFactory, CONFIG_ALIAS)
                         .getPrivateKey(ALIAS)
                 );
-                verify(ORIG_KEY_MANAGER).getPrivateKey(ALIAS);
+                verify(origKeyManager).getPrivateKey(ALIAS);
             }
 
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
@@ -15,6 +15,7 @@ import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClientConfig;
+import io.netty.handler.ssl.util.KeyManagerFactoryWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,8 +40,13 @@ import org.zowe.apiml.gateway.GatewayServiceApplication;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.tcp.SslProvider;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509KeyManager;
 import java.net.MalformedURLException;
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -198,6 +204,102 @@ class ConnectionsConfigTest {
                     .response().block();
 
                 assertNull(SslDetectorConfig.sslInfoHolder.get());
+            }
+
+        }
+
+        @Nested
+        class Wrapper {
+
+            private static final String CONFIG_ALIAS = "configAlias";
+            private static final String ALIAS = "alias";
+            private static final String[] ALIASES = new String[] { "alias" };
+            private static final String KEY_TYPE = "keyType";
+            private static final String[] KEY_TYPES = new String[] { KEY_TYPE };
+            private static final Principal[] ISSUERS = new Principal[0];
+            private static final Socket SOCKET = mock(Socket.class);
+            private static final X509Certificate[] CERTIFICATES = new X509Certificate[0];
+            private static final PrivateKey PRIVATE_KEY = mock(PrivateKey.class);
+
+            private final X509KeyManager ORIG_KEY_MANAGER = mock(X509KeyManager.class);
+            private final KeyManagerFactory ORIG_KEY_MANAGER_FACTORY = new KeyManagerFactoryWrapper(ORIG_KEY_MANAGER);
+
+            @Test
+            void whenGetClientAliases_thenRecall() {
+                doReturn(ALIASES).when(ORIG_KEY_MANAGER).getClientAliases(KEY_TYPE, ISSUERS);
+                assertSame(ALIASES,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .getClientAliases(KEY_TYPE, ISSUERS)
+                );
+                verify(ORIG_KEY_MANAGER).getClientAliases(KEY_TYPE, ISSUERS);
+            }
+
+            @Test
+            void givenNoAlias_whenChooseClientAlias_thenRecall() {
+                doReturn(ALIAS).when(ORIG_KEY_MANAGER).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+                assertSame(ALIAS,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, null)
+                        .chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET)
+                );
+                verify(ORIG_KEY_MANAGER).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+            }
+
+            @Test
+            void givenAlias_whenChooseClientAlias_thenReturnAlias() {
+                assertSame(CONFIG_ALIAS,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET)
+                );
+                verify(ORIG_KEY_MANAGER, never()).chooseClientAlias(KEY_TYPES, ISSUERS, SOCKET);
+            }
+
+            @Test
+            void whenGetServerAliases_thenRecall() {
+                doReturn(ALIASES).when(ORIG_KEY_MANAGER).getServerAliases(KEY_TYPE, ISSUERS);
+                assertSame(ALIASES,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .getServerAliases(KEY_TYPE, ISSUERS)
+                );
+                verify(ORIG_KEY_MANAGER).getServerAliases(KEY_TYPE, ISSUERS);
+            }
+
+            @Test
+            void givenNoAlias_whenChooseServerAlias_thenRecall() {
+                doReturn(ALIAS).when(ORIG_KEY_MANAGER).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+                assertSame(ALIAS,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, null)
+                        .chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET)
+                );
+                verify(ORIG_KEY_MANAGER).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+            }
+
+            @Test
+            void givenAlias_whenChooseServerAlias_thenReturnAlias() {
+                assertSame(CONFIG_ALIAS,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET)
+                );
+                verify(ORIG_KEY_MANAGER, never()).chooseServerAlias(KEY_TYPE, ISSUERS, SOCKET);
+            }
+
+            @Test
+            void whenGetCertificateChain_thenRecall() {
+                doReturn(CERTIFICATES).when(ORIG_KEY_MANAGER).getCertificateChain(ALIAS);
+                assertSame(CERTIFICATES,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .getCertificateChain(ALIAS)
+                );
+                verify(ORIG_KEY_MANAGER).getCertificateChain(ALIAS);
+            }
+
+            @Test
+            void whenGetPrivateKey_thenRecall() {
+                doReturn(PRIVATE_KEY).when(ORIG_KEY_MANAGER).getPrivateKey(ALIAS);
+                assertSame(PRIVATE_KEY,
+                    new ConnectionsConfig.X509KeyManagerSelectedAlias(ORIG_KEY_MANAGER_FACTORY, CONFIG_ALIAS)
+                        .getPrivateKey(ALIAS)
+                );
+                verify(ORIG_KEY_MANAGER).getPrivateKey(ALIAS);
             }
 
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
@@ -28,9 +28,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.WebFilter;
+import org.zowe.apiml.gateway.GatewayServiceApplication;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.tcp.SslProvider;
 
@@ -131,42 +136,70 @@ class ConnectionsConfigTest {
     }
 
     @Nested
-    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"management.port=-1"})
+    @SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = { "management.port=-1" },
+        classes = { GatewayServiceApplication.class, ConnectionsConfigTest.SslDetectorConfig.class }
+    )
     class ChooseAlias {
 
         @LocalServerPort
         protected int port;
 
-        @Value("${server.ssl.keyAlias}")
-        private String keyAlias;
+        @Nested
+        class UsingX509KeyManagerSelectedAlias {
 
-        @MockitoSpyBean
-        private ConnectionsConfig connectionsConfig;
+            @Value("${server.ssl.keyAlias}")
+            private String keyAlias;
 
-        @Test
-        void whenAliasIsSet_thenReturnItByX509KeyManagerSelectedAlias() {
-            AtomicReference<X509KeyManager> returnValue = new AtomicReference<>();
-            doAnswer(answer -> {
-                if (returnValue.get() == null) {
-                    returnValue.set(spy((X509KeyManager) answer.callRealMethod()));
-                }
-                return returnValue.get();
-            }).when(connectionsConfig).x509KeyManagerSelectedAlias(any());
+            @MockitoSpyBean
+            private ConnectionsConfig connectionsConfig;
 
-            var sslContext = connectionsConfig.getSslContext(true);
-            var sslProvider =  SslProvider.builder().sslContext(sslContext).build();
-            var httpClient = HttpClient.create().secure(sslProvider);
-            try {
+            @Test
+            void whenAliasIsSet_thenReturnItByX509KeyManagerSelectedAlias() {
+                AtomicReference<X509KeyManager> returnValue = new AtomicReference<>();
+                doAnswer(answer -> {
+                    if (returnValue.get() == null) {
+                        returnValue.set(spy((X509KeyManager) answer.callRealMethod()));
+                    }
+                    return returnValue.get();
+                }).when(connectionsConfig).x509KeyManagerSelectedAlias(any());
+
+                var sslContext = connectionsConfig.getSslContext(true);
+                var sslProvider = SslProvider.builder().sslContext(sslContext).build();
+                var httpClient = HttpClient.create().secure(sslProvider);
                 reset(returnValue.get());
                 httpClient.get()
                     .uri(String.format("https://localhost:%d/", port))
                     .response().block();
-            } catch (Exception e) {
-                // the HTTP call is just to load the key
+                assertNotNull(SslDetectorConfig.sslInfoHolder.get());
+
+                verify(returnValue.get(), atLeastOnce()).chooseClientAlias(any(), any(), any());
+                assertEquals(keyAlias, returnValue.get().chooseClientAlias(null, null, null));
             }
 
-            verify(returnValue.get(), atLeastOnce()).chooseClientAlias(any(), any(), any());
-            assertEquals(keyAlias, returnValue.get().chooseClientAlias(null, null, null));
+        }
+
+        @Nested
+        class Negative {
+
+            @Autowired
+            private ConnectionsConfig connectionsConfig;
+
+            @Test
+            void whenAliasIsInvalid_thenNoCertificateProvided() {
+                ReflectionTestUtils.setField(connectionsConfig, "keyAlias", "invalid");
+
+                var sslContext = connectionsConfig.getSslContext(true);
+                var sslProvider = SslProvider.builder().sslContext(sslContext).build();
+                var httpClient = HttpClient.create().secure(sslProvider);
+                httpClient.get()
+                    .uri(String.format("https://localhost:%d/", port))
+                    .response().block();
+
+                assertNull(SslDetectorConfig.sslInfoHolder.get());
+            }
+
         }
 
     }
@@ -280,6 +313,21 @@ class ConnectionsConfigTest {
         void givenDelegator_whenGetStatusPageUrl_thenCallInstanceInfo() {
             doReturn("statuspageUrl").when(instanceInfo).getStatusPageUrl();
             assertEquals("statuspageUrl", delegator.getStatusPageUrl());
+        }
+
+    }
+
+    @Configuration
+    static class SslDetectorConfig {
+
+        static final AtomicReference<SslInfo> sslInfoHolder = new AtomicReference<>();
+
+        @Bean
+        WebFilter sslDetector() {
+            return (exchange, chain) -> {
+                sslInfoHolder.set(exchange.getRequest().getSslInfo());
+                return chain.filter(exchange);
+            };
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
@@ -22,16 +22,23 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.util.ReflectionTestUtils;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.SslProvider;
 
+import javax.net.ssl.X509KeyManager;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -119,6 +126,47 @@ class ConnectionsConfigTest {
             assertThat(ReflectionTestUtils.getField(noContextConnectionsConfig, "trustStorePath")).isEqualTo("/path2");
             assertThat(ReflectionTestUtils.getField(noContextConnectionsConfig, "keyStorePassword")).isNull();
             assertThat(ReflectionTestUtils.getField(noContextConnectionsConfig, "trustStorePassword")).isNull();
+        }
+
+    }
+
+    @Nested
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"management.port=-1"})
+    class ChooseAlias {
+
+        @LocalServerPort
+        protected int port;
+
+        @Value("${server.ssl.keyAlias}")
+        private String keyAlias;
+
+        @MockitoSpyBean
+        private ConnectionsConfig connectionsConfig;
+
+        @Test
+        void whenAliasIsSet_thenReturnItByX509KeyManagerSelectedAlias() {
+            AtomicReference<X509KeyManager> returnValue = new AtomicReference<>();
+            doAnswer(answer -> {
+                if (returnValue.get() == null) {
+                    returnValue.set(spy((X509KeyManager) answer.callRealMethod()));
+                }
+                return returnValue.get();
+            }).when(connectionsConfig).x509KeyManagerSelectedAlias(any());
+
+            var sslContext = connectionsConfig.getSslContext(true);
+            var sslProvider =  SslProvider.builder().sslContext(sslContext).build();
+            var httpClient = HttpClient.create().secure(sslProvider);
+            try {
+                reset(returnValue.get());
+                httpClient.get()
+                    .uri(String.format("https://localhost:%d/", port))
+                    .response().block();
+            } catch (Exception e) {
+                // the HTTP call is just to load the key
+            }
+
+            verify(returnValue.get(), atLeastOnce()).chooseClientAlias(any(), any(), any());
+            assertEquals(keyAlias, returnValue.get().chooseClientAlias(null, null, null));
         }
 
     }


### PR DESCRIPTION
# Description

When keystore contains multiple private keys the default implementation selects the "first" one. The bug is that in the case the keystore contains multiple keys the Gateway selects a client certificate randomly.

This could be an issue with forwarding client certificates. Ie. call from the Gateway to determine authentication scheme (call from the gateway to the ZAAS) could failed when the chosen certificate is different from the server one. The ZAAS consider is as client certificate and it could leads to unexpected behaviour. In case of mapping the certificate to an user it reuses its identity, otherwise it could fail or ignore forwarded client certificate in the HTTP header.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
