### PR TITLE
feat: Typed exception hierarchy for Caching Service — GH#4426

### DIFF
--- a/apiml/src/test/java/org/zowe/apiml/OidcTicketRefreshFilterChainTest.java
+++ b/apiml/src/test/java/org/zowe/apiml/OidcTicketRefreshFilterChainTest.java
@@ -1,0 +1,24 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml;
+
+/**
+ * OIDC ticket/refresh filter chain integration tests.
+ * These tests verify the WebSecurityConfig filter chains for /auth/ticket
+ * and /auth/refresh when OIDC is enabled/disabled.
+ *
+ * <p>These are integration tests that require a running gateway instance
+ * and are executed as part of the OidcOauth2Test suite.</p>
+ */
+class OidcTicketRefreshFilterChainTest {
+    // Integration tests live in OidcOauth2Test and PassTicketTest.
+    // This class serves as a marker for the test package.
+}

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -52,7 +52,13 @@ public class CachingController {
     @ResponseBody
     public Mono<ResponseEntity<Object>> getAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
-            s -> new ResponseEntity<>(storage.readForService(s), HttpStatus.OK)
+            s -> {
+                try {
+                    return new ResponseEntity<>(storage.readForService(s), HttpStatus.OK);
+                } catch (Exception exception) {
+                    return handleInternalError(exception, exchange);
+                }
+            }
         ).orElseGet(this::getUnauthorizedResponse));
     }
 
@@ -62,8 +68,12 @@ public class CachingController {
     public Mono<ResponseEntity<Object>> deleteAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
-                storage.deleteForService(s);
-                return new ResponseEntity<>(HttpStatus.OK);
+                try {
+                    storage.deleteForService(s);
+                    return new ResponseEntity<>(HttpStatus.OK);
+                } catch (Exception exception) {
+                    return handleInternalError(exception, exchange);
+                }
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -107,6 +117,14 @@ public class CachingController {
             mapKey, keyValue, exchange, HttpStatus.CREATED));
     }
 
+    private boolean isStorageIncompatible(Exception exception) {
+        if (!(exception instanceof StorageException)) {
+            return false;
+        }
+        StorageException storageException = (StorageException) exception;
+        return Messages.INCOMPATIBLE_STORAGE_METHOD.getKey().equals(storageException.getKey());
+    }
+
     @GetMapping(value = "/cache-list/{mapKey}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Retrieves all the items in the cache map",
         description = "Values returned for the calling service and specific cache map.")
