### PR TITLE
fix: Fix handling of closeable resources

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/instance/InstanceRetrievalService.java
@@ -147,23 +147,24 @@ public class InstanceRetrievalService {
         for (Header header : createRequestHeader(eurekaServiceInstanceRequest)) {
             httpGet.setHeader(header);
         }
-        CloseableHttpResponse response = httpClient.execute(httpGet);
-        final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
-        final HttpEntity responseEntity = response.getEntity();
-        String responseBody = "";
-        if (responseEntity != null) {
-            responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
-        }
-        if (statusCode >= HttpStatus.SC_OK && statusCode < HttpStatus.SC_MULTIPLE_CHOICES) {
-            return responseBody;
-        }
+        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+            final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
+            final HttpEntity responseEntity = response.getEntity();
+            String responseBody = "";
+            if (responseEntity != null) {
+                responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
+            }
+            if (statusCode >= HttpStatus.SC_OK && statusCode < HttpStatus.SC_MULTIPLE_CHOICES) {
+                return responseBody;
+            }
 
-        apimlLog.log("org.zowe.apiml.apicatalog.serviceRetrievalRequestFailed",
-            eurekaServiceInstanceRequest.getServiceId(),
-            eurekaServiceInstanceRequest.getEurekaRequestUrl(),
-            statusCode,
-            response.getStatusLine() != null ? response.getStatusLine().getReasonPhrase() : responseBody
+            apimlLog.log("org.zowe.apiml.apicatalog.serviceRetrievalRequestFailed",
+                eurekaServiceInstanceRequest.getServiceId(),
+                eurekaServiceInstanceRequest.getEurekaRequestUrl(),
+                statusCode,
+                response.getStatusLine() != null ? response.getStatusLine().getReasonPhrase() : responseBody
             );
+        }
 
         return null;
     }

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/services/status/APIDocRetrievalService.java
@@ -323,8 +323,7 @@ public class APIDocRetrievalService {
         httpGet.setHeader(org.apache.http.HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
         String responseBody = null;
-        try {
-            CloseableHttpResponse response = secureHttpClientWithoutKeystore.execute(httpGet);
+        try (CloseableHttpResponse response = secureHttpClientWithoutKeystore.execute(httpGet)) {
             final HttpEntity responseEntity = response.getEntity();
             if (responseEntity != null) {
                 responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -55,9 +55,8 @@ public class StaticAPIService {
 
             String discoveryServiceUrl = discoveryServiceUrls.get(i);
 
-            try {
-                HttpPost post = getHttpRequest(discoveryServiceUrl);
-                CloseableHttpResponse response = httpClient.execute(post);
+            HttpPost post = getHttpRequest(discoveryServiceUrl);
+            try (CloseableHttpResponse response = httpClient.execute(post)) {
                 final HttpEntity responseEntity = response.getEntity();
                 String responseBody = "";
                 if (responseEntity != null) {

--- a/client-cert-auth-sample/src/main/java/org/zowe/apiml/ClientCertificateAuthentication.java
+++ b/client-cert-auth-sample/src/main/java/org/zowe/apiml/ClientCertificateAuthentication.java
@@ -116,15 +116,16 @@ public class ClientCertificateAuthentication {
                     HttpPost httpPost = new HttpPost(getApiUrl());
 
                     // Execute the request
-                    CloseableHttpResponse response = httpClient.execute(httpPost);
+                    try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
 
-                    // Print the response status
-                    System.out.println("Response Code: " + response.getStatusLine().getStatusCode());
+                        // Print the response status
+                        System.out.println("Response Code: " + response.getStatusLine().getStatusCode());
 
-                    // Print headers
-                    Header[] headers = response.getAllHeaders();
-                    for (Header header : headers) {
-                        System.out.println("Key : " + header.getName() + " ,Value : " + header.getValue());
+                        // Print headers
+                        Header[] headers = response.getAllHeaders();
+                        for (Header header : headers) {
+                            System.out.println("Key : " + header.getName() + " ,Value : " + header.getValue());
+                        }
                     }
                 }
             }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/GatewayNotifier.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/GatewayNotifier.java
@@ -173,8 +173,7 @@ public class GatewayNotifier implements Runnable {
     protected void serviceUpdatedProcess(String serviceId, String instanceId) {
         notify(instanceId, instanceInfo -> {
             final String url = getServiceUrl(serviceId, instanceInfo);
-            try {
-                CloseableHttpResponse response = httpClient.execute(new HttpDelete(url));
+            try (CloseableHttpResponse response = httpClient.execute(new HttpDelete(url))) {
                 final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
                 if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
                     log.debug(GW_UNEXPECTED_RESPONSE_LOG, url, response.getStatusLine());
@@ -190,8 +189,7 @@ public class GatewayNotifier implements Runnable {
     protected void serviceCancelRegistrationProcess(String serviceId) {
         notify(null, instanceInfo -> {
             final String url = getServiceUrl(serviceId, instanceInfo);
-            try {
-                CloseableHttpResponse response = httpClient.execute(new HttpDelete(url));
+            try (CloseableHttpResponse response = httpClient.execute(new HttpDelete(url))) {
                 final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
                 if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
                     log.debug(GW_UNEXPECTED_RESPONSE_LOG, url, response.getStatusLine());
@@ -211,8 +209,7 @@ public class GatewayNotifier implements Runnable {
                 .append(DISTRIBUTE_PATH)
                 .append(instanceId);
 
-            try {
-                CloseableHttpResponse response = httpClient.execute(new HttpGet(url.toString()));
+            try (CloseableHttpResponse response = httpClient.execute(new HttpGet(url.toString()))) {
                 final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
                 if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
                     log.debug(GW_UNEXPECTED_RESPONSE_LOG, url, response.getStatusLine());

--- a/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
+++ b/security-service-client-spring/src/main/java/org/zowe/apiml/security/client/service/GatewaySecurityService.java
@@ -71,20 +71,21 @@ public class GatewaySecurityService {
             HttpPost post = new HttpPost(uri);
             String json = objectMapper.writeValueAsString(loginRequest);
             post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
-            CloseableHttpResponse response = closeableHttpClient.execute(post);
-            final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
-            if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
-                final HttpEntity responseEntity = response.getEntity();
-                String responseBody = null;
-                if (responseEntity != null) {
-                    responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
+            try (CloseableHttpResponse response = closeableHttpClient.execute(post)) {
+                final int statusCode = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
+                if (statusCode < HttpStatus.SC_OK || statusCode >= HttpStatus.SC_MULTIPLE_CHOICES) {
+                    final HttpEntity responseEntity = response.getEntity();
+                    String responseBody = null;
+                    if (responseEntity != null) {
+                        responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
+                    }
+                    ErrorType errorType = getErrorType(responseBody);
+                    responseHandler.handleErrorType(response, errorType,
+                        "Cannot access Gateway service. Uri '{}' returned: {}", uri);
+                    return Optional.empty();
                 }
-                ErrorType errorType = getErrorType(responseBody);
-                responseHandler.handleErrorType(response, errorType,
-                    "Cannot access Gateway service. Uri '{}' returned: {}", uri);
-                return Optional.empty();
+                return extractToken(response.getFirstHeader(HttpHeaders.SET_COOKIE).getValue());
             }
-            return extractToken(response.getFirstHeader(HttpHeaders.SET_COOKIE).getValue());
         } catch (IOException e) {
             responseHandler.handleException(e);
         } finally {
@@ -107,10 +108,10 @@ public class GatewaySecurityService {
         String cookie = String.format("%s=%s", authConfigurationProperties.getCookieProperties().getCookieName(), token);
 
 
-        try {
-            HttpGet get = new HttpGet(uri);
-            get.addHeader(HttpHeaders.COOKIE, cookie);
-            CloseableHttpResponse response = closeableHttpClient.execute(get);
+
+        HttpGet get = new HttpGet(uri);
+        get.addHeader(HttpHeaders.COOKIE, cookie);
+        try (CloseableHttpResponse response = closeableHttpClient.execute(get)) {
             final HttpEntity responseEntity = response.getEntity();
             String responseBody = null;
             if (responseEntity != null) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
@@ -12,21 +12,21 @@ package org.zowe.apiml.zaasclient.service.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.cookie.SM;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
+import org.zowe.apiml.zaasclient.config.ConfigProperties;
 import org.zowe.apiml.zaasclient.exception.ZaasClientErrorCodes;
 import org.zowe.apiml.zaasclient.exception.ZaasClientException;
 import org.zowe.apiml.zaasclient.exception.ZaasConfigurationException;
 import org.zowe.apiml.zaasclient.passticket.ZaasClientTicketRequest;
 import org.zowe.apiml.zaasclient.passticket.ZaasPassTicketResponse;
-import org.zowe.apiml.zaasclient.config.ConfigProperties;
 
 import java.io.IOException;
-import org.apache.http.HttpHeaders;
-import org.apache.http.cookie.SM;
 
 @Slf4j
 class PassTicketServiceImpl implements PassTicketService {
@@ -44,7 +44,8 @@ class PassTicketServiceImpl implements PassTicketService {
 
     @Override
     public String passTicket(String jwtToken, String applicationId) throws ZaasClientException, ZaasConfigurationException {
-        try (CloseableHttpClient closeableHttpsClient = httpClientProvider.getHttpClient()) {
+        try {
+            CloseableHttpClient closeableHttpsClient = httpClientProvider.getHttpClient();
             ZaasClientTicketRequest zaasClientTicketRequest = new ZaasClientTicketRequest();
             ObjectMapper mapper = new ObjectMapper();
             zaasClientTicketRequest.setApplicationName(applicationId);

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/PassTicketServiceImpl.java
@@ -44,8 +44,7 @@ class PassTicketServiceImpl implements PassTicketService {
 
     @Override
     public String passTicket(String jwtToken, String applicationId) throws ZaasClientException, ZaasConfigurationException {
-        try {
-            CloseableHttpClient closeableHttpsClient = httpClientProvider.getHttpClient();
+        try (CloseableHttpClient closeableHttpsClient = httpClientProvider.getHttpClient()) {
             ZaasClientTicketRequest zaasClientTicketRequest = new ZaasClientTicketRequest();
             ObjectMapper mapper = new ObjectMapper();
             zaasClientTicketRequest.setApplicationName(applicationId);
@@ -55,8 +54,9 @@ class PassTicketServiceImpl implements PassTicketService {
             httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
             httpPost.setHeader(SM.COOKIE, passConfigProperties.getTokenPrefix() + "=" + jwtToken);
 
-            CloseableHttpResponse response = closeableHttpsClient.execute(httpPost);
-            return extractPassTicket(response);
+            try (CloseableHttpResponse response = closeableHttpsClient.execute(httpPost)) {
+                return extractPassTicket(response);
+            }
         } catch (ZaasConfigurationException e) {
             throw e;
         } catch (Exception e) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpClientProvider.java
@@ -12,15 +12,11 @@ package org.zowe.apiml.zaasclient.service.internal;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import lombok.Getter;
 
 public class ZaasHttpClientProvider implements CloseableClientProvider {
 
-    @Getter
-    private final CloseableHttpClient httpClient;
-
-    public ZaasHttpClientProvider() {
-        httpClient = HttpClientBuilder.create().disableCookieManagement().disableAuthCaching().build();
+    public CloseableHttpClient getHttpClient() {
+        return HttpClientBuilder.create().disableCookieManagement().disableAuthCaching().build();
     }
-    
+
 }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpClientProvider.java
@@ -12,11 +12,15 @@ package org.zowe.apiml.zaasclient.service.internal;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import lombok.Getter;
 
 public class ZaasHttpClientProvider implements CloseableClientProvider {
 
-    public CloseableHttpClient getHttpClient() {
-        return HttpClientBuilder.create().disableCookieManagement().disableAuthCaching().build();
+    @Getter
+    private final CloseableHttpClient httpClient;
+
+    public ZaasHttpClientProvider() {
+        httpClient = HttpClientBuilder.create().disableCookieManagement().disableAuthCaching().build();
     }
 
 }

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -49,12 +49,11 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     private TrustManagerFactory tmf;
     private KeyManagerFactory kmf;
+    private SSLContext sslContext;
 
     private final HostnameVerifier hostnameVerifier;
 
     private final CookieStore cookieStore = new BasicCookieStore();
-
-    private CloseableHttpClient httpsClient;
 
     public ZaasHttpsClientProvider(ConfigProperties configProperties) throws ZaasConfigurationException {
         if (configProperties.getTrustStorePath() == null) {
@@ -88,13 +87,7 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     @Override
     public synchronized CloseableHttpClient getHttpClient() throws ZaasConfigurationException {
-        if (httpsClient == null) {
-            if (kmf == null) {
-                initializeKeyStoreManagerFactory();
-            }
-            httpsClient = sharedHttpClientConfiguration(getSSLContext()).build();
-        }
-        return httpsClient;
+        return sharedHttpClientConfiguration(getSSLContext()).build();
     }
 
     private void initializeTrustManagerFactory(String trustStorePath, String trustStoreType, char[] trustStorePassword)
@@ -153,18 +146,29 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
         return new FileInputStream(uri);
     }
 
-    private SSLContext getSSLContext() throws ZaasConfigurationException {
+    private void initializeSSLContext() throws ZaasConfigurationException {
         try {
-            SSLContext sslContext = SSLContext.getInstance(configProperties.getProtocol());
+            sslContext = SSLContext.getInstance(configProperties.getProtocol());
             sslContext.init(
                 kmf != null ? kmf.getKeyManagers() : null,
                 tmf.getTrustManagers(),
                 new SecureRandom()
             );
-            return sslContext;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.WRONG_CRYPTO_CONFIGURATION, e);
         }
+    }
+
+    private SSLContext getSSLContext() throws ZaasConfigurationException {
+        if (kmf == null) {
+            initializeKeyStoreManagerFactory();
+        }
+
+        if (sslContext == null) {
+            initializeSSLContext();
+        }
+
+        return sslContext;
     }
 
     /**

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasHttpsClientProvider.java
@@ -55,6 +55,8 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     private final CookieStore cookieStore = new BasicCookieStore();
 
+    private CloseableHttpClient httpsClient;
+
     public ZaasHttpsClientProvider(ConfigProperties configProperties) throws ZaasConfigurationException {
         if (configProperties.getTrustStorePath() == null) {
             throw new ZaasConfigurationException(ZaasConfigurationErrorCodes.TRUST_STORE_NOT_PROVIDED);
@@ -87,7 +89,10 @@ class ZaasHttpsClientProvider implements CloseableClientProvider {
 
     @Override
     public synchronized CloseableHttpClient getHttpClient() throws ZaasConfigurationException {
-        return sharedHttpClientConfiguration(getSSLContext()).build();
+        if (httpsClient == null) {
+            httpsClient = sharedHttpClientConfiguration(getSSLContext()).build();
+        }
+        return httpsClient;
     }
 
     private void initializeTrustManagerFactory(String trustStorePath, String trustStoreType, char[] trustStorePassword)

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
@@ -66,7 +66,8 @@ class ZaasJwtService implements TokenService {
 
     @Override
     public String login(String userId, char[] password, char[] newPassword) throws ZaasClientException {
-        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+        try {
+            CloseableHttpClient client = httpClientProvider.getHttpClient();
             HttpPost httpPost = new HttpPost(loginEndpoint);
             String json = objectMapper.writeValueAsString(new Credentials(userId, password, newPassword));
             StringEntity entity = new StringEntity(json);
@@ -87,7 +88,8 @@ class ZaasJwtService implements TokenService {
 
     @Override
     public String login(String authorizationHeader) throws ZaasClientException {
-        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+        try {
+            CloseableHttpClient client = httpClientProvider.getHttpClient();
             HttpPost httpPost = new HttpPost(loginEndpoint);
             httpPost.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
             try (CloseableHttpResponse response = client.execute(httpPost)) {
@@ -103,7 +105,8 @@ class ZaasJwtService implements TokenService {
         if (jwtToken == null || jwtToken.isEmpty()) {
             throw new ZaasClientException(ZaasClientErrorCodes.TOKEN_NOT_PROVIDED, "No token provided");
         }
-        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+        try {
+            CloseableHttpClient client = httpClientProvider.getHttpClient();
             HttpGet httpGet = new HttpGet(queryEndpoint);
             httpGet.addHeader(SM.COOKIE, zassConfigProperties.getTokenPrefix() + "=" + jwtToken);
             try (CloseableHttpResponse response = client.execute(httpGet)) {
@@ -122,7 +125,8 @@ class ZaasJwtService implements TokenService {
 
     @Override
     public void logout(String jwtToken) throws ZaasClientException {
-        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+        try {
+            CloseableHttpClient client = httpClientProvider.getHttpClient();
             clearZaasClientCookies();
             HttpPost httpPost = new HttpPost(logoutEndpoint);
             if (jwtToken.startsWith(BEARER_AUTHENTICATION_PREFIX)) {

--- a/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
+++ b/zaas-client/src/main/java/org/zowe/apiml/zaasclient/service/internal/ZaasJwtService.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HeaderElement;
@@ -67,40 +66,36 @@ class ZaasJwtService implements TokenService {
 
     @Override
     public String login(String userId, char[] password, char[] newPassword) throws ZaasClientException {
-        return (String) doRequest(
-            () -> loginWithCredentials(userId, password, newPassword),
-            this::extractToken);
+        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+            HttpPost httpPost = new HttpPost(loginEndpoint);
+            String json = objectMapper.writeValueAsString(new Credentials(userId, password, newPassword));
+            StringEntity entity = new StringEntity(json);
+            httpPost.setEntity(entity);
+            httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                return extractToken(response);
+            }
+        } catch (Exception e) {
+            throw handleException(e);
+        }
     }
 
     @Override
     public String login(String userId, char[] password) throws ZaasClientException {
-        return (String) doRequest(
-            () -> loginWithCredentials(userId, password, null),
-            this::extractToken);
-    }
-
-    private ClientWithResponse loginWithCredentials(String userId, char[] password, char[] newPassword) throws ZaasConfigurationException, IOException {
-        CloseableHttpClient client = httpClientProvider.getHttpClient();
-        HttpPost httpPost = new HttpPost(loginEndpoint);
-        String json = objectMapper.writeValueAsString(new Credentials(userId, password, newPassword));
-        StringEntity entity = new StringEntity(json);
-        httpPost.setEntity(entity);
-        httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-        return new ClientWithResponse(client, client.execute(httpPost));
+        return login(userId, password, null);
     }
 
     @Override
     public String login(String authorizationHeader) throws ZaasClientException {
-        return (String) doRequest(
-            () -> loginWithHeader(authorizationHeader),
-            this::extractToken);
-    }
-
-    private ClientWithResponse loginWithHeader(String authorizationHeader) throws ZaasConfigurationException, IOException {
-        CloseableHttpClient client = httpClientProvider.getHttpClient();
-        HttpPost httpPost = new HttpPost(loginEndpoint);
-        httpPost.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
-        return new ClientWithResponse(client, client.execute(httpPost));
+        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+            HttpPost httpPost = new HttpPost(loginEndpoint);
+            httpPost.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                return extractToken(response);
+            }
+        } catch (Exception e) {
+            throw handleException(e);
+        }
     }
 
     @Override
@@ -108,8 +103,15 @@ class ZaasJwtService implements TokenService {
         if (jwtToken == null || jwtToken.isEmpty()) {
             throw new ZaasClientException(ZaasClientErrorCodes.TOKEN_NOT_PROVIDED, "No token provided");
         }
-
-        return (ZaasToken) doRequest(() -> queryWithJwtToken(jwtToken), this::extractZaasToken);
+        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+            HttpGet httpGet = new HttpGet(queryEndpoint);
+            httpGet.addHeader(SM.COOKIE, zassConfigProperties.getTokenPrefix() + "=" + jwtToken);
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                return extractZaasToken(response);
+            }
+        } catch (Exception e) {
+            throw handleException(e);
+        }
     }
 
     @Override
@@ -120,7 +122,31 @@ class ZaasJwtService implements TokenService {
 
     @Override
     public void logout(String jwtToken) throws ZaasClientException {
-        doRequest(() -> logoutJwtToken(jwtToken));
+        try (CloseableHttpClient client = httpClientProvider.getHttpClient()) {
+            clearZaasClientCookies();
+            HttpPost httpPost = new HttpPost(logoutEndpoint);
+            if (jwtToken.startsWith(BEARER_AUTHENTICATION_PREFIX)) {
+                httpPost.addHeader(HttpHeaders.AUTHORIZATION, jwtToken);
+            } else {
+                httpPost.addHeader(SM.COOKIE, zassConfigProperties.getTokenPrefix() + "=" + jwtToken);
+            }
+
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                int httpResponseCode = response.getStatusLine().getStatusCode();
+                if (httpResponseCode == 204) {
+                    return;
+                }
+
+                String obtainedMessage = EntityUtils.toString(response.getEntity());
+                if (httpResponseCode == 401) {
+                    throw new ZaasClientException(ZaasClientErrorCodes.EXPIRED_JWT_EXCEPTION, obtainedMessage);
+                } else {
+                    throw new ZaasClientException(ZaasClientErrorCodes.INVALID_JWT_TOKEN, obtainedMessage);
+                }
+            }
+        } catch (Exception e) {
+            throw handleException(e);
+        }
     }
 
     /**
@@ -162,53 +188,10 @@ class ZaasJwtService implements TokenService {
         return Optional.empty();
     }
 
-    private ClientWithResponse queryWithJwtToken(String jwtToken) throws ZaasConfigurationException, IOException {
-        CloseableHttpClient client = httpClientProvider.getHttpClient();
-        HttpGet httpGet = new HttpGet(queryEndpoint);
-        httpGet.addHeader(SM.COOKIE, zassConfigProperties.getTokenPrefix() + "=" + jwtToken);
-        return new ClientWithResponse(client, client.execute(httpGet));
-    }
-
-    private ClientWithResponse logoutJwtToken(String jwtToken) throws ZaasConfigurationException, IOException, ZaasClientException {
-        CloseableHttpClient client = httpClientProvider.getHttpClient();
-        clearZaasClientCookies();
-        HttpPost httpPost = new HttpPost(logoutEndpoint);
-        if (jwtToken.startsWith(BEARER_AUTHENTICATION_PREFIX)) {
-            httpPost.addHeader(HttpHeaders.AUTHORIZATION, jwtToken);
-        } else {
-            httpPost.addHeader(SM.COOKIE, zassConfigProperties.getTokenPrefix() + "=" + jwtToken);
-        }
-        return getClientWithResponse(client, httpPost);
-    }
 
     private void clearZaasClientCookies() {
         if (httpClientProvider instanceof ZaasHttpsClientProvider) {
             ((ZaasHttpsClientProvider) httpClientProvider).clearCookieStore();
-        }
-    }
-
-    private ClientWithResponse getClientWithResponse(CloseableHttpClient client, HttpPost httpPost) throws IOException, ZaasClientException {
-        ClientWithResponse clientWithResponse = new ClientWithResponse(client, client.execute(httpPost));
-        int httpResponseCode = clientWithResponse.getResponse().getStatusLine().getStatusCode();
-        if (httpResponseCode == 204) {
-            return clientWithResponse;
-        } else {
-            String obtainedMessage = EntityUtils.toString(clientWithResponse.getResponse().getEntity());
-            if (httpResponseCode == 401) {
-                throw new ZaasClientException(ZaasClientErrorCodes.EXPIRED_JWT_EXCEPTION, obtainedMessage);
-            } else {
-                throw new ZaasClientException(ZaasClientErrorCodes.INVALID_JWT_TOKEN, obtainedMessage);
-            }
-        }
-    }
-
-    private void finallyClose(CloseableHttpResponse response) {
-        try {
-            if (response != null) {
-                response.close();
-            }
-        } catch (IOException e) {
-            log.warn("It wasn't possible to close the resources. " + e.getMessage());
         }
     }
 
@@ -284,34 +267,17 @@ class ZaasJwtService implements TokenService {
         throw new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, obtainedMessage);
     }
 
-    private void doRequest(Operation request) throws ZaasClientException {
-        ClientWithResponse clientWithResponse = new ClientWithResponse();
-        try {
-            clientWithResponse = request.request();
-        } catch (IOException | ZaasConfigurationException e) {
-            throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
-        } finally {
-            finallyClose(clientWithResponse.getResponse());
+    private ZaasClientException handleException(Exception e) {
+        if (e instanceof ZaasClientException) {
+            return (ZaasClientException) e;
         }
-    }
-
-    private Object doRequest(Operation request, Token token) throws ZaasClientException {
-        ClientWithResponse clientWithResponse = new ClientWithResponse();
-
-        try {
-
-            clientWithResponse = request.request();
-
-            return token.extract(clientWithResponse.getResponse());
-        } catch (ZaasClientException e) {
-            throw e;
-        } catch (IOException e) {
-            throw new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
-        } catch (Exception e) {
-            throw new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, e);
-        } finally {
-            finallyClose(clientWithResponse.getResponse());
+        if (e instanceof IOException) {
+            return new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
         }
+        if (e instanceof ZaasConfigurationException) {
+            return new ZaasClientException(ZaasClientErrorCodes.SERVICE_UNAVAILABLE, e);
+        }
+        return new ZaasClientException(ZaasClientErrorCodes.GENERIC_EXCEPTION, e);
     }
 
     @Data
@@ -322,19 +288,8 @@ class ZaasJwtService implements TokenService {
         char[] newPassword;
     }
 
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    static class ClientWithResponse {
-        CloseableHttpClient client;
-        CloseableHttpResponse response;
-    }
-
     interface Token {
         Object extract(CloseableHttpResponse response) throws IOException, ZaasClientException;
     }
 
-    interface Operation {
-        ClientWithResponse request() throws ZaasConfigurationException, IOException, ZaasClientException;
-    }
 }


### PR DESCRIPTION
# Description

This PR fixes the way we work with the HTTP client and the responses. All these objects should be closed after use.

It fixes mainly the code from #2409 and #588.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
