### PR TITLE
chore: temporarily remove publishing of nodejs enabler on binary release

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -42,21 +42,21 @@ jobs:
             - name: Set name
               run: git config user.name "Zowe Robot"
 
-            - name: Release to NPM automatic
-              shell: bash
-              run: |
-                  cd onboarding-enabler-nodejs
-                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-                  npm version ${{ github.event.inputs.scope || env.DEFAULT_SCOPE }} --allow-same-version
-                  npm publish --access public
-                  git add package.json
-                  git add package-lock.json
-                  git commit -m "[skip ci] Update version"
-                  git push --no-verify
-                  cd ..
-              env:
-                  DEFAULT_SCOPE: 'patch'
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+#            - name: Release to NPM automatic
+#              shell: bash
+#              run: |
+#                  cd onboarding-enabler-nodejs
+#                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+#                  npm version ${{ github.event.inputs.scope || env.DEFAULT_SCOPE }} --allow-same-version
+#                  npm publish --access public
+#                  git add package.json
+#                  git add package-lock.json
+#                  git commit -m "[skip ci] Update version"
+#                  git push --no-verify
+#                  cd ..
+#              env:
+#                  DEFAULT_SCOPE: 'patch'
+#                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Release with Gradle automatic
               shell: bash


### PR DESCRIPTION
# Description

Temporarily remove publishing of _onboarding-enabler-nodejs_ during binary release

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
