### PR TITLE
fix: Requirement of client certificate on ZAAS call when AT-TLS is used & add AT-TLS support to DC

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -66,22 +66,38 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
      * @param request Request to filter certificates
      */
     private void categorizeCerts(ServletRequest request) {
-        X509Certificate[] certs = (X509Certificate[]) request.getAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
+        var httpServletRequest = (HttpServletRequest) request;
+        var certs = (X509Certificate[]) httpServletRequest.getAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
         if (certs != null && certs.length > 0) {
-            Optional<Certificate> clientCert = getClientCertFromHeader((HttpServletRequest) request);
+            Optional<Certificate> clientCert = getClientCertFromHeader(httpServletRequest);
             if (certificateValidator.isForwardingEnabled() && certificateValidator.hasGatewayChain(certs) && clientCert.isPresent()) {
                 certificateValidator.updateAPIMLPublicKeyCertificates(certs);
                 // add the client certificate to the certs array
                 String subjectDN = ((X509Certificate) clientCert.get()).getSubjectX500Principal().getName();
                 log.debug("Found client certificate in header, adding it to the request. Subject DN: {}", subjectDN);
-                request.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(new X509Certificate[]{(X509Certificate) clientCert.get()}, certificateForClientAuth));
+                httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(new X509Certificate[]{(X509Certificate) clientCert.get()}, certificateForClientAuth));
+            } else if (isClientCertificateIgnored(httpServletRequest)) {
+                log.debug("Client certificate is ignored.");
+                httpServletRequest.removeAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE);
+                httpServletRequest.removeAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
             } else {
-                request.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(certs, certificateForClientAuth));
-                request.setAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, selectCerts(certs, apimlCertificate));
+                httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(certs, certificateForClientAuth));
+                httpServletRequest.setAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, selectCerts(certs, apimlCertificate));
             }
 
-            log.debug(LOG_FORMAT_FILTERING_CERTIFICATES, ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, request.getAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE));
+            log.debug(LOG_FORMAT_FILTERING_CERTIFICATES, ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, httpServletRequest.getAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE));
         }
+    }
+
+    boolean isClientCertificateIgnored(HttpServletRequest request) {
+        var forwardedClientCertificate = request.getHeader(CLIENT_CERT_HEADER);
+        if (forwardedClientCertificate == null) {
+            // no header means the certificate shouldn't be removed
+            log.debug("Request header Client-Cert was not defined.");
+            return false;
+        }
+        // empty header means to ignore the certificate from the request
+        return StringUtils.isBlank(forwardedClientCertificate);
     }
 
     private Optional<Certificate> getClientCertFromHeader(HttpServletRequest request) {

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -35,6 +35,8 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.function.Predicate;
 
+import static org.zowe.apiml.util.ServletRequestUtils.isClientCertificateIgnored;
+
 /**
  * This filter processes certificates on request. It decides, which certificates are considered for client authentication
  */
@@ -91,17 +93,6 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
 
             log.debug(LOG_FORMAT_FILTERING_CERTIFICATES, ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, httpServletRequest.getAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE));
         }