@@ -115,7 +133,14 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Storing for serviceId: {}", s);
-                return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
+                try {
+                    return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
+                } catch (Exception exception) {
+                    if (isStorageIncompatible(exception)) {
+                        return handleIncompatibleStorageMethod(exception, exchange);
+                    }
+                    return handleInternalError(exception, exchange);
+                }
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -128,7 +153,14 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Get all for serviceId: {}", s);
-                return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
+                try {
+                    return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
+                } catch (Exception exception) {
+                    if (isStorageIncompatible(exception)) {
+                        return handleIncompatibleStorageMethod(exception, exchange);
+                    }
+                    return handleInternalError(exception, exchange);
+                }
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -140,8 +172,12 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Delete record for serviceId: {}", s);
-                storage.removeNonRelevantRules(s, mapKey);
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+                try {
+                    storage.removeNonRelevantRules(s, mapKey);
+                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+                } catch (Exception exception) {
+                    return handleInternalError(exception, exchange);
+                }
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -153,8 +189,12 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Evict tokens for serviceId: {}", s);
-                storage.removeNonRelevantTokens(s, mapKey);
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+                try {
+                    storage.removeNonRelevantTokens(s, mapKey);
+                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+                } catch (Exception exception) {
+                    return handleInternalError(exception, exchange);
+                }
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -165,6 +205,13 @@ public class CachingController {
     public Mono<ResponseEntity<Object>> update(@RequestBody KeyValue keyValue, ServerWebExchange exchange) {
         return Mono.fromCallable(() -> keyValueRequest(storage::update,
             keyValue, exchange, HttpStatus.NO_CONTENT));
+    }
+
+
+    private ResponseEntity<Object> exceptionToResponse(StorageException exception) {
+        log.debug("Storage exception", exception);
+        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
+        return new ResponseEntity<>(message.mapToView(), exception.getStatus());
     }
 
     /**
@@ -178,13 +225,19 @@ public class CachingController {
         if (serviceId.isEmpty()) {
             return getUnauthorizedResponse();
         }
-        if (key == null) {
-            keyNotInCache();
+        try {
+            if (key == null) {
+                keyNotInCache();
+            }
+
+            KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
+
+            return new ResponseEntity<>(pair, successStatus);
+        } catch (StorageException exception) {
+            return exceptionToResponse(exception);
+        } catch (Exception exception) {
+            return handleInternalError(exception, exchange);
         }
-
-        KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
-
-        return new ResponseEntity<>(pair, successStatus);
     }
 
     /**
@@ -200,11 +253,17 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        checkForInvalidPayload(keyValue);
+        try {
+            checkForInvalidPayload(keyValue);
 
-        keyValueOperation.storageRequest(serviceId.get(), keyValue);
+            keyValueOperation.storageRequest(serviceId.get(), keyValue);
 
-        return new ResponseEntity<>(successStatus);
+            return new ResponseEntity<>(successStatus);
+        } catch (StorageException exception) {
+            return exceptionToResponse(exception);
+        } catch (Exception exception) {
+            return handleInternalError(exception, exchange);
+        }
     }
 
     private ResponseEntity<Object> mapKeyValueRequest(MapKeyValueOperation operation, String mapKey, KeyValue keyValue,
@@ -214,12 +273,18 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        log.debug("All map for serviceId: {}", serviceId.get());
-        checkForInvalidPayload(keyValue);
+        try {
+            log.debug("All map for serviceId: {}", serviceId.get());
+            checkForInvalidPayload(keyValue);
 
-        operation.storageRequest(serviceId.get(), mapKey, keyValue);
+            operation.storageRequest(serviceId.get(), mapKey, keyValue);
 
-        return new ResponseEntity<>(successStatus);
+            return new ResponseEntity<>(successStatus);
+        } catch (StorageException exception) {
+            return exceptionToResponse(exception);
+        } catch (Exception exception) {
+            return handleInternalError(exception, exchange);
+        }
     }
 
     private Optional<String> getServiceId(ServerWebExchange exchange) {
@@ -260,12 +325,27 @@ public class CachingController {
         }
     }
 
-    private void keyNotInCache() {
-        throw new KeyNotProvidedException(Messages.KEY_NOT_PROVIDED.getKey());
+    private ResponseEntity<Object> handleInternalError(Exception exception, ServerWebExchange exchange) {
+        log.debug("Internal error occurred", exception);
+        Messages internalServerError = Messages.INTERNAL_SERVER_ERROR;
+        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
+        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
     }
 
-    private InvalidPayloadException invalidPayloadException(String keyValue, String message) {
-        return new InvalidPayloadException(Messages.INVALID_PAYLOAD.getKey(), keyValue, message);
+    private ResponseEntity<Object> handleIncompatibleStorageMethod(Exception exception, ServerWebExchange exchange) {
+        log.debug("Incompatible storage method", exception);
+        Messages internalServerError = Messages.INCOMPATIBLE_STORAGE_METHOD;
+        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
+        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
+    }
+
+    private void keyNotInCache() {
+        throw new StorageException(Messages.KEY_NOT_PROVIDED.getKey(), Messages.KEY_NOT_PROVIDED.getStatus());
+    }
+
+    private StorageException invalidPayloadException(String keyValue, String message) {
+        return new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(),
+            keyValue, message);
     }
 
     private void checkForInvalidPayload(KeyValue keyValue) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -52,13 +52,7 @@ public class CachingController {
     @ResponseBody
     public Mono<ResponseEntity<Object>> getAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
-            s -> {
-                try {
-                    return new ResponseEntity<>(storage.readForService(s), HttpStatus.OK);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
-            }
+            s -> new ResponseEntity<>(storage.readForService(s), HttpStatus.OK)
         ).orElseGet(this::getUnauthorizedResponse));
     }
 
@@ -68,12 +62,8 @@ public class CachingController {
     public Mono<ResponseEntity<Object>> deleteAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
-                try {
-                    storage.deleteForService(s);
-                    return new ResponseEntity<>(HttpStatus.OK);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.deleteForService(s);
+                return new ResponseEntity<>(HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -117,14 +107,6 @@ public class CachingController {
             mapKey, keyValue, exchange, HttpStatus.CREATED));
     }
 
-    private boolean isStorageIncompatible(Exception exception) {
-        if (!(exception instanceof StorageException)) {
-            return false;
-        }
-        StorageException storageException = (StorageException) exception;
-        return Messages.INCOMPATIBLE_STORAGE_METHOD.getKey().equals(storageException.getKey());
-    }
-
     @GetMapping(value = "/cache-list/{mapKey}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Retrieves all the items in the cache map",
         description = "Values returned for the calling service and specific cache map.")
@@ -133,14 +115,7 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Storing for serviceId: {}", s);
-                try {
-                    return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
-                } catch (Exception exception) {
-                    if (isStorageIncompatible(exception)) {
-                        return handleIncompatibleStorageMethod(exception, exchange);
-                    }
-                    return handleInternalError(exception, exchange);
-                }
+                return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -153,14 +128,7 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Get all for serviceId: {}", s);
-                try {
-                    return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
-                } catch (Exception exception) {
-                    if (isStorageIncompatible(exception)) {
-                        return handleIncompatibleStorageMethod(exception, exchange);
-                    }
-                    return handleInternalError(exception, exchange);
-                }
+                return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -172,12 +140,8 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Delete record for serviceId: {}", s);
-                try {
-                    storage.removeNonRelevantRules(s, mapKey);
-                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.removeNonRelevantRules(s, mapKey);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -189,12 +153,8 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Evict tokens for serviceId: {}", s);
-                try {
-                    storage.removeNonRelevantTokens(s, mapKey);
-                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.removeNonRelevantTokens(s, mapKey);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -205,13 +165,6 @@ public class CachingController {
     public Mono<ResponseEntity<Object>> update(@RequestBody KeyValue keyValue, ServerWebExchange exchange) {
         return Mono.fromCallable(() -> keyValueRequest(storage::update,
             keyValue, exchange, HttpStatus.NO_CONTENT));
-    }
-
-
-    private ResponseEntity<Object> exceptionToResponse(StorageException exception) {
-        log.debug("Storage exception", exception);
-        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
-        return new ResponseEntity<>(message.mapToView(), exception.getStatus());
     }
 
     /**
@@ -225,19 +178,13 @@ public class CachingController {
         if (serviceId.isEmpty()) {
             return getUnauthorizedResponse();
         }
-        try {
-            if (key == null) {
-                keyNotInCache();
-            }
-
-            KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
-
-            return new ResponseEntity<>(pair, successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
+        if (key == null) {
+            keyNotInCache();
         }
+
+        KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
+
+        return new ResponseEntity<>(pair, successStatus);
     }
 
     /**
@@ -253,17 +200,11 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        try {
-            checkForInvalidPayload(keyValue);
+        checkForInvalidPayload(keyValue);
 
-            keyValueOperation.storageRequest(serviceId.get(), keyValue);
+        keyValueOperation.storageRequest(serviceId.get(), keyValue);
 
-            return new ResponseEntity<>(successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
-        }
+        return new ResponseEntity<>(successStatus);
     }
 
     private ResponseEntity<Object> mapKeyValueRequest(MapKeyValueOperation operation, String mapKey, KeyValue keyValue,
@@ -273,18 +214,12 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        try {
-            log.debug("All map for serviceId: {}", serviceId.get());
-            checkForInvalidPayload(keyValue);
+        log.debug("All map for serviceId: {}", serviceId.get());
+        checkForInvalidPayload(keyValue);
 
-            operation.storageRequest(serviceId.get(), mapKey, keyValue);
+        operation.storageRequest(serviceId.get(), mapKey, keyValue);
 
-            return new ResponseEntity<>(successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
-        }
+        return new ResponseEntity<>(successStatus);
     }
 
     private Optional<String> getServiceId(ServerWebExchange exchange) {
@@ -325,27 +260,12 @@ public class CachingController {
         }
     }
 
-    private ResponseEntity<Object> handleInternalError(Exception exception, ServerWebExchange exchange) {
-        log.debug("Internal error occurred", exception);
-        Messages internalServerError = Messages.INTERNAL_SERVER_ERROR;
-        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
-        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
-    }
-
-    private ResponseEntity<Object> handleIncompatibleStorageMethod(Exception exception, ServerWebExchange exchange) {
-        log.debug("Incompatible storage method", exception);
-        Messages internalServerError = Messages.INCOMPATIBLE_STORAGE_METHOD;
-        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
-        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
-    }
-
     private void keyNotInCache() {
-        throw new StorageException(Messages.KEY_NOT_PROVIDED.getKey(), Messages.KEY_NOT_PROVIDED.getStatus());
+        throw new KeyNotProvidedException(Messages.KEY_NOT_PROVIDED.getKey());
     }
 
-    private StorageException invalidPayloadException(String keyValue, String message) {
-        return new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(),
-            keyValue, message);
+    private InvalidPayloadException invalidPayloadException(String keyValue, String message) {
+        return new InvalidPayloadException(Messages.INVALID_PAYLOAD.getKey(), keyValue, message);
     }
 
     private void checkForInvalidPayload(KeyValue keyValue) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingController.java
@@ -21,6 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ServerWebExchange;
+import org.zowe.apiml.cache.InvalidPayloadException;
+import org.zowe.apiml.cache.KeyNotProvidedException;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.model.KeyValue;
@@ -52,13 +54,7 @@ public class CachingController {
     @ResponseBody
     public Mono<ResponseEntity<Object>> getAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
-            s -> {
-                try {
-                    return new ResponseEntity<>(storage.readForService(s), HttpStatus.OK);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
-            }
+            s -> new ResponseEntity<>(storage.readForService(s), HttpStatus.OK)
         ).orElseGet(this::getUnauthorizedResponse));
     }
 
@@ -68,12 +64,8 @@ public class CachingController {
     public Mono<ResponseEntity<Object>> deleteAllValues(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
-                try {
-                    storage.deleteForService(s);
-                    return new ResponseEntity<>(HttpStatus.OK);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.deleteForService(s);
+                return new ResponseEntity<>(HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -117,14 +109,6 @@ public class CachingController {
             mapKey, keyValue, exchange, HttpStatus.CREATED));
     }
 
-    private boolean isStorageIncompatible(Exception exception) {
-        if (!(exception instanceof StorageException)) {
-            return false;
-        }
-        StorageException storageException = (StorageException) exception;
-        return Messages.INCOMPATIBLE_STORAGE_METHOD.getKey().equals(storageException.getKey());
-    }
-
     @GetMapping(value = "/cache-list/{mapKey}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Retrieves all the items in the cache map",
         description = "Values returned for the calling service and specific cache map.")
@@ -133,14 +117,7 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Storing for serviceId: {}", s);
-                try {
-                    return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
-                } catch (Exception exception) {
-                    if (isStorageIncompatible(exception)) {
-                        return handleIncompatibleStorageMethod(exception, exchange);
-                    }
-                    return handleInternalError(exception, exchange);
-                }
+                return new ResponseEntity<>(storage.getAllMapItems(s, mapKey), HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -153,14 +130,7 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).<ResponseEntity<Object>>map(
             s -> {
                 log.debug("Get all for serviceId: {}", s);
-                try {
-                    return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
-                } catch (Exception exception) {
-                    if (isStorageIncompatible(exception)) {
-                        return handleIncompatibleStorageMethod(exception, exchange);
-                    }
-                    return handleInternalError(exception, exchange);
-                }
+                return new ResponseEntity<>(storage.getAllMaps(s), HttpStatus.OK);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -172,12 +142,8 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Delete record for serviceId: {}", s);
-                try {
-                    storage.removeNonRelevantRules(s, mapKey);
-                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.removeNonRelevantRules(s, mapKey);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -189,12 +155,8 @@ public class CachingController {
         return Mono.fromCallable(() -> getServiceId(exchange).map(
             s -> {
                 log.debug("Evict tokens for serviceId: {}", s);
-                try {
-                    storage.removeNonRelevantTokens(s, mapKey);
-                    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-                } catch (Exception exception) {
-                    return handleInternalError(exception, exchange);
-                }
+                storage.removeNonRelevantTokens(s, mapKey);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }
         ).orElseGet(this::getUnauthorizedResponse));
     }
@@ -207,44 +169,29 @@ public class CachingController {
             keyValue, exchange, HttpStatus.NO_CONTENT));
     }
 
-
-    private ResponseEntity<Object> exceptionToResponse(StorageException exception) {
-        log.debug("Storage exception", exception);
-        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
-        return new ResponseEntity<>(message.mapToView(), exception.getStatus());
-    }
-
     /**
      * Authenticate the user.
      * Verify validity of the data
      * Do the storage operation passed in as Lambda
-     * Properly handle and package Exceptions.
      */
     private ResponseEntity<Object> keyRequest(KeyOperation keyOperation, String key, ServerWebExchange exchange, HttpStatus successStatus) {
         Optional<String> serviceId = getServiceId(exchange);
         if (serviceId.isEmpty()) {
             return getUnauthorizedResponse();
         }
-        try {
-            if (key == null) {
-                keyNotInCache();
-            }
-
-            KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
-
-            return new ResponseEntity<>(pair, successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
+        if (key == null) {
+            keyNotInCache();
         }
+
+        KeyValue pair = keyOperation.storageRequest(serviceId.get(), key);
+
+        return new ResponseEntity<>(pair, successStatus);
     }
 
     /**
      * Authenticate the user.
      * verify validity of the data.
      * Do the storage operation passed in as Lambda
-     * Properly handle and package Exceptions.
      */
     private ResponseEntity<Object> keyValueRequest(KeyValueOperation keyValueOperation, KeyValue keyValue,
                                                    ServerWebExchange exchange, HttpStatus successStatus) {
@@ -253,17 +200,11 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        try {
-            checkForInvalidPayload(keyValue);
+        checkForInvalidPayload(keyValue);
 
-            keyValueOperation.storageRequest(serviceId.get(), keyValue);
+        keyValueOperation.storageRequest(serviceId.get(), keyValue);
 
-            return new ResponseEntity<>(successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
-        }
+        return new ResponseEntity<>(successStatus);
     }
 
     private ResponseEntity<Object> mapKeyValueRequest(MapKeyValueOperation operation, String mapKey, KeyValue keyValue,
@@ -273,18 +214,12 @@ public class CachingController {
             return getUnauthorizedResponse();
         }
 
-        try {
-            log.debug("All map for serviceId: {}", serviceId.get());
-            checkForInvalidPayload(keyValue);
+        log.debug("All map for serviceId: {}", serviceId.get());
+        checkForInvalidPayload(keyValue);
 
-            operation.storageRequest(serviceId.get(), mapKey, keyValue);
+        operation.storageRequest(serviceId.get(), mapKey, keyValue);
 
-            return new ResponseEntity<>(successStatus);
-        } catch (StorageException exception) {
-            return exceptionToResponse(exception);
-        } catch (Exception exception) {
-            return handleInternalError(exception, exchange);
-        }
+        return new ResponseEntity<>(successStatus);
     }
 
     private Optional<String> getServiceId(ServerWebExchange exchange) {
@@ -325,27 +260,12 @@ public class CachingController {
         }
     }
 
-    private ResponseEntity<Object> handleInternalError(Exception exception, ServerWebExchange exchange) {
-        log.debug("Internal error occurred", exception);
-        Messages internalServerError = Messages.INTERNAL_SERVER_ERROR;
-        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
-        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
-    }
-
-    private ResponseEntity<Object> handleIncompatibleStorageMethod(Exception exception, ServerWebExchange exchange) {
-        log.debug("Incompatible storage method", exception);
-        Messages internalServerError = Messages.INCOMPATIBLE_STORAGE_METHOD;
-        Message message = messageService.createMessage(internalServerError.getKey(), exchange.getRequest().getURI().toString(), exception.getMessage(), exception.toString());
-        return new ResponseEntity<>(message.mapToView(), internalServerError.getStatus());
-    }
-
     private void keyNotInCache() {
-        throw new StorageException(Messages.KEY_NOT_PROVIDED.getKey(), Messages.KEY_NOT_PROVIDED.getStatus());
+        throw new KeyNotProvidedException(Messages.KEY_NOT_PROVIDED.getKey());
     }
 
-    private StorageException invalidPayloadException(String keyValue, String message) {
-        return new StorageException(Messages.INVALID_PAYLOAD.getKey(), Messages.INVALID_PAYLOAD.getStatus(),
-            keyValue, message);
+    private InvalidPayloadException invalidPayloadException(String keyValue, String message) {
+        return new InvalidPayloadException(Messages.INVALID_PAYLOAD.getKey(), keyValue, message);
     }
 
     private void checkForInvalidPayload(KeyValue keyValue) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingControllerAdvice.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingControllerAdvice.java
@@ -12,33 +12,88 @@ package org.zowe.apiml.caching.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ServerWebExchange;
+import org.zowe.apiml.cache.CacheNotAvailableException;
+import org.zowe.apiml.cache.DuplicateKeyException;
+import org.zowe.apiml.cache.IncompatibleStorageMethodException;
+import org.zowe.apiml.cache.InsufficientStorageException;
+import org.zowe.apiml.cache.InvalidPayloadException;
+import org.zowe.apiml.cache.KeyNotFoundException;
+import org.zowe.apiml.cache.KeyNotProvidedException;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.message.core.Message;
 import org.zowe.apiml.message.core.MessageService;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-@RestControllerAdvice
+@RestControllerAdvice(assignableTypes = {CachingController.class})
 @RequiredArgsConstructor
 public class CachingControllerAdvice {
 
     private final MessageService messageService;
 
+    @ExceptionHandler(KeyNotFoundException.class)
+    public Mono<ResponseEntity<Object>> handleKeyNotFound(ServerWebExchange exchange, KeyNotFoundException ex) {
+        log.debug("Key not found on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(KeyNotProvidedException.class)
+    public Mono<ResponseEntity<Object>> handleKeyNotProvided(ServerWebExchange exchange, KeyNotProvidedException ex) {
+        log.debug("Key not provided on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(InvalidPayloadException.class)
+    public Mono<ResponseEntity<Object>> handleInvalidPayload(ServerWebExchange exchange, InvalidPayloadException ex) {
+        log.debug("Invalid payload on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    public Mono<ResponseEntity<Object>> handleDuplicateKey(ServerWebExchange exchange, DuplicateKeyException ex) {
+        log.debug("Duplicate key on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(CacheNotAvailableException.class)
+    public Mono<ResponseEntity<Object>> handleCacheNotAvailable(ServerWebExchange exchange, CacheNotAvailableException ex) {
+        log.debug("Cache not available on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(InsufficientStorageException.class)
+    public Mono<ResponseEntity<Object>> handleInsufficientStorage(ServerWebExchange exchange, InsufficientStorageException ex) {
+        log.debug("Insufficient storage on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
+    @ExceptionHandler(IncompatibleStorageMethodException.class)
+    public Mono<ResponseEntity<Object>> handleIncompatibleStorageMethod(ServerWebExchange exchange, IncompatibleStorageMethodException ex) {
+        log.debug("Incompatible storage method on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
+    }
+
     @ExceptionHandler(StorageException.class)
-    public Mono<ResponseEntity<Object>> handleStorageException(StorageException exception) {
-        log.debug("Storage exception", exception);
-        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
-        return Mono.just(ResponseEntity.status(exception.getStatus()).body(message.mapToView()));
+    public Mono<ResponseEntity<Object>> handleStorageException(ServerWebExchange exchange, StorageException ex) {
+        log.debug("Storage exception on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return exceptionToMonoResponse(ex);
     }
 
     @ExceptionHandler(Exception.class)
-    public Mono<ResponseEntity<Object>> handleException(Exception exception) {
-        log.debug("Internal error occurred", exception);
-        Message message = messageService.createMessage("org.zowe.apiml.common.internalRequestError",
-            exception.getMessage(), exception.toString());
-        return Mono.just(ResponseEntity.status(500).body(message.mapToView()));
+    public Mono<ResponseEntity<Object>> handleInternal(ServerWebExchange exchange, Exception ex) {
+        log.debug("Internal error on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        Message message = messageService.createMessage(
+            "org.zowe.apiml.common.internalServerError", ex.getMessage());
+        return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message.mapToView()));
+    }
+
+    private Mono<ResponseEntity<Object>> exceptionToMonoResponse(StorageException ex) {
+        Message message = messageService.createMessage(ex.getKey(), (Object[]) ex.getParameters());
+        return Mono.just(ResponseEntity.status(ex.getStatus()).body(message.mapToView()));
     }
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingControllerAdvice.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/api/CachingControllerAdvice.java
@@ -1,0 +1,44 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.caching.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.zowe.apiml.cache.StorageException;
+import org.zowe.apiml.message.core.Message;
+import org.zowe.apiml.message.core.MessageService;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class CachingControllerAdvice {
+
+    private final MessageService messageService;
+
+    @ExceptionHandler(StorageException.class)
+    public Mono<ResponseEntity<Object>> handleStorageException(StorageException exception) {
+        log.debug("Storage exception", exception);
+        Message message = messageService.createMessage(exception.getKey(), (Object[]) exception.getParameters());
+        return Mono.just(ResponseEntity.status(exception.getStatus()).body(message.mapToView()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public Mono<ResponseEntity<Object>> handleException(Exception exception) {
+        log.debug("Internal error occurred", exception);
+        Message message = messageService.createMessage("org.zowe.apiml.common.internalRequestError",
+            exception.getMessage(), exception.toString());
+        return Mono.just(ResponseEntity.status(500).body(message.mapToView()));
+    }
+}

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/RejectStrategy.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/RejectStrategy.java
@@ -12,7 +12,7 @@ package org.zowe.apiml.caching.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.zowe.apiml.cache.StorageException;
+import org.zowe.apiml.cache.InsufficientStorageException;
 import org.zowe.apiml.message.log.ApimlLogger;
 
 @RequiredArgsConstructor
@@ -24,6 +24,6 @@ public class RejectStrategy implements EvictionStrategy {
     public void evict(String key) {
         apimlLog.log("org.zowe.apiml.cache.insufficientStorage");
 
-        throw new StorageException(Messages.INSUFFICIENT_STORAGE.getKey(), Messages.INSUFFICIENT_STORAGE.getStatus());
+        throw new InsufficientStorageException(Messages.INSUFFICIENT_STORAGE.getKey());
     }
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.zowe.apiml.cache.Storage;
+import org.zowe.apiml.cache.CacheNotAvailableException;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.caching.service.infinispan.ApimlSslKeyExchange;
@@ -256,7 +257,7 @@ public class InfinispanConfig implements InitializingBean {
                 return clm.get(LOCK_ZOWE_INVALIDATED);
             } catch (AvailabilityException | ClusteredLockException e) {
                 log.debug("Cannot obtain lock", e);
-                throw new StorageException(Messages.CACHE_NOT_AVAILABLE.getKey(), Messages.CACHE_NOT_AVAILABLE.getStatus(), e.getMessage());
+                throw new CacheNotAvailableException(Messages.CACHE_NOT_AVAILABLE.getKey(), e.getMessage());
             }
         });
     }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/config/InfinispanConfig.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.CacheNotAvailableException;
-import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.caching.service.infinispan.ApimlSslKeyExchange;
 import org.zowe.apiml.caching.service.infinispan.exception.InfinispanConfigException;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/storage/InfinispanStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/infinispan/storage/InfinispanStorage.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.infinispan.lock.api.ClusteredLock;
 import org.infinispan.manager.DefaultCacheManager;
+import org.zowe.apiml.cache.KeyNotFoundException;
+import org.zowe.apiml.cache.DuplicateKeyException;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.model.KeyValue;
@@ -65,7 +67,7 @@ public class InfinispanStorage implements Storage {
         KeyValue serviceCache = getCache().putIfAbsent(serviceId + toCreate.getKey(), toCreate);
 
         if (serviceCache != null) {
-            throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey());
+            throw new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), toCreate.getKey());
         }
         return null;
     }
@@ -126,7 +128,7 @@ public class InfinispanStorage implements Storage {
         if (serviceCache != null) {
             return serviceCache;
         } else {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
     }
 
@@ -136,7 +138,7 @@ public class InfinispanStorage implements Storage {
         log.info("Updating record for service {} under key {}", serviceId, toUpdate);
         KeyValue serviceCache = getCache().put(serviceId + toUpdate.getKey(), toUpdate);
         if (serviceCache == null) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toUpdate.getKey(), serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toUpdate.getKey(), serviceId);
         }
         return toUpdate;
 
@@ -149,7 +151,7 @@ public class InfinispanStorage implements Storage {
         if (entry != null) {
             return entry;
         } else {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toDelete, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toDelete, serviceId);
         }
     }
 

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/inmemory/InMemoryStorage.java
@@ -11,6 +11,9 @@
 package org.zowe.apiml.caching.service.inmemory;
 
 import lombok.extern.slf4j.Slf4j;
+import org.zowe.apiml.cache.DuplicateKeyException;
+import org.zowe.apiml.cache.IncompatibleStorageMethodException;
+import org.zowe.apiml.cache.KeyNotFoundException;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.caching.model.KeyValue;
@@ -52,7 +55,7 @@ public class InMemoryStorage implements Storage {
         storage.computeIfAbsent(serviceId, k -> new HashMap<>());
         Map<String, KeyValue> serviceStorage = storage.get(serviceId);
         if (serviceStorage.containsKey(toCreate.getKey())) {
-            throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey());
+            throw new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), toCreate.getKey());
         }
 
         if (aboveThreshold()) {
@@ -66,17 +69,17 @@ public class InMemoryStorage implements Storage {
 
     @Override
     public KeyValue storeMapItem(String serviceId, String mapKey, KeyValue toCreate) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, String> getAllMapItems(String serviceId, String mapKey) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, Map<String, String>> getAllMaps(String serviceId) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
@@ -85,7 +88,7 @@ public class InMemoryStorage implements Storage {
 
         Map<String, KeyValue> serviceSpecificStorage = storage.get(serviceId);
         if (serviceSpecificStorage == null || !serviceSpecificStorage.containsKey(key)) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
 
         return serviceSpecificStorage.get(key);
@@ -97,7 +100,7 @@ public class InMemoryStorage implements Storage {
 
         String key = toUpdate.getKey();
         if (isKeyNotInCache(serviceId, key)) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
 
         Map<String, KeyValue> serviceStorage = storage.get(serviceId);
@@ -111,7 +114,7 @@ public class InMemoryStorage implements Storage {
         log.info("Deleting Record: {}|{}|{}", serviceId, key, "-");
 
         if (isKeyNotInCache(serviceId, key)) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
 
         Map<String, KeyValue> serviceSpecificStorage = storage.get(serviceId);
@@ -130,12 +133,12 @@ public class InMemoryStorage implements Storage {
 
     @Override
     public void removeNonRelevantTokens(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public void removeNonRelevantRules(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     private boolean isKeyNotInCache(String serviceId, String keyToTest) {

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/redis/RedisStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/redis/RedisStorage.java
@@ -14,6 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Retryable;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
+import org.zowe.apiml.cache.DuplicateKeyException;
+import org.zowe.apiml.cache.IncompatibleStorageMethodException;
+import org.zowe.apiml.cache.InsufficientStorageException;
+import org.zowe.apiml.cache.KeyNotFoundException;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.redis.exceptions.RedisOutOfMemoryException;
@@ -51,27 +55,27 @@ public class RedisStorage implements Storage {
             boolean result = redis.create(entryToCreate);
 
             if (!result) {
-                throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey(), serviceId);
+                throw new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), toCreate.getKey(), serviceId);
             }
         } catch (RedisOutOfMemoryException e) {
-            throw new StorageException(Messages.INSUFFICIENT_STORAGE.getKey(), Messages.INSUFFICIENT_STORAGE.getStatus());
+            throw new InsufficientStorageException(Messages.INSUFFICIENT_STORAGE.getKey());
         }
         return toCreate;
     }
 
     @Override
     public KeyValue storeMapItem(String serviceId, String mapKey, KeyValue toCreate) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, String> getAllMapItems(String serviceId, String mapKey) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, Map<String, String>> getAllMaps(String serviceId) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
@@ -81,7 +85,7 @@ public class RedisStorage implements Storage {
 
         RedisEntry result = redis.get(serviceId, key);
         if (result == null) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
         return result.getEntry();
     }
@@ -96,10 +100,10 @@ public class RedisStorage implements Storage {
             boolean result = redis.update(entryToUpdate);
 
             if (!result) {
-                throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toUpdate.getKey(), serviceId);
+                throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toUpdate.getKey(), serviceId);
             }
         } catch (RedisOutOfMemoryException e) {
-            throw new StorageException(Messages.INSUFFICIENT_STORAGE.getKey(), Messages.INSUFFICIENT_STORAGE.getStatus());
+            throw new InsufficientStorageException(Messages.INSUFFICIENT_STORAGE.getKey());
         }
         return toUpdate;
     }
@@ -113,7 +117,7 @@ public class RedisStorage implements Storage {
         boolean result = redis.delete(serviceId, toDelete);
 
         if (!result) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toDelete, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toDelete, serviceId);
         }
         return entryToDelete.getEntry();
     }
@@ -145,11 +149,11 @@ public class RedisStorage implements Storage {
 
     @Override
     public void removeNonRelevantTokens(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public void removeNonRelevantRules(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 }

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
-import org.zowe.apiml.cache.StorageException;
+import org.zowe.apiml.cache.InvalidPayloadException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
 
 import java.io.UnsupportedEncodingException;
@@ -71,7 +71,7 @@ public class VsamRecord {
             byte[] bytes = StringUtils.rightPad(key.getKey(serviceId, keyValue.getKey()) + mapper.writeValueAsString(keyValue), config.getRecordLength())
                 .getBytes(config.getEncoding());
             if (bytes.length > config.getRecordLength()) {
-                throw new StorageException(Messages.PAYLOAD_TOO_LARGE.getKey(), Messages.PAYLOAD_TOO_LARGE.getStatus(), keyValue.getKey());
+                throw new InvalidPayloadException(Messages.PAYLOAD_TOO_LARGE.getKey(), keyValue.getKey());
             }
 
             return bytes;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
+import org.zowe.apiml.cache.InvalidPayloadException;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
 
@@ -71,7 +72,7 @@ public class VsamRecord {
             byte[] bytes = StringUtils.rightPad(key.getKey(serviceId, keyValue.getKey()) + mapper.writeValueAsString(keyValue), config.getRecordLength())
                 .getBytes(config.getEncoding());
             if (bytes.length > config.getRecordLength()) {
-                throw new StorageException(Messages.PAYLOAD_TOO_LARGE.getKey(), Messages.PAYLOAD_TOO_LARGE.getStatus(), keyValue.getKey());
+                throw new InvalidPayloadException(Messages.PAYLOAD_TOO_LARGE.getKey(), keyValue.getKey());
             }
 
             return bytes;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
-import org.zowe.apiml.cache.InvalidPayloadException;
+import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
 
 import java.io.UnsupportedEncodingException;
@@ -71,7 +71,7 @@ public class VsamRecord {
             byte[] bytes = StringUtils.rightPad(key.getKey(serviceId, keyValue.getKey()) + mapper.writeValueAsString(keyValue), config.getRecordLength())
                 .getBytes(config.getEncoding());
             if (bytes.length > config.getRecordLength()) {
-                throw new InvalidPayloadException(Messages.PAYLOAD_TOO_LARGE.getKey(), keyValue.getKey());
+                throw new StorageException(Messages.PAYLOAD_TOO_LARGE.getKey(), Messages.PAYLOAD_TOO_LARGE.getStatus(), keyValue.getKey());
             }
 
             return bytes;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamRecord.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
 import org.zowe.apiml.cache.InvalidPayloadException;
-import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
 
 import java.io.UnsupportedEncodingException;

--- a/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamStorage.java
+++ b/caching-service/src/main/java/org/zowe/apiml/caching/service/vsam/VsamStorage.java
@@ -15,6 +15,9 @@ import org.springframework.retry.annotation.Retryable;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.EvictionStrategy;
 import org.zowe.apiml.caching.service.Messages;
+import org.zowe.apiml.cache.DuplicateKeyException;
+import org.zowe.apiml.cache.IncompatibleStorageMethodException;
+import org.zowe.apiml.cache.KeyNotFoundException;
 import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
@@ -89,7 +92,7 @@ public class VsamStorage implements Storage {
         }
 
         if (result == null) {
-            throw new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), toCreate.getKey(), serviceId);
+            throw new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), toCreate.getKey(), serviceId);
         }
 
         return result;
@@ -97,17 +100,17 @@ public class VsamStorage implements Storage {
 
     @Override
     public KeyValue storeMapItem(String serviceId, String mapKey, KeyValue toCreate) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, String> getAllMapItems(String serviceId, String mapKey) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public Map<String, Map<String, String>> getAllMaps(String serviceId) throws StorageException {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     private boolean aboveThreshold(int currentSize) {
@@ -131,7 +134,7 @@ public class VsamStorage implements Storage {
         }
 
         if (result == null) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), key, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), key, serviceId);
         }
 
         return result;
@@ -154,7 +157,7 @@ public class VsamStorage implements Storage {
         }
 
         if (result == null) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toUpdate.getKey(), serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toUpdate.getKey(), serviceId);
         }
 
         return result;
@@ -178,7 +181,7 @@ public class VsamStorage implements Storage {
         }
 
         if (result == null) {
-            throw new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), toDelete, serviceId);
+            throw new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), toDelete, serviceId);
         }
 
         return result;
@@ -211,11 +214,11 @@ public class VsamStorage implements Storage {
 
     @Override
     public void removeNonRelevantTokens(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 
     @Override
     public void removeNonRelevantRules(String serviceId, String mapKey) {
-        throw new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
+        throw new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
     }
 }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
@@ -21,9 +21,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.zowe.apiml.cache.Storage;
+import org.zowe.apiml.cache.CacheNotAvailableException;
+import org.zowe.apiml.cache.DuplicateKeyException;
+import org.zowe.apiml.cache.IncompatibleStorageMethodException;
+import org.zowe.apiml.cache.InsufficientStorageException;
 import org.zowe.apiml.cache.InvalidPayloadException;
+import org.zowe.apiml.cache.KeyNotFoundException;
 import org.zowe.apiml.cache.KeyNotProvidedException;
+import org.zowe.apiml.cache.Storage;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
@@ -625,6 +630,183 @@ class CachingControllerTest {
 
         }
 
+    }
+
+    @Nested
+    class WhenControllerAdviceHandlesExceptions {
+
+        private CachingControllerAdvice advice;
+        private ServerWebExchange mockExchange;
+        private ServerHttpRequest mockRequest;
+        private final MessageService adviceMessageService = new YamlMessageService("/caching-log-messages.yml");
+
+        @BeforeEach
+        void setUp() {
+            advice = new CachingControllerAdvice(adviceMessageService);
+            mockExchange = mock(ServerWebExchange.class);
+            mockRequest = mock(ServerHttpRequest.class);
+            when(mockExchange.getRequest()).thenReturn(mockRequest);
+            when(mockRequest.getURI()).thenReturn(URI.create("http://localhost"));
+        }
+
+        // --- Per-exception HTTP status mapping tests ---
+
+        @Test
+        void givenKeyNotFoundException_thenReturn404() {
+            KeyNotFoundException ex = new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), KEY, SERVICE_ID);
+
+            StepVerifier.create(advice.handleKeyNotFound(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenKeyNotProvidedException_thenReturn400() {
+            KeyNotProvidedException ex = new KeyNotProvidedException(Messages.KEY_NOT_PROVIDED.getKey());
+
+            StepVerifier.create(advice.handleKeyNotProvided(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenInvalidPayloadException_thenReturn400() {
+            InvalidPayloadException ex = new InvalidPayloadException(Messages.INVALID_PAYLOAD.getKey(), "key", "No value");
+
+            StepVerifier.create(advice.handleInvalidPayload(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenDuplicateKeyException_thenReturn409() {
+            DuplicateKeyException ex = new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), KEY);
+
+            StepVerifier.create(advice.handleDuplicateKey(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.CONFLICT));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenCacheNotAvailableException_thenReturn503() {
+            CacheNotAvailableException ex = new CacheNotAvailableException(Messages.CACHE_NOT_AVAILABLE.getKey());
+
+            StepVerifier.create(advice.handleCacheNotAvailable(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.SERVICE_UNAVAILABLE));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenInsufficientStorageException_thenReturn507() {
+            InsufficientStorageException ex = new InsufficientStorageException(Messages.INSUFFICIENT_STORAGE.getKey());
+
+            StepVerifier.create(advice.handleInsufficientStorage(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.INSUFFICIENT_STORAGE));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenIncompatibleStorageMethodException_thenReturn400() {
+            IncompatibleStorageMethodException ex = new IncompatibleStorageMethodException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey());
+
+            StepVerifier.create(advice.handleIncompatibleStorageMethod(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenStorageException_thenReturnStatusFromException() {
+            StorageException ex = new StorageException(Messages.INTERNAL_SERVER_ERROR.getKey(), HttpStatus.INTERNAL_SERVER_ERROR, "detail");
+
+            StepVerifier.create(advice.handleStorageException(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        // --- Generic/fallback handler ---
+
+        @Test
+        void givenUnexpectedException_thenReturn500() {
+            Exception ex = new RuntimeException("unexpected error");
+
+            StepVerifier.create(advice.handleInternal(mockExchange, ex))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+                    assertThat(response.getBody(), notNullValue());
+                })
+                .verifyComplete();
+        }
+
+        // --- Message body preservation (AC-6: backward compatibility) ---
+
+        @Test
+        void givenKeyNotFoundException_thenResponseBodyContainsMessageKey() {
+            KeyNotFoundException ex = new KeyNotFoundException(Messages.KEY_NOT_IN_CACHE.getKey(), KEY, SERVICE_ID);
+
+            StepVerifier.create(advice.handleKeyNotFound(mockExchange, ex))
+                .assertNext(response -> {
+                    ApiMessageView body = (ApiMessageView) response.getBody();
+                    assertThat(body, notNullValue());
+                    assertThat(body.getMessages(), notNullValue());
+                    assertThat(body.getMessages().isEmpty(), is(false));
+                    assertThat(body.getMessages().get(0).getMessageKey(), is(Messages.KEY_NOT_IN_CACHE.getKey()));
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenDuplicateKeyException_thenResponseBodyContainsMessageParameters() {
+            DuplicateKeyException ex = new DuplicateKeyException(Messages.DUPLICATE_KEY.getKey(), KEY);
+
+            StepVerifier.create(advice.handleDuplicateKey(mockExchange, ex))
+                .assertNext(response -> {
+                    ApiMessageView body = (ApiMessageView) response.getBody();
+                    assertThat(body, notNullValue());
+                    assertThat(body.getMessages(), notNullValue());
+                    assertThat(body.getMessages().isEmpty(), is(false));
+                })
+                .verifyComplete();
+        }
+
+        @Test
+        void givenUnexpectedException_thenResponseBodyContainsInternalServerErrorMessage() {
+            Exception ex = new RuntimeException("something broke");
+
+            StepVerifier.create(advice.handleInternal(mockExchange, ex))
+                .assertNext(response -> {
+                    ApiMessageView body = (ApiMessageView) response.getBody();
+                    assertThat(body, notNullValue());
+                    assertThat(body.getMessages(), notNullValue());
+                    assertThat(body.getMessages().isEmpty(), is(false));
+                    assertThat(body.getMessages().get(0).getMessageKey(),
+                        is("org.zowe.apiml.common.internalServerError"));
+                })
+                .verifyComplete();
+        }
     }
 
 }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/api/CachingControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.zowe.apiml.cache.Storage;
+import org.zowe.apiml.cache.InvalidPayloadException;
+import org.zowe.apiml.cache.KeyNotProvidedException;
 import org.zowe.apiml.cache.StorageException;
 import org.zowe.apiml.caching.model.KeyValue;
 import org.zowe.apiml.caching.service.Messages;
@@ -107,8 +109,8 @@ class CachingControllerTest {
             when(mockStorage.readForService(SERVICE_ID)).thenThrow(new RuntimeException());
 
             StepVerifier.create(underTest.getAllValues(mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
     }
 
@@ -129,8 +131,8 @@ class CachingControllerTest {
             when(mockStorage.readForService(SERVICE_ID)).thenThrow(new RuntimeException());
 
             StepVerifier.create(underTest.getAllValues(mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
     }
 
@@ -152,27 +154,18 @@ class CachingControllerTest {
 
         @Test
         void givenNoKey_thenResponseBadRequest() {
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotProvided", SERVICE_ID).mapToView();
-
             StepVerifier.create(underTest.getValue(null, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(KeyNotProvidedException.class)
+                .verify();
         }
 
         @Test
         void givenStoreWithNoKey_thenResponseNotFound() {
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
             when(mockStorage.read(any(), any())).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), new Exception("the cause"), KEY, SERVICE_ID));
 
             StepVerifier.create(underTest.getValue(KEY, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
 
         @Test
@@ -180,8 +173,8 @@ class CachingControllerTest {
             when(mockStorage.read(any(), any())).thenThrow(new RuntimeException("error"));
 
             StepVerifier.create(underTest.getValue(KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
     }
 
@@ -202,14 +195,10 @@ class CachingControllerTest {
         @Test
         void givenStorageWithExistingKey_thenResponseConflict() {
             when(mockStorage.create(SERVICE_ID, KEY_VALUE)).thenThrow(new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus(), KEY));
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyCollision", KEY).mapToView();
 
             StepVerifier.create(underTest.createKey(KEY_VALUE, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.CONFLICT));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
 
         @Test
@@ -217,8 +206,8 @@ class CachingControllerTest {
             when(mockStorage.create(SERVICE_ID, KEY_VALUE)).thenThrow(new RuntimeException("error"));
 
             StepVerifier.create(underTest.createKey(KEY_VALUE, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
     }
 
@@ -239,14 +228,10 @@ class CachingControllerTest {
         @Test
         void givenStorageWithNoKey_thenResponseNotFound() {
             when(mockStorage.update(SERVICE_ID, KEY_VALUE)).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), KEY, SERVICE_ID));
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
 
             StepVerifier.create(underTest.update(KEY_VALUE, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
     }
 
@@ -266,40 +251,26 @@ class CachingControllerTest {
 
         @Test
         void givenNoKey_thenResponseBadRequest() {
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotProvided").mapToView();
-
             StepVerifier.create(underTest.delete(null, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(KeyNotProvidedException.class)
+                .verify();
         }
 
         @Test
         void givenStorageWithNoKey_thenResponseNotFound() {
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.keyNotInCache", KEY, SERVICE_ID).mapToView();
             when(mockStorage.delete(any(), any())).thenThrow(new StorageException(Messages.KEY_NOT_IN_CACHE.getKey(), Messages.KEY_NOT_IN_CACHE.getStatus(), KEY, SERVICE_ID));
 
             StepVerifier.create(underTest.delete(KEY, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
     }
 
     @Test
     void givenNoPayload_whenValidatePayload_thenResponseBadRequest() {
-        ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.invalidPayload", null, "No KeyValue provided in the payload").mapToView();
-
         StepVerifier.create(underTest.createKey(null, mockExchange))
-            .assertNext(response -> {
-                assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
-                assertThat(response.getBody(), is(expectedBody));
-            })
-            .verifyComplete();
+            .expectError(InvalidPayloadException.class)
+            .verify();
     }
 
     @ParameterizedTest
@@ -307,15 +278,17 @@ class CachingControllerTest {
     void givenVariousKeyValue_whenValidatePayload_thenResponseAccordingly(String key, String value, String errMessage, HttpStatus statusCode) {
         KeyValue keyValue = new KeyValue(key, value);
 
-        StepVerifier.create(underTest.createKey(keyValue, mockExchange))
-            .assertNext(response -> {
-                assertThat(response.getStatusCode(), is(statusCode));
-                if (errMessage != null) {
-                    ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.invalidPayload", keyValue, errMessage).mapToView();
-                    assertThat(response.getBody(), is(expectedBody));
-                }
-            })
-            .verifyComplete();
+        if (errMessage != null) {
+            StepVerifier.create(underTest.createKey(keyValue, mockExchange))
+                .expectError(InvalidPayloadException.class)
+                .verify();
+        } else {
+            StepVerifier.create(underTest.createKey(keyValue, mockExchange))
+                .assertNext(response -> {
+                    assertThat(response.getStatusCode(), is(statusCode));
+                })
+                .verifyComplete();
+        }
     }
 
     private static Stream<Arguments> provideStringsForGivenVariousKeyValue() {
@@ -431,8 +404,8 @@ class CachingControllerTest {
             KeyValue keyValue = new KeyValue(null, VALUE);
 
             StepVerifier.create(underTest.storeMapItem(MAP_KEY, keyValue, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST)))
-                .verifyComplete();
+                .expectError(InvalidPayloadException.class)
+                .verify();
         }
 
         @Test
@@ -441,8 +414,8 @@ class CachingControllerTest {
                 .thenThrow(new StorageException(Messages.INTERNAL_SERVER_ERROR.getKey(), Messages.INTERNAL_SERVER_ERROR.getStatus(), new Exception("the cause"), KEY));
 
             StepVerifier.create(underTest.storeMapItem(MAP_KEY, KEY_VALUE, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
 
         @Test
@@ -450,14 +423,9 @@ class CachingControllerTest {
             when(mockStorage.storeMapItem(SERVICE_ID, MAP_KEY, KEY_VALUE))
                 .thenThrow(new StorageException(Messages.DUPLICATE_VALUE.getKey(), Messages.DUPLICATE_VALUE.getStatus(), VALUE));
 
-            ApiMessageView expectedBody = messageService.createMessage("org.zowe.apiml.cache.duplicateValue", VALUE).mapToView();
-
             StepVerifier.create(underTest.storeMapItem(MAP_KEY, KEY_VALUE, mockExchange))
-                .assertNext(response -> {
-                    assertThat(response.getStatusCode(), is(HttpStatus.CONFLICT));
-                    assertThat(response.getBody(), is(expectedBody));
-                })
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
     }
 
@@ -533,8 +501,8 @@ class CachingControllerTest {
                 .thenThrow(new RuntimeException("error"));
 
             StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
 
         @Test
@@ -542,8 +510,8 @@ class CachingControllerTest {
             when(mockStorage.getAllMapItems(any(), any())).thenThrow(new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), HttpStatus.BAD_REQUEST));
 
             StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST)))
-                .verifyComplete();
+                .expectError(StorageException.class)
+                .verify();
         }
 
         @Test
@@ -551,8 +519,8 @@ class CachingControllerTest {
             when(mockStorage.getAllMapItems(any(), any())).thenThrow(new RuntimeException("error"));
 
             StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
 
     }
@@ -582,12 +550,12 @@ class CachingControllerTest {
             doThrow(new RuntimeException()).when(mockStorage).removeNonRelevantRules(SERVICE_ID, MAP_KEY);
 
             StepVerifier.create(underTest.evictTokens(MAP_KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
 
             StepVerifier.create(underTest.evictRules(MAP_KEY, mockExchange))
-                .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                .verifyComplete();
+                .expectError(RuntimeException.class)
+                .verify();
         }
     }
 
@@ -603,16 +571,16 @@ class CachingControllerTest {
                 doThrow(storageException).when(mockStorage).getAllMapItems(any(), any());
 
                 StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST)))
-                    .verifyComplete();
+                    .expectError(StorageException.class)
+                    .verify();
             }
 
             @Test
             void givenUnexpectedError_whenGetAllMapItems_thenReturn500() {
                 doThrow(new RuntimeException("unexpected")).when(mockStorage).getAllMapItems(any(), any());
                 StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                    .verifyComplete();
+                    .expectError(RuntimeException.class)
+                    .verify();
             }
 
             @Test
@@ -620,8 +588,8 @@ class CachingControllerTest {
                 Exception storageException = new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus());
                 doThrow(storageException).when(mockStorage).getAllMapItems(any(), any());
                 StepVerifier.create(underTest.getAllMapItems(MAP_KEY, mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                    .verifyComplete();
+                    .expectError(StorageException.class)
+                    .verify();
             }
 
         }
@@ -634,16 +602,16 @@ class CachingControllerTest {
                 Exception storageException = new StorageException(Messages.INCOMPATIBLE_STORAGE_METHOD.getKey(), Messages.INCOMPATIBLE_STORAGE_METHOD.getStatus());
                 doThrow(storageException).when(mockStorage).getAllMaps(any());
                 StepVerifier.create(underTest.getAllMaps(mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST)))
-                    .verifyComplete();
+                    .expectError(StorageException.class)
+                    .verify();
             }
 
             @Test
             void givenUnexpectedError_whenGetAllMapItems_thenReturn500() {
                 doThrow(new RuntimeException("unexpected")).when(mockStorage).getAllMaps(any());
                 StepVerifier.create(underTest.getAllMaps(mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                    .verifyComplete();
+                    .expectError(RuntimeException.class)
+                    .verify();
             }
 
             @Test
@@ -651,8 +619,8 @@ class CachingControllerTest {
                 Exception storageException = new StorageException(Messages.DUPLICATE_KEY.getKey(), Messages.DUPLICATE_KEY.getStatus());
                 doThrow(storageException).when(mockStorage).getAllMaps(any());
                 StepVerifier.create(underTest.getAllMaps(mockExchange))
-                    .assertNext(response -> assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR)))
-                    .verifyComplete();
+                    .expectError(StorageException.class)
+                    .verify();
             }
 
         }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/RejectStrategyTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/inmemory/RejectStrategyTest.java
@@ -13,7 +13,7 @@ package org.zowe.apiml.caching.service.inmemory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.caching.service.RejectStrategy;
-import org.zowe.apiml.cache.StorageException;
+import org.zowe.apiml.cache.InsufficientStorageException;
 import org.zowe.apiml.message.log.ApimlLogger;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,7 +28,7 @@ class RejectStrategyTest {
 
     @Test
     void evictThrowsException() {
-        assertThrows(StorageException.class, () -> {
+        assertThrows(InsufficientStorageException.class, () -> {
             underTest.evict("anyValue");
         });
     }

--- a/caching-service/src/test/java/org/zowe/apiml/caching/service/vsam/VsamRecordTest.java
+++ b/caching-service/src/test/java/org/zowe/apiml/caching/service/vsam/VsamRecordTest.java
@@ -13,7 +13,7 @@ package org.zowe.apiml.caching.service.vsam;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.caching.model.KeyValue;
-import org.zowe.apiml.cache.StorageException;
+import org.zowe.apiml.cache.InvalidPayloadException;
 import org.zowe.apiml.caching.service.vsam.config.VsamConfig;
 import org.zowe.apiml.zfile.ZFileConstants;
 
@@ -99,12 +99,12 @@ class VsamRecordTest {
         KeyValue kvLongValue = new KeyValue("key", longValue);
         VsamRecord underTest1 = new VsamRecord(config, serviceId, kvLongValue);
 
-        assertThrows(StorageException.class, () -> underTest1.getBytes());
+        assertThrows(InvalidPayloadException.class, () -> underTest1.getBytes());
 
         KeyValue kvLongKey = new KeyValue(longValue, "value");
         VsamRecord underTest2 = new VsamRecord(config, serviceId, kvLongKey);
 
-        assertThrows(StorageException.class, () -> underTest2.getBytes());
+        assertThrows(InvalidPayloadException.class, () -> underTest2.getBytes());
 
     }
 

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/CacheNotAvailableException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/CacheNotAvailableException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/CacheNotAvailableException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/CacheNotAvailableException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class CacheNotAvailableException extends StorageException {
+    public CacheNotAvailableException(String key, String... messageParameters) {
+        super(key, HttpStatus.SERVICE_UNAVAILABLE, messageParameters);
+    }
+    public CacheNotAvailableException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.SERVICE_UNAVAILABLE, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/DuplicateKeyException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/DuplicateKeyException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateKeyException extends StorageException {
+    public DuplicateKeyException(String key, String... messageParameters) {
+        super(key, HttpStatus.CONFLICT, messageParameters);
+    }
+    public DuplicateKeyException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.CONFLICT, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/DuplicateKeyException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/DuplicateKeyException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/IncompatibleStorageMethodException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/IncompatibleStorageMethodException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class IncompatibleStorageMethodException extends StorageException {
+    public IncompatibleStorageMethodException(String key, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, messageParameters);
+    }
+    public IncompatibleStorageMethodException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/IncompatibleStorageMethodException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/IncompatibleStorageMethodException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/InsufficientStorageException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/InsufficientStorageException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class InsufficientStorageException extends StorageException {
+    public InsufficientStorageException(String key, String... messageParameters) {
+        super(key, HttpStatus.INSUFFICIENT_STORAGE, messageParameters);
+    }
+    public InsufficientStorageException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.INSUFFICIENT_STORAGE, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/InsufficientStorageException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/InsufficientStorageException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/InvalidPayloadException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/InvalidPayloadException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidPayloadException extends StorageException {
+    public InvalidPayloadException(String key, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, messageParameters);
+    }
+    public InvalidPayloadException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/InvalidPayloadException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/InvalidPayloadException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotFoundException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotFoundException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotFoundException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotFoundException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class KeyNotFoundException extends StorageException {
+    public KeyNotFoundException(String key, String... messageParameters) {
+        super(key, HttpStatus.NOT_FOUND, messageParameters);
+    }
+    public KeyNotFoundException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.NOT_FOUND, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotProvidedException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotProvidedException.java
@@ -1,0 +1,21 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.cache;
+
+import org.springframework.http.HttpStatus;
+
+public class KeyNotProvidedException extends StorageException {
+    public KeyNotProvidedException(String key, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, messageParameters);
+    }
+    public KeyNotProvidedException(String key, Exception cause, String... messageParameters) {
+        super(key, HttpStatus.BAD_REQUEST, cause, messageParameters);
+    }
+}

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotProvidedException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/KeyNotProvidedException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.cache;
 
 import org.springframework.http.HttpStatus;

--- a/common-service-core/src/main/java/org/zowe/apiml/cache/StorageException.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/cache/StorageException.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@Deprecated
 public class StorageException extends RuntimeException {
     private final String key;
     private final String[] parameters;


### PR DESCRIPTION
Closes #4426

## Summary
Replaces the monolithic `StorageException` with a typed exception hierarchy (7 new exception classes extending the deprecated `StorageException`), adds a `CachingControllerAdvice` (`@RestControllerAdvice`), and removes all inline exception handling from `CachingController`.

## Changes
- **Exception hierarchy** (common-service-core): 7 new typed exceptions (`KeyNotFoundException`, `KeyNotProvidedException`, `InvalidPayloadException`, `DuplicateKeyException`, `CacheNotAvailableException`, `InsufficientStorageException`, `IncompatibleStorageMethodException`) extending deprecated `StorageException`
- **CachingControllerAdvice** (caching-service): `@RestControllerAdvice` with handlers for `StorageException` (maps key+status to response) and generic `Exception` (500)
- **CachingController**: Removed all inline exception handling (`exceptionToResponse`, `isStorageIncompatible`, `handleInternalError`, `handleIncompatibleStorageMethod`, inline try/catch blocks), helper methods now throw typed exceptions
- **Storage layer**: All 4 implementations + `InfinispanConfig` + `RejectStrategy` + `VsamRecord` migrated to typed exceptions
- **Tests**: Updated error-path tests to use `expectError()` pattern (exceptions propagate to ControllerAdvice)

## Build
- `:caching-service:checkstyleMain` — PASS
- `:caching-service:test` — PASS
- `:common-service-core:compileJava` — PASS