### PR TITLE
fix: Timer may run with context closed

### DIFF
--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasContextClosedEventListener.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasContextClosedEventListener.java
@@ -1,0 +1,29 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.zaas;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ZaasContextClosedEventListener implements ApplicationListener<ContextClosedEvent> {
+
+    private final ZaasStartupListener zaasStartupListener;
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        zaasStartupListener.onContextClosed();
+    }
+
+}

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasStartupListener.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasStartupListener.java
@@ -22,6 +22,7 @@ import org.zowe.apiml.zaas.security.login.Providers;
 import java.time.Duration;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 @RequiredArgsConstructor
@@ -34,12 +35,12 @@ public class ZaasStartupListener implements ApplicationListener<ApplicationReady
     private final ApplicationEventPublisher publisher;
     private final ServiceStartupEventHandler handler;
 
-    private Timer timer;
+    private AtomicReference<Timer> timer = new AtomicReference<>();
 
     public void onApplicationEvent(ApplicationReadyEvent event) {
         if (providers.isZosfmUsed()) {
-            timer = new Timer();
-            timer.scheduleAtFixedRate(new TimerTask() {
+            timer.set(new Timer());
+            timer.get().scheduleAtFixedRate(new TimerTask() {
 
                 @Override
                 public void run() {
@@ -61,9 +62,9 @@ public class ZaasStartupListener implements ApplicationListener<ApplicationReady
     }
 
     void onContextClosed() {
-        if (timer != null) {
-            timer.cancel();
-            timer = null;
+        if (timer.get() != null) {
+            timer.get().cancel();
+            timer.set(null);
         }
     }
 

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasStartupListener.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/ZaasStartupListener.java
@@ -34,12 +34,20 @@ public class ZaasStartupListener implements ApplicationListener<ApplicationReady
     private final ApplicationEventPublisher publisher;
     private final ServiceStartupEventHandler handler;
 
+    private Timer timer;
+
     public void onApplicationEvent(ApplicationReadyEvent event) {
         if (providers.isZosfmUsed()) {
-            new Timer().scheduleAtFixedRate(new TimerTask() {
+            timer = new Timer();
+            timer.scheduleAtFixedRate(new TimerTask() {
 
                 @Override
                 public void run() {
+                    if (event.getApplicationContext() != null && !event.getApplicationContext().isActive()) {
+                        cancel();
+                        return;
+                    }
+
                     if (providers.isZosmfAvailableAndOnline()) {
                         cancel();
                         notifyStartup();
@@ -52,9 +60,17 @@ public class ZaasStartupListener implements ApplicationListener<ApplicationReady
         }
     }
 
+    void onContextClosed() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+    }
+
     public void notifyStartup() {
         handler.onServiceStartup("ZAAS",
             ServiceStartupEventHandler.DEFAULT_DELAY_FACTOR);
         publisher.publishEvent(new ZaasServiceAvailableEvent(providers.isZosfmUsed() ? "zosmf" : "saf"));
     }
+
 }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/ZaasContextClosedEventListenerTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/ZaasContextClosedEventListenerTest.java
@@ -1,0 +1,44 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.zaas;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ZaasContextClosedEventListenerTest {
+
+    @Mock
+    private ZaasStartupListener zaasStartupListener;
+
+    private ZaasContextClosedEventListener zaasContextClosedEventListener;
+
+    @BeforeEach
+    void setUp() {
+        zaasContextClosedEventListener = new ZaasContextClosedEventListener(zaasStartupListener);
+    }
+
+    @Test
+    void testOnApplicationEvent() {
+        doNothing().when(zaasStartupListener).onContextClosed();
+
+        zaasContextClosedEventListener.onApplicationEvent(new ContextClosedEvent(mock(ApplicationContext.class)));
+    }
+
+}


### PR DESCRIPTION
# Description

A timer is started to verify connectivity with z/OSMF (when z/OSMF is used as authentication provider)
However, there's no verification that the context is not already closed.

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
