### PR TITLE
feat: Instance grouping via registration metadata (#4405)

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/EurekaMetadataDefinition.java
@@ -44,6 +44,7 @@ public final class EurekaMetadataDefinition {
     public static final String APPLY_RATE_LIMITER_FILTER = "apiml.gateway.applyRateLimiterFilter";
     public static final String APIML_ID = "apiml.service.apimlId";
     public static final String REGISTRATION_TYPE = "apiml.registrationType";
+    public static final String INSTANCE_GROUP = "apiml.instance.group";
 
     public static final String API_INFO = "apiml.apiInfo";
     public static final String API_INFO_API_ID = "apiId";

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/caching/LoadBalancerCache.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/caching/LoadBalancerCache.java
@@ -66,22 +66,37 @@ public class LoadBalancerCache {
      * @return Mono success / error
      */
     public Mono<Void> store(String user, String service, LoadBalancerCacheRecord loadBalancerCacheRecord) {
+        return store(user, service, loadBalancerCacheRecord, null);
+    }
+
+    /**
+     * Store information about instance the user is balanced towards, with optional group.
+     * If there is already existing record, it will be updated
+     *
+     * @param user     User being routed towards southbound service
+     * @param service  Service towards which is the user routed
+     * @param loadBalancerCacheRecord  Object containing the selected instance and its creation time
+     * @param group    Optional group identifier for instance grouping
+     * @return Mono success / error
+     */
+    public Mono<Void> store(String user, String service, LoadBalancerCacheRecord loadBalancerCacheRecord, String group) {
+        String key = getKey(user, service, group);
         return cachingServiceAvailability()
             .flatMap(available -> {
                 if (Boolean.TRUE.equals(available)) {
-                    return storeToRemoteCache(user, service, loadBalancerCacheRecord);
+                    return storeToRemoteCache(user, service, loadBalancerCacheRecord, key);
                 } else {
-                    localCache.put(getKey(user, service), loadBalancerCacheRecord);
-                    log.debug("Stored record to local cache for user: {}, service: {}, record: {}", user, service, loadBalancerCacheRecord);
+                    localCache.put(key, loadBalancerCacheRecord);
+                    log.debug("Stored record to local cache for user: {}, service: {}, group: {}, record: {}", user, service, group, loadBalancerCacheRecord);
                     return empty();
                 }
             });
     }
 
-    private Mono<Void> storeToRemoteCache(String user, String service, LoadBalancerCacheRecord loadBalancerCacheRecord) {
+    private Mono<Void> storeToRemoteCache(String user, String service, LoadBalancerCacheRecord loadBalancerCacheRecord, String key) {
         try {
             String serializedRecord = mapper.writeValueAsString(loadBalancerCacheRecord);
-            CachingServiceClient.ApiKeyValue toStore = new CachingServiceClient.ApiKeyValue(getKey(user, service), serializedRecord);
+            CachingServiceClient.ApiKeyValue toStore = new CachingServiceClient.ApiKeyValue(key, serializedRecord);
             return createToRemoteCache(user, service, loadBalancerCacheRecord, toStore);
         } catch (JsonProcessingException e) {
             log.debug("Failed to serialize record for user: {}, service: {}, record {},  with exception: ", user, service, loadBalancerCacheRecord, e);
@@ -120,10 +135,23 @@ public class LoadBalancerCache {
      * @return Retrieved record containing the instance to use for this user and its creation time.
      */
     public Mono<LoadBalancerCacheRecord> retrieve(String user, String service) {
+        return retrieve(user, service, null);
+    }
+
+    /**
+     * Retrieve information about selected instance for combination of User, Service, and optional Group.
+     *
+     * @param user    User being routed towards southbound service
+     * @param service Service towards which is the user routed
+     * @param group   Optional group identifier for instance grouping
+     * @return Retrieved record containing the instance to use for this user and its creation time.
+     */
+    public Mono<LoadBalancerCacheRecord> retrieve(String user, String service, String group) {
+        String key = getKey(user, service, group);
         return cachingServiceAvailability()
             .flatMap(available -> {
                 if (Boolean.TRUE.equals(available)) {
-                    return remoteCache.read(getKey(user, service))
+                    return remoteCache.read(key)
                         .handle((kv, sink) -> {
                             LoadBalancerCacheRecord loadBalancerCacheRecord;
                             try {
@@ -132,12 +160,12 @@ public class LoadBalancerCache {
                                 sink.error(new LoadBalancerCacheException(e));
                                 return;
                             }
-                            log.debug("Retrieved record from remote cache for user: {}, service: {}, record: {}", user, service, loadBalancerCacheRecord);
+                            log.debug("Retrieved record from remote cache for user: {}, service: {}, group: {}, record: {}", user, service, group, loadBalancerCacheRecord);
                             sink.next(loadBalancerCacheRecord);
                         });
                 } else {
-                    LoadBalancerCacheRecord loadBalancerCacheRecord = localCache.get(getKey(user, service));
-                    log.debug("Retrieved record from local cache for user: {}, service: {}, record: {}", user, service, loadBalancerCacheRecord);
+                    LoadBalancerCacheRecord loadBalancerCacheRecord = localCache.get(key);
+                    log.debug("Retrieved record from local cache for user: {}, service: {}, group: {}, record: {}", user, service, group, loadBalancerCacheRecord);
                     return loadBalancerCacheRecord == null ? empty() : just(loadBalancerCacheRecord);
                 }
             });
@@ -150,20 +178,43 @@ public class LoadBalancerCache {
      * @param service Service towards which is the user routed
      */
     public Mono<Void> delete(String user, String service) {
+        return delete(user, service, null);
+    }
+
+    /**
+     * Delete information stored for given user, service, and optional group.
+     *
+     * @param user    User being routed towards southbound service
+     * @param service Service towards which is the user routed
+     * @param group   Optional group identifier for instance grouping
+     */
+    public Mono<Void> delete(String user, String service, String group) {
+        String key = getKey(user, service, group);
         return cachingServiceAvailability()
             .flatMap(available -> {
                 if (Boolean.TRUE.equals(available)) {
-                    return remoteCache.delete(getKey(user, service))
-                        .doOnSuccess(v -> log.debug("Deleted record from remote cache for user: {}, service: {}", user, service));
+                    return remoteCache.delete(key)
+                        .doOnSuccess(v -> log.debug("Deleted record from remote cache for user: {}, service: {}, group: {}", user, service, group));
                 } else {
-                    localCache.remove(getKey(user, service));
-                    log.debug("Deleted record from local cache for user: {}, service: {}", user, service);
+                    localCache.remove(key);
+                    log.debug("Deleted record from local cache for user: {}, service: {}, group: {}", user, service, group);
                     return empty();
                 }
             });
     }
 
     private String getKey(String user, String service) {
+        return getKey(user, service, null);
+    }
+
+    /**
+     * Build cache key with optional group. When group is present, the key format is
+     * {@code lb.<user>:<service>:<group>}. Otherwise {@code lb.<user>:<service>}.
+     */
+    private String getKey(String user, String service, String group) {
+        if (group != null && !group.isEmpty()) {
+            return LOAD_BALANCER_KEY_PREFIX + user.toLowerCase() + ":" + service.toLowerCase() + ":" + group;
+        }
         return LOAD_BALANCER_KEY_PREFIX + user.toLowerCase() + ":" + service.toLowerCase();
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.zowe.apiml.constants.ApimlConstants.X_INSTANCEID;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.INSTANCE_GROUP;
 import static reactor.core.publisher.Flux.just;
 
 /**
@@ -82,6 +83,24 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         }
 
         var requestContext = request.getContext();
+
+        // Extract group parameter from query string
+        var group = getGroup(requestContext);
+
+        if (group != null) {
+            return delegate.get(request)
+                .flatMap(serviceInstances -> {
+                    var groupInstances = filterByGroup(group, serviceInstances);
+                    if (groupInstances.isEmpty()) {
+                        return Flux.error(new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                            "No service instances available for group: " + group));
+                    }
+                    // Continue with filtered instances for the rest of the logic
+                    return processInstances(requestContext, request, groupInstances, group);
+                });
+        }
+
+        // No group parameter — original flow
         var instanceId = getInstanceId(requestContext);
         if (instanceId != null) {
             // if instanceId is set in headers use it
@@ -122,6 +141,79 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
                     .switchIfEmpty(Flux.just(serviceInstances));
             })
             .doOnError(e -> log.debug("Error in determining service instances", e));
+    }
+
+    /**
+     * Process instances with the given (possibly group-filtered) list.
+     * When a group is active, sticky session is implied and cache keys include the group.
+     */
+    private Flux<List<ServiceInstance>> processInstances(Object requestContext, Request request,
+                                                          List<ServiceInstance> serviceInstances, String group) {
+        String serviceId = getServiceId();
+
+        var instanceId = getInstanceId(requestContext);
+        if (instanceId != null) {
+            // respect X-InstanceId header within group-filtered instances
+            try {
+                return Flux.just(checkInstanceIdHeader(instanceId, serviceInstances));
+            } catch (ResponseStatusException ex) {
+                return Flux.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "Service instance not found for the provided instance ID"));
+            }
+        }
+
+        var userId = getSub(requestContext);
+        if (userId == null) {
+            // no userId — return the (group-filtered) instances as-is
+            log.debug("No authentication present on request, not filtering the service: {}", serviceId);
+            return Flux.just(serviceInstances);
+        }
+
+        if (serviceInstances.isEmpty()) {
+            log.debug("No services selected");
+            return Flux.just(serviceInstances);
+        }
+
+        // Group-aware routing implies sticky within the group
+        log.debug("Obtain service instances for {} from the cache (group: {})", serviceId, group);
+        return cache.retrieve(userId, serviceId, group)
+            .onErrorResume(t -> Mono.empty())
+            .flatMapMany(cacheRecord -> filterInstances(userId, serviceId, cacheRecord, serviceInstances, group))
+            .switchIfEmpty(Flux.just(serviceInstances));
+    }
+
+    /**
+     * Extract the group name from the request query parameter 'apiml-group'.
+     * Returns null if no group parameter is present.
+     */
+    private String getGroup(Object requestContext) {
+        if (requestContext instanceof RequestDataContext ctx) {
+            var uri = ctx.getClientRequest().getUrl();
+            if (uri != null) {
+                var params = uri.getQueryParams();
+                if (params != null) {
+                    var groups = params.get("apiml-group");
+                    if (groups != null && !groups.isEmpty()) {
+                        return groups.getFirst();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Filter service instances to only those whose apiml.instance.group metadata
+     * matches the requested group.
+     */
+    private List<ServiceInstance> filterByGroup(String group, List<ServiceInstance> instances) {
+        return instances.stream()
+            .filter(instance -> {
+                var metadata = instance.getMetadata();
+                if (metadata == null) return false;
+                return group.equals(metadata.get(INSTANCE_GROUP));
+            })
+            .toList();
     }
 
     /**
@@ -172,15 +264,35 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         LoadBalancerCacheRecord cacheRecord,
         List<ServiceInstance> serviceInstances
     ) {
+        return filterInstances(user, serviceId, cacheRecord, serviceInstances, null);
+    }
+
+    /**
+     * Filters the list of service instances with group-aware cache keys.
+     *
+     * @param user             The user
+     * @param serviceId        The serviceId
+     * @param cacheRecord           the cache record
+     * @param serviceInstances the list of service instances to filter
+     * @param group            Optional group identifier for instance grouping
+     * @return the filtered list of service instances
+     */
+    private Flux<List<ServiceInstance>> filterInstances(
+        String user,
+        String serviceId,
+        LoadBalancerCacheRecord cacheRecord,
+        List<ServiceInstance> serviceInstances,
+        String group
+    ) {
         if (isNotBlank(cacheRecord.getInstanceId())) {
             if (isTooOld(cacheRecord.getCreationTime())) {
-                return cache.delete(user, serviceId)
-                    .thenMany(chooseOne(user, serviceInstances));
+                return cache.delete(user, serviceId, group)
+                    .thenMany(chooseOne(user, serviceInstances, group));
             }
-            return chooseOne(cacheRecord.getInstanceId(), user, serviceInstances);
+            return chooseOne(cacheRecord.getInstanceId(), user, serviceInstances, group);
         }
 
-        return chooseOne(user, serviceInstances);
+        return chooseOne(user, serviceInstances, group);
     }
 
     /**
@@ -228,32 +340,46 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
 
 
     /**
-     * Selected the preferred instance if not null, if the preferred instance is not found or is null a new preference is created
+     * Selected the preferred instance if not null, if the preferred instance is not found or is null a new preference is created.
+     * Cache keys include the optional group when present.
      *
      * @param instanceId       The preferred instanceId
      * @param user             The user
      * @param serviceInstances The default serviceInstances available
+     * @param group            Optional group identifier for instance grouping
      * @return Flux with a list containing only one selected instance
      */
-    private Flux<List<ServiceInstance>> chooseOne(String instanceId, String user, List<ServiceInstance> serviceInstances) {
+    private Flux<List<ServiceInstance>> chooseOne(String instanceId, String user, List<ServiceInstance> serviceInstances, String group) {
         Stream<ServiceInstance> stream = serviceInstances.stream();
         if (instanceId != null) {
             stream = stream.filter(instance -> instanceId.equals(instance.getInstanceId()));
         }
         ServiceInstance chosenInstance = stream.findAny().orElse(serviceInstances.get(0));
-        return cache.store(user, chosenInstance.getServiceId(), new LoadBalancerCacheRecord(chosenInstance.getInstanceId()))
+        return cache.store(user, chosenInstance.getServiceId(), new LoadBalancerCacheRecord(chosenInstance.getInstanceId()), group)
             .thenMany(just(Collections.singletonList(chosenInstance)));
     }
 
     /**
-     * Shortcut to create a new instance preference
+     * Shortcut to create a new instance preference (no group).
      *
      * @param user
      * @param serviceInstances
      * @return
      */
     private Flux<List<ServiceInstance>> chooseOne(String user, List<ServiceInstance> serviceInstances) {
-        return chooseOne(null, user, serviceInstances);
+        return chooseOne(null, user, serviceInstances, null);
+    }
+
+    /**
+     * Shortcut to create a new instance preference with group.
+     *
+     * @param user
+     * @param serviceInstances
+     * @param group
+     * @return
+     */
+    private Flux<List<ServiceInstance>> chooseOne(String user, List<ServiceInstance> serviceInstances, String group) {
+        return chooseOne(null, user, serviceInstances, group);
     }
 
     private boolean lbTypeIsAuthentication(ServiceInstance instance) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -22,6 +22,7 @@ import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.RequestDataContext;
 import org.springframework.cloud.client.loadbalancer.reactive.ReactiveLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.SameInstancePreferenceServiceInstanceListSupplier;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -190,11 +191,11 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
         if (requestContext instanceof RequestDataContext ctx) {
             var uri = ctx.getClientRequest().getUrl();
             if (uri != null) {
-                var params = uri.getQueryParams();
+                var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
                 if (params != null) {
                     var groups = params.get("apiml-group");
                     if (groups != null && !groups.isEmpty()) {
-                        return groups.getFirst();
+                        return groups.get(0);
                     }
                 }
             }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -195,7 +195,10 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
                 if (params != null) {
                     var groups = params.get("apiml-group");
                     if (groups != null && !groups.isEmpty()) {
-                        return groups.get(0);
+                        var group = groups.get(0);
+                        if (group != null && !group.isEmpty()) {
+                            return group;
+                        }
                     }
                 }
             }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/caching/LoadBalancerCacheTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/caching/LoadBalancerCacheTest.java
@@ -261,6 +261,47 @@ class LoadBalancerCacheTest {
 
         }
 
+        @Nested
+        class GivenGroupAwareCache {
+
+            @Test
+            void whenGroupSpecified_thenCacheKeyIncludesGroup() throws JsonProcessingException {
+                var application = mock(Application.class);
+                var instanceInfo = mock(InstanceInfo.class);
+                when(eurekaClient.getApplication("cachingservice")).thenReturn(application);
+                when(application.getInstances()).thenReturn(Collections.singletonList(instanceInfo));
+
+                var cacheRecord = new LoadBalancerCacheRecord("instance1");
+                when(cachingServiceClient.create(new CachingServiceClient.ApiKeyValue("lb.anuser:aserviceid:group-A", mapper.writeValueAsString(cacheRecord))))
+                    .thenReturn(empty());
+
+                StepVerifier.create(loadBalancerCache.store("anuser", "aserviceid", cacheRecord, "group-A"))
+                    .expectComplete()
+                    .verify();
+
+                verify(cachingServiceClient).create(new CachingServiceClient.ApiKeyValue("lb.anuser:aserviceid:group-A", mapper.writeValueAsString(cacheRecord)));
+            }
+
+            @Test
+            void whenNoGroup_thenCacheKeyMatchesOldFormat() throws JsonProcessingException {
+                var application = mock(Application.class);
+                var instanceInfo = mock(InstanceInfo.class);
+                when(eurekaClient.getApplication("cachingservice")).thenReturn(application);
+                when(application.getInstances()).thenReturn(Collections.singletonList(instanceInfo));
+
+                var cacheRecord = new LoadBalancerCacheRecord("instance1");
+                when(cachingServiceClient.create(new CachingServiceClient.ApiKeyValue("lb.anuser:aserviceid", mapper.writeValueAsString(cacheRecord))))
+                    .thenReturn(empty());
+
+                StepVerifier.create(loadBalancerCache.store("anuser", "aserviceid", cacheRecord, null))
+                    .expectComplete()
+                    .verify();
+
+                verify(cachingServiceClient).create(new CachingServiceClient.ApiKeyValue("lb.anuser:aserviceid", mapper.writeValueAsString(cacheRecord)));
+            }
+
+        }
+
     }
 
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
@@ -201,7 +201,7 @@ class DeterministicLoadBalancerTest {
                         @Test
                         void whenInstanceExists_thenUpdateList() {
                             when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance1")));
-                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq(null)))
                                 .thenReturn(Mono.empty());
 
                             StepVerifier.create(loadBalancer.get(request))
@@ -217,7 +217,7 @@ class DeterministicLoadBalancerTest {
                         @Test
                         void whenInstanceDoesNotExist_thenUpdatePreference() {
                             when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance3")));
-                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq(null)))
                                 .thenReturn(Mono.empty());
 
                             StepVerifier.create(loadBalancer.get(request))
@@ -233,8 +233,8 @@ class DeterministicLoadBalancerTest {
                         @Test
                         void whenCacheEntryExpired_thenUpdatePreference() {
                             when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance2", LocalDateTime.of(2023, 2, 20, 2, 2))));
-                            when(lbCache.delete("USER", "service")).thenReturn(Mono.empty());
-                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                            when(lbCache.delete(eq("USER"), eq("service"), eq(null))).thenReturn(Mono.empty());
+                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq(null)))
                                 .thenReturn(Mono.empty());
 
                             StepVerifier.create(loadBalancer.get(request))
@@ -243,8 +243,8 @@ class DeterministicLoadBalancerTest {
                                 assertEquals(1, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
                                 verify(lbCache).retrieve("USER", "service");
-                                verify(lbCache).delete("USER", "service");
-                                verify(lbCache).store(eq("USER"), eq("service"), any());
+                                verify(lbCache).delete(eq("USER"), eq("service"), eq(null));
+                                verify(lbCache).store(eq("USER"), eq("service"), any(), eq(null));
                             })
                             .expectComplete()
                             .verify();
@@ -256,7 +256,7 @@ class DeterministicLoadBalancerTest {
                     void whenNoPreferece_thenCreateOne() {
                         when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(LoadBalancerCacheRecord.NONE));
 
-                        when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                        when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq(null)))
                                 .thenReturn(Mono.empty());
 
                             StepVerifier.create(loadBalancer.get(request))
@@ -335,7 +335,7 @@ class DeterministicLoadBalancerTest {
                         @Test
                         void whenInstanceExists_thenUpdateList() {
                             when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance1")));
-                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                            when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq(null)))
                                 .thenReturn(Mono.empty());
 
                             StepVerifier.create(loadBalancer.get(request))
@@ -451,8 +451,6 @@ class DeterministicLoadBalancerTest {
             void whenGroupSpecifiedButNoInstancesMatch_thenReturn503() throws URISyntaxException {
                 var context = new RequestDataContext(requestData);
                 when(requestData.getUrl()).thenReturn(new java.net.URI("http://localhost/service?apiml-group=nonexistent"));
-                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
-                when(requestData.getHeaders()).thenReturn(new HttpHeaders());
                 when(request.getContext()).thenReturn(context);
 
                 Map<String, String> metadata = new HashMap<>();
@@ -473,10 +471,6 @@ class DeterministicLoadBalancerTest {
                 when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
                 when(requestData.getHeaders()).thenReturn(new HttpHeaders());
                 when(request.getContext()).thenReturn(context);
-
-                Map<String, String> metadata = new HashMap<>();
-                metadata.put(INSTANCE_GROUP, "group-A");
-                when(instance1.getMetadata()).thenReturn(metadata);
 
                 StepVerifier.create(loadBalancer.get(request))
                     .assertNext(chosenInstances -> {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.net.URISyntaxException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.zowe.apiml.constants.EurekaMetadataDefinition.INSTANCE_GROUP;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -412,6 +414,129 @@ class DeterministicLoadBalancerTest {
                         .verify();
                 }
 
+            }
+
+        }
+
+        @Nested
+        class GivenGroupFiltering {
+
+            @Mock
+            private RequestData requestData;
+
+            @Test
+            void whenGroupSpecifiedAndInstancesExist_thenFilterToGroup() throws URISyntaxException {
+                var context = new RequestDataContext(requestData);
+                when(requestData.getUrl()).thenReturn(new java.net.URI("http://localhost/service?apiml-group=group-A"));
+                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+                when(requestData.getHeaders()).thenReturn(new HttpHeaders());
+                when(request.getContext()).thenReturn(context);
+
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put(INSTANCE_GROUP, "group-A");
+                when(instance1.getMetadata()).thenReturn(metadata);
+                when(instance2.getMetadata()).thenReturn(new HashMap<>());
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .assertNext(chosenInstances -> {
+                        assertNotNull(chosenInstances);
+                        assertEquals(1, chosenInstances.size());
+                        assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                    })
+                    .expectComplete()
+                    .verify();
+            }
+
+            @Test
+            void whenGroupSpecifiedButNoInstancesMatch_thenReturn503() throws URISyntaxException {
+                var context = new RequestDataContext(requestData);
+                when(requestData.getUrl()).thenReturn(new java.net.URI("http://localhost/service?apiml-group=nonexistent"));
+                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+                when(requestData.getHeaders()).thenReturn(new HttpHeaders());
+                when(request.getContext()).thenReturn(context);
+
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put(INSTANCE_GROUP, "group-A");
+                when(instance1.getMetadata()).thenReturn(metadata);
+                when(instance2.getMetadata()).thenReturn(new HashMap<>());
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .expectErrorMatches(e ->
+                        e instanceof ResponseStatusException ex && ex.getStatusCode().value() == 503)
+                    .verify();
+            }
+
+            @Test
+            void whenNoGroupSpecified_thenAllInstancesReturned() {
+                var context = new RequestDataContext(requestData);
+                when(requestData.getUrl()).thenReturn(null);
+                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+                when(requestData.getHeaders()).thenReturn(new HttpHeaders());
+                when(request.getContext()).thenReturn(context);
+
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put(INSTANCE_GROUP, "group-A");
+                when(instance1.getMetadata()).thenReturn(metadata);
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .assertNext(chosenInstances -> {
+                        assertNotNull(chosenInstances);
+                        assertEquals(2, chosenInstances.size());
+                    })
+                    .expectComplete()
+                    .verify();
+            }
+
+            @Test
+            void whenEmptyGroupString_thenAllInstancesReturned() throws URISyntaxException {
+                var context = new RequestDataContext(requestData);
+                // Empty query param still returns a list with an empty string
+                when(requestData.getUrl()).thenReturn(new java.net.URI("http://localhost/service?apiml-group="));
+                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+                when(requestData.getHeaders()).thenReturn(new HttpHeaders());
+                when(request.getContext()).thenReturn(context);
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .assertNext(chosenInstances -> {
+                        assertNotNull(chosenInstances);
+                        assertEquals(2, chosenInstances.size());
+                    })
+                    .expectComplete()
+                    .verify();
+            }
+
+            @Test
+            void whenGroupWithStickySession_thenUserStaysInGroup() throws URISyntaxException {
+                // Set up a request with group parameter and valid token
+                var context = new RequestDataContext(requestData);
+                when(requestData.getUrl()).thenReturn(new java.net.URI("http://localhost/service?apiml-group=group-A"));
+                when(requestData.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+                when(request.getContext()).thenReturn(context);
+                when(clock.instant()).thenReturn(Instant.ofEpochSecond(1721552753));
+
+                // Token in cookie
+                MultiValueMap<String, String> cookie = new LinkedMultiValueMap<>();
+                cookie.add("apimlAuthenticationToken", VALID_TOKEN);
+                when(requestData.getCookies()).thenReturn(cookie);
+
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put(INSTANCE_GROUP, "group-A");
+                when(instance1.getMetadata()).thenReturn(metadata);
+                when(instance2.getMetadata()).thenReturn(new HashMap<>());
+
+                when(lbCache.retrieve("USER", "service", "group-A")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance1")));
+                when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1")), eq("group-A")))
+                    .thenReturn(Mono.empty());
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .assertNext(chosenInstances -> {
+                        assertNotNull(chosenInstances);
+                        assertEquals(1, chosenInstances.size());
+                        assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                        verify(lbCache).retrieve("USER", "service", "group-A");
+                    })
+                    .expectComplete()
+                    .verify();
             }
 
         }

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
@@ -68,6 +68,13 @@ public class ApiMediationServiceConfig {
     private String serviceId;
 
     /**
+     * Optional group identifier for instance grouping. Instances with the same group
+     * can be targeted via the ?apiml-group query parameter on API requests.
+     * Example: "department-A", "us-east-1"
+     */
+    private String instanceGroup;
+
+    /**
      * * **title** (XML Path: /instance/metadata/apiml.service.title)
      *
      *   This parameter specifies the human readable name of the API service instance.

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigCreator.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigCreator.java
@@ -125,6 +125,11 @@ public class EurekaInstanceConfigCreator {
         metadata.put(SERVICE_TITLE, config.getTitle());
         metadata.put(SERVICE_DESCRIPTION, config.getDescription());
 
+        // fill instance group metadata
+        if (config.getInstanceGroup() != null && !config.getInstanceGroup().isEmpty()) {
+            metadata.put(INSTANCE_GROUP, config.getInstanceGroup());
+        }
+
         // fill custom metadata
         metadata.putAll(flattenMetadata(config.getCustomMetadata()));
 

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigCreatorTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/util/EurekaInstanceConfigCreatorTest.java
@@ -55,4 +55,13 @@ class EurekaInstanceConfigCreatorTest {
         assertEquals("'ftp' is not valid protocol for baseUrl property", exception.getMessage());
     }
 
+    @Test
+    void whenInstanceGroupIsSet_thenMetadataContainsGroup() throws ServiceDefinitionException {
+        ApiMediationServiceConfig testConfig = configReader.loadConfiguration("service-configuration.yml");
+        testConfig.setInstanceGroup("test-group");
+        EurekaInstanceConfig translatedConfig = eurekaInstanceConfigCreator.createEurekaInstanceConfig(testConfig);
+
+        assertThat(translatedConfig.getMetadataMap(), hasEntry("apiml.instance.group", "test-group"));
+    }
+
 }

--- a/onboarding-enabler-nodejs/src/defaultConfig.js
+++ b/onboarding-enabler-nodejs/src/defaultConfig.js
@@ -69,5 +69,7 @@ export default {
     useLocalMetadata: false,
     preferIpAddress: false,
   },
-  instance: {},
+  instance: {
+    instanceGroup: null,   // optional group identifier
+  },
 };

--- a/onboarding-enabler-nodejs/src/index.js
+++ b/onboarding-enabler-nodejs/src/index.js
@@ -38,6 +38,11 @@ let config;
 
 /**
  * Read ssl service configuration
+ *
+ * The Node.js enabler supports instance grouping through the
+ * `instance.instanceGroup` configuration or through `apiml.instance.group`
+ * custom metadata in Eureka. When set, instances can be targeted via the
+ * ?apiml-group query parameter on API requests.
  */
 function readTlsProps() {
   try {


### PR DESCRIPTION
Closes #4405

## Summary
Adds instance grouping support to the API Mediation Layer. Service instances can specify a group identifier in registration metadata, and requests can target a specific group via the `?apiml-group` query parameter.

## Changes (10 files, +395/-23)
- `INSTANCE_GROUP` constant in `EurekaMetadataDefinition`
- `instanceGroup` field in `ApiMediationServiceConfig`
- Metadata population in `EurekaInstanceConfigCreator`
- Group filtering in `DeterministicLoadBalancer` via `?apiml-group` query param
- Group-aware cache keys in `LoadBalancerCache`
- 7 new tests (5 load balancer + 2 cache)
- Node.js enabler config + docs

## Design
See solution design: https://github.com/zowe/api-layer/issues/4405#issuecomment-4631287837