### PR TITLE
fix: remove reversecategorize filter from attls

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/apicatalog/ApiCatalogAuthenticationTest.java
@@ -17,7 +17,11 @@ import io.restassured.response.Validatable;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -33,7 +37,6 @@ import org.zowe.apiml.util.service.DiscoveryUtils;
 
 import java.net.URISyntaxException;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
@@ -109,12 +112,12 @@ class ApiCatalogAuthenticationTest {
         RestAssured.useRelaxedHTTPSValidation();
         SslContext.prepareSslAuthentication(ItSslConfigFactory.integrationTests());
 
-        List<DiscoveryUtils.InstanceInfo> apiCatalogInstances = DiscoveryUtils.getInstances(CATALOG_SERVICE_ID);
+        var apiCatalogInstances = DiscoveryUtils.getInstances(CATALOG_SERVICE_ID);
         if (StringUtils.isEmpty(apiCatalogServiceUrl)) {
             apiCatalogServiceUrl = apiCatalogInstances.stream()
                 .filter(catalogInstance -> catalogInstance.getPort() == catalogConfig.getPort())
                 .findFirst()
-                .map(i -> String.format("%s", i.getUrl()))
+                .map(i -> String.format("%s", i.getUrl()).replace("https://", "http://").replace("http://", ConfigReader.environmentConfiguration().getApiCatalogServiceConfiguration().getScheme() + "://"))
                 .orElseThrow(() -> new RuntimeException("Cannot determine API Catalog service from Discovery"));
         }
     }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
@@ -520,12 +520,6 @@ public class NewSecurityConfiguration {
                     )
                     .logout(AbstractHttpConfigurer::disable);  // logout filter in this chain not needed
 
-                if (isServerAttlsEnabled) {
-                    http
-                        // filter out API ML certificate
-                        .addFilterBefore(reversedCategorizeCertFilter(), org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter.class);
-                }
-
                 return http.authenticationProvider(compoundAuthProvider) // for authenticating credentials
                     .authenticationProvider(tokenAuthenticationProvider) // for authenticating Tokens
                     .authenticationProvider(new CertificateAuthenticationProvider())

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
@@ -54,7 +54,12 @@ import org.zowe.apiml.security.common.filter.StoreAccessTokenInfoFilter;
 import org.zowe.apiml.security.common.handler.FailedAccessTokenHandler;
 import org.zowe.apiml.security.common.handler.FailedAuthenticationHandler;
 import org.zowe.apiml.security.common.handler.SuccessfulAccessTokenHandler;
-import org.zowe.apiml.security.common.login.*;
+import org.zowe.apiml.security.common.login.BasicAuthFilter;
+import org.zowe.apiml.security.common.login.LoginFilter;
+import org.zowe.apiml.security.common.login.NonCompulsoryAuthenticationProcessingFilter;
+import org.zowe.apiml.security.common.login.ShouldBeAlreadyAuthenticatedFilter;
+import org.zowe.apiml.security.common.login.X509AuthAwareFilter;
+import org.zowe.apiml.security.common.login.X509ForwardingAwareAuthenticationFilter;
 import org.zowe.apiml.security.common.verify.CertificateValidator;
 import org.zowe.apiml.zaas.controllers.AuthController;
 import org.zowe.apiml.zaas.controllers.SafResourceAccessController;
@@ -581,12 +586,6 @@ public class NewSecurityConfiguration {
                 }
             }
 
-            private CategorizeCertsFilter reversedCategorizeCertFilter() {
-                CategorizeCertsFilter out = new CategorizeCertsFilter(publicKeyCertificatesBase64, certificateValidator);
-                out.setCertificateForClientAuth(crt -> out.getPublicKeyCertificatesBase64().contains(CategorizeCertsFilter.base64EncodePublicKey(crt)));
-                out.setApimlCertificate(crt -> !out.getPublicKeyCertificatesBase64().contains(CategorizeCertsFilter.base64EncodePublicKey(crt)));
-                return out;
-            }
         }
 
         /**


### PR DESCRIPTION
# Description

auth/check endpoint fails in at-tls due to use of reverse filter (normal categorize certs filter is used instead)

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
