### PR TITLE
fix: non-strict hostname verification in Jetty client for WebSockets

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -216,6 +216,9 @@ public class HttpConfig {
         setTruststore(sslContextFactory);
         log.debug("jettySslContextFactory: {}", sslContextFactory.dump());
         sslContextFactory.setHostnameVerifier(secureHostnameVerifier());
+        if (nonStrictVerifySslCertificatesOfServices) {
+            sslContextFactory.setEndpointIdentificationAlgorithm(null);
+        }
         if (!verifySslCertificatesOfServices) {
             sslContextFactory.setTrustAll(true);
         }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "doc": "docs"
     },
     "scripts": {
-        "api-layer": "concurrently --names \"GS,DS,AC,DC,ZO,CS,CG\" -c cyan,yellow,white,blue,green npm:gateway-service npm:discovery-service npm:api-catalog-service npm:discoverable-client npm:mock-services npm:caching-service npm:cloud-gateway",
+        "api-layer": "concurrently --names \"GS,DS,AC,DC,ZO,CS,CG\" -c cyan,yellow,white,blue,green,red,magenta npm:gateway-service npm:discovery-service npm:api-catalog-service npm:discoverable-client npm:mock-services npm:caching-service npm:cloud-gateway",
         "api-layer-ci": "concurrently --names \"GS,DS,AC,DC,ZO,CS,NS\" -c cyan,yellow,white,blue,green,red npm:gateway-service-thin npm:discovery-service-thin npm:api-catalog-service-thin npm:discoverable-client npm:mock-services npm:caching-service npm:onboarding-enabler-nodejs-sample-app",
         "api-layer-core": "concurrently --names \"GW,DS,AC\" -c cyan,yellow,white npm:gateway-service npm:discovery-service npm:api-catalog-service",
         "api-layer-thin": "concurrently --names \"GW,DS,AC,DC,ZO,CS\" -c cyan,yellow,white,blue,green npm:gateway-service-thin npm:discovery-service-thin npm:api-catalog-service-thin npm:discoverable-client npm:mock-services npm:caching-service",


### PR DESCRIPTION
# Description

Fix SSL configuration for non-strict hostname verification mode in Jetty HTTP Client.

https://jetty.org/docs/jetty/12/programming-guide/client/http.html#configuration-tls

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
