### PR TITLE
chore: remove x-forward-* proxy headers from platform integration tests

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -207,7 +207,7 @@ task runAllIntegrationTestsForZoweNonHaTestingOnZos(type: Test) {
             'SAFProviderTest',
             'CloudGatewayProxyTest',
             'CloudGatewayAuthTest',
-            'CloudGatewayCentralRegistryXForwardHeaders',
+            'CloudGatewayCentralRegistry',
             'SafIdTokenTest'
         )
     }
@@ -250,7 +250,7 @@ task runAllIntegrationTestsForZoweHaTestingOnZos(type: Test) {
             'SAFProviderTest',
             'CloudGatewayProxyTest',
             'CloudGatewayAuthTest',
-            'CloudGatewayCentralRegistryXForwardHeaders',
+            'CloudGatewayCentralRegistry',
             'SafIdTokenTest',
             'ChaoticHATest',
             'GraphQLTest'
@@ -346,7 +346,6 @@ task runContainerTests(type: Test) {
             'CloudGatewayProxyTest',
             'CloudGatewayServiceRouting',
             'CloudGatewayCentralRegistry',
-            'CloudGatewayCentralRegistryXForwardHeaders',
             'ZaasTest',
             'HealthEndpointProtectionDisabledTest'
         )
@@ -384,7 +383,6 @@ task runBaseTests(type: Test) {
             'CloudGatewayProxyTest',
             'CloudGatewayServiceRouting',
             'CloudGatewayCentralRegistry',
-            'CloudGatewayCentralRegistryXForwardHeaders',
             'MultipleRegistrationsTest',
             'HealthEndpointProtectionDisabledTest'
         )
@@ -442,8 +440,7 @@ task runCloudGatewayCentralRegistryTest(type: Test) {
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(
-            'CloudGatewayCentralRegistry',
-            'CloudGatewayCentralRegistryXForwardHeaders'
+            'CloudGatewayCentralRegistry'
         )
     }
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -207,6 +207,7 @@ task runAllIntegrationTestsForZoweNonHaTestingOnZos(type: Test) {
             'SAFProviderTest',
             'CloudGatewayProxyTest',
             'CloudGatewayAuthTest',
+            'CloudGatewayCentralRegistryXForwardHeaders',
             'SafIdTokenTest'
         )
     }
@@ -249,6 +250,7 @@ task runAllIntegrationTestsForZoweHaTestingOnZos(type: Test) {
             'SAFProviderTest',
             'CloudGatewayProxyTest',
             'CloudGatewayAuthTest',
+            'CloudGatewayCentralRegistryXForwardHeaders',
             'SafIdTokenTest',
             'ChaoticHATest',
             'GraphQLTest'
@@ -344,6 +346,7 @@ task runContainerTests(type: Test) {
             'CloudGatewayProxyTest',
             'CloudGatewayServiceRouting',
             'CloudGatewayCentralRegistry',
+            'CloudGatewayCentralRegistryXForwardHeaders',
             'ZaasTest',
             'HealthEndpointProtectionDisabledTest'
         )
@@ -381,6 +384,7 @@ task runBaseTests(type: Test) {
             'CloudGatewayProxyTest',
             'CloudGatewayServiceRouting',
             'CloudGatewayCentralRegistry',
+            'CloudGatewayCentralRegistryXForwardHeaders',
             'MultipleRegistrationsTest',
             'HealthEndpointProtectionDisabledTest'
         )
@@ -438,7 +442,8 @@ task runCloudGatewayCentralRegistryTest(type: Test) {
     systemProperties System.getProperties()
     useJUnitPlatform {
         includeTags(
-            'CloudGatewayCentralRegistry'
+            'CloudGatewayCentralRegistry',
+            'CloudGatewayCentralRegistryXForwardHeaders'
         )
     }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/XForwardHeadersProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/XForwardHeadersProxyTest.java
@@ -32,7 +32,7 @@ import static org.zowe.apiml.util.SecurityUtils.COOKIE_NAME;
 import static org.zowe.apiml.util.SecurityUtils.gatewayToken;
 import static org.zowe.apiml.util.requests.Endpoints.REQUEST_INFO_ENDPOINT;
 
-@Tag("CloudGatewayCentralRegistry")
+@Tag("CloudGatewayCentralRegistryXForwardHeaders")
 @Slf4j
 class XForwardHeadersProxyTest {
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/XForwardHeadersProxyTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/proxy/XForwardHeadersProxyTest.java
@@ -32,7 +32,7 @@ import static org.zowe.apiml.util.SecurityUtils.COOKIE_NAME;
 import static org.zowe.apiml.util.SecurityUtils.gatewayToken;
 import static org.zowe.apiml.util.requests.Endpoints.REQUEST_INFO_ENDPOINT;
 
-@Tag("CloudGatewayCentralRegistryXForwardHeaders")
+@Tag("CloudGatewayCentralRegistry")
 @Slf4j
 class XForwardHeadersProxyTest {
 


### PR DESCRIPTION
# Description

These tests requires multi-tenancy deployment which is not available in platform tests.

Linked to # (#4188)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
