### PR TITLE
fix: Skip validation cache when token can not be validated

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/JwtUtils.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/util/JwtUtils.java
@@ -45,6 +45,21 @@ public class JwtUtils {
      * @throws TokenNotValidException in case of invalid input, or TokenExpireException if JWT is expired
      */
     public JWTClaimsSet getJwtClaims(String jwt) {
+        return getJwtClaimsInternal(jwt, true);
+    }
+
+    /**
+     * This method reads the claims without validating the token signature. It should be used only if the validity was checked in the calling code. Ignores token expiration.
+     *
+     * @param jwt token to be parsed
+     * @return parsed claims
+     * @throws TokenNotValidException in case of invalid input
+     */
+    public JWTClaimsSet getJwtClaimsIgnoreExpiration(String jwt) {
+        return getJwtClaimsInternal(jwt, false);
+    }
+
+    private JWTClaimsSet getJwtClaimsInternal(String jwt, boolean validateExpiration) {
         /*
          * Removes signature, because we don't have key to verify z/OS tokens, and we just need to read claim.
          * Verification is done by SAF itself. JWT library doesn't parse signed key without verification.
@@ -54,9 +69,10 @@ public class JwtUtils {
             var token = JWTParser.parse(jwtWithoutSignature);
             var claims = token.getJWTClaimsSet();
 
-            if (claims.getExpirationTime().toInstant().isBefore(Instant.now())) {
+            if (validateExpiration && claims.getExpirationTime().toInstant().isBefore(Instant.now())) {
                 throw new ExpiredJWTException("JWT token is expired");
             }
+
             return token.getJWTClaimsSet();
         } catch (RuntimeException | ParseException | BadJWTException exception) {
             throw handleJwtParserException(exception);

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/PassticketSchemeTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/schemes/PassticketSchemeTest.java
@@ -62,10 +62,10 @@ public class PassticketSchemeTest implements TestWithStartedInstances {
     public static Stream<Arguments> getTokens() {
         return Stream.of(
             Arguments.of("validJwt", SC_OK, Matchers.blankOrNullString()),
-            Arguments.of("noSignJwt", SC_OK, startsWith("ZWEAG160E")),
-            Arguments.of("publicKeySignedJwt", SC_OK, startsWith("ZWEAG160E")),
+            Arguments.of("noSignJwt", SC_OK, startsWith("ZWEAO402E")),
+            Arguments.of("publicKeySignedJwt", SC_OK, startsWith("ZWEAO402E")),
             Arguments.of("changedRealmJwt", SC_OK, startsWith("ZWEAO402E")),
-            Arguments.of("changedUserJwt", SC_OK, startsWith("ZWEAG160E")),
+            Arguments.of("changedUserJwt", SC_OK, startsWith("ZWEAO402E")),
             Arguments.of("personalAccessToken", SC_OK, Matchers.blankOrNullString())
         );
     }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
@@ -68,6 +68,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.zowe.apiml.security.common.util.JwtUtils.getJwtClaims;
+import static org.zowe.apiml.security.common.util.JwtUtils.getJwtClaimsIgnoreExpiration;
 import static org.zowe.apiml.security.common.util.JwtUtils.handleJwtParserException;
 import static org.zowe.apiml.zaas.security.service.zosmf.ZosmfService.TokenType.JWT;
 import static org.zowe.apiml.zaas.security.service.zosmf.ZosmfService.TokenType.LTPA;
@@ -375,26 +376,35 @@ public class AuthenticationService {
         if (jwtToken != null && validationJwtTokenCache != null) {
             Cache.ValueWrapper cached = validationJwtTokenCache.get(jwtToken);
             if (cached != null) {
-                log.debug("JWT found in the cache.");
-                return (TokenAuthentication) cached.get();
+                var tokenAuthentication = (TokenAuthentication) cached.get();
+                log.debug("JWT found in the cache. Is authenticated: {}", tokenAuthentication.isAuthenticated());
+                return tokenAuthentication;
             }
         }
 
-        QueryResponse queryResponse = parseJwtToken(jwtToken);
-        boolean isValid = switch (queryResponse.getSource()) {
-            case ZOWE -> {
-                validateAndParseLocalJwtToken(jwtToken);
-                yield true;
+        try {
+            QueryResponse queryResponse = parseJwtToken(jwtToken);
+            switch (queryResponse.getSource()) {
+                case ZOWE -> validateAndParseLocalJwtToken(jwtToken);
+                case ZOSMF -> zosmfService.validate(jwtToken);
+                default -> throw new TokenNotValidException("Unknown token type.");
             }
-            case ZOSMF -> zosmfService.validate(jwtToken);
-            default -> throw new TokenNotValidException("Unknown token type.");
-        };
-        boolean notInvalidated = !isInvalidated(jwtToken);
+            boolean notInvalidated = !isInvalidated(jwtToken);
+            return processJWTvalidationResult(queryResponse, jwtToken, notInvalidated);
+        } catch (TokenNotValidException | TokenExpireException ex) {
+            log.debug("JWT token is not valid", ex);
+            processJWTvalidationResult(parseJwtTokenIgnoreExpiration(jwtToken), jwtToken, false);
+            throw ex;
+        }
+    }
+
+    private TokenAuthentication processJWTvalidationResult(QueryResponse queryResponse, String jwtToken, Boolean tokenValid) {
         TokenAuthentication tokenAuthentication = new TokenAuthentication(queryResponse.getUserId(), jwtToken, TokenAuthentication.Type.JWT);
-        tokenAuthentication.setAuthenticated(notInvalidated && isValid);
+        tokenAuthentication.setAuthenticated(tokenValid);
 
         putValidationCache(jwtToken, tokenAuthentication);
         log.debug("JWT validation result: {}", tokenAuthentication.isAuthenticated());
+
         return tokenAuthentication;
     }
 
@@ -456,10 +466,9 @@ public class AuthenticationService {
         if (token == null) {
             throw new TokenNotValidException("Null token.");
         }
-        parseJwtToken(token.getCredentials()); // throws on expired token, this needs to happen before cache
-        
+
         var tokenAuth = validateJwtToken(token.getCredentials());
-        
+
         return tokenAuth;
     }
 
@@ -472,9 +481,21 @@ public class AuthenticationService {
      */
     public QueryResponse parseJwtToken(String jwtToken) {
         log.debug("Parsing JWT: ...{}", StringUtils.right(jwtToken, 15));
-        var claims = getJwtClaims(jwtToken);
-        return parseQueryResponse(claims);
+        return parseQueryResponse(getJwtClaims(jwtToken));
     }
+
+    /**
+     * Parses the JWT token and return a {@link QueryResponse} object containing the domain, user id, type (Zowe / z/OSMF),
+     * date of creation and date of expiration. Does not validate expiration.
+     *
+     * @param jwtToken the JWT token
+     * @return the query response
+     */
+    public QueryResponse parseJwtTokenIgnoreExpiration(String jwtToken) {
+        log.debug("Parsing JWT: ...{}", StringUtils.right(jwtToken, 15));
+        return parseQueryResponse(getJwtClaimsIgnoreExpiration(jwtToken));
+    }
+
 
     public QueryResponse parseQueryResponse(JWTClaimsSet claims) {
         Object scopesObject = claims.getClaim(SCOPES);
@@ -595,7 +616,6 @@ public class AuthenticationService {
 
         return Optional.empty();
     }
-
 
     /**
      * Calculate the expiration time

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
@@ -60,11 +60,7 @@ import javax.management.ServiceNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.zowe.apiml.zaas.security.service.zosmf.ZosmfService.TokenType.JWT;
 import static org.zowe.apiml.zaas.security.service.zosmf.ZosmfService.TokenType.LTPA;
@@ -487,9 +483,19 @@ public class ZosmfService extends AbstractZosmfService {
         return meAsProxy.jwtEndpointExists(headers);
     }
 
+    /**
+     * Validates jwt token with all available strategies.
+     *
+     * @param token
+     * @return true if at least one validation strategy evaluates token as valid
+     * @throws ServiceNotAccessibleException if all validation strategies failed because of an error
+     * @throws TokenNotValidException if all token validation strategies evaluate token as invalid
+     */
     public boolean validate(String token) {
         log.debug("ZosmfService validating token: ....{}", StringUtils.right(token, 15));
         TokenValidationRequest request = new TokenValidationRequest(TokenType.JWT, token, getURI(getZosmfServiceId()), getEndpointMap());
+
+        var isTokenValid = Optional.<Boolean>empty();
 
         for (TokenValidationStrategy s : tokenValidationStrategy) {
             log.debug("Trying to validate token with strategy: {}", s.toString());
@@ -497,14 +503,27 @@ public class ZosmfService extends AbstractZosmfService {
                 s.validate(request);
                 if (requestIsAuthenticated(request)) {
                     log.debug("Token validity has been successfully determined: {}", request.getAuthenticated());
-                    return true;
+                    isTokenValid = Optional.of(true);
+                    break;
+                } else {
+                    isTokenValid = Optional.of(false);
                 }
             } catch (RuntimeException re) {
                 log.debug("Exception during token validation:", re);
             }
         }
+
         log.debug("Token validation strategies exhausted, final validation status: {}", request.getAuthenticated());
-        return false;
+
+        if (isTokenValid.isPresent()) {
+            if (isTokenValid.get()) {
+                return true;
+            } else {
+                throw new TokenNotValidException("Token is not valid by any of zosmf validation strategies");
+            }
+        }
+
+        throw new ServiceNotAccessibleException("All token validation strategies has failed with " + request.getZosmfBaseUrl());
     }
 
     private boolean requestIsAuthenticated(TokenValidationRequest request) {

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
@@ -32,6 +32,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpHeaders;
@@ -48,6 +49,7 @@ import org.zowe.apiml.product.constants.CoreService;
 import org.zowe.apiml.product.gateway.GatewayClient;
 import org.zowe.apiml.security.SecurityUtils;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import org.zowe.apiml.security.common.token.QueryResponse;
 import org.zowe.apiml.security.common.token.TokenAuthentication;
 import org.zowe.apiml.security.common.token.TokenExpireException;
@@ -108,8 +110,11 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
     @Mock
     private CacheManager cacheManager;
     @Mock
+    private Cache validationJwtTokenCache;
+    @Mock
+    private Cache invalidatedJwtTokensCache;
+    @Mock
     private Clock clock;
-
 
     static {
         KeyPair keyPair = SecurityUtils.generateKeyPair("RSA", 2048);
@@ -124,10 +129,15 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
         authConfigurationProperties = new AuthConfigurationProperties();
         authConfigurationProperties.getZosmf().setServiceId(ZOSMF);
 
+        when(cacheManager.getCache("validationJwtToken")).thenReturn(validationJwtTokenCache);
+        when(cacheManager.getCache("invalidatedJwtTokens")).thenReturn(invalidatedJwtTokensCache);
+
         authService = new AuthenticationService(
             applicationContext, authConfigurationProperties, jwtSecurityInitializer,
             zosmfService, eurekaClient, restTemplate, cacheManager, cacheUtils, clock
         );
+        authService.afterPropertiesSet();
+
         scopes = new HashSet<>();
         scopes.add("Service1");
         scopes.add("Service2");
@@ -140,7 +150,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
         @BeforeEach
         void setup() {
             stubJWTSecurityForSign();
-            
+
         }
 
         @Test
@@ -159,6 +169,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             TokenAuthentication token = new TokenAuthentication(jwtToken);
             TokenAuthentication jwtValidation = authService.validateJwtToken(token);
 
+            verify(validationJwtTokenCache, times(1)).put(jwtToken, jwtValidation);
             assertEquals(USER, jwtValidation.getPrincipal());
             assertEquals(jwtValidation.getCredentials(), jwtToken);
             assertTrue(jwtValidation.isAuthenticated());
@@ -206,11 +217,14 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             stubJWTSecurityForSign();
             String jwtToken = authService.createJwtToken(USER, DOMAIN, LTPA);
             String brokenToken = jwtToken + "not";
-            TokenAuthentication token = new TokenAuthentication(brokenToken);
+            TokenAuthentication tokenAuthentication = new TokenAuthentication(brokenToken);
             assertThrows(
                 TokenNotValidException.class,
-                () -> authService.validateJwtToken(token)
+                () -> authService.validateJwtToken(tokenAuthentication)
             );
+            var invalidTokenAuthentication = new TokenAuthentication(USER, brokenToken, TokenAuthentication.Type.JWT);
+            invalidTokenAuthentication.setAuthenticated(false);
+            verify(validationJwtTokenCache, times(1)).put(brokenToken ,invalidTokenAuthentication);
         }
 
         @Test
@@ -219,15 +233,19 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
                 TokenNotValidException.class,
                 () -> authService.validateJwtToken((TokenAuthentication) null)
             );
+            verify(validationJwtTokenCache, never()).put(any(),any());
         }
 
         @Test
         void givenExpiredToken_thenThrowsTokenExpireException() {
             TokenAuthentication token = new TokenAuthentication(createExpiredJwtToken(privateKey));
+            var invalidTokenAuthentication = new TokenAuthentication(null, token.getCredentials(), TokenAuthentication.Type.JWT);
+            invalidTokenAuthentication.setAuthenticated(false);
             assertThrows(
                 TokenExpireException.class,
-                () -> authService.validateJwtToken(token)
+                () -> authService.validateJwtToken(token.getCredentials())
             );
+            verify(validationJwtTokenCache, times(1)).put(token.getCredentials(),invalidTokenAuthentication);
         }
 
         @Test
@@ -248,8 +266,8 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
                 TokenNotValidException.class,
                 () -> authService.validateJwtToken((String) null)
             );
+            verify(validationJwtTokenCache, never()).put(any(),any());
         }
