### PR TITLE
fix: backport tests for swagger redirection

### DIFF
--- a/discoverable-client/src/main/java/org/zowe/apiml/client/api/ApiDocRedirectController.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/api/ApiDocRedirectController.java
@@ -1,0 +1,46 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.client.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Controller to test the support of Catalog to render redirected Swagger
+ */
+@RestController
+@Tag(name = "Other Operations")
+public class ApiDocRedirectController {
+
+    @Value("${apiml.service.baseUrl}")
+    private String baseUrl;
+
+    @Value("${apiml.service.contextPath}")
+    private String contextPath;
+
+    private static final String REDIRECT_DOC_URL = "/docs/redirect";
+
+    @GetMapping(REDIRECT_DOC_URL)
+    public ResponseEntity<Void> getDocWithRedirect() {
+        String location = UriComponentsBuilder.fromUriString(baseUrl)
+            .path(contextPath)
+            .path("/v3/api-docs/apiv2").toUriString();
+
+        return ResponseEntity.status(301)
+            .header("Location", location)
+            .build();
+    }
+
+}

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -101,7 +101,7 @@ apiml:
             -   apiId: zowe.apiml.discoverableclient.rest
                 version: 2.0.0
                 gatewayUrl: api/v2
-                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/v3/api-docs/apiv2
+                swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/docs/redirect
                 documentationUrl: https://www.zowe.org
         catalog:
             tile:

--- a/discoverable-client/src/test/java/org/zowe/apiml/client/api/ApiDocRedirectControllerTest.java
+++ b/discoverable-client/src/test/java/org/zowe/apiml/client/api/ApiDocRedirectControllerTest.java
@@ -1,0 +1,42 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.client.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zowe.apiml.client.configuration.SecurityConfiguration;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = {ApiDocRedirectController.class})
+@Import(SecurityConfiguration.class)
+class ApiDocRedirectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void callApiDocRedirect() throws Exception {
+        this.mockMvc.perform(get("/docs/redirect"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(header().string("Location", containsString("/v3/api-docs/apiv2")));
+    }
+
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/ApiCatalogDiscoverableClientIntegrationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/ApiCatalogDiscoverableClientIntegrationTest.java
@@ -48,6 +48,7 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
     class WhenGettingApiDoc {
         @Nested
         class ReturnRelevantApiDoc {
+
             @Test
             void givenV1ApiDocPath() throws Exception {
                 final HttpResponse response = getResponse(DISCOVERABLE_CLIENT_API_DOC_ENDPOINT, HttpStatus.SC_OK);
@@ -69,11 +70,11 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
                     "\n**************************\n";
                 DocumentContext jsonContext = JsonPath.parse(jsonResponse);
 
-                LinkedHashMap swaggerInfo = jsonContext.read("$.info");
+                LinkedHashMap<Object, Object> swaggerInfo = jsonContext.read("$.info");
                 String swaggerServer = jsonContext.read("$.servers[0].url");
-                LinkedHashMap paths = jsonContext.read("$.paths");
-                LinkedHashMap definitions = jsonContext.read("$.components.schemas");
-                LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
+                LinkedHashMap<Object, Object> paths = jsonContext.read("$.paths");
+                LinkedHashMap<Object, Object> definitions = jsonContext.read("$.components.schemas");
+                LinkedHashMap<Object, Object> externalDoc = jsonContext.read("$.externalDocs");
 
                 assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);
                 assertThat(swaggerServer, endsWith(""));
@@ -101,7 +102,9 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
                 validateDiscoverableClientApiV1(dcJsonResponse, dcJsonContext);
             }
+
         }
+
     }
 
     @Test
@@ -112,14 +115,14 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
         validateContainer(containerJsonContext);
 
-        LinkedHashMap<String, LinkedHashMap<String, String>> apis = containerJsonContext.read("$[0].services[0].apis");
+        LinkedHashMap<String, LinkedHashMap<Object, Object>> apis = containerJsonContext.read("$[0].services[0].apis");
 
         assertNotNull(apis.get("default"));
         assertNotNull(apis.get("zowe.apiml.discoverableclient.rest v2.0.0"));
         assertNotNull(apis.get("zowe.apiml.discoverableclient.rest v1.0.0"));
         assertNotNull(apis.get("zowe.apiml.discoverableclient.ws v1.0.0"));
 
-        LinkedHashMap defaultApi = apis.get("default");
+        LinkedHashMap<Object, Object> defaultApi = apis.get("default");
         assertEquals("zowe.apiml.discoverableclient.rest", defaultApi.get("apiId"));
         assertEquals("api/v1", defaultApi.get("gatewayUrl"));
         assertEquals("1.0.0", defaultApi.get("version"));
@@ -129,6 +132,7 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
         JSONArray codeSnippets = (JSONArray) defaultApi.get("codeSnippet");
         assertEquals(2, codeSnippets.size());
+        @SuppressWarnings("unchecked")
         LinkedHashMap<String, String> codeSnippet = (LinkedHashMap<String, String>) codeSnippets.get(0);
         assertEquals("/greeting", codeSnippet.get("endpoint"));
         assertNotNull(codeSnippet.get("codeBlock"));
@@ -138,6 +142,7 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
 
     @Nested
     class WhenGettingDifferenceBetweenVersions {
+
         @Nested
         class ReturnDifference {
             @Test
@@ -153,10 +158,12 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
                 assertThat(textResponse, containsString(
                     "<div><h2>What&#x27;s Deleted</h2><hr><ol><li><span class=\"GET\">GET</span>"));
             }
+
         }
 
         @Nested
         class ReturnNotFound {
+
             @Test
             void givenWrongVersion() throws Exception {
                 getResponse(API_SERVICE_VERSION_DIFF_ENDPOINT_WRONG_VERSION, HttpStatus.SC_NOT_FOUND);
@@ -166,7 +173,9 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
             void givenWrongService() throws Exception {
                 getResponse(API_SERVICE_VERSION_DIFF_ENDPOINT_WRONG_SERVICE, HttpStatus.SC_NOT_FOUND);
             }
+
         }
+
     }
 
     // Execute the endpoint and check the response for a return code
@@ -198,11 +207,11 @@ class ApiCatalogDiscoverableClientIntegrationTest implements TestWithStartedInst
             "\n**************************\n";
 
         // When
-        LinkedHashMap swaggerInfo = jsonContext.read("$.info");
+        LinkedHashMap<Object, Object> swaggerInfo = jsonContext.read("$.info");
         String swaggerServer = jsonContext.read("$.servers[0].url");
-        LinkedHashMap paths = jsonContext.read("$.paths");
-        LinkedHashMap definitions = jsonContext.read("$.components.schemas");
-        LinkedHashMap externalDoc = jsonContext.read("$.externalDocs");
+        LinkedHashMap<Object, Object> paths = jsonContext.read("$.paths");
+        LinkedHashMap<Object, Object> definitions = jsonContext.read("$.components.schemas");
+        LinkedHashMap<Object, Object> externalDoc = jsonContext.read("$.externalDocs");
 
         // Then
         assertTrue(swaggerInfo.get("description").toString().contains("API"), apiCatalogSwagger);


### PR DESCRIPTION
# Description

Backport api doc redirect controller to test capability of API Catalog to follow redirects in getting the API doc contents.

## Type of change

- [ ] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
