### PR TITLE
fix: Use the same hostverification scheme as in the rest of Gateway

### DIFF
--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -141,13 +141,16 @@ verify_certificates_config=$(echo "${ZWE_zowe_verifyCertificates}" | tr '[:lower
 if [ "${verify_certificates_config}" = "DISABLED" ]; then
   verifySslCertificatesOfServices=false
   nonStrictVerifySslCertificatesOfServices=true
+  zuulSslHostnameValidationEnabled=false
 elif [ "${verify_certificates_config}" = "NONSTRICT" ]; then
   verifySslCertificatesOfServices=true
   nonStrictVerifySslCertificatesOfServices=true
+  zuulSslHostnameValidationEnabled=false
 else
   # default value is STRICT
   verifySslCertificatesOfServices=true
   nonStrictVerifySslCertificatesOfServices=false
+  zuulSslHostnameValidationEnabled=true
 fi
 
 if [ -z "${ZWE_configs_apiml_catalog_serviceId}" ]; then
@@ -440,6 +443,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dloader.path=${GATEWAY_LOADER_PATH} \
     -Djava.library.path=${LIBPATH} \
     -Djavax.net.debug=${ZWE_configs_sslDebug:-""} \
+    -Dzuul.sslHostnameValidationEnabled=${zuulSslHostnameValidationEnabled:-true} \
     -jar ${JAR_FILE} &
 
 pid=$!

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -164,7 +164,7 @@ server:
         supportedProtocols: v12.stomp,v11.stomp
 
 zuul:
-    sslHostnameValidationEnabled: false
+    sslHostnameValidationEnabled: true
     addProxyHeaders: true
     traceRequestBody: true
     ignoreSecurityHeaders: false


### PR DESCRIPTION
# Description

The ZUUL configuration of host verification is configured statically in the code. It doesn't respect the general configuration of SSL. This PR set the Ribbon by main configuration fields.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
