### PR TITLE
chore: Change nodejs enabler sample app port

### DIFF
--- a/api-catalog-ui/frontend/cypress/fixtures/enabler-test-files/testEnabler4.yaml
+++ b/api-catalog-ui/frontend/cypress/fixtures/enabler-test-files/testEnabler4.yaml
@@ -10,16 +10,16 @@ eureka:
 instance:
   app: ${serviceId}
   vipAddress: ${serviceId}
-  instanceId: localhost:hwexpress:10020
+  instanceId: localhost:hwexpress:10039
   homePageUrl: ${homePageRelativeUrl}
   hostname: localhost
   ipAddr: 127.0.0.1
   secureVipAddress: ${serviceId}
   port:
-    $: "10020"
+    $: "10039"
     "@enabled": false
   securePort:
-    $: "10020"
+    $: "10039"
     "@enabled": true
   dataCenterInfo:
     "@class": com.test
@@ -33,7 +33,7 @@ instance:
     apiml.routes.api_v1.serviceUrl: ${routes.serviceUrl}
     apiml.apiInfo.0.apiId: test.test
     apiml.apiInfo.0.gatewayUrl: ${routes.gatewayUrl}
-    apiml.apiInfo.0.swaggerUrl: http://localhost:10020/swagger.json
+    apiml.apiInfo.0.swaggerUrl: http://localhost:10039/swagger.json
     apiml.service.title: Test Service
     apiml.service.description: a service for testing
 ssl:

--- a/config/docker/nodejs-service/service-configuration.yml
+++ b/config/docker/nodejs-service/service-configuration.yml
@@ -12,16 +12,16 @@ eureka:
 instance:
   app: hwexpress
   vipAddress: hwexpress
-  instanceId: nodejs-sample-app:hwexpress:10020
-  homePageUrl: https://nodejs-sample-app:10020/
+  instanceId: nodejs-sample-app:hwexpress:10039
+  homePageUrl: https://nodejs-sample-app:10039/
   hostName: 'nodejs-sample-app'
   ipAddr: '127.0.0.1'
   secureVipAddress: hwexpress
   port:
-    $: 10020
+    $: 10039
     '@enabled': false
   securePort:
-    $: 10020
+    $: 10039
     '@enabled': "true"
 
   dataCenterInfo:
@@ -36,7 +36,7 @@ instance:
     apiml.routes.api_v1.serviceUrl: "/api/v1"
     apiml.apiInfo.0.apiId: org.zowe.hwexpress
     apiml.apiInfo.0.gatewayUrl: "api/v1"
-    apiml.apiInfo.0.swaggerUrl: https://nodejs-sample-app:10020/swagger.json
+    apiml.apiInfo.0.swaggerUrl: https://nodejs-sample-app:10039/swagger.json
     apiml.service.title: 'Zowe Sample Node Service'
     apiml.service.description: 'The Proxy Server is an HTTP HTTPS, and Websocket server built upon NodeJS and ExpressJS.'
 

