### PR TITLE
fix: health indicator

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
@@ -39,6 +39,9 @@ import static org.springframework.boot.actuate.health.Status.UP;
 @ConditionalOnMissingBean(name = "modulithConfig")
 public class GatewayHealthIndicator extends AbstractHealthIndicator {
 
+    @Value("${apiml.service.hostname")
+    private String hostname;
+
     protected final DiscoveryClient discoveryClient;
     private final String apiCatalogServiceId;
     @InjectApimlLogger
@@ -60,8 +63,8 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
 
         // When DS goes 'down' after it was already 'up', the new status is not shown. This is probably feature of
         // Eureka client which caches the status of services. When DS is down the cache is not refreshed.
-        var discoveryUp = !this.discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId()).isEmpty();
-        var zaasUp = !this.discoveryClient.getInstances(CoreService.ZAAS.getServiceId()).isEmpty();
+        var discoveryUp = isThisDeploymentServiceUp(CoreService.DISCOVERY.getServiceId());
+        var zaasUp = isThisDeploymentServiceUp(CoreService.ZAAS.getServiceId());
 
         var gatewayCount = this.discoveryClient.getInstances(CoreService.GATEWAY.getServiceId()).size();
         var zaasCount = this.discoveryClient.getInstances(CoreService.ZAAS.getServiceId()).size();
@@ -79,6 +82,11 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
         if (discoveryUp && apiCatalogUp && zaasUp && applicationReady.get()) {
             onFullyUp();
         }
