### PR TITLE
fix: disable hostname validation

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
@@ -10,8 +10,10 @@
 
 package org.zowe.apiml.security.common.config;
 
-import java.util.List;
-
+import io.netty.handler.ssl.SslContext;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,12 +33,9 @@ import org.zowe.apiml.product.web.HttpConfig;
 import org.zowe.apiml.security.HttpsConfigError;
 import org.zowe.apiml.security.common.util.ConnectionUtil;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.resolver.DefaultAddressResolverGroup;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.netty.http.client.HttpClient;
 
+import java.util.List;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
@@ -10,7 +10,6 @@
 
 package org.zowe.apiml.security.common.config;
 
-import io.netty.handler.ssl.SslContext;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +32,8 @@ import org.zowe.apiml.product.web.HttpConfig;
 import org.zowe.apiml.security.HttpsConfigError;
 import org.zowe.apiml.security.common.util.ConnectionUtil;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientSecurityUtils;
+import reactor.netty.tcp.SslProvider;
 
 import java.util.List;
 
@@ -55,9 +56,21 @@ public class WebClientConfig {
         ServerProperties serverProperties, List<HttpClientCustomizer> customizers,
         HttpClientSslConfigurer sslConfigurer
     ) {
-        SslContext sslContext;
+        SslProvider sslProvider;
         try {
-            sslContext = ConnectionUtil.getSslContext(config, false);
+            var sslProviderBuilder = SslProvider.builder().sslContext(ConnectionUtil.getSslContext(config, false));
+            // When NONSTRICT, we must NOT add hostname verification to disable hostname checking.
+            // When STRICT, we need to explicitly add it to ensure hostname verification is enabled.
+            boolean isNonStrict = config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices();
+            log.debug("WebClientConfig.gatewayHttpClientFactory - SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, isNonStrict={}, hostnameVerificationEnabled={}",
+                config.isVerifySslCertificatesOfServices(),
+                config.isNonStrictVerifySslCertificatesOfServices(),
+                isNonStrict,
+                !isNonStrict);
+            if (!isNonStrict) {
+                sslProviderBuilder.handlerConfigurator(HttpClientSecurityUtils.HOSTNAME_VERIFICATION_CONFIGURER);
+            }
+            sslProvider = sslProviderBuilder.build();
         } catch (Exception e) {
             apimlLog.log("org.zowe.apiml.common.sslContextInitializationError", e.getMessage());
             throw new HttpsConfigError("Error initializing SSL Context: " + e.getMessage(), e,
@@ -67,7 +80,7 @@ public class WebClientConfig {
             @Override
             protected HttpClient createInstance() {
                 return super.createInstance()
-                    .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
+                    .secure(sslProvider)
                     .resolver(DefaultAddressResolverGroup.INSTANCE);
             }
         };

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
@@ -10,9 +10,8 @@
 
 package org.zowe.apiml.security.common.config;
 
-import io.netty.resolver.DefaultAddressResolverGroup;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,11 +30,12 @@ import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
 import org.zowe.apiml.product.web.HttpConfig;
 import org.zowe.apiml.security.HttpsConfigError;
 import org.zowe.apiml.security.common.util.ConnectionUtil;
-import reactor.netty.http.client.HttpClient;
-import reactor.netty.http.client.HttpClientSecurityUtils;
-import reactor.netty.tcp.SslProvider;
 
-import java.util.List;
+import io.netty.handler.ssl.SslContext;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.netty.http.client.HttpClient;
 
 @Slf4j
 @Configuration
@@ -56,21 +56,9 @@ public class WebClientConfig {
         ServerProperties serverProperties, List<HttpClientCustomizer> customizers,
         HttpClientSslConfigurer sslConfigurer
     ) {
-        SslProvider sslProvider;
+        SslContext sslContext;
         try {
-            var sslProviderBuilder = SslProvider.builder().sslContext(ConnectionUtil.getSslContext(config, false));
-            // When NONSTRICT, we must NOT add hostname verification to disable hostname checking.
-            // When STRICT, we need to explicitly add it to ensure hostname verification is enabled.
-            boolean isNonStrict = config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices();
-            log.debug("WebClientConfig.gatewayHttpClientFactory - SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, isNonStrict={}, hostnameVerificationEnabled={}",
-                config.isVerifySslCertificatesOfServices(),
-                config.isNonStrictVerifySslCertificatesOfServices(),
-                isNonStrict,
-                !isNonStrict);
-            if (!isNonStrict) {
-                sslProviderBuilder.handlerConfigurator(HttpClientSecurityUtils.HOSTNAME_VERIFICATION_CONFIGURER);
-            }
-            sslProvider = sslProviderBuilder.build();
+            sslContext = ConnectionUtil.getSslContext(config, false);
         } catch (Exception e) {
             apimlLog.log("org.zowe.apiml.common.sslContextInitializationError", e.getMessage());
             throw new HttpsConfigError("Error initializing SSL Context: " + e.getMessage(), e,
@@ -80,7 +68,7 @@ public class WebClientConfig {
             @Override
             protected HttpClient createInstance() {
                 return super.createInstance()
-                    .secure(sslProvider)
+                    .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
                     .resolver(DefaultAddressResolverGroup.INSTANCE);
             }
         };

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
@@ -10,18 +10,11 @@
 
 package org.zowe.apiml.security.common.config;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.web.ServerProperties;
-import org.springframework.cloud.gateway.config.HttpClientCustomizer;
-import org.springframework.cloud.gateway.config.HttpClientFactory;
-import org.springframework.cloud.gateway.config.HttpClientProperties;
-import org.springframework.cloud.gateway.config.HttpClientSslConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -35,7 +28,6 @@ import org.zowe.apiml.security.common.util.ConnectionUtil;
 
 import reactor.netty.http.client.HttpClient;
 
-import java.util.List;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
@@ -48,30 +40,6 @@ public class WebClientConfig {
 
     @Value("${server.attlsClient.enabled:false}")
     private boolean isClientAttlsEnabled;
-
-    @Bean
-    HttpClientFactory gatewayHttpClientFactory(
-        HttpClientProperties properties,
-        ServerProperties serverProperties, List<HttpClientCustomizer> customizers,
-        HttpClientSslConfigurer sslConfigurer
-    ) {
-        SslContext sslContext;
-        try {
-            sslContext = ConnectionUtil.getSslContext(config, false);
-        } catch (Exception e) {
-            apimlLog.log("org.zowe.apiml.common.sslContextInitializationError", e.getMessage());
-            throw new HttpsConfigError("Error initializing SSL Context: " + e.getMessage(), e,
-                HttpsConfigError.ErrorCode.HTTP_CLIENT_INITIALIZATION_FAILED, config.httpsConfig());
-        }
-        return new HttpClientFactory(properties, serverProperties, sslConfigurer, customizers) {
-            @Override
-            protected HttpClient createInstance() {
-                return super.createInstance()
-                    .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
-                    .resolver(DefaultAddressResolverGroup.INSTANCE);
-            }
-        };
-    }
 
     HttpClient getHttpClient(HttpClient httpClient, boolean useClientCert) {
         try {

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
@@ -67,7 +67,7 @@ public class ConnectionUtil {
             builder.keyManager(keyManagerFactory);
         }
 
-        if (config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices()) {
+        if (!config.isVerifySslCertificatesOfServices() || (config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices())) {
             log.debug("ConnectionUtil.getSslContext - NONSTRICT mode: disabling endpointIdentificationAlgorithm");
             builder.endpointIdentificationAlgorithm(null);
         }
@@ -77,7 +77,7 @@ public class ConnectionUtil {
 
     public HttpClient getHttpClient(HttpConfig config, HttpClient httpClient, boolean useClientCert) throws UnrecoverableKeyException, CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
         var sslContextBuilder = SslProvider.builder().sslContext(ConnectionUtil.getSslContext(config, useClientCert));
-        boolean hostnameVerificationEnabled = !config.isNonStrictVerifySslCertificatesOfServices();
+        boolean hostnameVerificationEnabled = config.isVerifySslCertificatesOfServices() && !config.isNonStrictVerifySslCertificatesOfServices();
         log.debug("ConnectionUtil.getHttpClient - SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, hostnameVerificationEnabled={}, useClientCert={}",
             config.isVerifySslCertificatesOfServices(),
             config.isNonStrictVerifySslCertificatesOfServices(),

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
@@ -54,12 +54,13 @@ public class ConnectionUtil {
         var keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 
         if (setKeystore) {
-            log.info("Loading keystore: {}: {}", config.getKeyStoreType(), config.getKeyStorePath());
+            log.debug("Loading keystore: {}: {}", config.getKeyStoreType(), config.getKeyStorePath());
             var keyStore = SecurityUtils.loadKeyStore(
                 config.getKeyStoreType(), config.getKeyStorePath(), config.getKeyStorePassword());
             keyManagerFactory.init(keyStore, config.getKeyStorePassword());
             builder.keyManager(x509KeyManagerSelectedAlias(config, keyManagerFactory));
         } else {
+            log.debug("ConnectionUtil.getSslContext - no keystore: using empty keystore");
             var emptyKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
             emptyKeystore.load(null, null);
             keyManagerFactory.init(emptyKeystore, null);
@@ -67,6 +68,7 @@ public class ConnectionUtil {
         }
 
         if (config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices()) {
+            log.debug("ConnectionUtil.getSslContext - NONSTRICT mode: disabling endpointIdentificationAlgorithm");
             builder.endpointIdentificationAlgorithm(null);
         }
 
@@ -75,8 +77,23 @@ public class ConnectionUtil {
 
     public HttpClient getHttpClient(HttpConfig config, HttpClient httpClient, boolean useClientCert) throws UnrecoverableKeyException, CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
         var sslContextBuilder = SslProvider.builder().sslContext(ConnectionUtil.getSslContext(config, useClientCert));
-        if (!config.isNonStrictVerifySslCertificatesOfServices()) {
+        boolean hostnameVerificationEnabled = !config.isNonStrictVerifySslCertificatesOfServices();
+        log.debug("ConnectionUtil.getHttpClient - SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, hostnameVerificationEnabled={}, useClientCert={}",
+            config.isVerifySslCertificatesOfServices(),
+            config.isNonStrictVerifySslCertificatesOfServices(),
+            hostnameVerificationEnabled,
+            useClientCert);
+        if (hostnameVerificationEnabled) {
+            log.debug("ConnectionUtil.getHttpClient - hostname verification enabled");
             sslContextBuilder.handlerConfigurator(HttpClientSecurityUtils.HOSTNAME_VERIFICATION_CONFIGURER);
+        } else {
+            log.debug("ConnectionUtil.getHttpClient - hostname verification disabled");
+            sslContextBuilder.handlerConfigurator(handler -> {
+                var sslEngine = handler.engine();
+                var sslParameters = sslEngine.getSSLParameters();
+                sslParameters.setEndpointIdentificationAlgorithm(null);
+                sslEngine.setSSLParameters(sslParameters);
+            });
         }
         return httpClient.secure(sslContextBuilder.build());
     }

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/ConnectionUtil.java
@@ -67,7 +67,7 @@ public class ConnectionUtil {
             builder.keyManager(keyManagerFactory);
         }
 
-        if (!config.isVerifySslCertificatesOfServices() || (config.isVerifySslCertificatesOfServices() && config.isNonStrictVerifySslCertificatesOfServices())) {
+        if (!isHostnameVerificationEnabled(config)) {
             log.debug("ConnectionUtil.getSslContext - NONSTRICT mode: disabling endpointIdentificationAlgorithm");
             builder.endpointIdentificationAlgorithm(null);
         }
@@ -77,13 +77,12 @@ public class ConnectionUtil {
 
     public HttpClient getHttpClient(HttpConfig config, HttpClient httpClient, boolean useClientCert) throws UnrecoverableKeyException, CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
         var sslContextBuilder = SslProvider.builder().sslContext(ConnectionUtil.getSslContext(config, useClientCert));
-        boolean hostnameVerificationEnabled = config.isVerifySslCertificatesOfServices() && !config.isNonStrictVerifySslCertificatesOfServices();
         log.debug("ConnectionUtil.getHttpClient - SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, hostnameVerificationEnabled={}, useClientCert={}",
             config.isVerifySslCertificatesOfServices(),
             config.isNonStrictVerifySslCertificatesOfServices(),
-            hostnameVerificationEnabled,
+            isHostnameVerificationEnabled(config),
             useClientCert);
-        if (hostnameVerificationEnabled) {
+        if (isHostnameVerificationEnabled(config)) {
             log.debug("ConnectionUtil.getHttpClient - hostname verification enabled");
             sslContextBuilder.handlerConfigurator(HttpClientSecurityUtils.HOSTNAME_VERIFICATION_CONFIGURER);
         } else {
@@ -96,6 +95,10 @@ public class ConnectionUtil {
             });
         }
         return httpClient.secure(sslContextBuilder.build());
+    }
+
+    private boolean isHostnameVerificationEnabled(HttpConfig config) {
+        return config.isVerifySslCertificatesOfServices() && !config.isNonStrictVerifySslCertificatesOfServices();
     }
 
     @VisibleForTesting

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/util/ConnectionUtilTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/util/ConnectionUtilTest.java
@@ -51,6 +51,7 @@ class ConnectionUtilTest {
         when(httpConfig.getTrustStoreType()).thenReturn("PKCS12");
         when(httpConfig.getTrustStorePath()).thenReturn("../keystore/localhost/localhost.truststore.p12");
         when(httpConfig.getTrustStorePassword()).thenReturn("password".toCharArray()); //NOSONAR
+        when(httpConfig.isVerifySslCertificatesOfServices()).thenReturn(true);
     }
 
     @Test

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/util/ConnectionUtilTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/util/ConnectionUtilTest.java
@@ -12,13 +12,16 @@ package org.zowe.apiml.security.common.util;
 
 import io.netty.handler.ssl.SslContextBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.product.web.HttpConfig;
+import reactor.netty.http.client.HttpClient;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -30,7 +33,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -111,6 +116,57 @@ class ConnectionUtilTest {
 
             verify(builder, times(1)).trustManager(any(TrustManagerFactory.class));
             verify(builder, times(1)).endpointIdentificationAlgorithm(isNull());
+        }
+
+    }
+
+    @Nested
+    class WhenGetHttpClient {
+
+        @Test
+        void whenHostnameVerificationEnabled_thenEnableEndpointIdentificationAlgorithm() throws UnrecoverableKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+            when(httpConfig.isVerifySslCertificatesOfServices()).thenReturn(true);
+            when(httpConfig.isNonStrictVerifySslCertificatesOfServices()).thenReturn(false);
+            HttpClient baseHttpClient = HttpClient.create();
+            HttpClient result = ConnectionUtil.getHttpClient(httpConfig, baseHttpClient, false);
+            
+            assertEquals("HTTPS", ReflectionTestUtils.getField(result.configuration().sslProvider().getSslContext(), "endpointIdentificationAlgorithm"));
+        }
+
+        @Test
+        void whenUseClientCertTrueAndHostnameVerificationStrict_thenEnableEndpointIdentificationAlgorithm() throws UnrecoverableKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+            when(httpConfig.isVerifySslCertificatesOfServices()).thenReturn(true);
+            when(httpConfig.isNonStrictVerifySslCertificatesOfServices()).thenReturn(false);
+            when(httpConfig.getKeyStoreType()).thenReturn("PKCS12");
+            when(httpConfig.getKeyStorePath()).thenReturn("../keystore/localhost/localhost.keystore.p12");
+            when(httpConfig.getKeyStorePassword()).thenReturn("password".toCharArray()); //NOSONAR
+
+            HttpClient baseHttpClient = HttpClient.create();
+            HttpClient result = ConnectionUtil.getHttpClient(httpConfig, baseHttpClient, true);
+
+            assertEquals("HTTPS", ReflectionTestUtils.getField(result.configuration().sslProvider().getSslContext(), "endpointIdentificationAlgorithm"));
+        }
+
+        @Test
+        void whenHostnameVerificationDisabled_thenDisableEndpointIdentificationAlgorithm() throws UnrecoverableKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+            when(httpConfig.isVerifySslCertificatesOfServices()).thenReturn(true);
+            when(httpConfig.isNonStrictVerifySslCertificatesOfServices()).thenReturn(true);
+
+            HttpClient baseHttpClient = HttpClient.create();
+            HttpClient result = ConnectionUtil.getHttpClient(httpConfig, baseHttpClient, false);
+
+            assertNull(ReflectionTestUtils.getField(result.configuration().sslProvider().getSslContext(), "endpointIdentificationAlgorithm"));
+        }
+
+        @Test
+        void whenVerifySslDisabled_thenDisableEndpointIdentificationAlgorithm() throws UnrecoverableKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+            when(httpConfig.isVerifySslCertificatesOfServices()).thenReturn(false);
+            when(httpConfig.isNonStrictVerifySslCertificatesOfServices()).thenReturn(false);
+
+            HttpClient baseHttpClient = HttpClient.create();
+            HttpClient result = ConnectionUtil.getHttpClient(httpConfig, baseHttpClient, false);
+
+            assertNull(ReflectionTestUtils.getField(result.configuration().sslProvider().getSslContext(), "endpointIdentificationAlgorithm"));
         }
 
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
@@ -111,6 +111,10 @@ public class ConnectionsConfig {
     @Bean
     NettyRoutingFilterApiml createNettyRoutingFilterApiml(HttpClient httpClient, ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider, HttpClientProperties properties) {
         boolean isKeyLoadPrevented = StringUtils.isBlank(config.getKeyStorePath()) && isClientAttlsEnabled;
+        log.debug("ConnectionsConfig.createNettyRoutingFilterApiml - Creating routing filter with SSL config: verifySslCertificatesOfServices={}, nonStrictVerifySslCertificatesOfServices={}, isKeyLoadPrevented={}",
+            config.isVerifySslCertificatesOfServices(),
+            config.isNonStrictVerifySslCertificatesOfServices(),
+            isKeyLoadPrevented);
         try {
             return new NettyRoutingFilterApiml(
                 ConnectionUtil.getHttpClient(config, httpClient, false),

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
@@ -77,7 +77,7 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
         httpClient = httpClient
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutResult)
             .responseTimeout(Duration.ofMillis(responseTimeoutResult));
-        
+
         return httpClient;
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
@@ -77,7 +77,7 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
         httpClient = httpClient
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutResult)
             .responseTimeout(Duration.ofMillis(responseTimeoutResult));
-
+        
         return httpClient;
     }
 

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/ApiMediationServiceConfigReaderTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/ApiMediationServiceConfigReaderTest.java
@@ -237,8 +237,8 @@ class ApiMediationServiceConfigReaderTest {
         assertThat(exception.getCause(), instanceOf(MalformedURLException.class));
     }
 
-    // @Test
-    void testLoadConfiguration_IpAddressIsNull_UnknownHost() {
+    @Test
+    void testLoadConfiguration_IpAddressIsNull_andUnknownHostAsBaseUrl_thenThrowException() {
         String internalFileName = "/additional-service-configuration_ip-address-null_UnknownHost.yml";
 
         ApiMediationServiceConfigReader apiMediationServiceConfigReader = new ApiMediationServiceConfigReader();

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/ApiMediationServiceConfigReaderTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/ApiMediationServiceConfigReaderTest.java
@@ -237,7 +237,7 @@ class ApiMediationServiceConfigReaderTest {
         assertThat(exception.getCause(), instanceOf(MalformedURLException.class));
     }
 
-    @Test
+    // @Test
     void testLoadConfiguration_IpAddressIsNull_UnknownHost() {
         String internalFileName = "/additional-service-configuration_ip-address-null_UnknownHost.yml";
 

--- a/onboarding-enabler-java/src/test/resources/additional-service-configuration_ip-address-null_UnknownHost.yml
+++ b/onboarding-enabler-java/src/test/resources/additional-service-configuration_ip-address-null_UnknownHost.yml
@@ -1,7 +1,7 @@
 serviceId: service
 title: HelloWorld Spring REST API
 description: POC for exposing a Spring REST API
-baseUrl: http://blah.blah.blah.com:10021/hellospring
+baseUrl: http://uknownhostexception:10021/hellospring
 preferIpAddress: true
 
 homePageRelativeUrl: /


### PR DESCRIPTION
# Description

Hostname validation was disabled only when nonStrictVerifySslCertificatesOfServices=true, but this option was missing when certificate validation was disabled completely. This change addresses this case and disables endpoint protection.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
