### PR TITLE
fix: Accept VSAM details stored in apiml and caching-service namespaces

### DIFF
--- a/apiml-package/src/main/resources/bin/start.sh
+++ b/apiml-package/src/main/resources/bin/start.sh
@@ -173,7 +173,7 @@ else
 fi
 
 # VSAM file name for caching
-if [ -n "${ZWE_configs_storage_vsam_name}" ]; then
+if [ -n "${ZWE_configs_storage_vsam_name:-${ZWE_components_caching_service_storage_vsam_name}}" ]; then
     VSAM_FILE_NAME=//\'${ZWE_configs_storage_vsam_name:-${ZWE_components_caching_service_storage_vsam_name}}\'
 fi
 


### PR DESCRIPTION
# Description

VSAM configuration for single-service deployment can be provided either in components.apiml or components.caching-service, this fix makes sure that they are read in both scenarios.

Linked to #4312

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
