### PR TITLE
feat: Support configurable username field for oidc tokens

### DIFF
--- a/apiml-package/src/main/resources/bin/start.sh
+++ b/apiml-package/src/main/resources/bin/start.sh
@@ -381,6 +381,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${APIML_CODE} ${JAVA_BIN_DIR}java \
     -Dapiml.security.oidc.jwks.refreshInternalHours=${ZWE_components_gateway_apiml_security_oidc_jwks_refreshInternalHours:-${ZWE_configs_apiml_security_oidc_jwks_refreshInternalHours:-1}} \
     -Dapiml.security.oidc.jwks.uri=${ZWE_components_gateway_apiml_security_oidc_jwks_uri:-${ZWE_configs_apiml_security_oidc_jwks_uri:-}} \
     -Dapiml.security.oidc.registry=${ZWE_components_gateway_apiml_security_oidc_registry:-${ZWE_configs_apiml_security_oidc_registry:-}} \
+    -Dapiml.security.oidc.userIdField=${ZWE_components_gateway_apiml_security_oidc_userIdField:-${ZWE_configs_apiml_security_oidc_userIdField:-"sub"}} \
     -Dapiml.security.oidc.userInfo.uri=${ZWE_components_gateway_apiml_security_oidc_userInfo_uri:-${ZWE_configs_apiml_security_oidc_userInfo_uri:-}} \
     -Dapiml.security.oidc.validationType=${ZWE_components_gateway_apiml_security_oidc_validationType:-${ZWE_configs_apiml_security_oidc_validationType:-"JWK"}} \
     -Dapiml.security.personalAccessToken.enabled=${ZWE_components_gateway_apiml_security_personalAccessToken_enabled:-${ZWE_configs_apiml_security_personalAccessToken_enabled:-false}} \

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -377,6 +377,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${ZAAS_CODE} ${JAVA_BIN_DIR}java \
     -Dapiml.security.oidc.identityMapperUser=${ZWE_configs_apiml_security_oidc_identityMapperUser:-${ZWE_components_gateway_apiml_security_oidc_identityMapperUser:-${ZWE_zowe_setup_security_users_zowe:-ZWESVUSR}}} \
     -Dapiml.security.oidc.jwks.uri=${ZWE_configs_apiml_security_oidc_jwks_uri:-${ZWE_components_gateway_apiml_security_oidc_jwks_uri:-}} \
     -Dapiml.security.oidc.jwks.refreshInternalHours=${ZWE_configs_apiml_security_oidc_jwks_refreshInternalHours:-${ZWE_components_gateway_apiml_security_oidc_jwks_refreshInternalHours:-1}} \
+    -Dapiml.security.oidc.userIdField=${ZWE_configs_apiml_security_oidc_userIdField:-${ZWE_components_gateway_apiml_security_oidc_userIdField:-"sub"}} \
     -Dapiml.security.oidc.userInfo.uri=${ZWE_configs_apiml_security_oidc_userInfo_uri:-${ZWE_components_gateway_apiml_security_oidc_userInfo_uri:-}} \
     -Dapiml.security.oidc.validationType=${ZWE_configs_apiml_security_oidc_validationType:-${ZWE_components_gateway_apiml_security_oidc_validationType:-"JWK"}} \
     -Dapiml.security.allowTokenRefresh=${ZWE_configs_apiml_security_allowtokenrefresh:-${ZWE_components_gateway_apiml_security_allowtokenrefresh:-false}} \

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/JwtUtils.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/JwtUtils.java
@@ -10,14 +10,22 @@
 
 package org.zowe.apiml.zaas.security.service;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.security.common.token.TokenExpireException;