-
     }
 
     @Nested
@@ -439,6 +457,8 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
 
             assertEquals("Invalid Credentials", exception.getMessage());
             verify(zosmfService, times(1)).invalidate(ZosmfService.TokenType.JWT, token);
+            verify(validationJwtTokenCache, never()).evict(any());
+            verify(invalidatedJwtTokensCache, never()).put(any(), any());
         }
 
         @Test
@@ -473,6 +493,8 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
 
             assertTrue(authService.invalidateJwtToken(token, false));
             verify(zosmfService, times(1)).invalidate(ZosmfService.TokenType.JWT, token);
+            verify(validationJwtTokenCache, times(1)).evict(token);
+            verify(invalidatedJwtTokensCache, times(1)).put(token, Boolean.TRUE);
         }
 
         @Test
@@ -483,8 +505,9 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
 
             assertTrue(authService.invalidateJwtToken(token, false));
             verify(zosmfService, times(1)).invalidate(ZosmfService.TokenType.LTPA, LTPA_TOKEN);
+            verify(validationJwtTokenCache, times(1)).evict(token);
+            verify(invalidatedJwtTokensCache, times(1)).put(token, Boolean.TRUE);
         }
-
 
         @Test
         void thenValidateZosmfJwtToken() {
@@ -499,11 +522,26 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             assertEquals(zosmfJwt, tokenAuthentication.getCredentials());
             assertEquals(userId, tokenAuthentication.getPrincipal());
             verify(zosmfService, times(1)).validate(zosmfJwt);
+            verify(validationJwtTokenCache, times(1)).put(zosmfJwt, tokenAuthentication);
         }