-    }
-
-    boolean isClientCertificateIgnored(HttpServletRequest request) {
-        var forwardedClientCertificate = request.getHeader(CLIENT_CERT_HEADER);
-        if (forwardedClientCertificate == null) {
-            // no header means the certificate shouldn't be removed
-            log.debug("Request header Client-Cert was not defined.");
-            return false;
-        }
-        // empty header means to ignore the certificate from the request
-        return StringUtils.isBlank(forwardedClientCertificate);
     }
 
     private Optional<Certificate> getClientCertFromHeader(HttpServletRequest request) {

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilter.java
@@ -70,20 +70,24 @@ public class CategorizeCertsFilter extends OncePerRequestFilter {
         var certs = (X509Certificate[]) httpServletRequest.getAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
         if (certs != null && certs.length > 0) {
             Optional<Certificate> clientCert = getClientCertFromHeader(httpServletRequest);
-            if (certificateValidator.isForwardingEnabled() && certificateValidator.hasGatewayChain(certs) && clientCert.isPresent()) {
-                certificateValidator.updateAPIMLPublicKeyCertificates(certs);
-                // add the client certificate to the certs array
-                String subjectDN = ((X509Certificate) clientCert.get()).getSubjectX500Principal().getName();
-                log.debug("Found client certificate in header, adding it to the request. Subject DN: {}", subjectDN);
-                httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(new X509Certificate[]{(X509Certificate) clientCert.get()}, certificateForClientAuth));
-            } else if (isClientCertificateIgnored(httpServletRequest)) {
-                log.debug("Client certificate is ignored.");
-                httpServletRequest.removeAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE);
-                httpServletRequest.removeAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
-            } else {
-                httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(certs, certificateForClientAuth));
-                httpServletRequest.setAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, selectCerts(certs, apimlCertificate));
+            if (certificateValidator.isForwardingEnabled() && certificateValidator.hasGatewayChain(certs)) {
+                if (clientCert.isPresent()) {
+                    certificateValidator.updateAPIMLPublicKeyCertificates(certs);
+                    // add the client certificate to the certs array
+                    String subjectDN = ((X509Certificate) clientCert.get()).getSubjectX500Principal().getName();
+                    log.debug("Found client certificate in header, adding it to the request. Subject DN: {}", subjectDN);
+                    httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(new X509Certificate[]{(X509Certificate) clientCert.get()}, certificateForClientAuth));
+                    return;
+                } else if (isClientCertificateIgnored(httpServletRequest)) {
+                    log.debug("Client certificate is ignored.");
+                    httpServletRequest.removeAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE);
+                    httpServletRequest.removeAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE);
+                    return;
+                }
             }
+
+            httpServletRequest.setAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, selectCerts(certs, certificateForClientAuth));
+            httpServletRequest.setAttribute(ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, selectCerts(certs, apimlCertificate));
 
             log.debug(LOG_FORMAT_FILTERING_CERTIFICATES, ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, httpServletRequest.getAttribute(ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE));
         }

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
@@ -522,13 +522,30 @@ class CategorizeCertsFilterTest {
         }
 
         @Test
-        void whenClientCertHeaderNotDefined_thenReturnFalse() {
-            filter = new CategorizeCertsFilter(null, null);
-            request = new MockHttpServletRequest();
+        void whenClientCertHeaderNotDefined_thenReturnFalse() throws ServletException, IOException {
 
-            boolean result = filter.isClientCertificateIgnored(request);
+            filter = new CategorizeCertsFilter(new HashSet<>(), certificateValidator);
 
-            assertFalse(result, "Expected false when Client-Cert header is not defined");
+            X509Certificate[] certs = new X509Certificate[]{
+                X509Utils.getCertificate(X509Utils.correctBase64("foreignCert1"))
+            };
+            request.setAttribute(CategorizeCertsFilter.ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, certs);
+            request.setAttribute(CategorizeCertsFilter.ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE, certs);
+
+            request.addHeader(CategorizeCertsFilter.CLIENT_CERT_HEADER, "");
+
+            filter.doFilter(request, response, chain);
+
+            assertNull(
+                request.getAttribute(CategorizeCertsFilter.ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE),
+                "Expected client.auth.X509Certificate attribute to be removed"
+            );
+            assertNull(
+                request.getAttribute(CategorizeCertsFilter.ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE),
+                "Expected jakarta.servlet.request.X509Certificate attribute to be removed"
+            );
+
+            assertNotNull(chain.getRequest(), "Filter chain should continue normally");
         }
     }
 }

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
@@ -486,4 +486,49 @@ class CategorizeCertsFilterTest {
             }
         }
     }
