### PR TITLE
fix: unwanted warning messages

### DIFF
--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/PropertyContainsCondition.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/PropertyContainsCondition.java
@@ -1,0 +1,56 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.logging;
+
+import ch.qos.logback.core.boolex.PropertyConditionBase;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PropertyContainsCondition extends PropertyConditionBase {
+
+    @Setter
+    @Getter
+    String key;
+
+    @Setter
+    @Getter
+    String value;
+
+    @Override
+    public void start() {
+        if (key == null) {
+            addError("In PropertyContainsValue 'key' parameter cannot be null");
+            return;
+        }
+        if (value == null) {
+            addError("In PropertyContainsValue 'value' parameter cannot be null");
+            return;
+        }
+        super.start();
+    }
+
+    @Override
+    public boolean evaluate() {
+        if (key == null) {
+            addError("key cannot be null");
+            return false;
+        }
+
+        String val = p(key);
+        if (val == null)
+            return false;
+        else {
+            return val.contains(value);
+        }
+
+    }
+
+}

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/PropertyContainsCondition.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/PropertyContainsCondition.java
@@ -14,14 +14,11 @@ import ch.qos.logback.core.boolex.PropertyConditionBase;
 import lombok.Getter;
 import lombok.Setter;
 
+@Setter
+@Getter
 public class PropertyContainsCondition extends PropertyConditionBase {
 
-    @Setter
-    @Getter
     String key;
-
-    @Setter
-    @Getter
     String value;
 
     @Override

--- a/apiml-utility/src/main/resources/logback-spring.xml
+++ b/apiml-utility/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
         </encoder>
     </appender>
 
-    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition.class">
+    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition">
         <key>spring.profiles.active</key>
         <value>debug</value>
     </condition>
@@ -56,7 +56,7 @@
         </then>
     </if>
 
-    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition.class">
+    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition">
         <key>spring.profiles.active</key>
         <value>debug</value>
     </condition>

--- a/apiml-utility/src/main/resources/logback-spring.xml
+++ b/apiml-utility/src/main/resources/logback-spring.xml
@@ -28,7 +28,11 @@
         </encoder>
     </appender>
 
-    <if condition='isDefined("apiml.logs.location") &amp;&amp; property("spring.profiles.active").contains("debug")'>
+    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition.class">
+        <key>spring.profiles.active</key>
+        <value>debug</value>
+    </condition>
+    <if>
         <then>
             <appender name="FILE" class="org.zowe.apiml.product.logging.ApimlRollingFileAppender">
                 <file>${STORAGE_LOCATION}/${logbackService:-${logbackServiceName}}.log</file>
@@ -52,7 +56,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("apiml.logs.location") &amp;&amp; property("spring.profiles.active").contains("debug")'>
+    <condition class="org.zowe.apiml.product.logging.PropertyContainsCondition.class">
+        <key>spring.profiles.active</key>
+        <value>debug</value>
+    </condition>
+    <if>
         <then>
             <root level="INFO">
                 <appender-ref ref="STDOUT"/>

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
@@ -1,0 +1,30 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.logging;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyContainsConditionTest {
+
+    @Test
+    void testEvaluate() {
+
+    }
+
+    @Test
+    void testStart() {
+
+    }
+
+}

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
@@ -18,7 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class PropertyContainsConditionTest {
@@ -31,16 +31,18 @@ class PropertyContainsConditionTest {
 
         @ParameterizedTest
         @CsvSource(value = {
-            "abc,b,true",
-            "abc,a,true",
-            "abc,c,true",
-            "abc,d,false",
-            "abc,B,false"
-        }, delimiter = ',')
-        void expectResult(String returnedValue, String searchedForValue, boolean expectedResult) {
-            propertyContainsCondition.setKey("a.key");
+            "key,abc,b,true",
+            "key,abc,a,true",
+            "key,abc,c,true",
+            "key,abc,d,false",
+            "key,abc,B,false",
+            "null,abc,b,false",
+            "key,null,b,false"
+        }, delimiter = ',', nullValues = { "null" })
+        void expectResult(String key, String returnedValue, String searchedForValue, boolean expectedResult) {
+            propertyContainsCondition.setKey(key);
             propertyContainsCondition.setValue(searchedForValue);
-            doReturn(returnedValue).when(propertyContainsCondition).p("a.key");
+            lenient().doReturn(returnedValue).when(propertyContainsCondition).p(key);
             assertEquals(expectedResult, propertyContainsCondition.evaluate(), "Expected " + returnedValue + " to " + (expectedResult ? " contain " : " not contain ") + searchedForValue);
         }
 

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
@@ -10,20 +10,39 @@
 
 package org.zowe.apiml.product.logging;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 class PropertyContainsConditionTest {
 
-    @Test
-    void testEvaluate() {
+    @Spy
+    private PropertyContainsCondition propertyContainsCondition;
 
-    }
+    @Nested
+    class OnEvaluate {
 
-    @Test
-    void testStart() {
+        @ParameterizedTest
+        @CsvSource(value = {
+            "abc,b,true",
+            "abc,a,true",
+            "abc,c,true",
+            "abc,d,false",
+            "abc,B,false"
+        }, delimiter = ',')
+        void expectResult(String returnedValue, String searchedForValue, boolean expectedResult) {
+            propertyContainsCondition.setKey("a.key");
+            propertyContainsCondition.setValue(searchedForValue);
+            doReturn(returnedValue).when(propertyContainsCondition).p("a.key");
+            assertEquals(expectedResult, propertyContainsCondition.evaluate(), "Expected " + returnedValue + " to " + (expectedResult ? " contain " : " not contain ") + searchedForValue);
+        }
 
     }
 

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/PropertyContainsConditionTest.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.product.logging;
 
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -18,7 +19,14 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PropertyContainsConditionTest {
@@ -44,6 +52,45 @@ class PropertyContainsConditionTest {
             propertyContainsCondition.setValue(searchedForValue);
             lenient().doReturn(returnedValue).when(propertyContainsCondition).p(key);
             assertEquals(expectedResult, propertyContainsCondition.evaluate(), "Expected " + returnedValue + " to " + (expectedResult ? " contain " : " not contain ") + searchedForValue);
+        }
+
+    }
+
+    @Nested
+    class OnStart {
+
+        @Test
+        void whenValues_thenSucess() {
+            propertyContainsCondition.key = "key";
+            propertyContainsCondition.value = "value";
+
+            propertyContainsCondition.start();
+
+            verify(propertyContainsCondition, never()).addError(anyString());
+        }
+
+        @Test
+        void whenMissingKey_thenError() {
+            doNothing().when(propertyContainsCondition).addError(any());
+
+            propertyContainsCondition.key = null;
+            propertyContainsCondition.value = "value";
+
+            propertyContainsCondition.start();
+
+            verify(propertyContainsCondition, times(1)).addError(argThat(message -> message.contains("'key'")));
+        }
+
+        @Test
+        void whenMissingValue_thenError() {
+            doNothing().when(propertyContainsCondition).addError(any());
+
+            propertyContainsCondition.key = "key";
+            propertyContainsCondition.value = null;
+
+            propertyContainsCondition.start();
+
+            verify(propertyContainsCondition, times(1)).addError(argThat(message -> message.contains("'value'")));
         }
 
     }


### PR DESCRIPTION
# Description

Upgrade of logback dependency brought deprecation of conditional expressions using janino.
This PR implements the recommended alternative.

Messages appearing in the logs now are:

```
15:46:37,037 |-WARN in ch.qos.logback.core.model.processor.conditional.IfModelHandler - The 'condition' attribute in <if> element is deprecated and slated for removal. Use <condition> element instead.
15:46:37,038 |-WARN in ch.qos.logback.core.model.processor.conditional.IfModelHandler - See also https://logback.qos.ch/codes.html#conditionAttributeDeprecation
15:46:37,269 |-WARN in ch.qos.logback.core.model.processor.conditional.IfModelHandler - The 'condition' attribute in <if> element is deprecated and slated for removal. Use <condition> element instead.
15:46:37,270 |-WARN in ch.qos.logback.core.model.processor.conditional.IfModelHandler - See also https://logback.qos.ch/codes.html#conditionAttributeDeprecation
```

Updated documentation about the condition statement is located here: https://logback.qos.ch/manual/configuration.html#conditional

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