-
     }
 
     @Nested
+    class GivenZosmfTokenValidationFails {
+        @Test
+        void whenValidationFails_thenDoNotCacheResult() {
+            stubJWTSecurityForSign();
+            authConfigurationProperties.getTokenProperties().setIssuer(ZOSMF);
+            String token = authService.createJwtToken("user", DOMAIN, null);
+
+            when(zosmfService.validate(token)).thenThrow(new ServiceNotAccessibleException("All validation strategies failed"));
+
+            assertThrows(ServiceNotAccessibleException.class, () -> authService.validateJwtToken(token));
+            verify(validationJwtTokenCache, never()).put(any(), any());
+        }
+    }
+
+        @Nested
     class GivenTokenOriginTest {
 
         private static final String TOKEN = "some_token";
@@ -537,11 +575,6 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
                 assertThrows(TokenNotValidException.class, () -> authService.getTokenOrigin(TOKEN));
             }
         }
-    }
-
-    void stubJWTSecurityForSignAndVerify() {
-        stubJWTSecurityForSign();
-        when(jwtSecurityInitializer.getJwtPublicKey()).thenReturn(publicKey);
     }
 
     void stubJWTSecurityForSign() {
@@ -627,7 +660,6 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
         assertTokenAuthentication.accept(tokenAuthentication);
     }
 