+
+    @Nested
+    class GivenNoCertificateHeader {
+
+        @BeforeEach
+        void setUp() {
+            certificateValidator = mock(CertificateValidator.class);
+            when(certificateValidator.isForwardingEnabled()).thenReturn(true);
+            when(certificateValidator.hasGatewayChain(any())).thenReturn(true);
+
+            filter = new CategorizeCertsFilter(new HashSet<>(), certificateValidator);
+            request = new MockHttpServletRequest();
+            response = new MockHttpServletResponse();
+            chain = new MockFilterChain();
+        }
+
+        @Test
+        void whenClientCertHeaderEmpty_thenAttributesRemovedAndReturn() throws ServletException, IOException {
+            X509Certificate[] certs = new X509Certificate[]{
+                X509Utils.getCertificate(X509Utils.correctBase64("foreignCert1"))
+            };
+            request.setAttribute(CategorizeCertsFilter.ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE, certs);
+
+            request.addHeader(CategorizeCertsFilter.CLIENT_CERT_HEADER, "");
+
+            filter.doFilter(request, response, chain);
+
+            assertNull(request.getAttribute(CategorizeCertsFilter.ATTR_NAME_CLIENT_AUTH_X509_CERTIFICATE),
+                "Client auth cert attribute should be removed");
+            assertNull(request.getAttribute(CategorizeCertsFilter.ATTR_NAME_JAKARTA_SERVLET_REQUEST_X509_CERTIFICATE),
+                "Jakarta servlet cert attribute should be removed");
+
+            assertNotNull(chain.getRequest());
+        }
+
+        @Test
+        void whenClientCertHeaderNotDefined_thenReturnFalse() {
+            var filter = new CategorizeCertsFilter(null, null);
+            var request = new MockHttpServletRequest();
+
+            boolean result = filter.isClientCertificateIgnored(request);
+
+            assertFalse(result, "Expected false when Client-Cert header is not defined");
+        }
+    }
 }

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/filter/CategorizeCertsFilterTest.java
@@ -523,8 +523,8 @@ class CategorizeCertsFilterTest {
 
         @Test
         void whenClientCertHeaderNotDefined_thenReturnFalse() {
-            var filter = new CategorizeCertsFilter(null, null);
-            var request = new MockHttpServletRequest();
+            filter = new CategorizeCertsFilter(null, null);
+            request = new MockHttpServletRequest();
 
             boolean result = filter.isClientCertificateIgnored(request);
 

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
@@ -39,7 +39,9 @@ public class AttlsFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
-        if (!isClientCertificateIgnored(request)) {
+        if (isClientCertificateIgnored(request)) {
+            log.debug("Client certificate is ignored.");
+        } else {
             log.debug("Updating request with client certificate from the AT-TLS context.");
             try {
                 byte[] certificate = InboundAttls.getCertificate();

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
@@ -15,6 +15,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.zowe.commons.attls.InboundAttls;
@@ -34,19 +35,35 @@ import java.util.Base64;
 @Slf4j
 public class AttlsFilter extends OncePerRequestFilter {
 
+    private static final String CLIENT_CERT_HEADER = "Client-Cert";
+
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
-        try {
-            byte[] certificate = InboundAttls.getCertificate();
-            if (certificate != null && certificate.length > 0) {
-                log.debug("Certificate length: {}", certificate.length);
-                populateRequestWithCertificate(request, certificate);
+        if (!isClientCertificateIgnored(request)) {
+            log.debug("Updating request with client certificate from the AT-TLS context.");
+            try {
+                byte[] certificate = InboundAttls.getCertificate();
+                if (certificate != null && certificate.length > 0) {
+                    log.debug("Certificate length: {}", certificate.length);
+                    populateRequestWithCertificate(request, certificate);
+                }
+            } catch (Exception e) {
+                logger.error("Not possible to get certificate from AT-TLS context", e);
+                AttlsErrorHandler.handleError(response, "Exception reading certificate");
             }
-        } catch (Exception e) {
-            logger.error("Not possible to get certificate from AT-TLS context", e);
-            AttlsErrorHandler.handleError(response, "Exception reading certificate");
         }
         filterChain.doFilter(request, response);
+    }
+
+    boolean isClientCertificateIgnored(HttpServletRequest request) {
+        var forwardedClientCertificate = request.getHeader(CLIENT_CERT_HEADER);
+        if (forwardedClientCertificate == null) {
+            // no header means the certificate shouldn't be removed
+            log.debug("Request header Client-Cert was not defined.");
+            return false;
+        }
+        // empty header means to ignore the certificate from the request
+        return StringUtils.isBlank(forwardedClientCertificate);
     }
 
     public void populateRequestWithCertificate(HttpServletRequest request, byte[] rawCertificate) throws CertificateException {

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsFilter.java
@@ -15,9 +15,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.zowe.apiml.util.ServletRequestUtils;
 import org.zowe.commons.attls.InboundAttls;
 
 import java.io.ByteArrayInputStream;
@@ -39,7 +39,7 @@ public class AttlsFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
-        if (isClientCertificateIgnored(request)) {
+        if (ServletRequestUtils.isClientCertificateIgnored(request)) {
             log.debug("Client certificate is ignored.");
         } else {
             log.debug("Updating request with client certificate from the AT-TLS context.");
@@ -55,17 +55,6 @@ public class AttlsFilter extends OncePerRequestFilter {
             }
         }
         filterChain.doFilter(request, response);
-    }
-
-    boolean isClientCertificateIgnored(HttpServletRequest request) {
-        var forwardedClientCertificate = request.getHeader(CLIENT_CERT_HEADER);
-        if (forwardedClientCertificate == null) {
-            // no header means the certificate shouldn't be removed
-            log.debug("Request header Client-Cert was not defined.");
-            return false;
-        }
-        // empty header means to ignore the certificate from the request
-        return StringUtils.isBlank(forwardedClientCertificate);
     }
 
     public void populateRequestWithCertificate(HttpServletRequest request, byte[] rawCertificate) throws CertificateException {

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsHttpHandler.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/filter/AttlsHttpHandler.java
@@ -112,6 +112,7 @@ public class AttlsHttpHandler implements BeanPostProcessor {
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         if (bean instanceof HttpHandler httpHandler) {
             return (HttpHandler) (request, response) -> {
+                log.debug("Initialize reactive AT-TLS handler");
                 try {
                     var attlsContext = InboundAttls.get();
 

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/ApimlTomcatCustomizer.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/ApimlTomcatCustomizer.java
@@ -31,6 +31,18 @@ import java.lang.reflect.Method;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.SocketChannel;
 
+/**
+ * Customizes Tomcat connectors to enable AT-TLS support.
+ * <p>
+ * This component replaces the default Tomcat socket handler with a custom
+ * {@link ApimlAttlsHandler} that initializes and disposes AT-TLS contexts for
+ * each incoming connection. It allows the API ML to operate in AT-TLS mode on z/OS.
+ * </p>
+ *
+ * <p>
+ * Activated when <code>server.attlsServer.enabled=true</code> is set.
+ * </p>
+ */
 @Slf4j
 @Component
 @ConditionalOnProperty(name = "server.attlsServer.enabled", havingValue = "true")
@@ -61,6 +73,10 @@ public class ApimlTomcatCustomizer implements TomcatConnectorCustomizer, Initial
         }
     }
 
+    /**
+     * Custom Tomcat socket handler that wraps request processing with AT-TLS context
+     * initialization and cleanup.
+     */
     public static class ApimlAttlsHandler<S> implements AbstractEndpoint.Handler<S> {
 
         @Delegate(excludes = Overridden.class)

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/TomcatAcceptFixConfig.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/TomcatAcceptFixConfig.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * This bean is related only to z/OS.
  */
 @Slf4j
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class TomcatAcceptFixConfig {
 
     @Value("${server.tomcat.retryRebindTimeoutSecs:10}")

--- a/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/TomcatKeyringFix.java
+++ b/apiml-tomcat-common/src/main/java/org/zowe/apiml/product/web/TomcatKeyringFix.java
@@ -20,6 +20,13 @@ import org.springframework.stereotype.Component;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Customizer for Tomcat SSL configuration that fixes SAF keyring URLs.
+ * <p>
+ * If a keyStore or trustStore uses a SAF keyring (e.g. {@code safkeyring:///USER/KEYRING}),
+ * this class reformats the URL and sets default passwords if none are provided.
+ * </p>
+ */
 @Slf4j
 @Component
 public class TomcatKeyringFix implements WebServerFactoryCustomizer<AbstractConfigurableWebServerFactory> {
@@ -51,6 +58,17 @@ public class TomcatKeyringFix implements WebServerFactoryCustomizer<AbstractConf
         return matcher.matches();
     }
 
+    /**
+     * Normalizes the given keyring URL into a Tomcat-compatible format.
+     * <p>
+     * For example, converts:
+     * <pre>
+     * safkeyring:///USER/KEYRING → safkeyring://USER/KEYRING
+     * </pre>
+     *
+     * @param keyringUrl the original keyring URL
+     * @return the normalized URL or {@code null} if the input was {@code null}
+     */
     static String formatKeyringUrl(String keyringUrl) {
         if (keyringUrl == null) return null;
         Matcher matcher = KEYRING_PATTERN.matcher(keyringUrl);
@@ -60,6 +78,16 @@ public class TomcatKeyringFix implements WebServerFactoryCustomizer<AbstractConf
         return keyringUrl;
     }
 
+    /**
+     * Customizes the Tomcat {@link Ssl} configuration before the web server starts.
+     * <p>
+     * If keyring-based stores are detected, this method updates their configuration
+     * (URL format, alias, and password) to ensure that Tomcat can correctly access
+     * the keyring at runtime.
+     * </p>
+     *
+     * @param factory the Tomcat web server factory being customized
+     */
     @Override
     public void customize(AbstractConfigurableWebServerFactory factory) {
         Ssl ssl = factory.getSsl();

--- a/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
+++ b/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
@@ -14,16 +14,15 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.zowe.commons.attls.ContextIsNotInitializedException;
 import org.zowe.commons.attls.InboundAttls;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
+import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +31,7 @@ import static org.mockito.Mockito.*;
 class AttlsFilterTest {
 
     @Test
-    void providedCertificateInCorrectFormat_thenPopulateRequest() throws CertificateException, ContextIsNotInitializedException {
+    void providedCertificateInCorrectFormat_thenPopulateRequest() throws CertificateException {
         AttlsFilter attlsFilter = new AttlsFilter();
         String certificate = """
             MIID8TCCAtmgAwIBAgIUVyBCWfHF/ZwZKVsBEpTNIBj9mQcwDQYJKoZIhvcNAQEL
@@ -60,7 +59,8 @@ class AttlsFilterTest {
             """.stripIndent();
 
         HttpServletRequest request = new MockHttpServletRequest();
-        attlsFilter.populateRequestWithCertificate(request, Base64.decodeBase64(certificate));
+        byte[] decoded = Base64.getMimeDecoder().decode(certificate);
+        attlsFilter.populateRequestWithCertificate(request, decoded);
         assertNotNull(request.getAttribute("jakarta.servlet.request.X509Certificate"));
     }
 
@@ -97,7 +97,7 @@ class AttlsFilterTest {
         try (MockedStatic<InboundAttls> mockedInboundAttls = mockStatic(InboundAttls.class)) {
             mockedInboundAttls.when(InboundAttls::getCertificate).thenReturn(dummyCert);
 
-            doNothing().when(filter).populateRequestWithCertificate(eq(request), eq(dummyCert));
+            doNothing().when(filter).populateRequestWithCertificate(request, dummyCert);
 
             filter.doFilterInternal(request, response, chain);
 

--- a/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
+++ b/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
@@ -16,16 +16,18 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.zowe.commons.attls.ContextIsNotInitializedException;
+import org.zowe.commons.attls.InboundAttls;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 class AttlsFilterTest {
 
@@ -69,6 +71,40 @@ class AttlsFilterTest {
         HttpServletResponse response = new MockHttpServletResponse();
         filter.doFilterInternal(new MockHttpServletRequest(), response, chain);
         assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    void whenClientCertIsEmpty_thenIgnoreCertAndContinueWithChain() throws ServletException, IOException {
+        AttlsFilter filter = new AttlsFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Client-Cert", "");
+
+        FilterChain chain = mock(FilterChain.class);
+        HttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilterInternal(request, response, chain);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void whenValidCertificateFromInboundAttls_thenPopulateRequestAndContinueChain() throws ServletException, IOException, CertificateException {
+        AttlsFilter filter = spy(new AttlsFilter());
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        byte[] dummyCert = "dummyCertificate".getBytes();
+
+        try (MockedStatic<InboundAttls> mockedInboundAttls = mockStatic(InboundAttls.class)) {
+            mockedInboundAttls.when(InboundAttls::getCertificate).thenReturn(dummyCert);
+
+            doNothing().when(filter).populateRequestWithCertificate(eq(request), eq(dummyCert));
+
+            filter.doFilterInternal(request, response, chain);
+
+            mockedInboundAttls.verify(InboundAttls::getCertificate);
+            verify(filter, times(1)).populateRequestWithCertificate(eq(request), eq(dummyCert));
+            verify(chain, times(1)).doFilter(request, response);
+        }
     }
 
 }

--- a/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
+++ b/apiml-tomcat-common/src/test/java/org/zowe/apiml/filter/AttlsFilterTest.java
@@ -102,7 +102,7 @@ class AttlsFilterTest {
             filter.doFilterInternal(request, response, chain);
 
             mockedInboundAttls.verify(InboundAttls::getCertificate);
-            verify(filter, times(1)).populateRequestWithCertificate(eq(request), eq(dummyCert));
+            verify(filter, times(1)).populateRequestWithCertificate(request, dummyCert);
             verify(chain, times(1)).doFilter(request, response);
         }
     }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/CachingServiceApplication.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/CachingServiceApplication.java
@@ -12,19 +12,14 @@ package org.zowe.apiml.caching;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.retry.annotation.EnableRetry;
 import org.zowe.apiml.enable.EnableApiDiscovery;
 import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
-import org.zowe.apiml.product.web.ApimlTomcatCustomizer;
-import org.zowe.apiml.product.web.TomcatAcceptFixConfig;
-import org.zowe.apiml.product.web.TomcatKeyringFix;
 
 @SpringBootApplication
 @EnableApiDiscovery
 @EnableRetry
 @EnableApimlLogger
-@Import({TomcatKeyringFix.class, TomcatAcceptFixConfig.class, ApimlTomcatCustomizer.class})
 public class CachingServiceApplication {
 
     public static void main(String[] args) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/CachingServiceApplication.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/CachingServiceApplication.java
@@ -12,14 +12,19 @@ package org.zowe.apiml.caching;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 import org.springframework.retry.annotation.EnableRetry;
 import org.zowe.apiml.enable.EnableApiDiscovery;
 import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
+import org.zowe.apiml.product.web.ApimlTomcatCustomizer;
+import org.zowe.apiml.product.web.TomcatAcceptFixConfig;
+import org.zowe.apiml.product.web.TomcatKeyringFix;
 
 @SpringBootApplication
 @EnableApiDiscovery
 @EnableRetry
 @EnableApimlLogger
+@Import({TomcatKeyringFix.class, TomcatAcceptFixConfig.class, ApimlTomcatCustomizer.class})
 public class CachingServiceApplication {
 
     public static void main(String[] args) {

--- a/common-service-core/src/main/java/org/zowe/apiml/util/ServletRequestUtils.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/util/ServletRequestUtils.java
@@ -1,0 +1,40 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility class providing helper methods for working with {@link jakarta.servlet.http.HttpServletRequest}.
+ */
+@Slf4j
+public class ServletRequestUtils {
+
+    private static final String CLIENT_CERT_HEADER = "Client-Cert";
+
+    /**
+     * Determines whether the client certificate should be ignored based on the Client-Cert HTTP header.
+     * @param request the HTTP request to inspect
+     * @return true if the client certificate should be ignored, false otherwise.
+     */
+    public static boolean isClientCertificateIgnored(HttpServletRequest request) {
+        var forwardedClientCertificate = request.getHeader(CLIENT_CERT_HEADER);
+        if (forwardedClientCertificate == null) {
+            // no header means the certificate shouldn't be removed
+            log.debug("Request header Client-Cert was not defined.");
+            return false;
+        }
+        // empty header means to ignore the certificate from the request
+        return StringUtils.isBlank(forwardedClientCertificate);
+    }
+}

--- a/common-service-core/src/test/java/org/zowe/apiml/util/ServletRequestUtilsTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/util/ServletRequestUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServletRequestUtilsTest {
+
+    @Test
+    void whenClientCertHeaderNotDefined_thenReturnFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        boolean result = ServletRequestUtils.isClientCertificateIgnored(request);
+
+        assertFalse(result, "Expected false when Client-Cert header is not defined");
+    }
+
+    @Test
+    void whenClientCertHeaderEmpty_thenReturnTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Client-Cert", "");
+
+        boolean result = ServletRequestUtils.isClientCertificateIgnored(request);
+
+        assertTrue(result, "Expected true when Client-Cert header is empty");
+    }
+
+    @Test
+    void whenClientCertHeaderHasValue_thenReturnFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Client-Cert", "some-cert-data");
+
+        boolean result = ServletRequestUtils.isClientCertificateIgnored(request);
+
+        assertFalse(result, "Expected false when Client-Cert header has a value");
+    }
+}

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -50,6 +50,18 @@ bootRun {
         args project.args.split(',')
     }
 
+    jvmArgs([
+        '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+        '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
+        '--add-opens=java.base/java.net=ALL-UNNAMED'
+    ])
+
     debugOptions {
         port = 5012
         suspend = false

--- a/discoverable-client/build.gradle
+++ b/discoverable-client/build.gradle
@@ -51,15 +51,14 @@ bootRun {
     }
 
     jvmArgs([
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
         '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED',
-        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
-        '--add-opens=java.base/java.io=ALL-UNNAMED',
         '--add-opens=java.base/java.util=ALL-UNNAMED',
         '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
-        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
-        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
         '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
-        '--add-opens=java.base/java.net=ALL-UNNAMED'
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED',
     ])
 
     debugOptions {

--- a/discoverable-client/src/main/java/org/zowe/apiml/client/DiscoverableClientSampleApplication.java
+++ b/discoverable-client/src/main/java/org/zowe/apiml/client/DiscoverableClientSampleApplication.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.client;
 
+import org.springframework.context.annotation.Import;
 import org.zowe.apiml.enable.EnableApiDiscovery;
 import org.zowe.apiml.product.logging.annotations.EnableApimlLogger;
 import org.zowe.apiml.product.monitoring.LatencyUtilsConfigInitializer;
@@ -21,12 +22,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.zowe.apiml.product.web.ApimlTomcatCustomizer;
+import org.zowe.apiml.product.web.TomcatAcceptFixConfig;
+import org.zowe.apiml.product.web.TomcatKeyringFix;
 
 @SpringBootApplication
 @EnableApiDiscovery
 @EnableWebSocket
 @EnableApimlLogger
 @RequiredArgsConstructor
+@Import({TomcatKeyringFix.class, TomcatAcceptFixConfig.class, ApimlTomcatCustomizer.class})
 public class DiscoverableClientSampleApplication implements ApplicationListener<ApplicationReadyEvent> {
 
     private final ServiceStartupEventHandler handler;

--- a/discoverable-client/src/main/resources/application.yml
+++ b/discoverable-client/src/main/resources/application.yml
@@ -241,3 +241,8 @@ apiml:
 server:
     attlsClient:
         enabled: true
+
+eureka:
+    instance:
+        nonSecurePortEnabled: true
+        securePortEnabled: false

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/AuthEndpointConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/AuthEndpointConfig.java
@@ -87,17 +87,18 @@ public class AuthEndpointConfig {
             .headers(headers -> headers.addAll(serverRequest.headers().asHttpHeaders()))
             .headers(headers -> headers.remove(CLIENT_CERT_HEADER));
 
-        if (sslInfo != null) {
-            return request.headers(headers -> {
+        return request.headers(headers -> {
+            if (sslInfo != null) {
                 try {
                     headers.add(CLIENT_CERT_HEADER, X509Util.getEncodedClientCertificate(sslInfo));
                 } catch (CertificateEncodingException e) {
                     throw new IllegalStateException("Cannot forward client certificate", e);
                 }
-            });
-        }
-
-        return request;
+            } else {
+                // this empty certificate is to mark request as without x509 because AT-TLS adds client certificate
+                headers.add(CLIENT_CERT_HEADER, "");
+            }
+        });
     }
 
     private Mono<ServerResponse> resend(ServerRequest request, String path, String body) {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/service/RunningService.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/service/RunningService.java
@@ -57,6 +57,16 @@ public class RunningService {
         }
 
         shellCommand.add(path + "java");
+        shellCommand.addAll(Arrays.asList(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+            "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED"
+        ));
         parametersBefore
             .forEach((key1, value1) -> shellCommand.add(key1 + '=' + value1));
 


### PR DESCRIPTION
# Description

* There is a conflict on how client certificate is used between GW and ZAAS. In general there are endpoint that requires credentials (basic, JWT), requires any trusted certificate, trusted client certificate and Zowe certificate. The behaviour is little bit different for each type of authentication. The specific impact is from the AT-TLS. Documentation suggest to use an outbound rule signed by certificate. It means that services that requires any trusted certificate starts receiving x509 from AT-TLS layer even it is missing in the original request. It is a known issue that there is no way how to programatically control signing by x509. For these case this fix allows to define header Client-cert (it is used to forward client certificate) with empty value. Empty valud means forward no certificate - actually to remove / ignore the certificate. The usage is only in resending of calls between gateway and ZAAS, but it could be use elsewhere.

* Add spring components and config to support AT-TLS in DC


Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
