### PR TITLE
fix: Add ServiceAccessClassifier to distinguish TLS errors from service unavailability — GH#4512

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/ServiceAccessClassifier.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/error/ServiceAccessClassifier.java
@@ -1,0 +1,119 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.security.common.error;
+
+import javax.net.ssl.SSLException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.security.cert.CertificateException;
+
+/**
+ * Utility that inspects exception cause chains to classify service access failures.
+ *
+ * <p>The classifier distinguishes between SSL/TLS certificate errors (which indicate a
+ * configuration problem, not a down service) and genuine connectivity failures (service
+ * is unreachable).</p>
+ *
+ * <p>Two-phase cause-chain inspection for {@link #isServiceUnavailable(Throwable)}:
+ * <ol>
+ *   <li>Scan for SSL/cert exceptions (negative signal — returns false if found)</li>
+ *   <li>Scan for connectivity exceptions (positive signal — returns true if found)</li>
+ * </ol></p>
+ */
+public final class ServiceAccessClassifier {
+
+    private ServiceAccessClassifier() {
+    }
+
+    /**
+     * Checks whether the exception indicates the target service is genuinely unreachable.
+     *
+     * <p>Two-phase inspection of the full cause chain:</p>
+     * <ol>
+     *   <li>If ANY link is an SSLException or CertificateException, this is a TLS/cert
+     *       configuration problem, not a down service — returns {@code false}.</li>
+     *   <li>Otherwise, walks the chain looking for connectivity exceptions
+     *       (ConnectException, SocketTimeoutException, SocketException,
+     *       NoRouteToHostException, UnknownHostException) and returns {@code true}
+     *       if any is found.</li>
+     * </ol>
+     *
+     * @param error the exception to inspect; may be {@code null}
+     * @return {@code true} if the error chain indicates genuine service unavailability,
+     *         {@code false} for SSL/cert errors, non-connectivity errors, or {@code null}
+     */
+    public static boolean isServiceUnavailable(Throwable error) {
+        if (error == null) {
+            return false;
+        }
+
+        // Phase 1: check for SSL/certificate exceptions anywhere in the chain
+        if (hasSslOrCertificateCause(error)) {
+            return false;
+        }
+
+        // Phase 2: check for connectivity exceptions
+        Throwable current = error;
+        do {
+            if (current instanceof ConnectException
+                    || current instanceof SocketTimeoutException
+                    || current instanceof SocketException
+                    || current instanceof NoRouteToHostException
+                    || current instanceof UnknownHostException) {
+                return true;
+            }
+            Throwable previous = current;
+            current = current.getCause();
+            // guard against self-referencing cause chains
+            if (current == previous) {
+                break;
+            }
+        } while (current != null);
+
+        return false;
+    }
+
+    /**
+     * Walks the full cause chain and returns {@code true} if any link is an
+     * {@link SSLException} or {@link CertificateException} (or subclass thereof).
+     *
+     * <p>This correctly detects SSL errors even when they are wrapped inside
+     * other exception types (e.g., an SSLException wrapped inside a ConnectException
+     * by Netty).</p>
+     *
+     * @param error the exception to inspect; may be {@code null}
+     * @return {@code true} if SSLException or CertificateException (or subclass) is
+     *         anywhere in the cause chain, {@code false} otherwise or if {@code null}
+     */
+    public static boolean hasSslOrCertificateCause(Throwable error) {
+        if (error == null) {
+            return false;
+        }
+
+        Throwable current = error;
+        do {
+            if (current instanceof SSLException
+                    || current instanceof CertificateException) {
+                return true;
+            }
+            Throwable previous = current;
+            current = current.getCause();
+            if (current == previous) {
+                break;
+            }
+        } while (current != null);
+
+        return false;
+    }
+}

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/ServiceAccessClassifierTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/error/ServiceAccessClassifierTest.java
@@ -1,0 +1,156 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.security.common.error;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.security.cert.CertificateException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceAccessClassifierTest {
+
+    @Nested
+    class IsServiceUnavailable {
+
+        @Test
+        void givenNull_whenIsServiceUnavailable_thenReturnsFalse() {
+            assertFalse(ServiceAccessClassifier.isServiceUnavailable(null));
+        }
+
+        // --- Phase 1: SSL/cert exceptions → false ---
+
+        @Test
+        void givenSslExceptionDirect_whenIsServiceUnavailable_thenReturnsFalse() {
+            SSLException ex = new SSLException("TLS handshake failed");
+            assertFalse(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenCertificateExceptionDirect_whenIsServiceUnavailable_thenReturnsFalse() {
+            CertificateException ex = new CertificateException("cert expired");
+            assertFalse(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenSslWrappedInConnect_whenIsServiceUnavailable_thenReturnsFalse() {
+            SSLException sslEx = new SSLException("TLS handshake failed");
+            ConnectException connectEx = new ConnectException("connection refused");
+            connectEx.initCause(sslEx);
+            assertFalse(ServiceAccessClassifier.isServiceUnavailable(connectEx));
+        }
+
+        // --- Phase 2: connectivity exceptions → true ---
+
+        @Test
+        void givenConnectExceptionDirect_whenIsServiceUnavailable_thenReturnsTrue() {
+            ConnectException ex = new ConnectException("connection refused");
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenSocketTimeoutExceptionDirect_whenIsServiceUnavailable_thenReturnsTrue() {
+            SocketTimeoutException ex = new SocketTimeoutException("read timed out");
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenSocketExceptionDirect_whenIsServiceUnavailable_thenReturnsTrue() {
+            SocketException ex = new SocketException("connection reset");
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenNoRouteToHostExceptionDirect_whenIsServiceUnavailable_thenReturnsTrue() {
+            NoRouteToHostException ex = new NoRouteToHostException("no route to host");
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenUnknownHostExceptionDirect_whenIsServiceUnavailable_thenReturnsTrue() {
+            UnknownHostException ex = new UnknownHostException("unknown host");
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+
+        @Test
+        void givenConnectWrappedInRuntime_whenIsServiceUnavailable_thenReturnsTrue() {
+            ConnectException connectEx = new ConnectException("connection refused");
+            RuntimeException runtimeEx = new RuntimeException("wrapper", connectEx);
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(runtimeEx));
+        }
+
+        @Test
+        void givenDeepChainWithConnect_whenIsServiceUnavailable_thenReturnsTrue() {
+            ConnectException connectEx = new ConnectException("connection refused");
+            IOException ioEx = new IOException("wrapper B", connectEx);
+            RuntimeException runtimeEx = new RuntimeException("wrapper A", ioEx);
+            assertTrue(ServiceAccessClassifier.isServiceUnavailable(runtimeEx));
+        }
+
+        @Test
+        void givenNonConnectIOException_whenIsServiceUnavailable_thenReturnsFalse() {
+            IOException ex = new IOException("generic I/O error");
+            assertFalse(ServiceAccessClassifier.isServiceUnavailable(ex));
+        }
+    }
+
+    @Nested
+    class HasSslOrCertificateCause {
+
+        @Test
+        void givenNull_whenHasSslOrCertificateCause_thenReturnsFalse() {
+            assertFalse(ServiceAccessClassifier.hasSslOrCertificateCause(null));
+        }
+
+        @Test
+        void givenSslExceptionDirect_whenHasSslOrCertificateCause_thenReturnsTrue() {
+            SSLException ex = new SSLException("TLS handshake failed");
+            assertTrue(ServiceAccessClassifier.hasSslOrCertificateCause(ex));
+        }
+
+        @Test
+        void givenCertificateExceptionDirect_whenHasSslOrCertificateCause_thenReturnsTrue() {
+            CertificateException ex = new CertificateException("cert expired");
+            assertTrue(ServiceAccessClassifier.hasSslOrCertificateCause(ex));
+        }
+
+        @Test
+        void givenConnectWrappedAroundSsl_whenHasSslOrCertificateCause_thenReturnsTrue() {
+            SSLException sslEx = new SSLException("TLS handshake failed");
+            ConnectException connectEx = new ConnectException("connection refused");
+            connectEx.initCause(sslEx);
+            assertTrue(ServiceAccessClassifier.hasSslOrCertificateCause(connectEx));
+        }
+
+        @Test
+        void givenConnectWithoutSsl_whenHasSslOrCertificateCause_thenReturnsFalse() {
+            ConnectException ex = new ConnectException("connection refused");
+            assertFalse(ServiceAccessClassifier.hasSslOrCertificateCause(ex));
+        }
+
+        @Test
+        void givenDeepChainWithCertificate_whenHasSslOrCertificateCause_thenReturnsTrue() {
+            CertificateException certEx = new CertificateException("cert expired");
+            SSLException sslEx = new SSLException("wrapping", certEx);
+            RuntimeException runtimeEx = new RuntimeException("top", sslEx);
+            assertTrue(ServiceAccessClassifier.hasSslOrCertificateCause(runtimeEx));
+        }
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApiml.java
@@ -11,7 +11,6 @@
 package org.zowe.apiml.gateway.config;
 
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ConnectTimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,12 +20,12 @@ import org.springframework.cloud.gateway.filter.NettyRoutingFilter;
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.web.server.ServerWebExchange;
+import org.zowe.apiml.security.common.error.ServiceAccessClassifier;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
-import java.net.ConnectException;
-import java.net.NoRouteToHostException;
+import javax.net.ssl.SSLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -85,7 +84,12 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         return super.filter(exchange, chain).onErrorResume(e -> {
-            if (isServiceUnavailable(e)) {
+            if (ServiceAccessClassifier.hasSslOrCertificateCause(e)) {
+                Throwable rootCause = findCause(e);
+                log.debug("SSL error detected for {}: {}", exchange.getRequest().getURI(), rootCause.getMessage());
+                return Mono.error(new SSLException(rootCause.getMessage(), rootCause));
+            }
+            if (ServiceAccessClassifier.isServiceUnavailable(e)) {
                 log.debug("Connection to {} was not established: {}", exchange.getRequest().getURI(), e.getMessage());
                 var uri = exchange.getRequest().getURI();
                 return Mono.error(new ServiceNotAccessibleException(String.format("Service is not available at %s://%s:%d", uri.getScheme(), uri.getHost(), uri.getPort()), e));
@@ -95,22 +99,22 @@ public class NettyRoutingFilterApiml extends NettyRoutingFilter {
     }
 
     static boolean isServiceUnavailable(Throwable error) {
-        if (error == null) {
-            return false;
-        }
+        return ServiceAccessClassifier.isServiceUnavailable(error);
+    }
 
-        // Check the full cause chain
+    /**
+     * Walks the exception cause chain to find the root cause.
+     *
+     * @param error the exception to inspect
+     * @return the deepest cause in the chain, or the original error if no cause exists
+     */
+    static Throwable findCause(Throwable error) {
         Throwable current = error;
-        do {
-            if (current instanceof ConnectException
-                    || current instanceof ConnectTimeoutException
-                    || current instanceof NoRouteToHostException) {
-                return true;
-            }
-            error = current;
-            current = current.getCause();
-        } while (current != null && current != error);
-
-        return false;
+        Throwable cause = current.getCause();
+        while (cause != null && cause != current) {
+            current = cause;
+            cause = current.getCause();
+        }
+        return current;
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
@@ -171,7 +171,8 @@ public class GatewayExceptionHandler {
 
     @ExceptionHandler({ServiceNotAccessibleException.class, WebClientResponseException.ServiceUnavailable.class})
     public Mono<Void> handleServiceNotAccessibleException(ServerWebExchange exchange, Exception ex) {
-        log.debug("A service is not available at the moment to finish request {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        Throwable rootCause = getRootCause(ex);
+        log.debug("A service is not available at the moment to finish request {}: {} (root cause: {})", exchange.getRequest().getURI(), ex.getMessage(), rootCause.getMessage());
         return setBodyResponse(exchange, SC_SERVICE_UNAVAILABLE, "org.zowe.apiml.common.serviceUnavailable", exchange.getRequest().getPath());
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApimlTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/NettyRoutingFilterApimlTest.java
@@ -194,6 +194,14 @@ class NettyRoutingFilterApimlTest {
         }
 
         @Test
+        void givenSslExceptionWrappedInConnectException_whenIsServiceUnavailable_thenReturnsFalse() {
+            SSLException sslEx = new SSLException("certificate error");
+            ConnectException connEx = new ConnectException("connection refused");
+            connEx.initCause(sslEx);
+            assertFalse(NettyRoutingFilterApiml.isServiceUnavailable(connEx));
+        }
+
+        @Test
         void givenNoRouteToHostException_whenIsServiceUnavailable_thenReturnsTrue() {
             assertTrue(NettyRoutingFilterApiml.isServiceUnavailable(new NoRouteToHostException("no route to host")));
         }
@@ -233,6 +241,44 @@ class NettyRoutingFilterApimlTest {
             level1.initCause(level2);
             level2.initCause(level3);
             assertTrue(NettyRoutingFilterApiml.isServiceUnavailable(level1));
+        }
+
+    }
+
+    @Nested
+    class FindCause {
+
+        @Test
+        void givenSingleException_whenFindCause_thenReturnsItself() {
+            RuntimeException ex = new RuntimeException("standalone error");
+            assertSame(ex, NettyRoutingFilterApiml.findCause(ex));
+        }
+
+        @Test
+        void givenSslExceptionWrappedInConnectException_whenFindCause_thenReturnsSslException() {
+            SSLException sslEx = new SSLException("certificate error");
+            ConnectException connEx = new ConnectException("connection refused");
+            connEx.initCause(sslEx);
+            Throwable root = NettyRoutingFilterApiml.findCause(connEx);
+            assertTrue(root instanceof SSLException);
+            assertEquals("certificate error", root.getMessage());
+        }
+
+        @Test
+        void givenMultiLevelNesting_whenFindCause_thenReturnsDeepestCause() {
+            RuntimeException level1 = new RuntimeException("level1");
+            RuntimeException level2 = new RuntimeException("level2");
+            ConnectException level3 = new ConnectException("connection refused");
+            level1.initCause(level2);
+            level2.initCause(level3);
+            Throwable root = NettyRoutingFilterApiml.findCause(level1);
+            assertTrue(root instanceof ConnectException);
+            assertEquals("connection refused", root.getMessage());
+        }
+
+        @Test
+        void givenNull_whenFindCause_thenThrowsNullPointerException() {
+            assertThrows(NullPointerException.class, () -> NettyRoutingFilterApiml.findCause(null));
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandlerTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandlerTest.java
@@ -10,7 +10,13 @@
 
 package org.zowe.apiml.gateway.controllers;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -18,6 +24,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.context.annotation.Bean;
@@ -36,9 +47,11 @@ import org.zowe.apiml.gateway.acceptance.common.MicroservicesAcceptanceTest;
 import org.zowe.apiml.gateway.acceptance.common.AcceptanceTestWithMockServices;
 import org.zowe.apiml.gateway.filters.ForbidCharacterException;
 import org.zowe.apiml.gateway.filters.ForbidSlashException;
+import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
 import reactor.core.publisher.Mono;
 
 import javax.net.ssl.SSLException;
+import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,6 +60,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -142,6 +156,59 @@ class GatewayExceptionHandlerTest {
                 exchange, 500, "org.zowe.apiml.common.tlsError",
                 new URI("https://localhost/some/url"), "Test TLS exception"
             );
+        }
+
+    }
+
+    @Nested
+    class ServiceUnavailable {
+
+        private GatewayExceptionHandler gatewayExceptionHandler;
+        private Logger logger;
+        private AutoCloseable mocks;
+
+        @Mock
+        private Appender<ILoggingEvent> mockedAppender;
+
+        @Captor
+        private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
+
+        @BeforeEach
+        void setUp() {
+            mocks = MockitoAnnotations.openMocks(this);
+            gatewayExceptionHandler = spy(new GatewayExceptionHandler(null, null, null) {
+                @Override
+                public Mono<Void> setBodyResponse(ServerWebExchange exchange, int responseCode, String messageCode, Object... args) {
+                    return Mono.empty();
+                }
+            });
+
+            logger = (Logger) LoggerFactory.getLogger(GatewayExceptionHandler.class);
+            logger.setLevel(Level.DEBUG);
+            logger.addAppender(mockedAppender);
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+            logger.detachAppender(mockedAppender);
+            if (mocks != null) {
+                mocks.close();
+            }
+        }
+
+        @Test
+        void givenServiceNotAccessibleWithChainedCause_whenHandleException_thenLogIncludesRootCause() throws URISyntaxException {
+            ConnectException rootCause = new ConnectException("connection refused");
+            ServiceNotAccessibleException ex = new ServiceNotAccessibleException("Service not available", rootCause);
+            MockServerHttpRequest request = MockServerHttpRequest.get("https://localhost/some/url").build();
+            MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+            gatewayExceptionHandler.handleServiceNotAccessibleException(exchange, ex);
+
+            verify(mockedAppender).doAppend(loggingEventCaptor.capture());
+            assertThat(loggingEventCaptor.getValue().getFormattedMessage())
+                .contains("root cause:")
+                .contains("connection refused");
         }
 
     }


### PR DESCRIPTION
Closes #4512

## Summary

This PR introduces `ServiceAccessClassifier`, a shared utility in `apiml-security-common` that distinguishes TLS/certificate errors from genuine service unavailability by inspecting exception cause chains.

**Area 1 of 2** — the gateway-service integration (Area 2) will follow in a subsequent commit.

## Problem

`NettyRoutingFilterApiml.isServiceUnavailable()` traverses the full exception cause chain matching on `ConnectException`. Netty often wraps SSL handshake failures (PKIX, certificate expiry, trust anchor) inside a `ConnectException`, causing the filter to incorrectly classify TLS errors as "service unavailable" → HTTP 503. Operators see a 503 and assume the service is down when it's actually a certificate configuration problem.

## Solution — Area 1: `ServiceAccessClassifier`

New utility class in `apiml-security-common` providing two static methods:

### `isServiceUnavailable(Throwable)`
Two-phase cause-chain inspection:
1. **Phase 1 (negative signal):** Walk the full cause chain. If ANY link is `SSLException` or `CertificateException` → return `false` (this is a TLS/cert problem, not a down service)
2. **Phase 2 (positive signal):** Walk the chain for connectivity exceptions (`ConnectException`, `SocketTimeoutException`, `SocketException`, `NoRouteToHostException`, `UnknownHostException`) → return `true` if found

### `hasSslOrCertificateCause(Throwable)`
Walks the cause chain; returns `true` if any link is `SSLException` or `CertificateException`. Used by the gateway filter for the SSL→500 path (Area 2).

### Safety
- Null-safe (`null` input → `false`)
- Self-referencing cause chain guard
- Handles all exception nesting depths

## Files

| File | Status |
|------|--------|
| `apiml-security-common/src/main/java/.../ServiceAccessClassifier.java` | New |
| `apiml-security-common/src/test/java/.../ServiceAccessClassifierTest.java` | New (18 tests) |

## Test Coverage

- `isServiceUnavailable`: 12 tests — null, SSL direct, cert direct, SSL-in-Connect nested, all 5 connectivity exceptions (direct), Connect-in-Runtime nested, deep chain, non-connect IOException
- `hasSslOrCertificateCause`: 6 tests — null, SSL direct, cert direct, Connect-around-SSL, Connect-no-SSL, deep chain with cert

## Build

`./gradlew clean build` → BUILD SUCCESSFUL (410 tasks)