-
     @Nested
     class GivenDistributedInvalidationTest {
 
@@ -698,7 +730,5 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             assertFalse(authService.invalidateJwtToken(token, true));
 
         }
-
     }
-
 }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfServiceTest.java
@@ -93,7 +93,6 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -523,33 +522,66 @@ class ZosmfServiceTest {
         }
 
         @Test
-        void givenException_thenHandleExceptions() {
-            ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(Collections.singletonList(tokenValidationStrategy1));
+        void givenFirstValidationStrategyFailed_thenSecondSucceeds() {
+            ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
 
             doThrow(RuntimeException.class).when(tokenValidationStrategy1).validate(any());
-            assertDoesNotThrow(() -> zosmfService.validate("TOKN"));
+            doValidate(tokenValidationStrategy2, TokenValidationRequest.STATUS.AUTHENTICATED);
+
+            var validationResult = assertDoesNotThrow(() -> zosmfService.validate("TOKN"));
+            assertTrue(validationResult);
+
+            verify(tokenValidationStrategy1, times(1)).validate(any());
+            verify(tokenValidationStrategy2, times(1)).validate(any());
         }
+
+        @Test
+        void givenAllValidationStrategiesFail_thenThrowException() {
+            ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
+
+            doThrow(RuntimeException.class).when(tokenValidationStrategy1).validate(any());
+            doThrow(RuntimeException.class).when(tokenValidationStrategy2).validate(any());
+
+            assertThrows(ServiceNotAccessibleException.class, () -> zosmfService.validate("TOKN"));
+
+            verify(tokenValidationStrategy1, times(1)).validate(any());
+            verify(tokenValidationStrategy2, times(1)).validate(any());
+        }
+
+        @Test
+        void givenAllValidationStrategiesReturnInvalid_thenReturnFalse() {
+            ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
+
+            doValidate(tokenValidationStrategy1, TokenValidationRequest.STATUS.INVALID);
+            doValidate(tokenValidationStrategy2, TokenValidationRequest.STATUS.INVALID);
+
+            assertThrows(TokenNotValidException.class, () -> zosmfService.validate("TOKN"));
+
+            verify(tokenValidationStrategy1, times(1)).validate(any());
+            verify(tokenValidationStrategy2, times(1)).validate(any());
+        }
+
 
         @Test
         void givenOneValidationStrategy_thenReturnValidationStrategyResult() {
             ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(Collections.singletonList(tokenValidationStrategy1));
 
             //UNKNOWN by default
-            assertThat(zosmfService.validate("TOKN"), is(false));
+            assertThrows(TokenNotValidException.class, () -> zosmfService.validate("TOKN"));
 
             doValidate(tokenValidationStrategy1, TokenValidationRequest.STATUS.AUTHENTICATED);
 
             assertThat(zosmfService.validate("TOKN"), is(true));
 
             doValidate(tokenValidationStrategy1, TokenValidationRequest.STATUS.INVALID);
-            assertThat(zosmfService.validate("TOKN"), is(false));
+            assertThrows(TokenNotValidException.class, () -> zosmfService.validate("TOKN"));
         }
 
         @Test
         void givenFirstValidationStrategyAuthentications_thenDontUseSecondValidationStrategy() {
             ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
 
-            assertThat(zosmfService.validate("TOKN"), is(false));
+            assertThrows(TokenNotValidException.class, () -> zosmfService.validate("TOKN"));
             verify(tokenValidationStrategy1, times(1)).validate(any());
             verify(tokenValidationStrategy2, times(1)).validate(any());
 
@@ -572,18 +604,9 @@ class ZosmfServiceTest {
         }
 
         @Test
-        void doesNotRethrowExceptionsFromValidationStrategies() {
-            ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(Collections.singletonList(tokenValidationStrategy1));
-            TokenValidationRequest request = mock(TokenValidationRequest.class);
-
-            lenient().doThrow(RuntimeException.class).when(tokenValidationStrategy1).validate(request);
-            assertDoesNotThrow(() -> zosmfService.validate("TOKN"));
-        }
-
-        @Test
         void suppliesValidationRequestWithVerifiedEndpointsList() {
             ZosmfService zosmfService = getZosmfServiceWithValidationStrategy(validationStrategyList);
-            zosmfService.validate("TOKN");
+            assertThrows(TokenNotValidException.class, () -> zosmfService.validate("TOKN"));
             verify(tokenValidationStrategy1).validate(argThat(request -> !request.getEndpointExistenceMap().isEmpty()));
         }
 


### PR DESCRIPTION
# Description

Superseded by #4548 

When the zosmf jwt token could not be validated because of an error (e.g. zosmf not available), the validation result was false and the value saved in cache resulting in valid token being considered invalid.

This PR:
- fixes the issue described above - when the token cannot be validated, the result is not cached
- the flow is unified for apiml and zosmf jwt tokens

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
