### PR TITLE
fix: NPE in ApimlPeerEurekaNode stops heartbeats

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/eureka/client/ApimlPeerEurekaNode.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/eureka/client/ApimlPeerEurekaNode.java
@@ -560,13 +560,15 @@ public class ApimlPeerEurekaNode extends PeerEurekaNode {
          * @return true, if it is a network timeout, false otherwise.
          */
         private static boolean isNetworkConnectException(Throwable e) {
-            do {
-                if (e instanceof IOException && !(e instanceof SSLException)) {
-                    return true;
-                }
-                e = e.getCause();
-            } while (e != null);
-            return false;
+            if (e instanceof IOException && !(e instanceof SSLException)) {
+                return true;
+            }
+
+            Throwable cause = e.getCause();
+            if ((cause == null) || (cause == e)) {
+                return false;
+            }
+            return isNetworkConnectException(cause);
         }
 
         /**
@@ -576,19 +578,22 @@ public class ApimlPeerEurekaNode extends PeerEurekaNode {
          * @return true, if it may be a socket read time out exception.
          */
         private static boolean maybeReadTimeOut(Throwable e) {
-            do {
-                if (e instanceof IOException) {
-                    String message = e.getMessage().toLowerCase();
-                    Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message);
+            if (e instanceof IOException) {
+                String message = e.getMessage();
+                if (message != null) {
+                    Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message.toLowerCase());
                     if (matcher.find()) {
                         return true;
                     }
                 }
-                e = e.getCause();
-            } while (e != null);
-            return false;
-        }
+            }
 
+            Throwable cause = e.getCause();
+            if ((cause == null) || (cause == e)) {
+                return false;
+            }
+            return maybeReadTimeOut(cause);
+        }
 
         private static ReplicationInstance createReplicationInstanceOf(InstanceReplicationTask task) {
             ReplicationInstance.ReplicationInstanceBuilder instanceBuilder = aReplicationInstance();


### PR DESCRIPTION
# Description

When handling IOException in the ApimlPeerEurekaNode a NPE could occur that stops the thread responsible for heartbeats. The exception processing was cherry-picked from v3 #4142 .

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