+import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @UtilityClass
@@ -85,6 +93,44 @@ public class JwtUtils {
 
         log.debug(TOKEN_IS_NOT_VALID_DUE_TO, exception.getMessage());
         return new TokenNotValidException("An internal error occurred while validating the token therefore the token is no longer valid.", exception);
+    }
+
+    /**
+     * Extracts value of a field from an OIDC token. The value is extracted from a custom path which supports nested objects.
+     * @param token to extract the field from
+     * @param pathToField list of strings representing path to the field
+     * @return userId extracted from the token
+     *
+     * @throws TokenFormatNotValidException in case of the field value cannot be extracted from the token, is null, or empty
+     */
+    @SuppressWarnings("rawtypes")
+    public static String getFieldValueFromToken(String token, List<String> pathToField) throws TokenFormatNotValidException {
+        if (token == null || pathToField == null || pathToField.isEmpty() || StringUtils.isBlank(pathToField.get(0))) {
+            throw new IllegalArgumentException("Token and field path most not be null or empty");
+        }
+
+        try {
+            Claims claims = getJwtClaims(token);
+            String fieldValue;
+            if (pathToField.size() == 1) {
+                fieldValue = claims.get(pathToField.get(0), String.class);
+            } else {
+                var iterator = pathToField.iterator();
+                var key = iterator.next();
+                Map val = claims.get(key, Map.class);
+                while (iterator.hasNext()) {
+                    key = iterator.next();
+                    if (iterator.hasNext()) {
+                        val = (Map) val.get(key);
+                    }
+                }
+                fieldValue = (String) val.get(key);
+            }
+            if (StringUtils.isBlank(fieldValue)) throw new IllegalArgumentException();
+            return fieldValue;
+        } catch (Exception e) {
+            throw new TokenFormatNotValidException(String.format("Cannot extract value from field %s. The field does not exists, is empty, or is na object.", String.join(".", pathToField)));
+        }
     }
 
 }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
@@ -104,7 +104,7 @@ public class OIDCAuthSourceService extends TokenAuthSourceService implements Ini
             authSource.setDistributedId(getFieldValueFromToken(authSource.getRawSource(), userIdFieldPath));
             return true;
         } catch (TokenFormatNotValidException e) {
-            logger.log(MessageType.DEBUG, "Cannot extract distributed id from token.", e);
+            logger.log(MessageType.DEBUG, String.format("Cannot extract distributed id from token. Reason: %s", e.getMessage()));
             return false;
         }
     }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
@@ -13,7 +13,9 @@ package org.zowe.apiml.zaas.security.service.schema.source;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.zowe.apiml.message.core.MessageType;
@@ -22,18 +24,23 @@ import org.zowe.apiml.product.logging.annotations.InjectApimlLogger;
 import org.zowe.apiml.security.common.token.NoMainframeIdentityException;
 import org.zowe.apiml.security.common.token.OIDCProvider;
 import org.zowe.apiml.security.common.token.QueryResponse;
+import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
 import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+
+import static org.zowe.apiml.zaas.security.service.JwtUtils.getFieldValueFromToken;
 
 @Service
 @RequiredArgsConstructor
 @ConditionalOnProperty(value = "apiml.security.oidc.enabled", havingValue = "true")
