### PR TITLE
chore: add modulith on z/os integration test tasks

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -258,6 +258,99 @@ task runAllIntegrationTestsForZoweHaTestingOnZos(type: Test) {
     outputs.cacheIf { false }
 }
 
+task runAllIntegrationTestsForZoweModulithNonHaTestingOnZos(type: Test) {
+    // This task is intended to run on z/OS systems with some limitations:
+    // Only 1 Gateway (Non-HA mode)
+    // z/OSMF Authentication provider only
+    // No support for SAF ID Tokens
+
+    group "Integration tests"
+    description "Run all integration tests for Zowe Non-HA testing on z/OS with modulith mode (limited)"
+
+    def targetSystem = System.getenv("ZOS_TARGET_SYS") ? "-" + System.getenv("ZOS_TARGET_SYS") : ""
+    systemProperty "environment.config", targetSystem
+    systemProperty "environment.zos.target", "true"
+    systemProperty "environment.modulith", "true"
+    systemProperties System.properties
+    systemProperties.remove('java.endorsed.dirs')
+
+    useJUnitPlatform {
+        excludeTags(
+            'StartupCheck',
+            'EnvironmentCheck',
+            'AdditionalLocalTest',
+            'TestsNotMeantForZowe',
+            'DiscoverableClientDependentTest',
+            'HATest',
+            'ChaoticHATest',
+            'OktaOauth2Test',
+            'MultipleRegistrationsTest',
+            'NotForMainframeTest',
+            'ApiCatalogStandaloneTest',
+            'SAFProviderTest',
+            'GatewayProxyTest',
+            'GatewayCentralRegistry',
+            'SafIdTokenTest',
+            'ZaasTest' // These tests require ZAAS as a separate service with its own port and specific paths that are not part of the public API
+        )
+    }
+
+    debugOptions {
+        port = 5005
+        suspend = true
+        server = true
+    }
+    outputs.upToDateWhen { false }
+}
+
+task runAllIntegrationTestsForZoweModulithHaTestingOnZos(type: Test) {
+    // This task is intended to run on z/OS systems with some limitations:
+    // More than 1 Gateway (HA mode)
+    // z/OSMF Authentication provider only
+    // No support for SAF ID Tokens
+
+    group "Integration tests"
+    description "Run all integration tests for Zowe HA testing on z/OS with modulith mode (limited)"
+
+    def targetSystem = System.getenv("ZOS_TARGET_SYS") ? "-" + System.getenv("ZOS_TARGET_SYS") : ""
+    systemProperty "environment.config", targetSystem
+    systemProperty "environment.zos.target", "true"
+    systemProperty "environment.ha", true
+    systemProperty "environment.modulith", true
+    systemProperties System.properties
+    systemProperties.remove('java.endorsed.dirs')
+
+    useJUnitPlatform {
+        excludeTags(
+            'StartupCheck',
+            'EnvironmentCheck',
+            'AdditionalLocalTest',
+            'TestsNotMeantForZowe',
+            'DiscoverableClientDependentTest',
+            'OktaOauth2Test',
+            'MultipleRegistrationsTest',
+            'NotForMainframeTest',
+            'ApiCatalogStandaloneTest',
+            'SAFProviderTest',
+            'GatewayProxyTest',
+            'GatewayCentralRegistry',
+            'SafIdTokenTest',
+            'ChaoticHATest',
+            'GraphQLTest',
+            'ZaasTest' // These tests require ZAAS as a separate service with its own port and specific paths that are not part of the public API
+        )
+    }
+
+    debugOptions {
+        port = 5005
+        suspend = true
+        server = true
+    }
+
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+}
+
 task runAllIntegrationTestsForZoweTesting(type: Test) {
     group "Integration tests"
     description "Run all integration tests for Zowe testing"


### PR DESCRIPTION
# Description

Add integration test tasks that can be used to run selected integration tests to run against a z/OS-deployed version of the API ML with modulith mode enabled.

A difference with the non-modulith version of the same tasks is that we need to exclude `ZaasTest` tagged tests because they require ZAAS running on its own port an the specific APIs that are not part of the public API of the APIML.

## Type of change

- [ ] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
