### PR TITLE
fix: allow to specify number of infinispan index files, use truststore as truststore

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2256,7 +2256,6 @@ jobs:
                     CACHING_STORAGE_INFINISPAN_INITIALHOSTS: "apiml[7600],apiml-2[7600]"
                     CACHING_STORAGE_MODE: "infinispan"
                     JGROUPS_BIND_ADDRESS: "apiml"
-                    ZWE_haInstance_id: dvojka
             apiml-2:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -2272,7 +2271,6 @@ jobs:
                     JGROUPS_BIND_ADDRESS: "apiml-2"
                     APIML_SERVICE_HOSTNAME: "apiml-2"
                     logbackService: ZWEAGW2
-                    ZWE_haInstance_id: trojka
             api-catalog-services:
                 image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -297,6 +297,7 @@ jobs:
                     JGROUPS_BIND_PORT: 7600
                     JGROUPS_BIND_ADDRESS: apiml
                     JGROUPS_KEYEXCHANGE_PORT: 7601
+                    ZWE_haInstance_id: jednotka 
             apiml-2:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -318,6 +319,7 @@ jobs:
                     JGROUPS_BIND_PORT: 7600
                     JGROUPS_BIND_ADDRESS: apiml-2
                     JGROUPS_KEYEXCHANGE_PORT: 7601
+                    ZWE_haInstance_id: dvojka
             apiml-3:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -297,7 +297,6 @@ jobs:
                     JGROUPS_BIND_PORT: 7600
                     JGROUPS_BIND_ADDRESS: apiml
                     JGROUPS_KEYEXCHANGE_PORT: 7601
-                    ZWE_haInstance_id: jednotka 
             apiml-2:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -319,7 +318,6 @@ jobs:
                     JGROUPS_BIND_PORT: 7600
                     JGROUPS_BIND_ADDRESS: apiml-2
                     JGROUPS_KEYEXCHANGE_PORT: 7601
-                    ZWE_haInstance_id: dvojka
             apiml-3:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -2258,6 +2256,7 @@ jobs:
                     CACHING_STORAGE_INFINISPAN_INITIALHOSTS: "apiml[7600],apiml-2[7600]"
                     CACHING_STORAGE_MODE: "infinispan"
                     JGROUPS_BIND_ADDRESS: "apiml"
+                    ZWE_haInstance_id: dvojka
             apiml-2:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -2273,6 +2272,7 @@ jobs:
                     JGROUPS_BIND_ADDRESS: "apiml-2"
                     APIML_SERVICE_HOSTNAME: "apiml-2"
                     logbackService: ZWEAGW2
+                    ZWE_haInstance_id: trojka
             api-catalog-services:
                 image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2256,6 +2256,7 @@ jobs:
                     CACHING_STORAGE_INFINISPAN_INITIALHOSTS: "apiml[7600],apiml-2[7600]"
                     CACHING_STORAGE_MODE: "infinispan"
                     JGROUPS_BIND_ADDRESS: "apiml"
+                    CACHING_STORAGE_INFINISPAN_NUMSEGMENTS: "16"
             apiml-2:
                 image: ghcr.io/balhar-jakub/apiml:${{ github.run_id }}-${{ github.run_number }}
                 env:
@@ -2271,6 +2272,7 @@ jobs:
                     JGROUPS_BIND_ADDRESS: "apiml-2"
                     APIML_SERVICE_HOSTNAME: "apiml-2"
                     logbackService: ZWEAGW2
+                    CACHING_STORAGE_INFINISPAN_NUMSEGMENTS: "16"
             api-catalog-services:
                 image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
                 volumes:

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -97,6 +97,18 @@ bootRun {
         args project.args.split(',')
     }
 
