### PR TITLE
fix: Replace ServerProperties.getError() with direct ErrorProperties injection (SB4)

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/DiscoveryErrorController.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/DiscoveryErrorController.java
@@ -13,7 +13,7 @@ package org.zowe.apiml.discovery.config;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.server.autoconfigure.ServerProperties;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
 import org.springframework.boot.webmvc.autoconfigure.error.BasicErrorController;
 import org.springframework.boot.webmvc.autoconfigure.error.ErrorViewResolver;
 import org.springframework.boot.webmvc.error.ErrorAttributes;
@@ -32,8 +32,8 @@ import java.util.Map;
 @ConditionalOnMissingBean(name = "modulithConfig")
 public class DiscoveryErrorController extends BasicErrorController {
 
-    public DiscoveryErrorController(ErrorAttributes errorAttributes, ServerProperties serverProperties, List<ErrorViewResolver> errorViewResolvers) {
-        super(errorAttributes, serverProperties.getError(), errorViewResolvers);
+    public DiscoveryErrorController(ErrorAttributes errorAttributes, ErrorProperties errorProperties, List<ErrorViewResolver> errorViewResolvers) {
+        super(errorAttributes, errorProperties, errorViewResolvers);
     }
 
     @Override


### PR DESCRIPTION
## What Changed

Replaced `ServerProperties.getError()` (removed in Spring Boot 4) with direct `ErrorProperties` injection in `DiscoveryErrorController`.

## Root Cause

Spring Boot 4 removed `ServerProperties.getError()`. `DiscoveryErrorController` was calling it in its constructor to pass `ErrorProperties` to the parent `BasicErrorController`.

## Fix

- Import: `org.springframework.boot.web.server.ServerProperties` → `org.springframework.boot.autoconfigure.web.ErrorProperties`
- Constructor parameter: `ServerProperties serverProperties` → `ErrorProperties errorProperties`
- Super call: `serverProperties.getError()` → `errorProperties` (direct injection)

## Verification

`./gradlew :discovery-service:compileJava` — **BUILD SUCCESSFUL**

## Notes

- Only 1 of 4 originally-listed SB4 compilation errors in discovery-service actually manifested. The other 3 (InstanceRegistry.log privatization, @Slf4j in lambdas, @RequiredArgsConstructor inner static class) do not fail in the current build — likely pre-resolved by Lombok/SB4 compatibility or prior human commits.
- This class is annotated `@ConditionalOnMissingBean(name = "modulithConfig")` — microservice-only, will be deleted in V4. A separate `DiscoveryErrorController` commit (8cbea3dc3) already disabled it in modulith mode.