### PR TITLE
fix: Set JVM console encoding to IBM-1047 for Java 21

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -136,7 +136,7 @@ then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 fi
 

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -123,7 +123,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -136,7 +135,7 @@ then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 fi
 

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -123,6 +123,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -133,6 +134,9 @@ then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 fi
 
@@ -290,6 +294,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} ${JAVA_BIN_DIR}java \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \
     ${SHARED_CLASSES_OPTS} \
+    ${JAVA21_CONSOLE_ENCODING} \
     ${ADD_OPENS} \
     ${LOGBACK} \
     ${JVM_SECURITY_PROPERTIES} \

--- a/apiml-package/src/main/resources/bin/start.sh
+++ b/apiml-package/src/main/resources/bin/start.sh
@@ -164,7 +164,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
     APIML_LOADER_PATH=${COMMON_LIB},/usr/include/java_classes/IRRRacf.jar
@@ -177,7 +176,7 @@ if [ "$(uname)" = "OS/390" ]; then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 else
     APIML_LOADER_PATH=${COMMON_LIB}

--- a/apiml-package/src/main/resources/bin/start.sh
+++ b/apiml-package/src/main/resources/bin/start.sh
@@ -164,6 +164,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
     APIML_LOADER_PATH=${COMMON_LIB},/usr/include/java_classes/IRRRacf.jar
@@ -174,6 +175,9 @@ if [ "$(uname)" = "OS/390" ]; then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 else
     APIML_LOADER_PATH=${COMMON_LIB}
@@ -342,6 +346,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${APIML_CODE} ${JAVA_BIN_DIR}java \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \
     ${SHARED_CLASSES_OPTS} \
+    ${JAVA21_CONSOLE_ENCODING} \
     ${ADD_OPENS} \
     ${LOGBACK} \
     ${JVM_SECURITY_PROPERTIES} \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -93,7 +93,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -106,7 +105,7 @@ then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 fi
 

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -93,6 +93,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -103,6 +104,9 @@ then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 fi
 
@@ -257,6 +261,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} ${JAVA_BIN_DIR}java \
   -XX:+ExitOnOutOfMemoryError \
   ${QUICK_START} \
   ${SHARED_CLASSES_OPTS} \
+  ${JAVA21_CONSOLE_ENCODING} \
   ${ADD_OPENS} \
   ${LOGBACK} \
   ${JVM_SECURITY_PROPERTIES} \

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -113,7 +113,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
 
@@ -125,7 +124,7 @@ if [ "$(uname)" = "OS/390" ]; then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 fi
 

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -113,6 +113,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
 
@@ -122,6 +123,9 @@ if [ "$(uname)" = "OS/390" ]; then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 fi
 
@@ -270,6 +274,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} ${JAVA_BIN_DIR}java \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \
     ${SHARED_CLASSES_OPTS} \
+    ${JAVA21_CONSOLE_ENCODING} \
     ${ADD_OPENS} \
     ${LOGBACK} \
     ${JVM_SECURITY_PROPERTIES} \

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -131,7 +131,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 GATEWAY_LOADER_PATH=${COMMON_LIB}
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
@@ -144,7 +143,7 @@ if [ "$(uname)" = "OS/390" ]; then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 fi
 

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -131,6 +131,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 GATEWAY_LOADER_PATH=${COMMON_LIB}
 if [ "$(uname)" = "OS/390" ]; then
     QUICK_START="-Xquickstart"
@@ -141,6 +142,9 @@ if [ "$(uname)" = "OS/390" ]; then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 fi
 
@@ -308,6 +312,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} ${JAVA_BIN_DIR}java \
     -XX:+ExitOnOutOfMemoryError \
     ${QUICK_START} \
     ${SHARED_CLASSES_OPTS} \
+    ${JAVA21_CONSOLE_ENCODING} \
     ${ADD_OPENS} \
     ${LOGBACK} \
     ${JVM_SECURITY_PROPERTIES} \

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -142,6 +142,7 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
+JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -153,6 +154,9 @@ then
 
     if [ $JAVA_VERSION -ge 65 ]; then # Java 21
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
+        # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
+        # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
     fi
 else
     ZAAS_LOADER_PATH=${COMMON_LIB}
@@ -323,6 +327,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${ZAAS_CODE} ${JAVA_BIN_DIR}java \
     -Xms${ZWE_configs_heap_init:-32}m -Xmx${ZWE_configs_heap_max:-512}m \
     ${QUICK_START} \
     ${SHARED_CLASSES_OPTS} \
+    ${JAVA21_CONSOLE_ENCODING} \
     ${ADD_OPENS} \
     ${LOGBACK} \
     ${JVM_SECURITY_PROPERTIES} \

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -142,7 +142,6 @@ else
 fi
 
 ZOWE_CONSOLE_LOG_CHARSET=UTF-8
-JAVA21_CONSOLE_ENCODING=""
 if [ "$(uname)" = "OS/390" ]
 then
     QUICK_START=-Xquickstart
@@ -156,7 +155,7 @@ then
         ZOWE_CONSOLE_LOG_CHARSET=IBM-1047
         # Java 21+ changed default encoding to UTF-8 (JEP 400). Set console encoding
         # to EBCDIC for z/OS SYSPRINT to prevent garbled characters in early startup logs
-        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=IBM-1047 -Dstderr.encoding=IBM-1047"
+        JAVA21_CONSOLE_ENCODING="-Dstdout.encoding=${ZOWE_CONSOLE_LOG_CHARSET} -Dstderr.encoding=${ZOWE_CONSOLE_LOG_CHARSET}"
     fi
 else
     ZAAS_LOADER_PATH=${COMMON_LIB}


### PR DESCRIPTION
# Description
Java 21 (JEP 400) changed the default charset to UTF-8 for stdout/stderr. The z/OS SYSPRINT console expects EBCDIC (IBM-1047) encoding, causing UTF-8 bytes to display incorrectly. The existing `-Dlogging.charset.console` property only configures Logback's encoder and takes effect after Spring Boot initialization, not at JVM startup.

Added JVM-level properties for Java 21+ on z/OS:
- `-Dstdout.encoding=IBM-1047`
- `-Dstderr.encoding=IBM-1047`
These properties configure the JVM's `System.out` and `System.err` streams immediately at startup, before any application code runs, ensuring all console output uses the correct EBCDIC encoding.

Linked to #4419 

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc