### PR TITLE
fix: api ml startup mesage for HA scenarios

### DIFF
--- a/apiml/src/main/java/org/zowe/apiml/ApimlApplication.java
+++ b/apiml/src/main/java/org/zowe/apiml/ApimlApplication.java
@@ -74,4 +74,5 @@ public class ApimlApplication {
             System.exit(2);
         }
     }
+
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
@@ -16,7 +16,9 @@ import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.product.compatibility.ApimlHealthCheckHandler;
@@ -43,6 +45,7 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
     private final ApimlLogger apimlLog = ApimlLogger.empty();
 
     private AtomicBoolean startedInformationPublished = new AtomicBoolean(false);
+    private AtomicBoolean applicationReady = new AtomicBoolean(false);
 
     public GatewayHealthIndicator(DiscoveryClient discoveryClient,
                                   @Value("${apiml.catalog.serviceId:}") String apiCatalogServiceId) {
@@ -73,9 +76,14 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
             builder.withDetail(CoreService.API_CATALOG.getServiceId(), toStatus(apiCatalogUp).getCode());
         }
 
-        if (discoveryUp && apiCatalogUp && zaasUp) {
+        if (discoveryUp && apiCatalogUp && zaasUp && applicationReady.get()) {
             onFullyUp();
         }
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        applicationReady.set(true);
     }
 
     private void onFullyUp() {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/GatewayHealthIndicatorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/GatewayHealthIndicatorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.zowe.apiml.product.constants.CoreService;
@@ -91,6 +92,7 @@ class GatewayHealthIndicatorTest {
 
     @Nested
     class GivenEverythingIsHealthy {
+
         @Test
         void whenHealthRequested_onceLogMessageAboutStartup() {
 
@@ -104,9 +106,13 @@ class GatewayHealthIndicatorTest {
 
             GatewayHealthIndicator healthIndicator = new GatewayHealthIndicator(discoveryClient, CoreService.API_CATALOG.getServiceId());
             Health.Builder builder = new Health.Builder();
+            healthIndicator.onApplicationEvent(mock(ApplicationReadyEvent.class));
+
             healthIndicator.doHealthCheck(builder);
 
             assertThat(healthIndicator.isStartedInformationPublished(), is(true));
         }
+
     }
+
 }


### PR DESCRIPTION
# Description

When running in high availability scenarios, the message for API Mediation Layer startup was not waiting for itself (in Gateway) to be available to handle requests.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