-public class OIDCAuthSourceService extends TokenAuthSourceService {
+public class OIDCAuthSourceService extends TokenAuthSourceService implements InitializingBean {
     @InjectApimlLogger
     protected final ApimlLogger logger = ApimlLogger.empty();
 
@@ -42,6 +49,15 @@ public class OIDCAuthSourceService extends TokenAuthSourceService {
     private final AuthenticationService authenticationService;
     private final OIDCProvider oidcProvider;
     private final TokenCreationService tokenService;
+
+    @Value("${apiml.security.oidc.userIdField:sub}")
+    protected String userIdFieldPathProperty;
+    private List<String> userIdFieldPath;
+
+    @Override
+    public void afterPropertiesSet() {
+        userIdFieldPath = Arrays.asList(userIdFieldPathProperty.trim().split("\\."));
+    }
 
     @Override
     protected ApimlLogger getLogger() {
@@ -67,15 +83,13 @@ public class OIDCAuthSourceService extends TokenAuthSourceService {
 
     @Override
     public boolean isValid(AuthSource authSource) {
-        if (authSource instanceof OIDCAuthSource) {
-            String token = ((OIDCAuthSource) authSource).getRawSource();
+        if (authSource instanceof OIDCAuthSource oidcAuthSource) {
+            String token = oidcAuthSource.getRawSource();
             if (StringUtils.isNotBlank(token)) {
                 logger.log(MessageType.DEBUG, "Validating OIDC token.");
                 if (oidcProvider.isValid(token)) {
                     logger.log(MessageType.DEBUG, "OIDC token is valid, set the distributed id to the auth source.");
-                    QueryResponse tokenClaims = authenticationService.parseJwtToken(token);
-                    ((OIDCAuthSource) authSource).setDistributedId(tokenClaims.getUserId());
-                    return true;
+                    return extractUserId(oidcAuthSource);
                 }
                 logger.log(MessageType.DEBUG, "OIDC token is not valid or the validation failed.");
             }
@@ -85,11 +99,21 @@ public class OIDCAuthSourceService extends TokenAuthSourceService {
         return false;
     }
 
+    private boolean extractUserId(OIDCAuthSource authSource) {
+        try {
+            authSource.setDistributedId(getFieldValueFromToken(authSource.getRawSource(), userIdFieldPath));
+            return true;
+        } catch (TokenFormatNotValidException e) {
+            logger.log(MessageType.DEBUG, "Cannot extract distributed id from token.", e);
+            return false;
+        }
+    }
+
     @Override
     public AuthSource.Parsed parse(AuthSource authSource) {
-        if (authSource instanceof OIDCAuthSource) {
-            if (isValid(authSource)) {
-                return parseOIDCToken((OIDCAuthSource) authSource, mapper);
+        if (authSource instanceof OIDCAuthSource oidcAuthSource) {
+            if (isValid(oidcAuthSource)) {
+                return parseOIDCToken( oidcAuthSource, mapper);
             }
             throw new TokenNotValidException("OIDC token is not valid.");
         }
@@ -135,5 +159,4 @@ public class OIDCAuthSourceService extends TokenAuthSourceService {
         AuthSource.Parsed parsed = parse(authSource);
         return tokenService.createJwtTokenWithoutCredentials(parsed.getUserId());
     }
-
 }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/JwtUtilsTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/JwtUtilsTest.java
@@ -15,15 +15,25 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.zowe.apiml.security.common.token.TokenExpireException;
+import org.zowe.apiml.security.common.token.TokenFormatNotValidException;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-
 class JwtUtilsTest {
+
+    private static final String TOKEN_WITH_USERNAME_FIELDS = "ewogICJ0eXAiOiAiSldUIiwKICAibm9uY2UiOiAiYVZhbHVlVG9CZVZlcmlmaWVkIiwKICAiYWxnIjogIlJTMjU2IiwKICAia2lkIjogIlNlQ1JldEtleSIKfQ.ewogICJhdWQiOiAiMDAwMDAwMDMtMDAwMC0wMDAwLWMwMDAtMDAwMDAwMDAwMDAwIiwKICAiaXNzIjogImh0dHBzOi8vb2lkYy5wcm92aWRlci5vcmcvYXBwIiwKICAiaWF0IjogMTcyMjUxNDEyOSwKICAibmJmIjogMTcyMjUxNDEyOSwKICAiZXhwIjogODcyMjUxODEyNSwKICAic3ViIjogIm9pZGMudXNlcm5hbWUiLAogICJlbWFpbCI6ICJ1c2VybmFtZUBvaWRjLm9yZyIsCiAgIm9yZyI6IHsKICAgICJuYW1lIjogIm9wZW5tYWluZnJhbWUiLAogICAgImRlcCI6IHsKICAgICAgIm5hbWUiOiAiem93ZSIsCiAgICAgICJ0ZWFtIjogImFwaW1sIiwKICAgICAgImNvbnRyaWJ1dG9yIjogImNvbnRyaWJ1dG9yQGFwaW1sLnpvd2UiLAogICAgICAibmlja25hbWUiOiAiIiwKICAgICAgIm51bGxWYWx1ZSI6IG51bGwKICAgIH0KICB9LAogICJtZW1iZXJPZiI6IFsKICAgICJvcGVubWFpbmZyYW1lIiwKICAgICJ6b3dlIiwKICAgICJhcGltbCIKICBdCn0.c29tZVNpZ25lZEhhc2hDb2Rl";
 
     @Test
     void testHandleJwtParserExceptionForExpiredToken() {
@@ -47,4 +57,45 @@ class JwtUtilsTest {
         assertTrue(exception instanceof TokenNotValidException);
         assertEquals("An internal error occurred while validating the token therefore the token is no longer valid.", exception.getMessage());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+        "email,username@oidc.org",
+        "org.dep.contributor, contributor@apiml.zowe"})
+    void givenValidFieldPath_thenReturnCorrectValue(String fieldPath, String expectedValue) {
+        var actualValue = JwtUtils.getFieldValueFromToken(TOKEN_WITH_USERNAME_FIELDS, splitFieldPath(fieldPath));
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "nonexistent", "org.nonexistent.foo", "org.dep", "org.dep.nonexistent", "org.dep.nickname", "org.dep.nullValue"})
+    void givenInvalidFieldPath_thenThrowInvalidTokenFormatException(String fieldPath) {
+        assertThrows(TokenFormatNotValidException.class, () -> JwtUtils.getFieldValueFromToken(TOKEN_WITH_USERNAME_FIELDS, splitFieldPath(fieldPath)));
+    }
+
+    @Test
+    void givenNullToken_thenThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> JwtUtils.getFieldValueFromToken(null, List.of("foo")));
+    }
+
+    @Test
+    void givenNullFieldPath_thenThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> JwtUtils.getFieldValueFromToken(TOKEN_WITH_USERNAME_FIELDS, null));
+    }
+
+    @Test
+    void givenEmptyFieldPath_thenThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> JwtUtils.getFieldValueFromToken(TOKEN_WITH_USERNAME_FIELDS, Collections.emptyList()));
+    }
+
+    @Test
+    void givenEmptyStringFieldPath_thenThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> JwtUtils.getFieldValueFromToken(TOKEN_WITH_USERNAME_FIELDS, List.of(" ")));
+    }
+
+
+    private List<String> splitFieldPath(String fieldPath) {
+        return Arrays.asList(fieldPath.trim().split("\\."));
+    }
+
 }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceServiceTest.java
@@ -15,9 +15,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.zowe.apiml.security.common.token.*;
+import org.zowe.apiml.security.common.token.NoMainframeIdentityException;
+import org.zowe.apiml.security.common.token.OIDCProvider;
+import org.zowe.apiml.security.common.token.QueryResponse;
+import org.zowe.apiml.security.common.token.TokenExpireException;
+import org.zowe.apiml.security.common.token.TokenNotValidException;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
 import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
@@ -26,8 +33,17 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OIDCAuthSourceServiceTest {
@@ -38,10 +54,11 @@ class OIDCAuthSourceServiceTest {
     private AuthenticationService authenticationService;
     private OIDCProvider provider;
     private AuthenticationMapper mapper;
-    private static final String TOKEN = "token";
-    private static final String ISSUER = "issuer";
-    private static final String DISTRIB_USER = "pc.user@acme.com";
+    private static final String DUMMY_TOKEN = "token";
+    private static final String TOKEN_WITH_USERNAME_FIELDS = "ewogICJ0eXAiOiAiSldUIiwKICAibm9uY2UiOiAiYVZhbHVlVG9CZVZlcmlmaWVkIiwKICAiYWxnIjogIlJTMjU2IiwKICAia2lkIjogIlNlQ1JldEtleSIKfQ.ewogICJhdWQiOiAiMDAwMDAwMDMtMDAwMC0wMDAwLWMwMDAtMDAwMDAwMDAwMDAwIiwKICAiaXNzIjogImh0dHBzOi8vb2lkYy5wcm92aWRlci5vcmcvYXBwIiwKICAiaWF0IjogMTcyMjUxNDEyOSwKICAibmJmIjogMTcyMjUxNDEyOSwKICAiZXhwIjogODcyMjUxODEyNSwKICAic3ViIjogIm9pZGMudXNlcm5hbWUiLAogICJlbWFpbCI6ICJ1c2VybmFtZUBvaWRjLm9yZyIsCiAgIm9yZyI6IHsKICAgICJuYW1lIjogIm9wZW5tYWluZnJhbWUiLAogICAgImRlcCI6IHsKICAgICAgIm5hbWUiOiAiem93ZSIsCiAgICAgICJ0ZWFtIjogImFwaW1sIiwKICAgICAgImNvbnRyaWJ1dG9yIjogImNvbnRyaWJ1dG9yQGFwaW1sLnpvd2UiLAogICAgICAibmlja25hbWUiOiAiIiwKICAgICAgIm51bGxWYWx1ZSI6IG51bGwKICAgIH0KICB9LAogICJtZW1iZXJPZiI6IFsKICAgICJvcGVubWFpbmZyYW1lIiwKICAgICJ6b3dlIiwKICAgICJhcGltbCIKICBdCn0.c29tZVNpZ25lZEhhc2hDb2Rl";
+    public static final String SUB_USER = "oidc.username";
     private static final String MF_USER = "MF_USER";
+    private static final String DEFAULT_USERID_FIELD = "sub";
 
     @BeforeEach
     void setup() {
@@ -50,11 +67,13 @@ class OIDCAuthSourceServiceTest {
         provider = mock(OIDCProvider.class);
         mapper = mock(AuthenticationMapper.class);
         service = new OIDCAuthSourceService(mapper, authenticationService, provider, tokenCreationService);
+        service.userIdFieldPathProperty = DEFAULT_USERID_FIELD;
+        service.afterPropertiesSet();
     }
 
     @Test
     void returnOIDCSourceMapper() {
-        assertTrue(service.getMapper().apply(TOKEN) instanceof OIDCAuthSource);
+        assertTrue(service.getMapper().apply(DUMMY_TOKEN) instanceof OIDCAuthSource);
     }
 
     @Test
@@ -67,26 +86,29 @@ class OIDCAuthSourceServiceTest {
         @Test
         void givenOidcTokenInRequestContext_thenReturnTheToken() {
             HttpServletRequest request = new MockHttpServletRequest();
-            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
-            when(authenticationService.getTokenOrigin(TOKEN)).thenReturn(AuthSource.Origin.OIDC);
+            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(DUMMY_TOKEN));
+            when(authenticationService.getTokenOrigin(DUMMY_TOKEN)).thenReturn(AuthSource.Origin.OIDC);
             Optional<String> tokenResult = service.getToken(request);
             assertTrue(tokenResult.isPresent());
-            assertEquals(TOKEN, tokenResult.get());
+            assertEquals(DUMMY_TOKEN, tokenResult.get());
         }
 
         @Test
         void givenPatTokenInRequestContext_thenReturnEmpty() {
             HttpServletRequest request = new MockHttpServletRequest();
-            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
-            when(authenticationService.getTokenOrigin(TOKEN)).thenReturn(AuthSource.Origin.ZOWE_PAT);
+            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(DUMMY_TOKEN));
+            when(authenticationService.getTokenOrigin(DUMMY_TOKEN)).thenReturn(AuthSource.Origin.ZOWE_PAT);
             Optional<String> tokenResult = service.getToken(request);
             assertFalse(tokenResult.isPresent());
         }
 
         @Test
         void givenTokenInAuthSource_thenReturnValid() {
-            OIDCAuthSource authSource = mockValidAuthSource();
+            when(provider.isValid(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(true);
+            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN_WITH_USERNAME_FIELDS);
+
             assertTrue(service.isValid(authSource));
+            assertEquals(SUB_USER, authSource.getDistributedId());
         }
 
         @Test
@@ -96,13 +118,14 @@ class OIDCAuthSourceServiceTest {
             AuthSource.Parsed parsedSource = service.parse(authSource);
 
             verify(mapper, times(1)).mapToMainframeUserId(authSource);
+            assertEquals(SUB_USER, authSource.getDistributedId());
             assertEquals(MF_USER, parsedSource.getUserId());
         }
 
         @Test
         void givenNoMapping_whenParse_thenThrowException() {
-            OIDCAuthSource authSource = mockValidAuthSource();
-            when(mapper.mapToMainframeUserId(authSource)).thenReturn(null);
+            when(provider.isValid(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(true);
+            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN_WITH_USERNAME_FIELDS);
 
             assertThrows(NoMainframeIdentityException.class, () -> {
                 service.parse(authSource);
@@ -121,6 +144,7 @@ class OIDCAuthSourceServiceTest {
 
             String ltpaResult = service.getLtpaToken(authSource);
             assertEquals(expectedToken, ltpaResult);
+            assertEquals(SUB_USER, authSource.getDistributedId());
         }
 
         @Test
@@ -131,6 +155,35 @@ class OIDCAuthSourceServiceTest {
             when(tokenCreationService.createJwtTokenWithoutCredentials(MF_USER)).thenReturn(expectedToken);
             String jwtResult = service.getJWT(authSource);
             assertEquals(expectedToken, jwtResult);
+            assertEquals(SUB_USER, authSource.getDistributedId());
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "email,username@oidc.org",
+            "org.dep.contributor, contributor@apiml.zowe"})
+        void givenUserIdFieldProperty_thenReturnCorrectUsername(String preferredUsernameField, String username) {
+            when(provider.isValid(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(true);
+            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN_WITH_USERNAME_FIELDS);
+
+            service.userIdFieldPathProperty = preferredUsernameField;
+            service.afterPropertiesSet();
+
+            assertTrue(service.isValid(authSource));
+            assertEquals(username, authSource.getDistributedId());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "nonexistent", "org.nonexistent.foo", "org.dep", "org.dep.nonexistent", "org.dep.nickname", "org.dep.nullValue"})
+        void givenInvalidUserIdFieldProperty_thenThrowException(String preferredUsernameField) {
+            when(provider.isValid(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(true);
+            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN_WITH_USERNAME_FIELDS);
+
+            service.userIdFieldPathProperty = preferredUsernameField;
+            service.afterPropertiesSet();
+
+            assertFalse(service.isValid(authSource));
+            assertNull(authSource.getDistributedId());
         }
     }
 
@@ -139,14 +192,14 @@ class OIDCAuthSourceServiceTest {
 
         @Test
         void givenJWTAuthSourceWhenValidating_thenReturnFalse() {
-            JwtAuthSource authSource = new JwtAuthSource(TOKEN);
+            JwtAuthSource authSource = new JwtAuthSource(DUMMY_TOKEN);
             boolean isValid = service.isValid(authSource);
             assertFalse(isValid);
         }
 
         @Test
         void givenJWTAuthSource_thenReturnNull() {
-            JwtAuthSource authSource = new JwtAuthSource(TOKEN);
+            JwtAuthSource authSource = new JwtAuthSource(DUMMY_TOKEN);
             AuthSource.Parsed parsedSource = service.parse(authSource);
             assertNull(parsedSource);
         }
@@ -168,15 +221,15 @@ class OIDCAuthSourceServiceTest {
 
         @Test
         void whenIsInvalid_thenReturnTokenInvalid() {
-            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN);
-            when(provider.isValid(TOKEN)).thenReturn(false);
+            OIDCAuthSource authSource = new OIDCAuthSource(DUMMY_TOKEN);
+            when(provider.isValid(DUMMY_TOKEN)).thenReturn(false);
             assertFalse(service.isValid(authSource));
         }
 
         @Test
         void whenParse_thenReturnNull() {
-            OIDCAuthSource authSource = new OIDCAuthSource(TOKEN);
-            when(provider.isValid(TOKEN)).thenReturn(false);
+            OIDCAuthSource authSource = new OIDCAuthSource(DUMMY_TOKEN);
+            when(provider.isValid(DUMMY_TOKEN)).thenReturn(false);
             assertThrows(TokenNotValidException.class, () -> service.parse(authSource));
 
             verify(mapper, times(0)).mapToMainframeUserId(authSource);
@@ -185,28 +238,29 @@ class OIDCAuthSourceServiceTest {
         @Test
         void whenTokenIsExpired_thenThrow() {
             HttpServletRequest request = new MockHttpServletRequest();
-            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
-            when(authenticationService.getTokenOrigin(TOKEN)).thenThrow(new TokenExpireException("token expired"));
+            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(DUMMY_TOKEN));
+            when(authenticationService.getTokenOrigin(DUMMY_TOKEN)).thenThrow(new TokenExpireException("token expired"));
 
             assertThrows(TokenExpireException.class, () -> service.getToken(request));
-            verify(authenticationService, times(1)).getTokenOrigin(TOKEN);
+            verify(authenticationService, times(1)).getTokenOrigin(DUMMY_TOKEN);
         }
 
         @Test
         void whenTokenIsNotValid_thenThrow() {
             HttpServletRequest request = new MockHttpServletRequest();
-            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(TOKEN));
-            when(authenticationService.getTokenOrigin(TOKEN)).thenThrow(new TokenNotValidException("token not valid"));
+            when(authenticationService.getJwtTokenFromRequest(request)).thenReturn(Optional.of(DUMMY_TOKEN));
+            when(authenticationService.getTokenOrigin(DUMMY_TOKEN)).thenThrow(new TokenNotValidException("token not valid"));
 
             assertThrows(TokenNotValidException.class, () -> service.getToken(request));
-            verify(authenticationService, times(1)).getTokenOrigin(TOKEN);
+            verify(authenticationService, times(1)).getTokenOrigin(DUMMY_TOKEN);
         }
     }
 
     private OIDCAuthSource mockValidAuthSource() {
-        QueryResponse tokenResponse = new QueryResponse("domain", DISTRIB_USER, new Date(), new Date(), ISSUER, Collections.emptyList(), QueryResponse.Source.OIDC);
-        when(authenticationService.parseJwtToken(TOKEN)).thenReturn(tokenResponse);
-        when(provider.isValid(TOKEN)).thenReturn(true);
-        return new OIDCAuthSource(TOKEN);
+        //No QueryResponse field is validated, so it can have dummy values to simplify mocking.
+        QueryResponse tokenResponse = new QueryResponse("domain", "user", new Date(), new Date(), "issuer", Collections.emptyList(), QueryResponse.Source.OIDC);
+        when(authenticationService.parseJwtToken(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(tokenResponse);
+        when(provider.isValid(TOKEN_WITH_USERNAME_FIELDS)).thenReturn(true);
+        return new OIDCAuthSource(TOKEN_WITH_USERNAME_FIELDS);
     }
 }


### PR DESCRIPTION
# Description

Introduces a new configuration property `apiml.security.oidc.userIdField` which the userId is extracted from for the oidc tokens. Dot separated list is supported for nested objects.

Linked to #4231
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [x] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
