### PR TITLE
feat: Decouple listen/advertised address for DVIPA hot-standby — GH#4409

### DIFF
--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -113,6 +113,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} ${JAVA_BIN_DIR}java \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \
     -Dspring.profiles.active=${ZWE_configs_spring_profiles_active:-} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+    -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
     -Dapiml.service.port=${ZWE_configs_port:-7552} \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
     -Dapiml.service.gatewayHostname=${ZWE_GATEWAY_HOST:-${ZWE_haInstance_hostname:-localhost}} \

--- a/apiml-package/src/main/resources/bin/start.sh
+++ b/apiml-package/src/main/resources/bin/start.sh
@@ -306,6 +306,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${APIML_CODE} ${JAVA_BIN_DIR}java \
     -Dapiml.service.corsEnabled=${ZWE_components_gateway_apiml_service_corsEnabled:-${ZWE_configs_apiml_service_corsEnabled:-false}} \
     -Dapiml.service.forwardClientCertEnabled=${ZWE_components_gateway_apiml_security_x509_enabled:-${ZWE_configs_apiml_security_x509_enabled:-false}} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+    -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
     -Dapiml.service.port=${ZWE_components_gateway_port:-${ZWE_configs_port:-7554}} \
     -Dapiml.service.ssl.ciphers=${ZWE_configs_apiml_service_ssl_ciphers:-${client_ciphers}} \
     -Dapiml.service.ssl.enabled-protocols=${ZWE_configs_apiml_service_ssl_enabled_protocols:-${client_enabled_protocols}} \

--- a/apiml/src/main/java/org/zowe/apiml/ModulithConfig.java
+++ b/apiml/src/main/java/org/zowe/apiml/ModulithConfig.java
@@ -120,6 +120,9 @@ public class ModulithConfig {
     @Value("${apiml.service.ipAddress:127.0.0.1}")
     private String ipAddress;
 
+    @Value("${apiml.service.advertisedIpAddress:${apiml.service.ipAddress:127.0.0.1}}")
+    private String advertisedIpAddress;
+
     @Value("${apiml.service.port:10010}")
     private int gatewayPort;
 
@@ -183,7 +186,7 @@ public class ModulithConfig {
             .setHostName(hostname)
             .setHomePageUrl(null, String.format("%s://%s:%d%s", scheme, hostname, port, homePagePath))
             .setStatus(InstanceInfo.InstanceStatus.UP)
-            .setIPAddr(ipAddress)
+            .setIPAddr(advertisedIpAddress)
             .setPort(port)
             .setSecurePort(port)
             .enablePort(InstanceInfo.PortType.SECURE, https || isServerAttlsEnabled)

--- a/apiml/src/test/java/org/zowe/apiml/ModulithConfigTest.java
+++ b/apiml/src/test/java/org/zowe/apiml/ModulithConfigTest.java
@@ -19,14 +19,19 @@ import org.zowe.apiml.auth.AuthenticationScheme;
 import org.zowe.apiml.eurekaservice.client.util.EurekaMetadataParser;
 import org.zowe.apiml.services.ServiceInfo;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -74,6 +79,32 @@ class ModulithConfigTest {
         var basicInfoService = mc.basicInfoService(discoveryClient, eurekaParser);
         List<ServiceInfo> servicesInfo = basicInfoService.getServicesInfo();
         assertThat(servicesInfo, emptyIterable());
+    }
+
+    @Test
+    void givenAdvertisedIpAddressSet_thenGetInstanceInfoUsesAdvertisedIpAddress() throws Exception {
+        // Mock the dependencies needed by getInstanceInfo for "gateway" service
+        var eurekaInstanceGw = mock(GatewayEurekaInstanceConfigBean.class);
+        when(eurekaInstanceGw.getMetadataMap()).thenReturn(new HashMap<>());
+
+        ModulithConfig mc = new ModulithConfig(null, eurekaInstanceGw, null, null, null, null);
+
+        // Set advertisedIpAddress to a specific value and ipAddress to a different value
+        ReflectionTestUtils.setField(mc, "advertisedIpAddress", "192.168.1.100");
+        ReflectionTestUtils.setField(mc, "ipAddress", "10.0.0.1");
+        ReflectionTestUtils.setField(mc, "hostname", "testhost");
+        ReflectionTestUtils.setField(mc, "gatewayPort", 10010);
+        ReflectionTestUtils.setField(mc, "https", false);
+
+        // Invoke private getInstanceInfo via reflection
+        Method method = ModulithConfig.class.getDeclaredMethod("getInstanceInfo", String.class);
+        method.setAccessible(true);
+        InstanceInfo instanceInfo = (InstanceInfo) method.invoke(mc, "gateway");
+
+        assertNotNull(instanceInfo);
+        // advertisedIpAddress should take precedence over ipAddress
+        assertEquals("192.168.1.100", instanceInfo.getIPAddr(),
+            "getInstanceInfo should use advertisedIpAddress when it is set");
     }
 
 }

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -108,6 +108,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} ${JAVA_BIN_DIR}java \
   -Dapiml.health.protected=${ZWE_configs_apiml_health_protected:-true} \
   -Dapiml.service.port=${ZWE_configs_port:-7555} \
   -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+  -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
   -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
   -Dapiml.service.customMetadata.apiml.gatewayPort=${ZWE_components_gateway_port:-7554} \
   -Dapiml.service.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -112,6 +112,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} ${JAVA_BIN_DIR}java \
     -Dapiml.security.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
     -Dapiml.security.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+    -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
     -Dapiml.service.port=${ZWE_configs_port:-7553} \
     -Dapiml.service.ssl.ciphers=${ZWE_configs_apiml_service_ssl_ciphers:-${client_ciphers}} \
     -Dapiml.service.ssl.enabled-protocols=${ZWE_configs_apiml_service_ssl_enabled_protocols:-${client_enabled_protocols}} \

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -77,7 +77,7 @@ eureka:
     instance:
         instanceId: ${apiml.service.hostname}:${apiml.service.id}:${apiml.service.port}
         hostname: ${apiml.service.hostname}
