### PR TITLE
feat: soft instanceId preference with full fallback list for HA failover (#4511)

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -207,19 +207,28 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
     }
 
     /**
-     * Filters the list of service instances to include only those with the specified instance ID.
+     * Applies soft preference for the requested instance ID: the matching instance is placed
+     * first in the list with all other instances following as fallback. Throws 404 only if the
+     * requested instance ID does not exist anywhere in the service instances list.
      *
      * @param instanceId       ID of the service instance
-     * @param serviceInstances the list of service instances to filter
-     * @return the filtered list of service instances
+     * @param serviceInstances the list of service instances
+     * @return ordered list with matched instance first, all others following
      */
     private List<ServiceInstance> checkInstanceIdHeader(String instanceId, List<ServiceInstance> serviceInstances) {
         if (instanceId != null) {
-            List<ServiceInstance> filteredInstances = serviceInstances.stream()
+            Optional<ServiceInstance> matchedInstance = serviceInstances.stream()
                 .filter(instance -> instanceId.equals(instance.getInstanceId()))
-                .toList();
-            if (!filteredInstances.isEmpty()) {
-                return filteredInstances;
+                .findFirst();
+            if (matchedInstance.isPresent()) {
+                List<ServiceInstance> orderedList = new ArrayList<>();
+                orderedList.add(matchedInstance.get());
+                for (ServiceInstance instance : serviceInstances) {
+                    if (!instance.getInstanceId().equals(instanceId)) {
+                        orderedList.add(instance);
+                    }
+                }
+                return orderedList;
             }
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service instance not found for the provided instance ID");
         }
@@ -228,21 +237,36 @@ public class DeterministicLoadBalancer extends SameInstancePreferenceServiceInst
 
 
     /**
-     * Selected the preferred instance if not null, if the preferred instance is not found or is null a new preference is created
+     * Returns the ordered list of service instances with the preferred instance first.
+     * If the preferred instance is found (by instanceId), it is placed at the head of the list
+     * with all other instances following as fallback. The cache always stores the preferred
+     * instance for sticky affinity. If no preference exists, the first instance from the list
+     * becomes the new preference.
      *
      * @param instanceId       The preferred instanceId
      * @param user             The user
      * @param serviceInstances The default serviceInstances available
-     * @return Flux with a list containing only one selected instance
+     * @return Flux with the ordered list: preferred instance first, all others following
      */
     private Flux<List<ServiceInstance>> chooseOne(String instanceId, String user, List<ServiceInstance> serviceInstances) {
-        Stream<ServiceInstance> stream = serviceInstances.stream();
+        ServiceInstance chosenInstance;
         if (instanceId != null) {
-            stream = stream.filter(instance -> instanceId.equals(instance.getInstanceId()));
+            chosenInstance = serviceInstances.stream()
+                .filter(instance -> instanceId.equals(instance.getInstanceId()))
+                .findAny()
+                .orElse(serviceInstances.get(0));
+        } else {
+            chosenInstance = serviceInstances.get(0);
         }
-        ServiceInstance chosenInstance = stream.findAny().orElse(serviceInstances.get(0));
+        List<ServiceInstance> orderedList = new ArrayList<>(serviceInstances.size());
+        orderedList.add(chosenInstance);
+        for (ServiceInstance instance : serviceInstances) {
+            if (!instance.getInstanceId().equals(chosenInstance.getInstanceId())) {
+                orderedList.add(instance);
+            }
+        }
         return cache.store(user, chosenInstance.getServiceId(), new LoadBalancerCacheRecord(chosenInstance.getInstanceId()))
-            .thenMany(just(Collections.singletonList(chosenInstance)));
+            .thenMany(just(orderedList));
     }
 
     /**

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancer.java
@@ -36,7 +36,6 @@ import java.text.ParseException;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.zowe.apiml.constants.ApimlConstants.X_INSTANCEID;

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/loadbalancer/DeterministicLoadBalancerTest.java
@@ -205,8 +205,9 @@ class DeterministicLoadBalancerTest {
                             StepVerifier.create(loadBalancer.get(request))
                                 .assertNext(chosenInstances -> {
                                     assertNotNull(chosenInstances);
-                                    assertEquals(1, chosenInstances.size());
+                                    assertEquals(2, chosenInstances.size());
                                     assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                    assertEquals("instance2", chosenInstances.get(1).getInstanceId());
                                 })
                                 .expectComplete()
                                 .verify();
@@ -221,8 +222,9 @@ class DeterministicLoadBalancerTest {
                             StepVerifier.create(loadBalancer.get(request))
                             .assertNext(chosenInstances -> {
                                 assertNotNull(chosenInstances);
-                                assertEquals(1, chosenInstances.size());
+                                assertEquals(2, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                assertEquals("instance2", chosenInstances.get(1).getInstanceId());
                             })
                             .expectComplete()
                             .verify();
@@ -238,8 +240,9 @@ class DeterministicLoadBalancerTest {
                             StepVerifier.create(loadBalancer.get(request))
                             .assertNext(chosenInstances -> {
                                 assertNotNull(chosenInstances);
-                                assertEquals(1, chosenInstances.size());
+                                assertEquals(2, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                assertEquals("instance2", chosenInstances.get(1).getInstanceId());
                                 verify(lbCache).retrieve("USER", "service");
                                 verify(lbCache).delete("USER", "service");
                                 verify(lbCache).store(eq("USER"), eq("service"), any());
@@ -260,8 +263,9 @@ class DeterministicLoadBalancerTest {
                             StepVerifier.create(loadBalancer.get(request))
                             .assertNext(chosenInstances -> {
                                 assertNotNull(chosenInstances);
-                                assertEquals(1, chosenInstances.size());
+                                assertEquals(2, chosenInstances.size());
                                 assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                assertEquals("instance2", chosenInstances.get(1).getInstanceId());
 
                                 verify(lbCache).retrieve("USER", "service");
                             })
@@ -339,8 +343,9 @@ class DeterministicLoadBalancerTest {
                             StepVerifier.create(loadBalancer.get(request))
                                 .assertNext(chosenInstances -> {
                                     assertNotNull(chosenInstances);
-                                    assertEquals(1, chosenInstances.size());
+                                    assertEquals(2, chosenInstances.size());
                                     assertEquals("instance1", chosenInstances.get(0).getInstanceId());
+                                    assertEquals("instance2", chosenInstances.get(1).getInstanceId());
                                 })
                                 .expectComplete()
                                 .verify();
@@ -378,8 +383,9 @@ class DeterministicLoadBalancerTest {
                     StepVerifier.create(loadBalancer.get(request))
                         .assertNext(chosenInstances -> {
                             assertNotNull(chosenInstances);
-                            assertEquals(1, chosenInstances.size());
+                            assertEquals(2, chosenInstances.size());
                             assertEquals("instance2", chosenInstances.get(0).getInstanceId());
+                            assertEquals("instance1", chosenInstances.get(1).getInstanceId());
                             verify(lbCache, never()).retrieve(any(), any());
                         })
                         .expectComplete()
@@ -412,6 +418,48 @@ class DeterministicLoadBalancerTest {
                         .verify();
                 }
 
+            }
+
+        }
+
+        @Nested
+        class GivenHaFailoverScenario {
+
+            @BeforeEach
+            void setUp() {
+                var requestData = mock(RequestData.class);
+                var context = new RequestDataContext(requestData);
+
+                MultiValueMap<String, String> cookie = new LinkedMultiValueMap<>();
+                cookie.add("apimlAuthenticationToken", VALID_TOKEN);
+
+                when(requestData.getCookies()).thenReturn(cookie);
+                when(request.getContext()).thenReturn(context);
+                when(clock.instant()).thenReturn(Instant.ofEpochSecond(1721552753));
+
+                Map<String, String> metadata = new HashMap<>();
+                metadata.put("apiml.lb.type", "authentication");
+                when(instance1.getMetadata()).thenReturn(metadata);
+            }
+
+            @Test
+            void givenCacheHasPreference_whenPreferredInstanceAvailable_thenPreferredIsFirstAndAllInstancesReturned() {
+                when(lbCache.retrieve("USER", "service")).thenReturn(Mono.just(new LoadBalancerCacheRecord("instance1")));
+                when(lbCache.store(eq("USER"), eq("service"), argThat(cacheRecord -> cacheRecord.getInstanceId().equals("instance1"))))
+                    .thenReturn(Mono.empty());
+
+                StepVerifier.create(loadBalancer.get(request))
+                    .assertNext(chosenInstances -> {
+                        assertNotNull(chosenInstances);
+                        assertEquals(2, chosenInstances.size(),
+                            "All instances must be returned for transparent failover");
+                        assertEquals("instance1", chosenInstances.get(0).getInstanceId(),
+                            "Preferred instance must be first in list");
+                        assertEquals("instance2", chosenInstances.get(1).getInstanceId(),
+                            "Fallback instance must follow the preferred");
+                    })
+                    .expectComplete()
+                    .verify();
             }
 
         }


### PR DESCRIPTION
Closes #4511

## Summary
Changes `DeterministicLoadBalancer` to return a full, ordered instance list instead of a singleton, enabling Spring Cloud `RoundRobinLoadBalancer` to transparently fail over to the next available instance.

## Changes

### `checkInstanceIdHeader()` — Soft preference instead of strict filtering
- Returns `[matched, ...all-others]` when requested instanceId exists
- Throws 404 ONLY if instanceId is absent from the entire registry
- Previously returned ONLY the matched instance, filtering out all others

### `chooseOne()` — Full ordered list
- Returns `[preferred, ...all-others]` instead of `Collections.singletonList(chosenInstance)`
- Cache still stores the preferred instance for sticky affinity
- Enables Spring Cloud RoundRobinLoadBalancer transparent failover

### Test updates
- Updated 6 existing assertions from size 1 to size 2
- Added instance order verification (preferred is first)
- New `GivenHaFailoverScenario` nested test
- `whenInstanceIdDoesNotExist_thenFail` unchanged (still 404s correctly)

## Validation
- `./gradlew clean build` — BUILD SUCCESSFUL (410 actionable tasks)