### PR TITLE
fix: SB4 compilation errors in zaas-service, api-catalog-services, caching-service

### DIFF
--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/CustomErrorStatusHandlingBean.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/controllers/handlers/CustomErrorStatusHandlingBean.java
@@ -11,7 +11,7 @@
 package org.zowe.apiml.apicatalog.controllers.handlers;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.error.ErrorPage;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
 import org.springframework.http.HttpStatus;

--- a/caching-service/build.gradle
+++ b/caching-service/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation libs.spring.boot.starter.webflux
     implementation libs.spring.boot.starter.security
     implementation libs.spring.boot.starter.actuator
+    implementation libs.spring.boot.starter.cache
     implementation libs.spring.doc.webflux.ui
     implementation libs.spring.retry
     implementation libs.eureka.jersey.client

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/error/custom/CustomErrorStatusHandlingBean.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/error/custom/CustomErrorStatusHandlingBean.java
@@ -11,7 +11,7 @@
 package org.zowe.apiml.zaas.error.custom;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.error.ErrorPage;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
 import org.springframework.http.HttpStatus;

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/NewSecurityConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.zowe.apiml.filter.AttlsFilter;
 import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
@@ -148,8 +148,8 @@ public class NewSecurityConfiguration {
                         .anyRequest().permitAll())
 
                 .logout(logout -> logout
-                    .logoutRequestMatcher(new AntPathRequestMatcher(
-                        authConfigurationProperties.getZaasLogoutEndpoint(), HttpMethod.POST.name()
+                    .logoutRequestMatcher(PathPatternRequestMatcher.pathPattern(
+                        HttpMethod.POST, authConfigurationProperties.getZaasLogoutEndpoint()
                     ))
                     .addLogoutHandler(logoutHandler())
                     .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT)))


### PR DESCRIPTION
## Summary
Fixes 3 Spring Boot 4 compilation errors across 4 files:

### Fix 1: ErrorPage import relocation (2 files)
Spring Boot 4 moved ErrorPage from `org.springframework.boot.web.server` to `org.springframework.boot.web.error`
- `zaas-service/.../CustomErrorStatusHandlingBean.java`
- `api-catalog-services/.../CustomErrorStatusHandlingBean.java`

### Fix 2: AntPathRequestMatcher → PathPatternRequestMatcher (1 file)
Spring Security 7 removed `AntPathRequestMatcher`. Replaced with `PathPatternRequestMatcher` using its static factory `pathPattern(HttpMethod, String)`. The class moved to `org.springframework.security.web.servlet.util.matcher`.
- `zaas-service/.../NewSecurityConfiguration.java`

### Fix 3: Missing CachesEndpoint dependency (1 file)
Added `spring_boot_starter_cache` dependency which provides `CachesEndpoint` class.
- `caching-service/build.gradle`

## Verification
- `./gradlew :api-catalog-services:compileJava` → BUILD SUCCESSFUL
- `./gradlew :zaas-service:compileJava` — Fix 1 and Fix 2 errors resolved; 4 pre-existing errors remain (getRawStatusCode × 2 in AbstractZosmfService, DummyAuthenticationProvider constructor × 2) — these exist on the base branch `feat/sb4-health-tomcat-migration` and are addressed in separate tasks
- `./gradlew :caching-service:compileJava` — Fix 3 errors resolved; 1 pre-existing error remains (configurePathMatch/setUseTrailingSlashMatch in GeneralConfig) — also exists on base branch