### PR TITLE
fix: start caching service with disabled cert verification 

### DIFF
--- a/apiml/src/main/java/org/zowe/apiml/WebSecurityConfig.java
+++ b/apiml/src/main/java/org/zowe/apiml/WebSecurityConfig.java
@@ -122,7 +122,7 @@ public class WebSecurityConfig {
     @Bean
     @Order(0)
     SecurityWebFilterChain discoveryServiceClientCertificateFilterChain(ServerHttpSecurity http) {
-        http
+        http.csrf(ServerHttpSecurity.CsrfSpec::disable)
             .securityMatcher(new AndServerWebExchangeMatcher(
                 discoveryPortMatcher,
                 pathMatchers("/eureka/**"),

--- a/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/config/SpringSecurityConfig.java
@@ -61,15 +61,15 @@ public class SpringSecurityConfig {
             .securityMatcher(new AndServerWebExchangeMatcher(
                 ServerWebExchangeMatchers.pathMatchers("/cachingservice/**")
             ))
-            .authorizeExchange(exchange -> exchange
-                .pathMatchers(antMatchersToIgnore.toArray(new String[0])).permitAll()
-                .anyExchange().authenticated()
-            ).exceptionHandling(exceptionHandlingSpec ->
+            .exceptionHandling(exceptionHandlingSpec ->
                 exceptionHandlingSpec.authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.FORBIDDEN))
             );
 
         if (verifyCertificates || !nonStrictVerifyCerts) {
-            http.x509(x509spec -> x509spec.principalExtractor(X509Util.x509PrincipalExtractor())
+            http.authorizeExchange(exchange -> exchange
+                .pathMatchers(antMatchersToIgnore.toArray(new String[0])).permitAll()
+                .anyExchange().authenticated()
+            ).x509(x509spec -> x509spec.principalExtractor(X509Util.x509PrincipalExtractor())
                 .authenticationManager(X509Util.x509ReactiveAuthenticationManager()));
         } else {
             http.authorizeExchange(exchange -> exchange.anyExchange().permitAll());

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/token/OIDCTokenProvider.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/token/OIDCTokenProvider.java
@@ -89,10 +89,10 @@ public class OIDCTokenProvider implements OIDCProvider {
             log.debug("OIDC JWK URI not provided, JWK refresh not performed");
             return;
         }
-        log.debug("Refreshing JWK endpoints {}", jwksUri);
 
         publicKeys.clear();
         for (String url : jwksUri) {
+            log.debug("Refreshing JWK endpoints {}", url);
             try {
                 Resource resource = resourceRetriever.retrieveResource(new URL(url));
                 var tmpJwk = JWKSet.parse(resource.getContent());
@@ -108,7 +108,7 @@ public class OIDCTokenProvider implements OIDCProvider {
     @Override
     public boolean isValid(String token) {
         try {
-            log.debug("Validating the token with JWK: {}", jwksUri);
+
             if (Collections.isEmpty(jwksUri) || getClaims(token).isEmpty()) {
                 return isValidExternal(token);
             }
@@ -151,7 +151,7 @@ public class OIDCTokenProvider implements OIDCProvider {
         if (StringUtils.isBlank(token)) {
             throw new JwtException("Empty string provided instead of a token.");
         }
-
+        log.debug("Validating the token with JWK");
         return Jwts.parser()
             .clock(clock)
             .keyLocator(keyLocator)


### PR DESCRIPTION
# Description

A bug prevents the caching service from starting when SSL verification was disabled.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
