### PR TITLE
fix: configure ssl only if context is not null

### DIFF
--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/DiscoveryRestTemplateConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/DiscoveryRestTemplateConfig.java
@@ -98,7 +98,16 @@ public class DiscoveryRestTemplateConfig {
     private static HttpClientConnectionManager buildConnectionManager(SSLContext sslContext, HostnameVerifier hostnameVerifier) {
         PoolingHttpClientConnectionManagerBuilder connectionManagerBuilder = PoolingHttpClientConnectionManagerBuilder
             .create();
-        connectionManagerBuilder.setTlsSocketStrategy(new DefaultClientTlsStrategy(sslContext, hostnameVerifier));
+        DefaultClientTlsStrategy tlsStrategy;
+        if (sslContext != null) {
+            if (hostnameVerifier != null) {
+                tlsStrategy = new DefaultClientTlsStrategy(sslContext, hostnameVerifier);
+            } else {
+                tlsStrategy = new DefaultClientTlsStrategy(sslContext);
+            }
+            connectionManagerBuilder.setTlsSocketStrategy(tlsStrategy);
+        }
+
         connectionManagerBuilder.setDefaultSocketConfig(SocketConfig.custom()
             .setSoTimeout(Timeout.of(SOCKET_TIMEOUT, TimeUnit.MILLISECONDS))
             .build());

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/DiscoveryRestTemplateConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/DiscoveryRestTemplateConfig.java
@@ -48,6 +48,8 @@ public class DiscoveryRestTemplateConfig {
     private static final int REQUEST_TIMEOUT = 180_000;
     private static final int SOCKET_TIMEOUT = 180_000;
     private static final int IDLE_TIMEOUT = 60;
+    private static final int MAX_CONNECTIONS_TOTAL = 100;
+    private static final int MAX_CONNECTIONS_PER_ROUTE = 10;
 
     @Bean
     RestClientTransportClientFactories restTemplateTransportClientFactories(RestClientDiscoveryClientOptionalArgs restClientDiscoveryClientOptionalArgs) {
@@ -108,6 +110,8 @@ public class DiscoveryRestTemplateConfig {
             connectionManagerBuilder.setTlsSocketStrategy(tlsStrategy);
         }
 
+        connectionManagerBuilder.setMaxConnTotal(MAX_CONNECTIONS_TOTAL);
+        connectionManagerBuilder.setMaxConnPerRoute(MAX_CONNECTIONS_PER_ROUTE);
         connectionManagerBuilder.setDefaultSocketConfig(SocketConfig.custom()
             .setSoTimeout(Timeout.of(SOCKET_TIMEOUT, TimeUnit.MILLISECONDS))
             .build());


### PR DESCRIPTION
# Description

When API ML runs with AT-TLS no ssl context is available and it should not be cofigured for eureka as well.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