+    jvmArgs([
+        '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+        '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
+        '--add-opens=java.base/java.net=ALL-UNNAMED'
+    ])
+    
     debugOptions {
         port = 5016
         suspend = false

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -104,6 +104,9 @@ public class InfinispanConfig implements InitializingBean {
     @Value("${caching.storage.infinispan.distributedSyncTimeoutSecs:360}")
     private int distributedSyncTimeout;
 
+    @Value("${caching.storage.infinispan.segmented:false}")
+    private boolean segmented;
+
     private AtomicReference<ClusteredLock> zoweInvalidatedTokenLock = new AtomicReference<>();
 
     @Override
@@ -153,6 +156,7 @@ public class InfinispanConfig implements InitializingBean {
         holder.newConfigurationBuilder("default")
             .persistence()
             .addSoftIndexFileStore()
+            .segmented(segmented)
             .clustering().cacheMode(CacheMode.REPL_SYNC);
         holder.getGlobalConfigurationBuilder().defaultCacheName("default");
         holder.getGlobalConfigurationBuilder().transport().stack("prod").distributedSyncTimeout(distributedSyncTimeout, TimeUnit.SECONDS);
@@ -180,9 +184,9 @@ public class InfinispanConfig implements InitializingBean {
         System.setProperty("infinispan.ssl.keyStore", keyStore);
         System.setProperty("infinispan.ssl.keyStorePassword", keyStorePass);
 
-        System.setProperty("infinispan.ssl.trustStoreType", keyStoreType);
-        System.setProperty("infinispan.ssl.trustStore", keyStore);
-        System.setProperty("infinispan.ssl.trustStorePassword", keyStorePass);
+        System.setProperty("infinispan.ssl.trustStoreType", trustStoreType);
+        System.setProperty("infinispan.ssl.trustStore", trustStore);
+        System.setProperty("infinispan.ssl.trustStorePassword", trustStorePass);
 
         List<String> caches;
         if (applicationInfo.isModulith()) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -167,7 +167,7 @@ public class InfinispanConfig implements InitializingBean {
         ConfigurationBuilder builder = new ConfigurationBuilder();
         builder
             .encoding().mediaType(MediaType.APPLICATION_JBOSS_MARSHALLING_TYPE)
-            .persistence().addSoftIndexFileStore().clustering()
+            .persistence().addSoftIndexFileStore().segmented(segmented).clustering()
             .clustering().cacheMode(CacheMode.REPL_SYNC);
         return builder;
     }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -104,8 +104,8 @@ public class InfinispanConfig implements InitializingBean {
     @Value("${caching.storage.infinispan.distributedSyncTimeoutSecs:360}")
     private int distributedSyncTimeout;
 
-    @Value("${caching.storage.infinispan.segmented:true}")
-    private boolean segmented;
+    @Value("${caching.storage.infinispan.numSegments:256}")
+    private int numSegments;
 
     private AtomicReference<ClusteredLock> zoweInvalidatedTokenLock = new AtomicReference<>();
 
@@ -156,8 +156,9 @@ public class InfinispanConfig implements InitializingBean {
         holder.newConfigurationBuilder("default")
             .persistence()
             .addSoftIndexFileStore()
-            .segmented(segmented)
-            .clustering().cacheMode(CacheMode.REPL_SYNC).hash().numSegments(16);
+            .clustering()
+            .cacheMode(CacheMode.REPL_SYNC)
+            .hash().numSegments(numSegments);
         holder.getGlobalConfigurationBuilder().defaultCacheName("default");
         holder.getGlobalConfigurationBuilder().transport().stack("prod").distributedSyncTimeout(distributedSyncTimeout, TimeUnit.SECONDS);
         return holder;
@@ -167,8 +168,11 @@ public class InfinispanConfig implements InitializingBean {
         ConfigurationBuilder builder = new ConfigurationBuilder();
         builder
             .encoding().mediaType(MediaType.APPLICATION_JBOSS_MARSHALLING_TYPE)
-            .persistence().addSoftIndexFileStore().segmented(segmented).clustering()
-            .clustering().cacheMode(CacheMode.REPL_SYNC).hash().numSegments(16);
+            .persistence()
+            .addSoftIndexFileStore()
+            .clustering()
+            .cacheMode(CacheMode.REPL_SYNC)
+            .hash().numSegments(numSegments);
         return builder;
     }
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -104,7 +104,7 @@ public class InfinispanConfig implements InitializingBean {
     @Value("${caching.storage.infinispan.distributedSyncTimeoutSecs:360}")
     private int distributedSyncTimeout;
 
-    @Value("${caching.storage.infinispan.segmented:false}")
+    @Value("${caching.storage.infinispan.segmented:true}")
     private boolean segmented;
 
     private AtomicReference<ClusteredLock> zoweInvalidatedTokenLock = new AtomicReference<>();

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -157,7 +157,7 @@ public class InfinispanConfig implements InitializingBean {
             .persistence()
             .addSoftIndexFileStore()
             .segmented(segmented)
-            .clustering().cacheMode(CacheMode.REPL_SYNC);
+            .clustering().cacheMode(CacheMode.REPL_SYNC).hash().numSegments(16);
         holder.getGlobalConfigurationBuilder().defaultCacheName("default");
         holder.getGlobalConfigurationBuilder().transport().stack("prod").distributedSyncTimeout(distributedSyncTimeout, TimeUnit.SECONDS);
         return holder;
@@ -168,7 +168,7 @@ public class InfinispanConfig implements InitializingBean {
         builder
             .encoding().mediaType(MediaType.APPLICATION_JBOSS_MARSHALLING_TYPE)
             .persistence().addSoftIndexFileStore().segmented(segmented).clustering()
-            .clustering().cacheMode(CacheMode.REPL_SYNC);
+            .clustering().cacheMode(CacheMode.REPL_SYNC).hash().numSegments(16);
         return builder;
     }
 


### PR DESCRIPTION
# Description
Allow users to configure number of segments for infinispan storage. This change allows to decrease number of index files.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
