### PR TITLE
fix: Ensure correct scheme is set in hybrid AT-TLS setup 

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -187,14 +187,11 @@ fi
 # Verify discovery service URL in case AT-TLS is enabled, assumes outgoing rules are in place
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
 internalProtocol="https"
-if [ "$ATTLS_SERVER_ENABLED" = "true" -o "$ATTLS_CLIENT_ENABLED" = "true" ]; then # Keep current 2.18 behaviour, changed in v3
-    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
-fi
-if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
+if [ "$ATTLS_CLIENT_ENABLED" = "true" ]; then # Keep current 2.18 behaviour, changed in v3
     add_profile "attlsClient"
-    internalProtocol=http
+    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
+    internalProtocol="http"
 fi
-
 
 get_enabled_protocol_limit() {
     target=$1

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -165,12 +165,9 @@ fi
 
 # Verify discovery service URL in case AT-TLS is enabled, assumes outgoing rules are in place
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
-if [ "${ATTLS_SERVER_ENABLED}" = "true" -o "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
-    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
-fi
-
 if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
     add_profile "attlsClient"
+    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
 fi
 
 get_enabled_protocol_limit() {

--- a/caching-service/src/test/java/org/zowe/apiml/caching/config/AttlsConfigTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/config/AttlsConfigTest.java
@@ -54,7 +54,7 @@ class AttlsConfigTest {
         classes = CachingService.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
     )
-    @ActiveProfiles({"AttlsConfigTestCachingService", "attlsClient", "attlsServer"})
+    @ActiveProfiles({"AttlsConfigTestCachingService", "attlsServer", "attlsClient"})
     @TestPropertySource(
         properties = {
             "caching.storage.mode=inMemory"
@@ -130,7 +130,7 @@ class AttlsConfigTest {
             "apiml.service.discoveryServiceUrls=http://localhost:10011/eureka/" // Caching-service loads onboarding-enabler, which validates SSL configuration for Eureka client if it starts in https
         }
     )
-    @ActiveProfiles({"attlsClient", "attlsServer"})
+    @ActiveProfiles({"attlsServer", "attlsClient"})
     @DirtiesContext
     @SpringBootTest(
         classes = CachingService.class,

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -133,13 +133,10 @@ if [ "${ATTLS_SERVER_ENABLED}" = "true" ]; then
   ZWE_configs_server_ssl_enabled="false"
 fi
 
-if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
-    add_profile "attlsClient"
-fi
-
 # Verify discovery service URL in case AT-TLS is enabled, assumes outgoing rules are in place
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
-if [ "${ATTLS_SERVER_ENABLED}" = "true" -o "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
+if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
+    add_profile "attlsClient"
     ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
 fi
 

--- a/cloud-gateway-service/src/main/resources/application.yml
+++ b/cloud-gateway-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ eureka:
         #ports are computed in code
         homePageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/
         healthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
+        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
+        securePortEnabled: ${apiml.service.securePortEnabled}
         metadata-map:
             apiml:
                 service:
@@ -44,6 +46,8 @@ apiml:
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
         port: 10023
         scheme: https  # "https" or "http"
+        nonSecurePortEnabled: false
+        securePortEnabled: true
     security:
         ssl:
             nonStrictVerifySslCertificatesOfServices: true

--- a/cloud-gateway-service/src/main/resources/application.yml
+++ b/cloud-gateway-service/src/main/resources/application.yml
@@ -7,8 +7,6 @@ eureka:
         #ports are computed in code
         homePageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/
         healthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
-        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
-        securePortEnabled: ${apiml.service.securePortEnabled}
         metadata-map:
             apiml:
                 service:
@@ -46,8 +44,6 @@ apiml:
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
         port: 10023
         scheme: https  # "https" or "http"
-        nonSecurePortEnabled: false
-        securePortEnabled: true
     security:
         ssl:
             nonStrictVerifySslCertificatesOfServices: true
@@ -131,9 +127,17 @@ server:
     ssl:
         enabled: false
 
-    apiml:
-        service:
-            corsEnabled: true
+apiml:
+    service:
+        nonSecurePortEnabled: false
+        securePortEnabled: true
+        corsEnabled: true
+
+eureka:
+    instance:
+        securePort: ${apiml.service.port}
+        nonSecurePortEnabled: false
+        securePortEnabled: true
 
 ---
 spring:

--- a/cloud-gateway-service/src/main/resources/application.yml
+++ b/cloud-gateway-service/src/main/resources/application.yml
@@ -153,3 +153,9 @@ apiml:
         nonSecurePortEnabled: true
         securePortEnabled: false
         discoveryServiceUrls: http://localhost:10011/eureka/
+
+eureka:
+    instance:
+        securePort: 0
+        nonSecurePortEnabled: true
+        securePortEnabled: false

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -161,12 +161,9 @@ fi
 
 # Verify discovery service URL in case AT-TLS is enabled, assumes outgoing rules are in place
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
-if [ "${ATTLS_SERVER_ENABLED}" = "true" -o "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
-    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
-fi
-
 if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
     add_profile "attlsClient"
+    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
 fi
 # End AT-TLS section
 

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -219,6 +219,7 @@ fi
 if [ "${ATTLS_SERVER_ENABLED}" = "true" ]; then
   add_profile "attlsServer"
   ZWE_configs_server_ssl_enabled="false"
+  ZWE_configs_server_internal_ssl_enabled="${ZWE_configs_server_internal_ssl_enabled:-false}"
   ZWE_configs_apiml_service_corsEnabled=true
 fi
 

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -231,7 +231,6 @@ if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
     add_profile "attlsClient"
     ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
     internalProtocol=http
-    ZWE_configs_apiml_service_corsEnabled=true
 fi
 
 if [ "${ZWE_configs_server_ssl_enabled:-true}" = "true" -o "$ATTLS_SERVER_ENABLED" = "true" ]; then

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -219,21 +219,18 @@ fi
 if [ "${ATTLS_SERVER_ENABLED}" = "true" ]; then
   add_profile "attlsServer"
   ZWE_configs_server_ssl_enabled="false"
+  ZWE_configs_apiml_service_corsEnabled=true
 fi
 
 # Verify discovery service URL in case AT-TLS client is enabled
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
 internalProtocol=https
-if [ "${ATTLS_CLIENT_ENABLED}" = "true" -o "${ATTLS_SERVER_ENABLED}" = "true" ]; then
-    # Keep current behaviour, change in v3
-    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
-    ZWE_configs_server_internal_ssl_enabled="${ZWE_configs_server_internal_ssl_enabled:-false}"
-    ZWE_configs_apiml_service_corsEnabled=true
-fi
-
 if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
+    # Keep current behaviour, change in v3
     add_profile "attlsClient"
+    ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
     internalProtocol=http
+    ZWE_configs_apiml_service_corsEnabled=true
 fi
 
 if [ "${ZWE_configs_server_ssl_enabled:-true}" = "true" -o "$ATTLS_SERVER_ENABLED" = "true" ]; then

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -47,6 +47,8 @@ apiml:
         port: 10010  # Default port name for gateway service
         ipAddress: 127.0.0.1  # IP address that is advertised in Eureka. Default is valid only for localhost
         scheme: https  # "https" or "http"
+        nonSecurePortEnabled: false
+        securePortEnabled: true
         preferIpAddress: false
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
         additionalRegistration: # List of additional Apiml Discovery Services metadata to register with
@@ -247,6 +249,8 @@ eureka:
         statusPageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/info
         healthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
         secureHealthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
+        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
+        securePortEnabled: ${apiml.service.securePortEnabled}
         metadata-map:
             apiml:
                 catalog:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -47,8 +47,6 @@ apiml:
         port: 10010  # Default port name for gateway service
         ipAddress: 127.0.0.1  # IP address that is advertised in Eureka. Default is valid only for localhost
         scheme: https  # "https" or "http"
-        nonSecurePortEnabled: false
-        securePortEnabled: true
         preferIpAddress: false
         ignoredHeadersWhenCorsEnabled: Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin
         additionalRegistration: # List of additional Apiml Discovery Services metadata to register with
@@ -249,8 +247,6 @@ eureka:
         statusPageUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/info
         healthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
         secureHealthCheckUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}/application/health
-        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
-        securePortEnabled: ${apiml.service.securePortEnabled}
         metadata-map:
             apiml:
                 catalog:
@@ -357,7 +353,15 @@ server:
 
 apiml:
     service:
+        nonSecurePortEnabled: false
+        securePortEnabled: true
         corsEnabled: true
+
+eureka:
+    instance:
+        securePort: ${apiml.service.port}
+        nonSecurePortEnabled: false
+        securePortEnabled: true
 
 ---
 spring:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -380,6 +380,9 @@ apiml:
 
 eureka:
     instance:
+        securePort: 0
+        nonSecurePortEnabled: true
+        securePortEnabled: false
         metadata-map:
             apiml:
                 apiInfo:

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
@@ -45,7 +45,7 @@ class CorsBeanTest {
         @Test
         void whenGetDefaultOrigins_thenAllowHttps() throws URISyntaxException {
             CorsBeans corsBeans = new CorsBeans(new ZuulProperties());
-            when(environment.getActiveProfiles()).thenReturn(new String[]{ "attlsClient", "attlsServer" });
+            when(environment.getActiveProfiles()).thenReturn(new String[]{ "attlsServer", "attlsClient" });
 
             List<String> allowedOrigins = corsBeans.getDefaultAllowedOrigins(environment, "https://dvipahost:10010", "lparhost", 10010);
             assertEquals(2, allowedOrigins.size());

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -138,16 +138,12 @@ if [ "${ATTLS_SERVER_ENABLED}" = "true" ]; then
   ZWE_configs_server_ssl_enabled="false"
 fi
 
-if [ "${ATTLS_CLIENT_ENABLED}" = "true" ]; then
-    add_profile "attlsClient"
-fi
-
 # Verify discovery service URL in case AT-TLS is enabled, assumes outgoing rules are in place
 ZWE_DISCOVERY_SERVICES_LIST=${ZWE_DISCOVERY_SERVICES_LIST:-"https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_discovery_port:-7553}/eureka/"}
-if [ "$ATTLS_CLIENT_ENABLED" = "true" -o "$ATTLS_SERVER_ENABLED" = "true" ]; then
+if [ "$ATTLS_CLIENT_ENABLED" = "true" ]; then
+    add_profile "attlsClient"
     ZWE_DISCOVERY_SERVICES_LIST=$(echo "${ZWE_DISCOVERY_SERVICES_LIST=}" | sed -e 's|https://|http://|g')
 fi
-
 
 get_enabled_protocol_limit() {
     target=$1

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -16,6 +16,9 @@ logging:
         javax.net.ssl: ERROR # For running with java 17
 
 eureka:
+    instance:
+        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
+        securePortEnabled: ${apiml.service.securePortEnabled}
     client:
         initialInstanceInfoReplicationIntervalSeconds: 1
         registryFetchIntervalSeconds: 1
@@ -37,6 +40,8 @@ apiml:
         discoveryServiceUrls: https://localhost:10011/eureka/
 
         scheme: https
+        nonSecurePortEnabled: false
+        securePortEnabled: true
 
         hostname: localhost
         port: 10019

--- a/metrics-service/src/main/resources/application.yml
+++ b/metrics-service/src/main/resources/application.yml
@@ -16,9 +16,6 @@ logging:
         javax.net.ssl: ERROR # For running with java 17
 
 eureka:
-    instance:
-        nonSecurePortEnabled: ${apiml.service.nonSecurePortEnabled}
-        securePortEnabled: ${apiml.service.securePortEnabled}
     client:
         initialInstanceInfoReplicationIntervalSeconds: 1
         registryFetchIntervalSeconds: 1
@@ -40,8 +37,6 @@ apiml:
         discoveryServiceUrls: https://localhost:10011/eureka/
 
         scheme: https
-        nonSecurePortEnabled: false
-        securePortEnabled: true
 
         hostname: localhost
         port: 10019
@@ -178,6 +173,17 @@ server:
         enabled: true
     ssl:
         enabled: false
+
+apiml:
+    service:
+        nonSecurePortEnabled: false
+        securePortEnabled: true
+
+eureka:
+    instance:
+        securePort: ${apiml.service.port}
+        nonSecurePortEnabled: false
+        securePortEnabled: true
 
 ---
 spring:


### PR DESCRIPTION
# Description

Ensure correct scheme is used when there is a hybrid AT-TLS setup (server-attls and client-https)

Note: Related to #4337 

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