-        ipAddress: ${apiml.service.ipAddress}
+        ipAddress: ${apiml.service.advertisedIpAddress:${apiml.service.ipAddress}}
         port: ${server.port}
         securePort: 0
         nonSecurePortEnabled: true

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -192,6 +192,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} ${JAVA_BIN_DIR}java \
     -Dapiml.service.corsEnabled=${ZWE_configs_apiml_service_corsEnabled:-false} \
     -Dapiml.service.forwardClientCertEnabled=${ZWE_configs_apiml_security_x509_enabled:-false} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+    -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
     -Dapiml.service.http.password=${ZWE_configs_apiml_service_http_password:-} \
     -Dapiml.service.http.userId=${ZWE_configs_apiml_service_http_userId:-} \
     -Dapiml.service.port=${ZWE_configs_port:-7554} \

--- a/zaas-package/src/main/resources/bin/start.sh
+++ b/zaas-package/src/main/resources/bin/start.sh
@@ -148,6 +148,7 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${ZAAS_CODE} ${JAVA_BIN_DIR}java \
     -Djava.io.tmpdir=${TMPDIR:-/tmp} \
     -Dspring.profiles.active=${ZWE_configs_spring_profiles_active:-} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
+    -Dapiml.service.advertisedIpAddress=${ZWE_configs_apiml_service_advertisedIpAddress:-${ZWE_configs_zowe_network_server_listenAddresses:-${ZWE_haInstance_hostname:-localhost}}} \
     -Dapiml.service.port=${ZWE_configs_port:-7558} \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
     -Dapiml.connection.timeout=${ZWE_configs_apiml_connection_timeout:-60000} \

--- a/zaas-service/src/main/resources/application.yml
+++ b/zaas-service/src/main/resources/application.yml
@@ -165,7 +165,7 @@ eureka:
     instance:
         instanceId: ${apiml.service.hostname}:${apiml.service.id}:${apiml.service.port}
         hostname: ${apiml.service.hostname}
-        ipAddress: ${apiml.service.ipAddress}
+        ipAddress: ${apiml.service.advertisedIpAddress:${apiml.service.ipAddress}}
         securePortEnabled: true
         #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}

--- a/zaas-service/src/test/resources/application-test.yml
+++ b/zaas-service/src/test/resources/application-test.yml
@@ -105,7 +105,7 @@ management:
 eureka:
     instance:
         hostname: ${apiml.service.hostname}
-        ipAddress: ${apiml.service.ipAddress}
+        ipAddress: ${apiml.service.advertisedIpAddress:${apiml.service.ipAddress}}
         #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}
         homePageUrl: ${apiml.service.scheme}://${apiml.zaas.hostname}:${apiml.service.port}/

--- a/zaas-service/src/test/resources/application.yml
+++ b/zaas-service/src/test/resources/application.yml
@@ -120,7 +120,7 @@ otel:
 eureka:
     instance:
         hostname: ${apiml.service.hostname}
-        ipAddress: ${apiml.service.ipAddress}
+        ipAddress: ${apiml.service.advertisedIpAddress:${apiml.service.ipAddress}}
         #ports are computed in code
         preferIpAddress: ${apiml.service.preferIpAddress}
         homePageUrl: ${apiml.service.scheme}://${apiml.zaas.hostname}:${apiml.service.port}/


### PR DESCRIPTION
Closes #4409

## Summary
Introduce `apiml.service.advertisedIpAddress` property to decouple the network bind address from the Eureka-registration advertised address for DVIPA hot-standby HA deployments.

## Changes

### ModulithConfig.java
- Added `advertisedIpAddress` field with fallback chain: `advertisedIpAddress` → `ipAddress` → `127.0.0.1`
- Changed `getInstanceInfo()` to use `advertisedIpAddress` instead of `ipAddress`
- New unit test verifies advertisedIpAddress takes precedence over ipAddress

### YAML Configuration (discovery + zaas)
- Changed `eureka.instance.ipAddress` in 4 YAML files from `${apiml.service.ipAddress}` to `${apiml.service.advertisedIpAddress:${apiml.service.ipAddress}}`
- Full backward compatibility preserved via the fallback

### Start Scripts (6 services)
- Added `-Dapiml.service.advertisedIpAddress` to all 6 start.sh files
- Fallback chain: ZWE_configs_apiml_service_advertisedIpAddress → listenAddresses → haInstance_hostname → localhost

### Documentation (docs-site PR #5055)
- Updated configure-sysplex.md, zowe-ha-overview.md, onboard-spring-boot-enabler.md at https://github.com/zowe/docs-site/pull/5055

## Verification
- Compilation: all 6 changed modules compile successfully ✓
- ModulithConfigTest (new test): passes ✓
- Full `./gradlew clean build`: pre-existing YamlMessageService failures (environment issue, confirmed on stock v3.x.x)

## Design
See full design in [GH issue comment](https://github.com/zowe/api-layer/issues/4409#issuecomment-2794265444)