### PR TITLE
fix: gateway returns empty auth keys from zosmf when jwtAutoconfiguration is jwt

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -112,6 +112,7 @@ public class HttpConfig {
     private CloseableHttpClient secureHttpClient;
     private CloseableHttpClient secureHttpClientWithoutKeystore;
     private SSLContext secureSslContext;
+    private SSLContext secureSslContextWithoutKeystore;
     private HostnameVerifier secureHostnameVerifier;
     private final Timer connectionManagerTimer = new Timer(
         "ApimlHttpClientConfiguration.connectionManagerTimer", true);
@@ -166,6 +167,7 @@ public class HttpConfig {
             HttpsFactory factoryWithoutKeystore = new HttpsFactory(httpsConfigWithoutKeystore);
             ApimlPoolingHttpClientConnectionManager connectionManagerWithoutKeystore = getConnectionManager(factoryWithoutKeystore);
             secureHttpClientWithoutKeystore = factoryWithoutKeystore.createSecureHttpClient(connectionManagerWithoutKeystore);
+            secureSslContextWithoutKeystore = factoryWithoutKeystore.getSslContext();
 
             publicKeyCertificatesBase64 = SecurityUtils.loadCertificateChainBase64(httpsConfig);
         } catch (HttpsConfigError e) {
@@ -276,6 +278,11 @@ public class HttpConfig {
     @Bean
     public SSLContext secureSslContext() {
         return secureSslContext;
+    }
+
+    @Bean
+    public SSLContext secureSslContextWithoutKeystore() {
+        return secureSslContextWithoutKeystore;
     }
 
     @Bean

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ComponentsConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ComponentsConfiguration.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.security.config;
 
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,8 @@ import org.zowe.apiml.gateway.security.service.zosmf.ZosmfService;
 import org.zowe.apiml.passticket.PassTicketService;
 import org.zowe.apiml.security.common.audit.RauditxService;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+
+import javax.net.ssl.SSLContext;
 
 
 /**
@@ -92,5 +95,11 @@ public class ComponentsConfiguration {
     @Bean
     public SuccessfulAccessTokenHandler successfulAccessTokenHandler(ApimlAccessTokenProvider apimlAccessTokenProvider, RauditxService rauditxService) {
         return new SuccessfulAccessTokenHandler(apimlAccessTokenProvider, rauditxService);
+    }
+
+    @Bean
+    DefaultResourceRetriever defaultResourceRetriever(@Qualifier("secureSslContextWithoutKeystore") SSLContext secureSslContextWithoutKeystore) {
+        return new DefaultResourceRetriever(
+            0, 0, 0, true, secureSslContextWithoutKeystore.getSocketFactory());
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfService.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
 import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.Resource;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -124,6 +126,7 @@ public class ZosmfService extends AbstractZosmfService {
 
     private final ApplicationContext applicationContext;
     private final List<TokenValidationStrategy> tokenValidationStrategy;
+    private DefaultResourceRetriever resourceRetriever;
 
     public ZosmfService(
         final AuthConfigurationProperties authConfigurationProperties,
@@ -133,7 +136,8 @@ public class ZosmfService extends AbstractZosmfService {
         final ApplicationContext applicationContext,
         final AuthenticationService authenticationService,
         final TokenCreationService tokenCreationService,
-        List<TokenValidationStrategy> tokenValidationStrategy
+        List<TokenValidationStrategy> tokenValidationStrategy,
+        DefaultResourceRetriever resourceRetriever
     ) {
         super(
             authConfigurationProperties,
@@ -145,6 +149,7 @@ public class ZosmfService extends AbstractZosmfService {
         this.tokenValidationStrategy = tokenValidationStrategy;
         this.authenticationService = authenticationService;
         this.tokenCreationService = tokenCreationService;
+        this.resourceRetriever = resourceRetriever;
     }
 
     private ZosmfService meAsProxy;
@@ -562,7 +567,8 @@ public class ZosmfService extends AbstractZosmfService {
         final String url = getURI(getZosmfServiceId(), authConfigurationProperties.getZosmf().getJwtEndpoint());
 
         try {
-            return JWKSet.load(new URL(url));
+            Resource resource = resourceRetriever.retrieveResource(new URL(url));
+            return JWKSet.parse(resource.getContent());
         } catch (ParseException pe) {
             log.debug("Invalid format of public keys from z/OSMF", pe);
         } catch (HttpClientErrorException.NotFound nf) {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/login/zosmf/ZosmfAuthenticationProviderTest.java
@@ -114,7 +114,8 @@ class ZosmfAuthenticationProviderTest {
             applicationContext,
             authenticationService,
             tokenCreationService,
-            new ArrayList<>());
+            new ArrayList<>(),
+            null);
         ReflectionTestUtils.setField(zosmfService, "meAsProxy", zosmfService);
 
         return spy(zosmfService);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/query/SuccessfulQueryHandlerTest.java
@@ -92,7 +92,8 @@ class SuccessfulQueryHandlerTest {
             applicationContext,
             authenticationService,
             tokenCreationService,
-            new ArrayList<>());
+            new ArrayList<>(),
+            null);
         AuthenticationService authenticationService = new AuthenticationService(
             applicationContext, authConfigurationProperties, jwtSecurityInitializer, zosmfService,
             discoveryClient, restTemplate, cacheManager, new CacheUtils()

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/service/zosmf/ZosmfServiceTest.java
@@ -17,7 +17,8 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.discovery.DiscoveryClient;
-import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.Resource;
 import org.hamcrest.collection.IsMapContaining;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,8 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.LoggerFactory;
@@ -65,10 +64,9 @@ import org.zowe.apiml.zaas.ZaasTokenResponse;
 
 import javax.management.ServiceNotFoundException;
 import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
 import java.net.ConnectException;
-import java.net.URL;
 import java.nio.charset.Charset;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -147,6 +145,7 @@ class ZosmfServiceTest {
             applicationContext,
             authenticationService,
             tokenCreationService,
+            null,
             null);
         ZosmfService zosmfService = spy(zosmfServiceObj);
         doReturn(ZOSMF_ID).when(zosmfService).getZosmfServiceId();
@@ -163,7 +162,8 @@ class ZosmfServiceTest {
             applicationContext,
             authenticationService,
             tokenCreationService,
-            validationStrategyList);
+            validationStrategyList,
+            null);
 
         ZosmfService zosmfService = spy(zosmfServiceObj);
         doReturn("http://host:1433").when(zosmfService).getURI(any());
@@ -731,20 +731,22 @@ class ZosmfServiceTest {
             "}";
 
         @Test
-        void thenSuccess() throws JSONException, ParseException {
+        void thenSuccess() throws JSONException, IOException {
             String zosmfJwtUrl = "/jwt/ibm/api/zOSMFBuilder/jwk";
             when(authConfigurationProperties.getZosmf().getJwtEndpoint()).thenReturn(zosmfJwtUrl);
             ZosmfService zosmfService = getZosmfServiceSpy();
-            JWKSet jwkSet = JWKSet.parse(ZOSMF_PUBLIC_KEY_JSON);
-            try (MockedStatic<JWKSet> mockedStatic = Mockito.mockStatic(JWKSet.class)) {
-                mockedStatic.when(() -> JWKSet.load(any(URL.class))).thenReturn(jwkSet);
-                JSONAssert.assertEquals(ZOSMF_PUBLIC_KEY_JSON, new JSONObject(zosmfService.getPublicKeys().toString()), true);
-            }
+            DefaultResourceRetriever resourceRetriever = mock(DefaultResourceRetriever.class);
+            ReflectionTestUtils.setField(zosmfService, "resourceRetriever", resourceRetriever);
+
+            when(resourceRetriever.retrieveResource(any())).thenReturn(new Resource(ZOSMF_PUBLIC_KEY_JSON, null));
+
+            JSONAssert.assertEquals(ZOSMF_PUBLIC_KEY_JSON, new JSONObject(zosmfService.getPublicKeys().toString()), true);
         }
 
         @Test
         void thenReturnNull() {
             assertNull(new ZosmfService(null,
+                null,
                 null,
                 null,
                 null,
@@ -783,6 +785,7 @@ class ZosmfServiceTest {
                 applicationContext,
                 authenticationService,
                 tokenCreationService,
+                null,
                 null
             );
 
@@ -924,6 +927,7 @@ class ZosmfServiceTest {
                 applicationContext,
                 authenticationService,
                 tokenCreationService,
+                null,
                 null
             );
 
@@ -962,6 +966,7 @@ class ZosmfServiceTest {
                 applicationContext,
                 authenticationService,
                 tokenCreationService,
+                null,
                 null
             );
         }


### PR DESCRIPTION
# Description

Already fixed in v3 by validating the zosmf certificate against Zowe truststore. Cherry pick from #4108

Linked to # (#4092)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