--- a/docs/local-configuration.md
+++ b/docs/local-configuration.md
@@ -77,10 +77,10 @@ To run onboarding-enabler-nodejs-sample-app, follow the steps below:
 
 2. 2. Navigate to [https://localhost:10011]([https://localhost:10011]) and check if the service `HWEXPRESS` is registered to the Discovery Service. You should be able to reach the following endpoints using HTTPS:
    
-       * [https://localhost:10020/swagger.json](https://localhost:10020/swagger.json) which contains the API documentation.
-       * [https://localhost:10020/api/v1/status](https://localhost:10020/api/v1/status) for the health check endpoint containing the status of the application.
-       * [https://localhost:10020/api/v1/info](https://localhost:10020/api/v1/info) for the service information such as service ID and Node.js version.
-       * [https://localhost:10020/api/v1/hello](https://localhost:10020/api/v1/hello) for the greeting endpoint.
+       * [https://localhost:10039/swagger.json](https://localhost:10039/swagger.json) which contains the API documentation.
+       * [https://localhost:10039/api/v1/status](https://localhost:10039/api/v1/status) for the health check endpoint containing the status of the application.
+       * [https://localhost:10039/api/v1/info](https://localhost:10039/api/v1/info) for the service information such as service ID and Node.js version.
+       * [https://localhost:10039/api/v1/hello](https://localhost:10039/api/v1/hello) for the greeting endpoint.
        * [https://localhost:10010/hwexpress/api/v1/hello](https://localhost:10010/hwexpress/api/v1/hello) for the greeting endpoint, routed through API Gateway.
        
        Go to the [API Catalog](https://localhost:10010/apicatalog/ui/v1) and check if the API documentation of the service is retrieved.

--- a/onboarding-enabler-nodejs-sample-app/Dockerfile
+++ b/onboarding-enabler-nodejs-sample-app/Dockerfile
@@ -39,7 +39,7 @@ COPY src ./src
 COPY config/service-configuration.yml ./config/service-configuration.yml
 
 # ===== expose service port
-EXPOSE 10020
+EXPOSE 10039
 
 # ===== start
 CMD ["npm", "run", "start"]

--- a/onboarding-enabler-nodejs-sample-app/README.md
+++ b/onboarding-enabler-nodejs-sample-app/README.md
@@ -19,8 +19,8 @@ You can start the service using by running:
 
 If the APIML is already running then you should see the following messages:
 
-    hwexpress service listening on port 10020
-    registered with eureka:  hwexpress/localhost:hwexpress:10020
+    hwexpress service listening on port 10039
+    registered with eureka:  hwexpress/localhost:hwexpress:10039
 
 Then you can access it via Gateway by issuing the following command:
 

--- a/onboarding-enabler-nodejs-sample-app/config/service-configuration.yml
+++ b/onboarding-enabler-nodejs-sample-app/config/service-configuration.yml
@@ -12,16 +12,16 @@ eureka:
 instance:
   app: hwexpress
   vipAddress: hwexpress
-  instanceId: localhost:hwexpress:10020
-  homePageUrl: https://localhost:10020/
+  instanceId: localhost:hwexpress:10039
+  homePageUrl: https://localhost:10039/
   hostName: 'localhost'
   ipAddr: '127.0.0.1'
   secureVipAddress: hwexpress
   port:
-    $: 10020
+    $: 10039
     '@enabled': false
   securePort:
-    $: 10020
+    $: 10039
     '@enabled': "true"
 
   dataCenterInfo:
@@ -36,7 +36,7 @@ instance:
     apiml.routes.api_v1.serviceUrl: "/api/v1"
     apiml.apiInfo.0.apiId: org.zowe.hwexpress
     apiml.apiInfo.0.gatewayUrl: "api/v1"
-    apiml.apiInfo.0.swaggerUrl: https://localhost:10020/swagger.json
+    apiml.apiInfo.0.swaggerUrl: https://localhost:10039/swagger.json
     apiml.service.title: 'Zowe Sample Node Service'
     apiml.service.description: 'The Proxy Server is an HTTP HTTPS, and Websocket server built upon NodeJS and ExpressJS.'
 

--- a/onboarding-enabler-nodejs-sample-app/src/index.js
+++ b/onboarding-enabler-nodejs-sample-app/src/index.js
@@ -14,7 +14,7 @@ import * as apiLayerService from "@zowe/apiml-onboarding-enabler-nodejs";
 
 // Command-line arguments:
 const args = {
-    port: 10020,
+    port: 10039,
     serviceId: "hwexpress",
     // On z/OS, you need to use certificates encoded in EBCDIC
     // The APIML stores such certificates in files with `-ebcdic` suffix

--- a/onboarding-enabler-nodejs/README.md
+++ b/onboarding-enabler-nodejs/README.md
@@ -52,10 +52,10 @@ Below is an example of the configuration.
     
     
     description: Hello World REST API Service implemented in Express and Node.js
-    baseUrl: https://localhost:10020/hwexpress
-    homePageRelativeUrl: https://localhost:10020/
-    statusPageRelativeUrl: https://localhost:10020/info
-    healthCheckRelativeUrl: https://localhost:10020/status
+    baseUrl: https://localhost:10039/hwexpress
+    homePageRelativeUrl: https://localhost:10039/
+    statusPageRelativeUrl: https://localhost:10039/info
+    healthCheckRelativeUrl: https://localhost:10039/status
     discoveryServiceUrls:
       - https://localhost:10011/eureka
     routes:
@@ -64,7 +64,7 @@ Below is an example of the configuration.
     apiInfo:
       - apiId: org.zowe.hwexpress
         gatewayUrl: "api/v1"
-        swaggerUrl: https://localhost:10020/swagger.json
+        swaggerUrl: https://localhost:10039/swagger.json
     catalogUiTile:
       id: cademoapps
       title: Sample API Mediation Layer Applications
@@ -73,16 +73,16 @@ Below is an example of the configuration.
     instance:
       app: hwexpress
       vipAddress: hwexpress
-      instanceId: localhost:hwexpress:10020
-      homePageUrl: https://localhost:10020/
+      instanceId: localhost:hwexpress:10039
+      homePageUrl: https://localhost:10039/
       hostName: 'localhost'
       ipAddr: '127.0.0.1'
       secureVipAddress: hwexpress
       port:
-        $: 10020
+        $: 10039
         '@enabled': false
       securePort:
-        $: 10020
+        $: 10039
         '@enabled': "true"
     
       dataCenterInfo:
@@ -97,7 +97,7 @@ Below is an example of the configuration.
         apiml.routes.api_v1.serviceUrl: "/api/v1"
         apiml.apiInfo.0.apiId: org.zowe.hwexpress
         apiml.apiInfo.0.gatewayUrl: "api/v1"
-        apiml.apiInfo.0.swaggerUrl: https://localhost:10020/swagger.json
+        apiml.apiInfo.0.swaggerUrl: https://localhost:10039/swagger.json
         apiml.service.title: 'Zowe Sample Node Service'
         apiml.service.description: 'The Proxy Server is an HTTP HTTPS, and Websocket server built upon NodeJS and ExpressJS.'
     
@@ -129,17 +129,17 @@ Alternatively, you can also pass the config as a json to the client:
       },
       instance: {
         app: hwexpress,
-        instanceId: localhost:hwexpress:10020,
+        instanceId: localhost:hwexpress:10039,
         hostName: 'localhost',
         ipAddr: '127.0.0.1',
-        homePageUrl: https://localhost:10020/,
+        homePageUrl: https://localhost:10039/,
         secureVipAddress: hwexpress,
         port: {
-          $: 10020,
+          $: 10039,
           '@enabled': false
         },
         securePort: {
-          $: 10020,
+          $: 10039,
           '@enabled': true
         },
         dataCenterInfo: {


### PR DESCRIPTION
# Description

The nodejs onboarding enabler sample app uses the same port as modulith which results in flakiness in some integration tests. The port for the enabler sample app is moved to 10039

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
