### PR TITLE
fix: ZAAS startup with `apiml.security.oidc.validationType` = `endpoint`

### DIFF
--- a/apiml-common/src/testFixtures/java/org/zowe/apiml/util/HttpClientMockHelper.java
+++ b/apiml-common/src/testFixtures/java/org/zowe/apiml/util/HttpClientMockHelper.java
@@ -16,6 +16,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.mockito.ArgumentMatchers;
@@ -48,6 +49,12 @@ public class HttpClientMockHelper {
 
     }
 
+    public static void mockResponse(ClassicHttpResponse responseMock, int statusCode, String responseBody, Header... headers) {
+        mockResponse(responseMock, statusCode);
+        mockResponse(responseMock, responseBody);
+        mockResponse(responseMock, headers);
+    }
+
     public static void mockResponse(ClassicHttpResponse responseMock, int statusCode, String responseBody) {
         mockResponse(responseMock, statusCode);
         mockResponse(responseMock, responseBody);
@@ -60,5 +67,9 @@ public class HttpClientMockHelper {
 
     public static void mockResponse(ClassicHttpResponse responseMock, int statusCode) {
         Mockito.when(responseMock.getCode()).thenReturn(statusCode);
+    }
+
+    public static void mockResponse(ClassicHttpResponse responseMock, Header... headers) {
+        Mockito.when(responseMock.getHeaders()).thenReturn(headers);
     }
 }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/token/OIDCTokenProviderEndpoint.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/token/OIDCTokenProviderEndpoint.java
@@ -12,10 +12,9 @@ package org.zowe.apiml.zaas.security.service.token;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
@@ -43,11 +42,11 @@ public class OIDCTokenProviderEndpoint implements OIDCProvider {
             HttpGet httpGet = new HttpGet(endpointUrl);
             httpGet.addHeader(HttpHeaders.AUTHORIZATION, ApimlConstants.BEARER_AUTHENTICATION_PREFIX + " " + token);
 
-            HttpResponse httpResponse = secureHttpClientWithKeystore.execute(httpGet);
-
-            int responseCode = httpResponse.getStatusLine().getStatusCode();
-            log.debug("Response code: {}", responseCode);
-            return HttpStatus.valueOf(responseCode).is2xxSuccessful();
+            return secureHttpClientWithKeystore.execute(httpGet, response -> {
+                final int responseCode = response.getCode();
+                log.debug("Response code: {}", responseCode);
+                return HttpStatus.valueOf(responseCode).is2xxSuccessful();
+            });
         } catch (IOException e) {
             log.error("An error occurred during validation of OIDC token using userInfo URI {}: {}", endpointUrl, e.getMessage());
             return false;

--- a/zaas-service/src/test/java/org/zowe/apiml/acceptance/OIDCTokenProviderJWKEndpointTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/acceptance/OIDCTokenProviderJWKEndpointTest.java
@@ -13,20 +13,18 @@ package org.zowe.apiml.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.http.Header;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicStatusLine;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.core.Is;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentMatchers;
@@ -40,8 +38,10 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.product.web.HttpConfig;
+import org.zowe.apiml.util.HttpClientMockHelper;
 import org.zowe.apiml.zaas.ZaasApplication;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
 import org.zowe.apiml.zaas.security.service.token.OIDCTokenProviderEndpoint;
@@ -77,28 +77,20 @@ class OIDCTokenProviderJWKEndpointTest {
 
     @LocalServerPort
     private int port;
-
     private String zaasEndpoint;
     private RestAssuredConfig withClientCert;
-
     @Autowired
     HttpConfig httpConfig;
-
-    @Autowired
-    OIDCTokenProviderEndpoint oidcTokenProviderEndpoint;
-
-    @Autowired
-    CloseableHttpClient secureHttpClientWithKeystore;
+    @MockitoSpyBean
+    CloseableHttpClient httpClientSecure;
 
     private CloseableHttpResponse createResponse(int responseCode, String body, Header...headers) {
         CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-        Mockito.doReturn(new BasicStatusLine(new ProtocolVersion("http", 1, 1), responseCode, "")).when(response).getStatusLine();
-        Mockito.doReturn(new StringEntity(body, ContentType.APPLICATION_JSON)).when(response).getEntity();
-        Mockito.doReturn(headers).when(response).getAllHeaders();
+        HttpClientMockHelper.mockResponse(response, responseCode, body, headers);
         return response;
     }
 
-    @BeforeAll
+    @BeforeEach
     public void init() throws IOException {
         zaasEndpoint = "https://localhost:" + port + CONTROLLER_PATH + "/zoweJwt";
 
@@ -106,13 +98,13 @@ class OIDCTokenProviderJWKEndpointTest {
         withClientCert = RestAssuredConfig.newConfig().sslConfig(new SSLConfig().sslSocketFactory(new SSLSocketFactory(sslContext, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER))); // NOSONAR
 
         Mockito.doAnswer(invocation -> {
-            HttpUriRequest request = invocation.getArgument(0);
+            HttpGet request = invocation.getArgument(0);
             String authHeader = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
-            if (StringUtils.equals(ApimlConstants.BEARER_AUTHENTICATION_PREFIX + " " + VALID_TOKEN, authHeader)) {
-                return createResponse(HttpStatus.SC_OK, "{\"detail\":\"information\")");
+            if (Strings.CS.equals(ApimlConstants.BEARER_AUTHENTICATION_PREFIX + " " + VALID_TOKEN, authHeader)) {
+                return HttpClientMockHelper.invokeResponseHandler(invocation, createResponse(HttpStatus.SC_OK, "{\"detail\":\"information\")"));
             }
-            return createResponse(HttpStatus.SC_UNAUTHORIZED, "{\"error\":\"message\")");
-        }).when(secureHttpClientWithKeystore).execute(ArgumentMatchers.any());
+            return HttpClientMockHelper.invokeResponseHandler(invocation, createResponse(HttpStatus.SC_UNAUTHORIZED, "{\"error\":\"message\")"));
+        }).when(httpClientSecure).execute(ArgumentMatchers.any(ClassicHttpRequest.class), ArgumentMatchers.any(HttpClientResponseHandler.class));
     }
 
     @Test
@@ -177,7 +169,7 @@ class OIDCTokenProviderJWKEndpointTest {
         }
 
         @Bean
-        CloseableHttpClient secureHttpClientWithKeystore() {
+        CloseableHttpClient httpClientSecure() {
             return mock(CloseableHttpClient.class);
         }
 


### PR DESCRIPTION
# Description

ZAAS was failing to start, when `apiml.security.oidc.enabled = true`and `apiml.security.oidc.validationType = endpoint`, with following error:

```log
***************************
APPLICATION FAILED TO START
***************************
Description:
Parameter 0 of constructor in org.zowe.apiml.zaas.security.service.token.OIDCTokenProviderEndpoint required a bean of type 'org.apache.http.impl.client.CloseableHttpClient' that could not be found.
The injection point has the following annotations:
    - @org.springframework.lang.Nullable()
Action:
Consider defining a bean of type 'org.apache.http.impl.client.CloseableHttpClient' in your configuration.
```

## Type of change

Please delete options that are not relevant.

- [X] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
