### PR TITLE
fix: revert openTelemetry-core to 1.62.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -50,7 +50,7 @@ dependencyResolutionManagement {
             version('jakartaServlet', '6.1.0')
             version('javaxAnnotation', '1.3.2')
             version('openTelemetry-starter', '2.28.1')
-            version('openTelemetry-core', '1.63.0')
+            version('openTelemetry-core', '1.62.0')
 
             // Eureka requires this specific version of Jakarta JAXB bindings
             version('jaxbApi') {


### PR DESCRIPTION
## Problem
PR #4701 bumps `openTelemetry-core` from 1.62.0 to 1.63.0, which is incompatible with `openTelemetry-instrumentation-starter:2.28.1`. The instrumentation starter depends on OTel BOM 1.62.0, and `InstrumentationUtil` was moved from `io.opentelemetry.api.internal` to `io.opentelemetry.api.impl` in OTel 1.63.0, causing `ClassNotFoundException` in tests.

## Fix
Revert only `openTelemetry-core` back to 1.62.0. All other dependency bumps from the Renovate PR are preserved (Spring Boot 3.5.15, JGit 7.7.0, gRPC 1.82.0, etc.).

## Note
The OTel core 1.63.0 bump can be applied once a compatible instrumentation starter release is available (currently latest is 2.28.1).