### PR TITLE
refactor (enabler-nodejs): Initialize client only if config files exist

### DIFF
--- a/onboarding-enabler-nodejs/src/EurekaClient.js
+++ b/onboarding-enabler-nodejs/src/EurekaClient.js
@@ -90,21 +90,14 @@ export default class Eureka extends EventEmitter {
     const cwd = config.cwd || process.cwd();
     const env = process.env.EUREKA_ENV || process.env.NODE_ENV || 'development';
 
-    // Config can either be passed via config file or as json
-    // Check if config file and cwd was provided
-    if (cwd) {
-      const filename = config.filename || 'eureka-client';
+    const filename = config.filename || 'eureka-client';
 
-      // Load in the configuration files:
-      const defaultYml = getYaml(path.join(cwd, `${filename}.yml`));
-      const envYml = getYaml(path.join(cwd, `${filename}-${env}.yml`));
+    // Load in the configuration files:
+    const defaultYml = getYaml(path.join(cwd, `${filename}.yml`));
+    const envYml = getYaml(path.join(cwd, `${filename}-${env}.yml`));
 
-      // apply config overrides in appropriate order
-      this.config = merge({}, defaultConfig, defaultYml, envYml, config);
-    } else {
-      // config was provided as JSON
-      this.config = config;
-    }
+    // apply config overrides in appropriate order
+    this.config = merge({}, defaultConfig, defaultYml, envYml, config);
 
     // Validate the provided the values we need:
     this.validateConfig(this.config);

--- a/onboarding-enabler-nodejs/src/index.js
+++ b/onboarding-enabler-nodejs/src/index.js
@@ -16,6 +16,8 @@ let certFile = null;
 let keyFile = null;
 let caFile = null;
 let passPhrase = null;
+let client = null;
+let tlsOpts = null;
 
 /**
  * Read ssl service configuration
@@ -31,22 +33,30 @@ function readTlsProps() {
     console.log(e);
   }
 }
-readTlsProps();
 
-export const tlsOptions = {
-  cert: fs.readFileSync(certFile),
-  key: fs.readFileSync(keyFile),
-  passphrase: passPhrase,
-  ca: fs.readFileSync(caFile),
-};
+export const tlsOptions = tlsOpts;
 
-const client = new Eureka({
-  filename: 'service-configuration',
-  cwd: 'config/',
-  requestMiddleware: (requestOpts, done) => {
-    done(Object.assign(requestOpts, tlsOptions));
-  },
-});
+function init () {
+  const defaultFile = fs.existsSync('config/service-configuration.yml', 'utf8');
+  if (defaultFile) {
+    readTlsProps();
+    tlsOpts = {
+      cert: fs.readFileSync(certFile),
+      key: fs.readFileSync(keyFile),
+      passphrase: passPhrase,
+      ca: fs.readFileSync(caFile),
+    };
+    client = new Eureka({
+      filename: 'service-configuration',
+      cwd: 'config/',
+      requestMiddleware: (requestOpts, done) => {
+        done(Object.assign(requestOpts, tlsOpts));
+      },
+    });
+  }
+}
+
+init();
 
 /**
  * Function that uses the eureka-js-client library to register the application to Eureka


### PR DESCRIPTION
# Description

In the nodejs-enabler index, we initialize pulling tls options from a config file that can be optionally sent as a JSON. This also expects files to only be PEMs and doesn't support PKCS#12. Since we now expose the client directly we should make reading the TLS also conditional.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [x] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
