### PR TITLE
chore: v2 integration tests compatible with z/os pipeline

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -206,6 +206,7 @@ task runAllIntegrationTestsForZoweNonHaTestingOnZos(type: Test) {
             'ApiCatalogStandaloneTest',
             'SAFProviderTest',
             'CloudGatewayProxyTest',
+            'CloudGatewayAuthTest',
             'SafIdTokenTest'
         )
     }
@@ -247,6 +248,7 @@ task runAllIntegrationTestsForZoweHaTestingOnZos(type: Test) {
             'ApiCatalogStandaloneTest',
             'SAFProviderTest',
             'CloudGatewayProxyTest',
+            'CloudGatewayAuthTest',
             'SafIdTokenTest',
             'ChaoticHATest',
             'GraphQLTest'

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/CloudGatewayAuthTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/CloudGatewayAuthTest.java
@@ -14,6 +14,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -50,6 +51,7 @@ import static org.zowe.apiml.util.requests.Endpoints.ZOSMF_REQUEST;
 import static org.zowe.apiml.util.requests.Endpoints.ZOWE_JWT_REQUEST;
 
 @ZaasTest
+@Tag("CloudGatewayProxyTest")
 public class CloudGatewayAuthTest implements TestWithStartedInstances {
 
     private static final CloudGatewayConfiguration CLOUD_GATEWAY_CONFIGURATION = ConfigReader.environmentConfiguration().getCloudGatewayConfiguration();

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/CloudGatewayAuthTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/CloudGatewayAuthTest.java
@@ -51,7 +51,7 @@ import static org.zowe.apiml.util.requests.Endpoints.ZOSMF_REQUEST;
 import static org.zowe.apiml.util.requests.Endpoints.ZOWE_JWT_REQUEST;
 
 @ZaasTest
-@Tag("CloudGatewayProxyTest")
+@Tag("CloudGatewayAuthTest")
 public class CloudGatewayAuthTest implements TestWithStartedInstances {
 
     private static final CloudGatewayConfiguration CLOUD_GATEWAY_CONFIGURATION = ConfigReader.environmentConfiguration().getCloudGatewayConfiguration();

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ApiCatalogServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ApiCatalogServiceConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApiCatalogServiceConfiguration {
     private String scheme;
     private String url;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/AuxiliaryUserList.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/AuxiliaryUserList.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AuxiliaryUserList {
     private String value;
 

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/CachingServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/CachingServiceConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CachingServiceConfiguration {
     private String url;
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/CloudGatewayConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/CloudGatewayConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudGatewayConfiguration {
     private String scheme;
     private String host;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/Credentials.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/Credentials.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Credentials {
 
     private String key;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/DiscoverableClientConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/DiscoverableClientConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DiscoverableClientConfiguration {
     private String scheme;
     private String applId;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/DiscoveryServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/DiscoveryServiceConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DiscoveryServiceConfiguration {
     private String scheme;
     private String user;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/EnvironmentConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/EnvironmentConfiguration.java
@@ -29,7 +29,8 @@ public class EnvironmentConfiguration {
     private ApiCatalogServiceConfiguration apiCatalogServiceConfiguration;
     private ApiCatalogServiceConfiguration apiCatalogStandaloneConfiguration;
     private CachingServiceConfiguration cachingServiceConfiguration;
-    private CloudGatewayConfiguration cloudGatewayConfiguration;
+    // Cloud gateway tests are excluded from z/OS tests, leading to config load failure when the props are undefined
+    private CloudGatewayConfiguration cloudGatewayConfiguration = new CloudGatewayConfiguration();
     private TlsConfiguration tlsConfiguration;
     private ZosmfServiceConfiguration zosmfServiceConfiguration;
     private AuxiliaryUserList auxiliaryUserList;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/EnvironmentConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/EnvironmentConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EnvironmentConfiguration {
     private Credentials credentials;
     private GatewayServiceConfiguration gatewayServiceConfiguration;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/GatewayServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/GatewayServiceConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GatewayServiceConfiguration {
     private String scheme;
     private String host;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/IDPConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/IDPConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IDPConfiguration {
     private String host;
     private String user;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/OidcConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/OidcConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OidcConfiguration {
 
     private String clientId;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/SafIdtConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/SafIdtConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SafIdtConfiguration {
     private boolean enabled;
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/TlsConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/TlsConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TlsConfiguration {
     private String keyAlias;
     private char[] keyPassword;

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ZosmfServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ZosmfServiceConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.util.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ZosmfServiceConfiguration {
     private String scheme;
     private String host;


### PR DESCRIPTION
# Description

- v2 integration tests are now compatible to be run with the same z/os integration pipeline for z/os testing using the same environment-config file
- disables cloud gw auth integration tests as they are not relevant for z/os

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
