### PR TITLE
fix: enablers release process

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -52,7 +52,7 @@ jobs:
               shell: bash
               run: |
                   ./gradlew release -x test $RELEASE_ARGS -Prelease.useAutomaticVersion=true -Prelease.scope=${{ github.event.inputs.scope || env.DEFAULT_SCOPE }} -Pzowe.deploy.username=$ARTIFACTORY_USERNAME -Pzowe.deploy.password=$ARTIFACTORY_PASSWORD -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD
-                  if [ -n "$RELEASE_ARGS" ]; then
+                  if [ -z "$RELEASE_ARGS" ]; then
                      echo "RELEASE_ARGS is empty. Skipping api catalog .env update."
                   else
                       released_version=$(cat gradle.properties | grep "version=" | sed "s/version=//g")

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -17,7 +17,7 @@ on:
                     - major
                 default: 'patch'
             enablers:
-                description: 'Release enablers only.'
+                description: 'Release API ML and enablers.'
                 required: false
                 type: boolean
                 default: false

--- a/build.gradle
+++ b/build.gradle
@@ -337,6 +337,8 @@ task runChaoticHATests(dependsOn: ":integration-tests:runChaoticHATests") {
 clean.dependsOn nodejsClean
 
 publishAllVersions.dependsOn publishZoweServerArtifacts
+
+publishAllSDKVersions.dependsOn publishZoweServerArtifacts
 publishAllSDKVersions.dependsOn publishSDKArtifacts
 
 //-----------Release part start
@@ -403,7 +405,7 @@ release {
     }
 }
 
-if(project.hasProperty('releaseEnablers')) {
+if (project.hasProperty('releaseEnablers')) {
     afterReleaseBuild.dependsOn publishAllSDKVersions
 } else {
     afterReleaseBuild.dependsOn publishAllVersions

--- a/enabler.properties
+++ b/enabler.properties
@@ -1,2 +1,2 @@
 
-version=3.3.22
+version=3.3.23-SNAPSHOT

--- a/enabler.properties
+++ b/enabler.properties
@@ -1,2 +1,2 @@
 
-version=3.3.22-SNAPSHOT
+version=3.3.22


### PR DESCRIPTION
# Description

Releasing the enablers out of sync from API ML has a couple of issues related to it:
- if API ML contains changes neeed by the enablers (such as apiml-utility) it needs to be released first anyway.
- By default, the java enabler is picking up latest version, which when in-sync it was a release version, but now it may resolve a snapshot version. This should be fixed also in gradle to prevent it from resolving snapshots.

This PR makes it so API ML is released before enablers, but keeping the enablers release as optional.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules