### PR TITLE
fix: expect 401 on info endpoint

### DIFF
--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/PHBase.java
@@ -136,18 +136,6 @@ public class PHBase extends FunctionalApar {
     }
 
     private ResponseEntity<?> validInfo() {
-        return new ResponseEntity<>("{\n" +
-            "  \"zos_version\": \"04.27.00\",\n" +
-            "  \"zosmf_port\": \"1443\",\n" +
-            "  \"zosmf_version\": \"27\",\n" +
-            "  \"zosmf_hostname\": \"mock.service.host\",\n" +
-            "  \"plugins\": {\n" +
-            "    \"msgId\": \"IZUG612E\",\n" +
-            "    \"msgText\": \"IZUG612E\"\n" +
-            "  },\n" +
-            "  \"zosmf_saf_realm\": \"SAFRealm\",\n" +
-            "  \"zosmf_full_version\": \"27.0\",\n" +
-            "  \"api_version\": \"1\"\n" +
-            "}", HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/mock-services/src/test/java/org/zowe/apiml/client/api/RealJwtTokenEndpointTest.java
+++ b/mock-services/src/test/java/org/zowe/apiml/client/api/RealJwtTokenEndpointTest.java
@@ -33,7 +33,7 @@ class RealJwtTokenEndpointTest {
 
     @Test
     void infoTest() throws Exception {
-        mvc.perform(get("/zosmf/info")).andExpect(status().isOk());
+        mvc.perform(get("/zosmf/info")).andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
+++ b/mock-services/src/test/java/org/zowe/apiml/client/services/apars/PHBaseTest.java
@@ -51,7 +51,7 @@ class PHBaseTest {
             Optional<ResponseEntity<?>> result = underTest.apply("information", "", Optional.empty(), mockResponse, headers);
 
             assertThat(result.isPresent(), is(true));
-            assertThat(result.get().getStatusCode(), is(HttpStatus.OK));
+            assertThat(result.get().getStatusCode(), is(HttpStatus.UNAUTHORIZED));
             verify(mockResponse, never()).addCookie(any());
         }
 

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
@@ -291,6 +291,9 @@ public class ZosmfService extends AbstractZosmfService {
 
             return info.getStatusCode() == HttpStatus.OK;
         } catch (RuntimeException ex) {
+            if(ex instanceof HttpClientErrorException.Unauthorized) {
+                return true;
+            }
             handleExceptionOnCall(infoURIEndpoint, ex);
             return false;
         }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
@@ -291,7 +291,7 @@ public class ZosmfService extends AbstractZosmfService {
 
             return info.getStatusCode() == HttpStatus.OK;
         } catch (RuntimeException ex) {
-            if(ex instanceof HttpClientErrorException.Unauthorized) {
+            if (ex instanceof HttpClientErrorException.Unauthorized) {
                 return true;
             }
             handleExceptionOnCall(infoURIEndpoint, ex);


### PR DESCRIPTION
# Description

The z/OS maintenance package RSU2512 breaks compatibility with ZAAS by protecting the info endpoint. This change covers new response code as a valid response.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
