### PR TITLE
fix: change error code SERVICE_UNAVAILABLE to INTERNAL_SERVER_ERROR when ticket generation fails in v3

### DIFF
--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/exception/ZaasClientErrorCodes.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/exception/ZaasClientErrorCodes.java
@@ -25,6 +25,7 @@ public enum ZaasClientErrorCodes {
         "and application ID is configured properly by referring to  Using PassTickets in the guide for your security provider", 400),
     TOKEN_NOT_PROVIDED("ZWEAS401E", "Token is not provided", 401),
     SERVICE_UNAVAILABLE("ZWEAS404E", "Gateway service is unavailable", 503),
+    INTERNAL_SERVER_ERROR("ZWEAS504E", "Internal server error while generating PassTicket.", 500),
     EXPIRED_PASSWORD("ZWEAT412E", "The specified password is expired", 401),
     APPLICATION_NAME_NOT_FOUND("ZWEAS417E", "The application name wasn't found", 400);
 

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
@@ -47,7 +47,7 @@ class PassTicketServiceImpl implements PassTicketService {
         } catch (ZaasClientException e) {
             throw e;
         } catch (Exception e) {
-            throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
+            throw new ZaasClientException(ZaasClientErrorCodes.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -77,7 +77,7 @@ class PassTicketServiceImpl implements PassTicketService {
             } else if (statusCode == 400) {
                 throw new ZaasClientException(ZaasClientErrorCodes.BAD_REQUEST, obtainedMessage);
             } else if (statusCode == 500) {
-                throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, obtainedMessage);
+                throw new ZaasClientException(ZaasClientErrorCodes.INTERNAL_SERVER_ERROR, obtainedMessage);
             } else {
                 throw new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, obtainedMessage);
             }

--- a/zaas-client/src/main/resources/zaas-client-log-messages.yml
+++ b/zaas-client/src/main/resources/zaas-client-log-messages.yml
@@ -107,6 +107,13 @@ messages:
       reason: "There was an invalid path to either trust store or keystore"
       action: "Ensure that both provided paths are resolved to valid trust store and valid key store"
 
+    - key: org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.INTERNAL_SERVER_ERROR
+      number: ZWEAS504
+      type: ERROR
+      text: "Internal server error while generating PassTicket: %s"
+      reason: "Unable to generate PassTicket."
+      action: "Supply a valid user and application name, and check that corresponding permissions have been set up."
+
     # Various messages
     # 600-699
 

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpsTests.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientImplHttpsTests.java
@@ -350,6 +350,19 @@ class ZaasClientImplHttpsTests {
     }
 
     @Test
+    void testPassTicketWithToken_InValidApplicationID_throwsException() throws Exception {
+
+        ZaasPassTicketResponse zaasPassTicketResponse = new ZaasPassTicketResponse();
+
+        var response = prepareResponse(500, false);
+        when(response.getEntity()).thenReturn(httpsEntity);
+        when(httpsEntity.getContent()).thenReturn(new ByteArrayInputStream(new ObjectMapper().writeValueAsBytes(zaasPassTicketResponse)));
+
+        ZaasClientException exception = assertThrows(ZaasClientException.class, () -> passTicketService.passTicket(token, "XBADAPPL"));
+        assertTrue(exception.getMessage().contains("'ZWEAS504E', message='Internal server error while generating PassTicket.'"));
+    }
+
+    @Test
     void givenValidToken_whenLogout_thenSuccess() throws ZaasClientException {
         prepareResponse(HttpStatus.SC_NO_CONTENT, true);
         String authToken = tokenService.login(getAuthHeader(VALID_USER, VALID_PASSWORD));

--- a/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
+++ b/zaas-client/src/test/java/org/zowe/apiml/zaasclient/service/internal/ZaasClientTest.java
@@ -33,25 +33,14 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.APPLICATION_NAME_NOT_FOUND;
-import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.EMPTY_NULL_AUTHORIZATION_HEADER;
-import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.EMPTY_NULL_USERNAME_PASSWORD;
-import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.SERVICE_UNAVAILABLE;
-import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.TOKEN_NOT_PROVIDED;
+import static org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes.*;
 import static org.zowe.apiml.zaasclient.exception.ZaasConfigurationErrorCodes.IO_CONFIGURATION_ISSUE;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,6 +57,7 @@ class ZaasClientTest {
     private static final String VALID_USERNAME = "username";
     private static final char[] VALID_NEW_PASSWORD = "username".toCharArray();
     private static final String VALID_APPLICATION_ID = "APPLID";
+    private static final String INVALID_APPLICATION_ID = "XBADAPPL";
     private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
     private static final String[] SSL_SYSTEM_ENVIRONMENT_VALUES = {
@@ -159,6 +149,13 @@ class ZaasClientTest {
         ZaasClientException exception = assertThrows(ZaasClientException.class, () -> underTest.passTicket(token, applicationId));
 
         assertThatExceptionContainValidCode(exception, errorCode);
+    }
+
+    @Test
+    void givenValidTokenInvalidApplId_whenPassTicketApiIsCalled_thenRaisedClientExceptionIsRethrown() throws Exception {
+        when(passTickets.passTicket(anyString(), anyString())).thenThrow(new ZaasClientException(INTERNAL_SERVER_ERROR));
+        ZaasClientException exception = assertThrows(ZaasClientException.class, () -> underTest.passTicket(VALID_TOKEN, INVALID_APPLICATION_ID));
+        assertTrue(exception.getMessage().contains("'ZWEAS504E', message='Internal server error while generating PassTicket.'"));
     }
 
     @Test


### PR DESCRIPTION
# Description

This is to fix passticket error code  when the passticket generation fails.


Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [x] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

