### PR TITLE
fix: Do not call of caching service during routing to check sticky session if not needed

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -16,6 +16,7 @@ import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.ExpiredJWTException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.RequestDataContext;
@@ -25,7 +26,6 @@ import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
-import org.zowe.apiml.constants.ApimlConstants;
 import org.zowe.apiml.gateway.caching.LoadBalancerCache;
 import org.zowe.apiml.gateway.caching.LoadBalancerCache.LoadBalancerCacheRecord;
 import reactor.core.publisher.Flux;
@@ -35,18 +35,12 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.zowe.apiml.constants.ApimlConstants.X_INSTANCEID;
 import static reactor.core.publisher.Flux.just;
-import static reactor.core.publisher.Mono.empty;
 
 /**
  * A sticky session load balancer that ensures requests from the same user are routed to the same service instance.
@@ -54,6 +48,7 @@ import static reactor.core.publisher.Mono.empty;
 @Slf4j
 public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInstanceListSupplier {
 
+    public static final String HEADER_PREFIX = "Bearer ";
     private static final String HEADER_NONE_SIGNATURE = Base64.getEncoder().encodeToString("{\"typ\":\"JWT\",\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8));
 
     private final LoadBalancerCache cache;
@@ -85,22 +80,44 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         if (serviceId == null) {
             return Flux.empty();
         }
-        AtomicReference<String> principal = new AtomicReference<>();
+
+        var requestContext = request.getContext();
+        var instanceId = getInstanceId(requestContext);
+        if (instanceId != null) {
+            // if instanceId is set in headers use it
+            try {
+                return delegate.get(request)
+                    .map(serviceInstances -> checkInstanceIdHeader(instanceId, serviceInstances));
+            } catch (ResponseStatusException ex) {
+                return Flux.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Service instance not found for the provided instance ID"));
+            }
+        }
+
+        var userId = getSub(requestContext);
+        if (userId == null) {
+            // if no userId is available return all
+            log.debug("No authentication present on request, not filtering the service: {}", serviceId);
+            return delegate.get(request);
+        }
+
         return delegate.get(request)
-            .flatMap(serviceInstances -> getSub(request.getContext())
-                .switchIfEmpty(Mono.just(""))
-                .flatMap(user -> {
-                    if (user == null || user.isEmpty()) {
-                        log.debug("No authentication present on request, not filtering the service: {}", serviceId);
-                        return empty();
-                    } else {
-                        principal.set(user);
-                        return cache.retrieve(user, serviceId).onErrorResume(t -> Mono.empty());
-                    }
-                })
-                .switchIfEmpty(Mono.just(LoadBalancerCacheRecord.NONE))
-                .flatMapMany(cacheRecord -> filterInstances(principal.get(), serviceId, cacheRecord, serviceInstances, request.getContext()))
-            )
+            .flatMap(serviceInstances -> {
+                if (serviceInstances.isEmpty()) {
+                    // no instances available - just return
+                    return Flux.just(serviceInstances);
+                }
+
+                boolean stickySession = lbTypeIsAuthentication(serviceInstances.iterator().next());
+                if (!stickySession) {
+                    // service does not support sticky session by userId, just return
+                    return Flux.just(serviceInstances);
+                }
+
+                return cache.retrieve(userId, serviceId)
+                    .onErrorResume(t -> Mono.empty())
+                    .flatMapMany(cacheRecord -> filterInstances(userId, serviceId, cacheRecord, serviceInstances))
+                    .switchIfEmpty(Flux.just(serviceInstances));
+            })
             .doOnError(e -> log.debug("Error in determining service instances", e));
     }
 
@@ -115,30 +132,23 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         return now.isAfter(cachedDate);
     }
 
-    private Mono<String> getSub(Object requestContext) {
+    private String getSub(Object requestContext) {
         if (requestContext instanceof RequestDataContext ctx) {
             var token = Optional.ofNullable(getTokenFromCookie(ctx))
                                 .orElseGet(() -> getTokenFromHeader(ctx));
-            return Mono.just(extractSubFromToken(token));
+            return extractSubFromToken(token);
         }
-        return Mono.just("");
+        return null;
     }
 
     private String getTokenFromCookie(RequestDataContext ctx) {
-        var tokens = ctx.getClientRequest().getCookies().get("apimlAuthenticationToken");
-        return tokens == null || tokens.isEmpty() ? null : tokens.get(0);
+        return ctx.getClientRequest().getCookies().getFirst("apimlAuthenticationToken");
     }
 
     private String getTokenFromHeader(RequestDataContext ctx) {
-        var authHeaderValues = ctx.getClientRequest().getHeaders().get(HttpHeaders.AUTHORIZATION);
-        var token = authHeaderValues == null || authHeaderValues.isEmpty() ? null : authHeaderValues.get(0);
-        if (token != null && token.startsWith(ApimlConstants.BEARER_AUTHENTICATION_PREFIX)) {
-            token = token.replaceFirst(ApimlConstants.BEARER_AUTHENTICATION_PREFIX, "").trim();
-            if (token.isEmpty()) {
-                return null;
-            }
-
-            return token;
+        var authHeaderValue = ctx.getClientRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (Strings.CS.startsWith(authHeaderValue, HEADER_PREFIX)) {
+            return authHeaderValue.substring(HEADER_PREFIX.length());
         }
         return null;
     }
@@ -157,27 +167,17 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         String user,
         String serviceId,
         LoadBalancerCacheRecord cacheRecord,
-        List<ServiceInstance> serviceInstances,
-        Object requestContext) {
-
-        Flux<List<ServiceInstance>> result;
-        if (shouldIgnore(serviceInstances, user)) {
-            var instanceId = getInstanceId(requestContext);
-            try {
-                return just(checkInstanceIdHeader(instanceId, serviceInstances));
-            } catch (ResponseStatusException ex) {
-                return Flux.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Service instance not found for the provided instance ID"));
+        List<ServiceInstance> serviceInstances
+    ) {
+        if (isNotBlank(cacheRecord.getInstanceId())) {
+            if (isTooOld(cacheRecord.getCreationTime())) {
+                return cache.delete(user, serviceId)
+                    .thenMany(chooseOne(user, serviceInstances));
             }
+            return chooseOne(cacheRecord.getInstanceId(), user, serviceInstances);
         }
-        if (isNotBlank(cacheRecord.getInstanceId()) && isTooOld(cacheRecord.getCreationTime())) {
-            result = cache.delete(user, serviceId)
-                .thenMany(chooseOne(user, serviceInstances));
-        } else if (isNotBlank(cacheRecord.getInstanceId())) {
-            result = chooseOne(cacheRecord.getInstanceId(), user, serviceInstances);
-        } else {
-            result = chooseOne(user, serviceInstances);
-        }
-        return result;
+
+        return chooseOne(user, serviceInstances);
     }
 
     /**
@@ -253,10 +253,6 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         return chooseOne(null, user, serviceInstances);
     }
 
-    boolean shouldIgnore(List<ServiceInstance> instances, String user) {
-        return StringUtils.isEmpty(user) || instances.isEmpty() || !lbTypeIsAuthentication(instances.get(0));
-    }
-
     private boolean lbTypeIsAuthentication(ServiceInstance instance) {
         Map<String, String> metadata = instance.getMetadata();
         if (metadata != null) {
@@ -305,6 +301,7 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
                 return claims.getSubject();
             }
         }
-        return "";
+        return null;
     }
+
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -104,15 +104,18 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
             .flatMap(serviceInstances -> {
                 if (serviceInstances.isEmpty()) {
                     // no instances available - just return
+                    log.debug("No services selected");
                     return Flux.just(serviceInstances);
                 }
 
                 boolean stickySession = lbTypeIsAuthentication(serviceInstances.iterator().next());
                 if (!stickySession) {
                     // service does not support sticky session by userId, just return
+                    log.debug("Service {} does not support sticky session", serviceId);
                     return Flux.just(serviceInstances);
                 }
 
+                log.debug("Obtain service instances for {} from the cache", serviceId);
                 return cache.retrieve(userId, serviceId)
                     .onErrorResume(t -> Mono.empty())
                     .flatMapMany(cacheRecord -> filterInstances(userId, serviceId, cacheRecord, serviceInstances))

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
@@ -45,12 +45,8 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -162,7 +158,6 @@ class DeterministicLoadBalancerTest {
                 @Test
                 void whenServiceDoesNotHaveMetadata_thenUseDefaultList() {
                     when(instance1.getMetadata()).thenReturn(null);
-                    when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(LoadBalancerCacheRecord.NONE));
 
                     StepVerifier.create(loadBalancer.get(request))
                         .assertNext(chosenInstances -> {
@@ -178,8 +173,6 @@ class DeterministicLoadBalancerTest {
                     Map<String, String> metadata = new HashMap<>();
                     metadata.put("apiml.lb.type", "somethingelse");
                     when(instance1.getMetadata()).thenReturn(metadata);
-
-                    when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(LoadBalancerCacheRecord.NONE));
 
                     StepVerifier.create(loadBalancer.get(request))
                         .assertNext(chosenInstances -> {
@@ -247,6 +240,9 @@ class DeterministicLoadBalancerTest {
                                 assertNotNull(chosenInstances);
                                 assertEquals(1, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                verify(lbCache).retrieve("USER", "service");
+                                verify(lbCache).delete("USER", "service");
+                                verify(lbCache).store(eq("USER"), eq("service"), any());
                             })
                             .expectComplete()
                             .verify();
@@ -266,6 +262,8 @@ class DeterministicLoadBalancerTest {
                                 assertNotNull(chosenInstances);
                                 assertEquals(1, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+
+                                verify(lbCache).retrieve("USER", "service");
                             })
                             .expectComplete()
                             .verify();
@@ -368,15 +366,11 @@ class DeterministicLoadBalancerTest {
                 @BeforeEach
                 void setUp() {
                     var context = new RequestDataContext(requestData);
-                    MultiValueMap<String, String> cookie = new LinkedMultiValueMap<>();
-                    cookie.add("apimlAuthenticationToken", "invalidToken");
-
                     when(request.getContext()).thenReturn(context);
-                    when(requestData.getCookies()).thenReturn(cookie);
                 }
 
                 @Test
-                void whenInstanceIdExists_thenChoseeIt() {
+                void whenInstanceIdExists_thenChooseIt() {
                     var headers = new HttpHeaders();
                     headers.add("X-InstanceId", "instance2");
                     when(requestData.getHeaders()).thenReturn(headers);
@@ -386,6 +380,21 @@ class DeterministicLoadBalancerTest {
                             assertNotNull(chosenInstances);
                             assertEquals(1, chosenInstances.size());
                             assertEquals("instance2", chosenInstances.get(0).getInstanceId());
+                            verify(lbCache, never()).retrieve(any(), any());
+                        })
+                        .expectComplete()
+                        .verify();
+                }
+
+                @Test
+                void whenNoToken_thenDoNotCallCache() {
+                    when(requestData.getHeaders()).thenReturn(new HttpHeaders());
+                    when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+
+                    StepVerifier.create(loadBalancer.get(request))
+                        .assertNext(chosenInstances -> {
+                            assertNotNull(chosenInstances);
+                            verify(lbCache, never()).retrieve(any(), any());
                         })
                         .expectComplete()
                         .verify();


### PR DESCRIPTION
# Description

There is the class DeterministicLoadBalancer. This class is reposible for deterministic routing of request. It uses header X-InstanceId or last used used server to implement sticky session.

The issue is in the order of taken actions to process the request. If the request contains a token (the user could be detected) it always call caching service, even the value is not used there.

The impact:

more I/O and performance degradation for authenticated request
it could failed when Caching service is down (even the call is not needed)

Linked to #4510
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The java tests in the area I was working on leverage @Nested annotations
- [x] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