+    }
+
+    private boolean isThisDeploymentServiceUp(String serviceId) {
+        var instances = this.discoveryClient.getInstances(serviceId);
+        return !instances.isEmpty() && instances.stream().anyMatch(instance -> instance.getInstanceId().contains(hostname));
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -99,4 +107,5 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
     private Status toStatus(boolean up) {
         return up ? UP : DOWN;
     }
+
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
@@ -41,7 +41,7 @@ import static org.springframework.boot.actuate.health.Status.UP;
 @Slf4j
 public class GatewayHealthIndicator extends AbstractHealthIndicator {
 
-    @Value("${apiml.service.hostname")
+    @Value("${apiml.service.hostname}")
     private String hostname;
 
     protected final DiscoveryClient discoveryClient;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/GatewayHealthIndicator.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.gateway.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
@@ -37,6 +38,7 @@ import static org.springframework.boot.actuate.health.Status.UP;
  */
 @Component
 @ConditionalOnMissingBean(name = "modulithConfig")
+@Slf4j
 public class GatewayHealthIndicator extends AbstractHealthIndicator {
 
     @Value("${apiml.service.hostname")
@@ -86,6 +88,7 @@ public class GatewayHealthIndicator extends AbstractHealthIndicator {
 
     private boolean isThisDeploymentServiceUp(String serviceId) {
         var instances = this.discoveryClient.getInstances(serviceId);
+        log.error("instances: {}, hostname: {}", instances, hostname);
         return !instances.isEmpty() && instances.stream().anyMatch(instance -> instance.getInstanceId().contains(hostname));
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/GatewayHealthIndicatorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/GatewayHealthIndicatorTest.java
@@ -10,13 +10,18 @@
 
 package org.zowe.apiml.gateway.config;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.product.constants.CoreService;
 
 import java.util.Collections;
@@ -27,7 +32,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GatewayHealthIndicatorTest {
+
+    @Mock
+    private DiscoveryClient discoveryClient;
+
+    private GatewayHealthIndicator healthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        this.healthIndicator = new GatewayHealthIndicator(discoveryClient, CoreService.API_CATALOG.getServiceId());
+        ReflectionTestUtils.setField(healthIndicator, "hostname", "host");
+    }
 
     private DefaultServiceInstance getDefaultServiceInstance(String serviceId, String hostname, int port) {
         return new DefaultServiceInstance(
@@ -40,13 +57,13 @@ class GatewayHealthIndicatorTest {
     class WhenCatalogAndDiscoveryAreAvailable {
         @Test
         void testStatusIsUp() {
-            DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
             when(discoveryClient.getInstances(CoreService.API_CATALOG.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.API_CATALOG.getServiceId(), "host", 10014)));
             when(discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.DISCOVERY.getServiceId(), "host", 10011)));
+            when(discoveryClient.getInstances(CoreService.ZAAS.getServiceId())).thenReturn(
+                Collections.singletonList(getDefaultServiceInstance(CoreService.ZAAS.getServiceId(), "host", 10011)));
 
-            GatewayHealthIndicator healthIndicator = new GatewayHealthIndicator(discoveryClient, CoreService.API_CATALOG.getServiceId());
             Health.Builder builder = new Health.Builder();
             healthIndicator.doHealthCheck(builder);
             assertEquals(Status.UP, builder.build().getStatus());
@@ -57,12 +74,10 @@ class GatewayHealthIndicatorTest {
     class WhenDiscoveryIsNotAreAvailable {
         @Test
         void testStatusIsDown() {
-            DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
             when(discoveryClient.getInstances(CoreService.API_CATALOG.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.API_CATALOG.getServiceId(), "host", 10014)));
             when(discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId())).thenReturn(Collections.emptyList());
 
-            GatewayHealthIndicator healthIndicator = new GatewayHealthIndicator(discoveryClient, CoreService.API_CATALOG.getServiceId());
             Health.Builder builder = new Health.Builder();
             healthIndicator.doHealthCheck(builder);
             assertEquals(Status.DOWN, builder.build().getStatus());
@@ -71,23 +86,26 @@ class GatewayHealthIndicatorTest {
 
     @Nested
     class GivenCustomCatalogProvider {
+
         @Test
         void whenHealthIsRequested_thenStatusIsUp() {
             String customCatalogServiceId = "customCatalog";
 
-            DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
             when(discoveryClient.getInstances(customCatalogServiceId)).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(customCatalogServiceId, "host", 10014)));
             when(discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.DISCOVERY.getServiceId(), "host", 10011)));
 
-            GatewayHealthIndicator healthIndicator = new GatewayHealthIndicator(discoveryClient, customCatalogServiceId);
+            var healthIndicator = new GatewayHealthIndicator(discoveryClient, customCatalogServiceId);
+            ReflectionTestUtils.setField(healthIndicator, "hostname", "host");
+
             Health.Builder builder = new Health.Builder();
             healthIndicator.doHealthCheck(builder);
 
             String code = (String) builder.build().getDetails().get(CoreService.API_CATALOG.getServiceId());
             assertThat(code, is("UP"));
         }
+
     }
 
     @Nested
@@ -95,8 +113,6 @@ class GatewayHealthIndicatorTest {
 
         @Test
         void whenHealthRequested_onceLogMessageAboutStartup() {
-
-            DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
             when(discoveryClient.getInstances(CoreService.API_CATALOG.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.API_CATALOG.getServiceId(), "host", 10014)));
             when(discoveryClient.getInstances(CoreService.DISCOVERY.getServiceId())).thenReturn(
@@ -104,7 +120,6 @@ class GatewayHealthIndicatorTest {
             when(discoveryClient.getInstances(CoreService.ZAAS.getServiceId())).thenReturn(
                 Collections.singletonList(getDefaultServiceInstance(CoreService.ZAAS.getServiceId(), "host", 10023)));
 
-            GatewayHealthIndicator healthIndicator = new GatewayHealthIndicator(discoveryClient, CoreService.API_CATALOG.getServiceId());
             Health.Builder builder = new Health.Builder();
             healthIndicator.onApplicationEvent(mock(ApplicationReadyEvent.class));
 


### PR DESCRIPTION
# Description

Health indicator in multi-service deployment can show API Mediation Layer started message ZWEAM001I before the instance's Discovery / ZAAS (especially in slow environments)
This PR fixes it by verifying own instance's Discovery / ZAAS 

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
