### PR TITLE
fix: Integration tests to run with SAF auth provider

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/PATWithAllSchemesTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/pat/PATWithAllSchemesTest.java
@@ -48,6 +48,7 @@ import static org.zowe.apiml.util.requests.Endpoints.*;
 class PATWithAllSchemesTest {
 
     private static SafIdtConfiguration safIdtConfig = ConfigReader.environmentConfiguration().getSafIdtConfiguration();
+    private static final String AUTH_PROVIDER = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getAuthProvider();
 
     static Stream<Arguments> authentication() {
         return Stream.of(
@@ -67,7 +68,7 @@ class PATWithAllSchemesTest {
             String jwt = r.getBody().path("headers.cookie").toString();
             try {
                 String issuer = JWTParser.parse(jwt.substring(COOKIE_NAME.length()).trim()).getJWTClaimsSet().toJSONObject().get("iss").toString();
-                assertEquals("zOSMF", issuer);
+                assertEquals(AUTH_PROVIDER.equalsIgnoreCase("saf") ? "APIML" : "zOSMF", issuer);
             } catch (ParseException e) {
                 fail(e);
             }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/LoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/LoginTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
+import org.zowe.apiml.security.common.error.PlatformPwdErrno;
 import org.zowe.apiml.security.common.login.LoginRequest;
 import org.zowe.apiml.util.TestWithStartedInstances;
 import org.zowe.apiml.util.categories.GeneralAuthenticationTest;
@@ -67,6 +68,7 @@ class LoginTest implements TestWithStartedInstances {
     private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getUser();
     private final static String PASSWORD = ConfigReader.environmentConfiguration().getCredentials().getPassword();
     private final static String CLIENT_USER = ConfigReader.environmentConfiguration().getCredentials().getClientUser();
+    private static final String AUTH_PROVIDER = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getAuthProvider();
     private final static String INVALID_USERNAME = "incorrectUser";
     private final static String INVALID_PASSWORD = "incorrectPassword";
 
@@ -144,7 +146,11 @@ class LoginTest implements TestWithStartedInstances {
             @MethodSource("org.zowe.apiml.integration.authentication.providers.LoginTest#loginUrlsSource")
             void givenInvalidCredentialsInBody(URI loginUrl) {
                 String expectedMessage = "Invalid username or password for URL '" + getPath(loginUrl) + "'";
-
+                String expectedMessageNumber = "ZWEAG120E";
+                if (AUTH_PROVIDER.equalsIgnoreCase("saf")) {
+                    expectedMessage = "The platform returned error: " + PlatformPwdErrno.EINVAL.shortErrorName + ": " + PlatformPwdErrno.EINVAL.explanation;
+                    expectedMessageNumber = "ZWEAT416E";
+                }
                 LoginRequest loginRequest = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD.toCharArray());
 
                 given()
@@ -153,9 +159,10 @@ class LoginTest implements TestWithStartedInstances {
                 .when()
                     .post(loginUrl)
                 .then()
+                    .log().ifValidationFails()
                     .statusCode(is(SC_UNAUTHORIZED))
                     .body(
-                        "messages.find { it.messageNumber == 'ZWEAG120E' }.messageContent", equalTo(expectedMessage)
+                        "messages.find { it.messageNumber == '" + expectedMessageNumber + "' }.messageContent", equalTo(expectedMessage)
                     );
             }
 
@@ -163,7 +170,11 @@ class LoginTest implements TestWithStartedInstances {
             @MethodSource("org.zowe.apiml.integration.authentication.providers.LoginTest#loginUrlsSource")
             void givenInvalidCredentialsInHeader(URI loginUrl) {
                 String expectedMessage = "Invalid username or password for URL '" + getPath(loginUrl) + "'";
-
+                String expectedMessageNumber = "ZWEAG120E";
+                if (AUTH_PROVIDER.equalsIgnoreCase("saf")) {
+                    expectedMessage = "The platform returned error: " + PlatformPwdErrno.EINVAL.shortErrorName + ": " + PlatformPwdErrno.EINVAL.explanation;
+                    expectedMessageNumber = "ZWEAT416E";
+                }
                 String headerValue = "Basic " + Base64.getEncoder().encodeToString((INVALID_USERNAME + ":" + INVALID_PASSWORD).getBytes(StandardCharsets.UTF_8));
 
                 given()
@@ -172,9 +183,10 @@ class LoginTest implements TestWithStartedInstances {
                 .when()
                     .post(loginUrl)
                 .then()
+                    .log().ifValidationFails()
                     .statusCode(is(SC_UNAUTHORIZED))
                     .body(
-                        "messages.find { it.messageNumber == 'ZWEAG120E' }.messageContent", equalTo(expectedMessage)
+                        "messages.find { it.messageNumber == '" + expectedMessageNumber + "' }.messageContent", equalTo(expectedMessage)
                     );
             }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/GatewayAuthTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/GatewayAuthTest.java
@@ -43,16 +43,12 @@ public class GatewayAuthTest implements TestWithStartedInstances {
 
     private static final GatewayServiceConfiguration GATEWAY_CONF = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
     private static final SafIdtConfiguration SAF_IDT_CONF = ConfigReader.environmentConfiguration().getSafIdtConfiguration();
+    private static final String AUTH_PROVIDER = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getAuthProvider();
 
     static Stream<Arguments> validToBeTransformed() {
         List<Arguments> arguments = new ArrayList<>(Arrays.asList(
             Arguments.of("Zowe auth scheme", ZOWE_JWT_REQUEST, (Consumer<Response>) response -> {
                 assertNotNull(response.jsonPath().getString("cookies.apimlAuthenticationToken"), "Expected not null apimlAuthenticationToken. Response was: " + response.asPrettyString());
-                assertNotNull(response.jsonPath().getString("headers.authorization"), "Expected not null Authorization header. Response was: " + response.asPrettyString());
-                assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")), "Expected empty certs list. Response was: " + response.asPrettyString());
-            }),
-            Arguments.of("z/OSMF auth scheme", ZOSMF_REQUEST, (Consumer<Response>) response -> {
-                assertNotNull(response.jsonPath().getString("cookies.jwtToken"), "Expected not null jwtToken cookie. Response was: " + response.asPrettyString());
                 assertNotNull(response.jsonPath().getString("headers.authorization"), "Expected not null Authorization header. Response was: " + response.asPrettyString());
                 assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")), "Expected empty certs list. Response was: " + response.asPrettyString());
             }),
@@ -62,6 +58,13 @@ public class GatewayAuthTest implements TestWithStartedInstances {
                 assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")));
             })
         ));
+        if (AUTH_PROVIDER.equalsIgnoreCase("zosmf")) {
+            arguments.add(Arguments.of("z/OSMF auth scheme", ZOSMF_REQUEST, (Consumer<Response>) response -> {
+                assertNotNull(response.jsonPath().getString("cookies.jwtToken"), "Expected not null jwtToken cookie. Response was: " + response.asPrettyString());
+                assertNotNull(response.jsonPath().getString("headers.authorization"), "Expected not null Authorization header. Response was: " + response.asPrettyString());
+                assertTrue(CollectionUtils.isEmpty(response.jsonPath().getList("certs")), "Expected empty certs list. Response was: " + response.asPrettyString());
+            }));
+        }
         if (SAF_IDT_CONF.isEnabled()) {
             arguments.add(Arguments.of("SAF IDT auth scheme", SAF_IDT_REQUEST, (Consumer<Response>) response -> {
                 assertNull(response.jsonPath().getString("cookies.jwtToken"));

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasNegativeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasNegativeTest.java
@@ -23,18 +23,29 @@ import org.zowe.apiml.security.common.token.QueryResponse;
 import org.zowe.apiml.ticket.TicketRequest;
 import org.zowe.apiml.util.SecurityUtils;
 import org.zowe.apiml.util.categories.ZaasTest;
-import org.zowe.apiml.util.config.*;
+import org.zowe.apiml.util.config.ConfigReader;
+import org.zowe.apiml.util.config.SafIdtConfiguration;
+import org.zowe.apiml.util.config.SslContext;
+import org.zowe.apiml.util.config.SslContextConfigurer;
+import org.zowe.apiml.util.config.TlsConfiguration;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.zowe.apiml.integration.zaas.ZaasTestUtil.*;
-import static org.zowe.apiml.util.SecurityUtils.*;
+import static org.zowe.apiml.util.SecurityUtils.generateJwtWithRandomSignature;
+import static org.zowe.apiml.util.SecurityUtils.getConfiguredSslConfig;
+import static org.zowe.apiml.util.SecurityUtils.getDummyClientCertificate;
+import static org.zowe.apiml.util.SecurityUtils.parseJwtStringUnsecure;
 
 @ZaasTest
 public class ZaasNegativeTest {
@@ -178,6 +189,7 @@ public class ZaasNegativeTest {
         @ParameterizedTest
         @MethodSource("org.zowe.apiml.integration.zaas.ZaasNegativeTest#provideZaasTokenEndpoints")
         void givenClientAndHeaderCertificates_thenReturnTokenFromClientCert(URI uri, RequestSpecification requestSpecification) throws Exception {
+            assumeTrue(isTestForZOSMF());
             TlsConfiguration tlsCfg = ConfigReader.environmentConfiguration().getTlsConfiguration();
             SslContextConfigurer sslContextConfigurer = new SslContextConfigurer(tlsCfg.getKeyStorePassword(), tlsCfg.getClientKeystore(), tlsCfg.getKeyStore());
             SslContext.prepareSslAuthentication(sslContextConfigurer);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasTestUtil.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZaasTestUtil.java
@@ -13,6 +13,7 @@ package org.zowe.apiml.integration.zaas;
 import lombok.experimental.UtilityClass;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.jupiter.params.provider.Arguments;
+import org.zowe.apiml.util.config.ConfigReader;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class ZaasTestUtil {
     static final String LTPA_COOKIE = "LtpaToken2";
 
     static final boolean ZOS_TARGET = Boolean.parseBoolean(System.getProperty("environment.zos.target", "false"));
+    static final String AUTH_PROVIDER = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration().getAuthProvider();
 
     static Stream<Arguments> provideClientCertificates() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException, NoSuchProviderException, OperatorCreationException {
         List<Arguments> args = new ArrayList<>();
@@ -63,4 +65,7 @@ public class ZaasTestUtil {
         return Boolean.getBoolean("hwkeyring");
     }
 
+    static boolean isTestForZOSMF() {
+        return AUTH_PROVIDER.equalsIgnoreCase("zosmf");
+    }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZosmfTokensTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/zaas/ZosmfTokensTest.java
@@ -32,10 +32,8 @@ import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.COOKIE;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.LTPA_COOKIE;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.ZAAS_ZOSMF_URI;
-import static org.zowe.apiml.integration.zaas.ZaasTestUtil.isTestForICSF;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.zowe.apiml.integration.zaas.ZaasTestUtil.*;
 import static org.zowe.apiml.util.SecurityUtils.*;
 
 @ZaasTest
@@ -87,6 +85,7 @@ class ZosmfTokensTest implements TestWithStartedInstances {
 
         @Test
         void givenValidAccessToken() {
+            assumeTrue(isTestForZOSMF());
             String serviceId = "gateway";
             String pat = personalAccessToken(Collections.singleton(serviceId));
 
@@ -106,6 +105,7 @@ class ZosmfTokensTest implements TestWithStartedInstances {
         @ParameterizedTest(name = "ZosmfTokensTest.givenX509Certificate {1}")
         @MethodSource("org.zowe.apiml.integration.zaas.ZaasTestUtil#provideClientCertificates")
         void givenX509Certificate(String certificate, String description) {
+            assumeTrue(isTestForZOSMF());
             assumeFalse(isTestForICSF());
             //@formatter:off
             given()
@@ -121,6 +121,7 @@ class ZosmfTokensTest implements TestWithStartedInstances {
 
         @Test
         void givenValidOAuthToken() {
+            assumeTrue(isTestForZOSMF());
             String oAuthToken = validOidcAccessToken(true);
 
             //@formatter:off

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/ConfigReader.java
@@ -63,7 +63,7 @@ public class ConfigReader {
                         log.warn("Can't read service configuration from resource file, using default: http://localhost:10010", e);
                         Credentials credentials = new Credentials("user", "user");
                         GatewayServiceConfiguration gatewayServiceConfiguration
-                            = new GatewayServiceConfiguration("https", "localhost", null, 10010, 10010, 1, "10010", ROUTED_SERVICE, 20);
+                            = new GatewayServiceConfiguration("https", "localhost", null, 10010, 10010, 1, "10010", ROUTED_SERVICE, 20, "zosmf");
                         CentralGatewayServiceConfiguration centralGatewayServiceConfiguration = new CentralGatewayServiceConfiguration("https", "localhost", 10010);
                         ZaasConfiguration zaasConfiguration = new ZaasConfiguration("https", "localhost", 10023, 1);
                         DiscoveryServiceConfiguration discoveryServiceConfiguration = new DiscoveryServiceConfiguration("https", "eureka", "password", "localhost","localhost", 10011,10021, 1);
@@ -116,6 +116,7 @@ public class ConfigReader {
                     configuration.getGatewayServiceConfiguration().setInstances(parseInt(System.getProperty("gateway.instances", String.valueOf(configuration.getGatewayServiceConfiguration().getInstances()))));
                     configuration.getGatewayServiceConfiguration().setServicesEndpoint(System.getProperty("gateway.servicesEndpoint", configuration.getGatewayServiceConfiguration().getServicesEndpoint()));
                     configuration.getGatewayServiceConfiguration().setBucketCapacity(parseInt(System.getProperty("gateway.bucketCapacity", String.valueOf(configuration.getGatewayServiceConfiguration().getBucketCapacity()))));
+                    configuration.getGatewayServiceConfiguration().setAuthProvider(System.getProperty("gateway.authProvider", configuration.getGatewayServiceConfiguration().getAuthProvider()));
 
                     CentralGatewayServiceConfiguration config = configuration.getCentralGatewayServiceConfiguration();
                     Optional.ofNullable(config).ifPresent(c -> {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/config/GatewayServiceConfiguration.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/config/GatewayServiceConfiguration.java
@@ -27,4 +27,5 @@ public class GatewayServiceConfiguration implements ServiceConfiguration {
     private String internalPorts;
     private String servicesEndpoint;
     private int bucketCapacity;
+    private String authProvider;
 }

--- a/integration-tests/src/test/resources/environment-configuration-attls.yml
+++ b/integration-tests/src/test/resources/environment-configuration-attls.yml
@@ -12,6 +12,7 @@ gatewayServiceConfiguration:
     instances: 1
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 zaasConfiguration:
     scheme: https
     host: zaas-service

--- a/integration-tests/src/test/resources/environment-configuration-docker-modulith-ha.yml
+++ b/integration-tests/src/test/resources/environment-configuration-docker-modulith-ha.yml
@@ -12,6 +12,7 @@ gatewayServiceConfiguration:
     instances: 2
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 centralGatewayServiceConfiguration:
     scheme: https
     host: central-gateway-service

--- a/integration-tests/src/test/resources/environment-configuration-docker-modulith.yml
+++ b/integration-tests/src/test/resources/environment-configuration-docker-modulith.yml
@@ -12,6 +12,7 @@ gatewayServiceConfiguration:
     instances: 1
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 centralGatewayServiceConfiguration:
     scheme: https
     host: central-gateway-service

--- a/integration-tests/src/test/resources/environment-configuration-docker.yml
+++ b/integration-tests/src/test/resources/environment-configuration-docker.yml
@@ -12,6 +12,7 @@ gatewayServiceConfiguration:
     instances: 1
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 centralGatewayServiceConfiguration:
     scheme: https
     host: central-gateway-service

--- a/integration-tests/src/test/resources/environment-configuration-ha.yml
+++ b/integration-tests/src/test/resources/environment-configuration-ha.yml
@@ -11,6 +11,7 @@ gatewayServiceConfiguration:
     instances: 2
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 zaasConfiguration:
     scheme: https
     host: zaas-service

--- a/integration-tests/src/test/resources/environment-configuration.yml
+++ b/integration-tests/src/test/resources/environment-configuration.yml
@@ -12,6 +12,7 @@ gatewayServiceConfiguration:
     instances: 1
     servicesEndpoint: gateway/api/v1/services
     bucketCapacity: 20
+    authProvider: zosmf
 centralGatewayServiceConfiguration:
     scheme: https
     host: localhost
@@ -64,9 +65,6 @@ auxiliaryUserList:
 oidcConfiguration:
     providerName: okta
     host: https://dev-15878923.okta.com
-    clientId: 0oalf0sc35aNKevXs5d7
-    user: zoweson@zowe.com
-    password: hKE6tisHdujbmSg
 safIdtConfiguration:
     enabled: true
 instanceEnv:


### PR DESCRIPTION
# Description

Added `gateway.authProvider` parameter in integration tests config to exclude some z/OSMF specific tests, when `saf` auth provider is used in zowe.yaml. And for some tests was changed expected result (message and JWT issuer). For GH actions run, the z/OSMF is still default becasue it uses MockServices.

Linked to # (issue)
Part of the # (epic)

## Type of change

- [X] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
