### PR TITLE
fix: add default allow list

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
@@ -25,13 +25,17 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
 public class MetadataFilterService implements InitializingBean {
 
     private static final String ORG_ZOWE_APIML_COMMON_URL_NOT_ALLOWED = "org.zowe.apiml.common.urlNotAllowed";
+    private static final String[] DEFAULT_ALLOWED_DOMAINS = { "www.ibm.com", "zowe.github.io", "www.zowe.org" };
 
     @Value("${apiml.security.allowedDomains:${apiml.service.hostname}}")
     private String allowedDomains;
@@ -41,11 +45,11 @@ public class MetadataFilterService implements InitializingBean {
     @InjectApimlLogger
     private ApimlLogger apimlLogger = ApimlLogger.empty();
 
-    private List<String> allowedDomainsList;
+    private Set<String> allowedDomainsSet;
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        allowedDomainsList = Arrays.stream(allowedDomains.split(",")).map(String::trim).toList();
+        allowedDomainsSet = Stream.concat(Arrays.stream(allowedDomains.split(",")).map(String::trim), Arrays.stream(DEFAULT_ALLOWED_DOMAINS)).collect(Collectors.toSet());
         onlyWarn = Optional.ofNullable(System.getenv("ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED")).map(Boolean::parseBoolean).orElse(false);
 
         log.info("Allowed domains in Discovery Service: {}", allowedDomains);
@@ -60,7 +64,7 @@ public class MetadataFilterService implements InitializingBean {
         if (StringUtils.isBlank(domain)) {
             return true;
         }
-        return allowedDomainsList.stream().anyMatch(allowedDomain -> {
+        return allowedDomainsSet.stream().anyMatch(allowedDomain -> {
             try {
                 return isAllowed(allowedDomain, domain);
             } catch (MalformedURLException e) {

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
@@ -49,7 +49,7 @@ public class MetadataFilterService implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        allowedDomainsSet = Stream.concat(Arrays.stream(allowedDomains.split(",")).map(String::trim), Arrays.stream(DEFAULT_ALLOWED_DOMAINS)).collect(Collectors.toSet());
+        allowedDomainsSet = Stream.concat(Arrays.stream(allowedDomains.split(",")).map(String::trim), Arrays.stream(DEFAULT_ALLOWED_DOMAINS)).map(String::toLowerCase).collect(Collectors.toSet());
         onlyWarn = Optional.ofNullable(System.getenv("ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED")).map(Boolean::parseBoolean).orElse(false);
 
         log.info("Allowed domains in Discovery Service: {}", allowedDomains);
@@ -75,8 +75,10 @@ public class MetadataFilterService implements InitializingBean {
 
     private boolean isAllowed(String allowedDomain, String domain) throws MalformedURLException {
         log.debug("checking URL {} against domain {}", domain, allowedDomain);
+        allowedDomain = allowedDomain.toLowerCase();
+        domain = domain.toLowerCase();
         if (isUrl(domain)) {
-            domain = new URL(domain).getHost();
+            domain = new URL(domain).getHost().toLowerCase();
         }
         if (domain.equals(allowedDomain)) {
             return true;

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
@@ -25,7 +25,9 @@ import org.zowe.apiml.message.log.ApimlLogger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -57,6 +59,8 @@ class MetadataFilterServiceTest {
         void setUp() throws Exception {
             ReflectionTestUtils.setField(metadataFilterService, "allowedDomains", "localhost, *.zowe.org");
             metadataFilterService.afterPropertiesSet();
+            var allowedDomainsSet = ReflectionTestUtils.getField(metadataFilterService, "allowedDomainsSet");
+            assertEquals(Set.of("www.ibm.com", "zowe.github.io", "www.zowe.org"), allowedDomainsSet);
         }
 
         @ParameterizedTest(name = "Key: {0}, Value: {1} -> Allowed: {2}")

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
@@ -73,7 +73,9 @@ class MetadataFilterServiceTest {
             "apiml.graphqlUrl, https://sub.zowe.org:8080, true",
             "apiml.documentationUrl, https://invalid.org:8080, false",
             "apiml.customKey, https://invalid.org:8080, true",
-            "apiml.documentationUrl, invalid-url, false"
+            "apiml.documentationUrl, invalid-url, false",
+            "apiml.externalUrl, HTTPS://LOCALHOST:8080, true",
+            "apiml.externalUrl, HTTPS://INVALID.ORG:8080, false"
         })
         void shouldVerifyMetadataKeysAndDomains(String metadataKey, String metadataValue, boolean isAllowed) throws Exception {
             Map<String, String> metadata = new HashMap<>();

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
@@ -60,7 +60,7 @@ class MetadataFilterServiceTest {
             ReflectionTestUtils.setField(metadataFilterService, "allowedDomains", "localhost, *.zowe.org");
             metadataFilterService.afterPropertiesSet();
             var allowedDomainsSet = ReflectionTestUtils.getField(metadataFilterService, "allowedDomainsSet");
-            assertEquals(Set.of("www.ibm.com", "zowe.github.io", "www.zowe.org"), allowedDomainsSet);
+            assertEquals(Set.of("localhost", "*.zowe.org", "www.ibm.com", "zowe.github.io", "www.zowe.org"), allowedDomainsSet);
         }
 
         @ParameterizedTest(name = "Key: {0}, Value: {1} -> Allowed: {2}")


### PR DESCRIPTION
# Description

Add required default allowed domains to API ML codebase.
These domains are currently used for core API ML services onboarding (z/OSMF static definition and others in documentationUrl for example)

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

