### PR TITLE
fix: Use relaxed firewall only for routed request (v2)

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ApimlStrictServerWebExchangeFirewall.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/ApimlStrictServerWebExchangeFirewall.java
@@ -1,0 +1,61 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.security.config;
+
+import org.apache.commons.lang3.Strings;
+import org.springframework.security.web.firewall.FirewalledRequest;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class ApimlStrictServerWebExchangeFirewall extends StrictHttpFirewall {
+
+    private static final String[] BASE_PATH = {
+        "/gateway",
+        "/application",
+        "/images",
+        "/api-doc"
+    };
+
+        private StrictHttpFirewall nonRoutingFirewall = new StrictHttpFirewall();
+
+    boolean isPathToRoute(String path, String[] prefixes) {
+        // homepage
+        if (Strings.CS.equals(path, "/")) {
+            return false;
+        }
+        for (String prefix : prefixes) {
+            if (Strings.CS.equals(path, prefix)) {
+                return false;
+            }
+            if (Strings.CS.startsWith(path, prefix + "/")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    boolean isPathToRoute(HttpServletRequest request) {
+        return isPathToRoute(request.getRequestURI(), BASE_PATH);
+    }
+
+    @Override
+    public FirewalledRequest getFirewalledRequest(HttpServletRequest request) throws RequestRejectedException {
+        // in case of Gateway and a request to routing use a configured values
+        if (isPathToRoute(request)) {
+            return super.getFirewalledRequest(request);
+        }
+
+        return nonRoutingFirewall.getFirewalledRequest(request);
+    }
+
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -598,7 +598,7 @@ public class NewSecurityConfiguration {
             // Web security only needs to be configured once, putting it to multiple filter chains causes multiple evaluations of the same rules
             @Bean
             public WebSecurityCustomizer webSecurityCustomizer() {
-                StrictHttpFirewall firewall = new StrictHttpFirewall();
+                StrictHttpFirewall firewall = new ApimlStrictServerWebExchangeFirewall();
                 firewall.setAllowUrlEncodedSlash(true);
                 firewall.setAllowBackSlash(true);
                 firewall.setAllowUrlEncodedPercent(true);

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlStrictServerWebExchangeFirewallTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/ApimlStrictServerWebExchangeFirewallTest.java
@@ -1,0 +1,70 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.gateway.security.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApimlStrictServerWebExchangeFirewallTest {
+
+    private ApimlStrictServerWebExchangeFirewall apimlStrictServerWebExchangeFirewall = new ApimlStrictServerWebExchangeFirewall();
+    @Mock
+    private StrictHttpFirewall nonRoutingFirewall;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(apimlStrictServerWebExchangeFirewall, "nonRoutingFirewall", nonRoutingFirewall);
+    }
+
+    @ParameterizedTest(name = "givenLocalEndpointPath_whenFirewallCheck_thenDecideToUseStrictOne({0})")
+    @CsvSource({
+        "/",
+        "/gateway",
+        "/gateway/api/v1/anyUrl",
+        "/images",
+        "/images/homepage/picture.gif",
+        "/application",
+        "/application/health",
+        "/api-doc"
+    })
+    void givenLocalEndpointPath_whenFirewallCheck_thenDecideToUseStrictOne(String path) {
+        HttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.name(), path);
+
+        apimlStrictServerWebExchangeFirewall.getFirewalledRequest(request);
+
+        verify(nonRoutingFirewall).getFirewalledRequest(request);
+    }
+
+    @Test
+    void givenSouthBoundServicePath_whenFirewallCheck_thenDecideToUseCustomizedOne() {
+        HttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.name(), "/south-bound/service/api/v1");
+
+        apimlStrictServerWebExchangeFirewall.getFirewalledRequest(request);
+
+        verify(nonRoutingFirewall, never()).getFirewalledRequest(request);
+    }
+
+}


### PR DESCRIPTION
# Description

This PR is an equivalent of #4643 for v2:

Currently the whole services uses a relaxed firewalls. It is based on an original issue https://github.com/zowe/api-layer/issues/23. Some services requires to provide these type of URLs. Anyway, it is valid only for gateway - the routing part. For the rest of the endpoints there could be use a strict firewall. This PR allows to define relaxed one only for proxying.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
