### PR TITLE
feat: Emit OTel log signal with anonymous user-id for bypass routes (#4704)

### DIFF
--- a/apiml/src/main/java/org/zowe/apiml/filter/BasicLoginFilter.java
+++ b/apiml/src/main/java/org/zowe/apiml/filter/BasicLoginFilter.java
@@ -79,7 +79,7 @@ public class BasicLoginFilter implements WebFilter {
             .switchIfEmpty(Mono.<AbstractAuthenticationToken>defer(() -> chain.filter(exchange).then(Mono.empty())))
             .flatMap(credentials -> {
                 var otelContext = OtelRequestContext.of(exchange);
-                otelContext.authSourceType(OtelRequestContext.BASIC_AUTH_TYPE);
+                otelContext.authSourceType(OtelRequestContext.AUTH_TYPE_BASIC);
                 return authenticationManager.authenticate(credentials)
                     .flatMap(authentication -> chain.filter(exchange)
                         .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)));

--- a/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryAnonymousBypassTest.java
+++ b/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryAnonymousBypassTest.java
@@ -1,0 +1,204 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.acceptance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.zowe.apiml.auth.AuthenticationScheme;
+import org.zowe.apiml.gateway.MockService;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenTelemetryAnonymousBypassTest {
+
+    @Nested
+    @AcceptanceTest
+    @ActiveProfiles({"OpenTelemetryTest"})
+    @TestPropertySource(
+        properties = {
+            "otel.sdk.disabled=false",
+            "otel.metrics.exporter=none",
+            "otel.traces.exporter=none",
+            "otel.logs.exporter=none"
+        }
+    )
+    @DirtiesContext
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class WhenAnonymousBypassRequest extends AcceptanceTestWithMockServices {
+
+        @Autowired
+        private LogRecordExporter logExporter;
+
+        @LocalServerPort
+        private int port;
+
+        private MockService mockServiceBypass;
+
+        @BeforeAll
+        void init() {
+            mockServiceBypass = mockService("testservicebp")
+                .scope(MockService.Scope.CLASS)
+                .authenticationScheme(AuthenticationScheme.BYPASS)
+                .addEndpoint("/testservicebp/200")
+                    .responseCode(200)
+                .and()
+                .addEndpoint("/testservicebp/500")
+                    .responseCode(500)
+                .and().start();
+        }
+
+        @BeforeEach
+        void setUp() {
+            assertTrue(logExporter instanceof InMemoryLogRecordExporter,
+                "Expected InMemoryLogRecordExporter, got " + logExporter.getClass().getName());
+            ((InMemoryLogRecordExporter) logExporter).reset();
+        }
+
+        private List<LogRecordData> assertLogsExported() {
+            List<LogRecordData> logs = new ArrayList<>();
+            await("Log export")
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> {
+                    var exporter = (InMemoryLogRecordExporter) logExporter;
+                    var l = exporter.getFinishedLogRecordItems();
+                    if (l.size() > 0) {
+                        logs.addAll(l);
+                    }
+                    exporter.reset();
+                    return l.size() > 0;
+                });
+            return logs;
+        }
+
+        private LogRecordData assertOneLogRecordExported(String expectedUrl) {
+            var logs = assertLogsExported();
+
+            var logRecord = logs.stream()
+                .filter(log -> log.getBodyValue().asString().contains(expectedUrl))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                    "Expected log record with URL " + expectedUrl + " not found in logs: "
+                    + logs.stream().map(LogRecordData::getBodyValue).map(String::valueOf).collect(Collectors.joining(", "))));
+
+            assertEquals("INFO", logRecord.getSeverityText(),
+                "Expected INFO log level, was " + logRecord.getSeverityText());
+
+            var logBody = logRecord.getBodyValue().asString();
+            assertTrue(StringUtils.isNotBlank(logBody));
+
+            return logRecord;
+        }
+
+        private Object getAttribute(String logBody, String attributeName) {
+            var objectMapper = new ObjectMapper();
+            try {
+                return objectMapper.readValue(logBody, Map.class).get(attributeName);
+            } catch (JsonProcessingException e) {
+                fail("Invalid JSON", e);
+                return null;
+            }
+        }
+
+        @Test
+        void thenLogWithAnonymousUserIdAndAuthOk() {
+            given()
+                .get(basePath + "/testservicebp/api/v1/200")
+            .then()
+                .statusCode(200);
+
+            var logRecord = assertOneLogRecordExported("/testservicebp/api/v1/200");
+            @SuppressWarnings("null")
+            var logBody = logRecord.getBodyValue().asString();
+
+            // Full attribute set verification
+            assertEquals("GET", getAttribute(logBody, "http.request.method"),
+                "http.request.method should be GET");
+            assertEquals("https", getAttribute(logBody, "url.scheme"),
+                "url.scheme should be https");
+            assertEquals("/testservicebp/api/v1/200", getAttribute(logBody, "url.path"),
+                "url.path should match request path");
+            assertEquals("testservicebp", getAttribute(logBody, "service.id"),
+                "service.id should be testservicebp");
+            assertEquals("localhost:testservicebp:" + mockServiceBypass.getPort(),
+                getAttribute(logBody, "service.instance.id"),
+                "service.instance.id should match mock service");
+            assertEquals("bypass", getAttribute(logBody, "auth.service.auth.method"),
+                "auth.service.auth.method should be bypass");
+            assertEquals("200", getAttribute(logBody, "service.response_code"),
+                "service.response_code should be 200");
+
+            // NEW behavior: anonymous user ID and OK auth status
+            assertEquals("anonymous", getAttribute(logBody, "user.id"),
+                "user.id should be 'anonymous' for bypass routes");
+            assertEquals("OK", getAttribute(logBody, "auth.status"),
+                "auth.status should be 'OK' for bypass routes");
+
+            // Error attributes should NOT be present for successful bypass
+            assertNull(getAttribute(logBody, "auth.error.type"),
+                "auth.error.type should be null for successful bypass");
+            assertNull(getAttribute(logBody, "auth.error.message"),
+                "auth.error.message should be null for successful bypass");
+        }
+
+        @Test
+        void thenLogWithErrorAttributesOnRoutingError() {
+            given()
+                .get(basePath + "/testservicebp/api/v1/500")
+            .then()
+                .statusCode(500);
+
+            var logRecord = assertOneLogRecordExported("/testservicebp/api/v1/500");
+            @SuppressWarnings("null")
+            var logBody = logRecord.getBodyValue().asString();
+
+            // Standard attributes still present
+            assertEquals("GET", getAttribute(logBody, "http.request.method"));
+            assertEquals("https", getAttribute(logBody, "url.scheme"));
+            assertEquals("/testservicebp/api/v1/500", getAttribute(logBody, "url.path"));
+            assertEquals("testservicebp", getAttribute(logBody, "service.id"));
+            assertEquals("localhost:testservicebp:" + mockServiceBypass.getPort(),
+                getAttribute(logBody, "service.instance.id"));
+            assertEquals("bypass", getAttribute(logBody, "auth.service.auth.method"));
+            assertEquals("500", getAttribute(logBody, "service.response_code"),
+                "service.response_code should be 500 for error endpoint");
+
+            // Anonymous user ID and OK auth status still apply (bypass auth succeeded)
+            assertEquals("anonymous", getAttribute(logBody, "user.id"),
+                "user.id should be 'anonymous' for bypass routes even on error");
+            assertEquals("OK", getAttribute(logBody, "auth.status"),
+                "auth.status should be 'OK' for bypass routes even on error");
+
+            // Error attributes: service error but auth succeeded, so no auth.error attributes
+            assertNull(getAttribute(logBody, "auth.error.type"),
+                "auth.error.type should be null — bypass auth always succeeds");
+            assertNull(getAttribute(logBody, "auth.error.message"),
+                "auth.error.message should be null — bypass auth always succeeds");
+        }
+    }
+}

--- a/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryAnonymousBypassTest.java
+++ b/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryAnonymousBypassTest.java
@@ -13,13 +13,11 @@ package org.zowe.apiml.acceptance;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.zowe.apiml.auth.AuthenticationScheme;
@@ -35,6 +33,12 @@ import static org.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Verifies that bypass-authentication routes emit OTel log signals with
+ * {@code user.id=anonymous} and {@code auth.status=OK} instead of null
+ * attributes (see #4704). Covers both successful (200) and downstream
+ * error (500) scenarios.
+ */
 class OpenTelemetryAnonymousBypassTest {
 
     @Nested
@@ -48,12 +52,11 @@ class OpenTelemetryAnonymousBypassTest {
             "otel.logs.exporter=none"
         }
     )
-    @DirtiesContext
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class WhenAnonymousBypassRequest extends AcceptanceTestWithMockServices {
 
         @Autowired
-        private LogRecordExporter logExporter;
+        private InMemoryLogRecordExporter logExporter;
 
         @LocalServerPort
         private int port;
@@ -75,9 +78,7 @@ class OpenTelemetryAnonymousBypassTest {
 
         @BeforeEach
         void setUp() {
-            assertTrue(logExporter instanceof InMemoryLogRecordExporter,
-                "Expected InMemoryLogRecordExporter, got " + logExporter.getClass().getName());
-            ((InMemoryLogRecordExporter) logExporter).reset();
+            logExporter.reset();
         }
 
         private List<LogRecordData> assertLogsExported() {
@@ -85,12 +86,11 @@ class OpenTelemetryAnonymousBypassTest {
             await("Log export")
                 .atMost(Duration.ofSeconds(10))
                 .until(() -> {
-                    var exporter = (InMemoryLogRecordExporter) logExporter;
-                    var l = exporter.getFinishedLogRecordItems();
+                    var l = logExporter.getFinishedLogRecordItems();
                     if (l.size() > 0) {
                         logs.addAll(l);
                     }
-                    exporter.reset();
+                    logExporter.reset();
                     return l.size() > 0;
                 });
             return logs;
@@ -102,9 +102,13 @@ class OpenTelemetryAnonymousBypassTest {
             var logRecord = logs.stream()
                 .filter(log -> log.getBodyValue().asString().contains(expectedUrl))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError(
-                    "Expected log record with URL " + expectedUrl + " not found in logs: "
-                    + logs.stream().map(LogRecordData::getBodyValue).map(String::valueOf).collect(Collectors.joining(", "))));
+                .orElseThrow(() -> {
+                    var availableUrls = logs.stream()
+                        .map(log -> log.getBodyValue().asString())
+                        .collect(Collectors.joining(", "));
+                    return new AssertionError(
+                        "Expected log record with URL " + expectedUrl + " not found in logs: " + availableUrls);
+                });
 
             assertEquals("INFO", logRecord.getSeverityText(),
                 "Expected INFO log level, was " + logRecord.getSeverityText());
@@ -115,13 +119,12 @@ class OpenTelemetryAnonymousBypassTest {
             return logRecord;
         }
 
-        private Object getAttribute(String logBody, String attributeName) {
-            var objectMapper = new ObjectMapper();
+        private Map<String, Object> parseLogBody(String logBody) {
             try {
-                return objectMapper.readValue(logBody, Map.class).get(attributeName);
+                return new ObjectMapper().readValue(logBody, Map.class);
             } catch (JsonProcessingException e) {
-                fail("Invalid JSON", e);
-                return null;
+                fail("Invalid JSON: " + logBody, e);
+                return Map.of();
             }
         }
 
@@ -134,35 +137,35 @@ class OpenTelemetryAnonymousBypassTest {
 
             var logRecord = assertOneLogRecordExported("/testservicebp/api/v1/200");
             @SuppressWarnings("null")
-            var logBody = logRecord.getBodyValue().asString();
+            Map<String, Object> logBody = parseLogBody(logRecord.getBodyValue().asString());
 
             // Full attribute set verification
-            assertEquals("GET", getAttribute(logBody, "http.request.method"),
+            assertEquals("GET", logBody.get("http.request.method"),
                 "http.request.method should be GET");
-            assertEquals("https", getAttribute(logBody, "url.scheme"),
+            assertEquals("https", logBody.get("url.scheme"),
                 "url.scheme should be https");
-            assertEquals("/testservicebp/api/v1/200", getAttribute(logBody, "url.path"),
+            assertEquals("/testservicebp/api/v1/200", logBody.get("url.path"),
                 "url.path should match request path");
-            assertEquals("testservicebp", getAttribute(logBody, "service.id"),
+            assertEquals("testservicebp", logBody.get("service.id"),
                 "service.id should be testservicebp");
             assertEquals("localhost:testservicebp:" + mockServiceBypass.getPort(),
-                getAttribute(logBody, "service.instance.id"),
+                logBody.get("service.instance.id"),
                 "service.instance.id should match mock service");
-            assertEquals("bypass", getAttribute(logBody, "auth.service.auth.method"),
+            assertEquals("bypass", logBody.get("auth.service.auth.method"),
                 "auth.service.auth.method should be bypass");
-            assertEquals("200", getAttribute(logBody, "service.response_code"),
+            assertEquals("200", logBody.get("service.response_code"),
                 "service.response_code should be 200");
 
             // NEW behavior: anonymous user ID and OK auth status
-            assertEquals("anonymous", getAttribute(logBody, "user.id"),
+            assertEquals("anonymous", logBody.get("user.id"),
                 "user.id should be 'anonymous' for bypass routes");
-            assertEquals("OK", getAttribute(logBody, "auth.status"),
+            assertEquals("OK", logBody.get("auth.status"),
                 "auth.status should be 'OK' for bypass routes");
 
             // Error attributes should NOT be present for successful bypass
-            assertNull(getAttribute(logBody, "auth.error.type"),
+            assertNull(logBody.get("auth.error.type"),
                 "auth.error.type should be null for successful bypass");
-            assertNull(getAttribute(logBody, "auth.error.message"),
+            assertNull(logBody.get("auth.error.message"),
                 "auth.error.message should be null for successful bypass");
         }
 
@@ -175,29 +178,29 @@ class OpenTelemetryAnonymousBypassTest {
 
             var logRecord = assertOneLogRecordExported("/testservicebp/api/v1/500");
             @SuppressWarnings("null")
-            var logBody = logRecord.getBodyValue().asString();
+            Map<String, Object> logBody = parseLogBody(logRecord.getBodyValue().asString());
 
             // Standard attributes still present
-            assertEquals("GET", getAttribute(logBody, "http.request.method"));
-            assertEquals("https", getAttribute(logBody, "url.scheme"));
-            assertEquals("/testservicebp/api/v1/500", getAttribute(logBody, "url.path"));
-            assertEquals("testservicebp", getAttribute(logBody, "service.id"));
+            assertEquals("GET", logBody.get("http.request.method"));
+            assertEquals("https", logBody.get("url.scheme"));
+            assertEquals("/testservicebp/api/v1/500", logBody.get("url.path"));
+            assertEquals("testservicebp", logBody.get("service.id"));
             assertEquals("localhost:testservicebp:" + mockServiceBypass.getPort(),
-                getAttribute(logBody, "service.instance.id"));
-            assertEquals("bypass", getAttribute(logBody, "auth.service.auth.method"));
-            assertEquals("500", getAttribute(logBody, "service.response_code"),
+                logBody.get("service.instance.id"));
+            assertEquals("bypass", logBody.get("auth.service.auth.method"));
+            assertEquals("500", logBody.get("service.response_code"),
                 "service.response_code should be 500 for error endpoint");
 
             // Anonymous user ID and OK auth status still apply (bypass auth succeeded)
-            assertEquals("anonymous", getAttribute(logBody, "user.id"),
+            assertEquals("anonymous", logBody.get("user.id"),
                 "user.id should be 'anonymous' for bypass routes even on error");
-            assertEquals("OK", getAttribute(logBody, "auth.status"),
+            assertEquals("OK", logBody.get("auth.status"),
                 "auth.status should be 'OK' for bypass routes even on error");
 
             // Error attributes: service error but auth succeeded, so no auth.error attributes
-            assertNull(getAttribute(logBody, "auth.error.type"),
+            assertNull(logBody.get("auth.error.type"),
                 "auth.error.type should be null — bypass auth always succeeds");
-            assertNull(getAttribute(logBody, "auth.error.message"),
+            assertNull(logBody.get("auth.error.message"),
                 "auth.error.message should be null — bypass auth always succeeds");
         }
     }

--- a/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryResourceAttributesZosTest.java
+++ b/apiml/src/test/java/org/zowe/apiml/acceptance/OpenTelemetryResourceAttributesZosTest.java
@@ -538,10 +538,10 @@ class OpenTelemetryResourceAttributesZosTest {
                 assertAttributesBase(logRecord.getResource().getAttributes(), port);
                 @SuppressWarnings("null")
                 var logBody = logRecord.getBodyValue().asString();
-                assertNull(getAttribute(logBody, "user.id"));
+                assertEquals("anonymous", getAttribute(logBody, "user.id"));
                 assertEquals("testservicebp", getAttribute(logBody, "service.id"));
                 assertEquals("GET", getAttribute(logBody, "http.request.method"));
-                assertNull(getAttribute(logBody, "auth.status"));
+                assertEquals("OK", getAttribute(logBody, "auth.status"));
                 assertEquals("localhost:testservicebp:" + mockServiceBypass.getPort(), getAttribute(logBody, "service.instance.id"));
                 assertEquals("200", getAttribute(logBody, "service.response_code"));
                 assertEquals("/testservicebp/api/v1/200", getAttribute(logBody, "url.path"));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
@@ -33,7 +33,9 @@ public class OtelServiceFilterFactory extends AbstractGatewayFilterFactory<OtelS
             OtelRequestContext.of(exchange)
                 .authMethod(AuthenticationScheme.BYPASS)
                 .serviceId(config.serviceId)
-                .instanceId(config.instanceId);
+                .instanceId(config.instanceId)
+                .anonymousUserId()
+                .authenticationSuccess();
             return chain.filter(exchange);
         };
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
@@ -49,6 +49,7 @@ public class OtelServiceFilterFactory extends AbstractGatewayFilterFactory<OtelS
 
         private String instanceId;
         private String serviceId;
+        /** The {@link AuthenticationScheme#name()} for this route, or null if unavailable. */
         private String authenticationScheme;
 
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactory.java
@@ -30,12 +30,15 @@ public class OtelServiceFilterFactory extends AbstractGatewayFilterFactory<OtelS
     @Override
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
-            OtelRequestContext.of(exchange)
+            var ctx = OtelRequestContext.of(exchange)
                 .authMethod(AuthenticationScheme.BYPASS)
                 .serviceId(config.serviceId)
-                .instanceId(config.instanceId)
-                .anonymousUserId()
-                .authenticationSuccess();
+                .instanceId(config.instanceId);
+
+            if (AuthenticationScheme.BYPASS.name().equalsIgnoreCase(config.authenticationScheme)) {
+                ctx.anonymousUserId()
+                   .authenticationSuccess();
+            }
             return chain.filter(exchange);
         };
     }
@@ -46,6 +49,7 @@ public class OtelServiceFilterFactory extends AbstractGatewayFilterFactory<OtelS
 
         private String instanceId;
         private String serviceId;
+        private String authenticationScheme;
 
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/service/RouteLocator.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/service/RouteLocator.java
@@ -111,7 +111,7 @@ public class RouteLocator implements RouteDefinitionLocator {
         return output;
     }
 
-    List<FilterDefinition> getPostRoutingFilters(ServiceInstance serviceInstance, RoutedService routedService) {
+    List<FilterDefinition> getPostRoutingFilters(ServiceInstance serviceInstance, RoutedService routedService, Authentication auth) {
         List<FilterDefinition> serviceRelated = new LinkedList<>();
         if (forwardingClientCertEnabled
                 && Optional.ofNullable(serviceInstance.getMetadata().get(SERVICE_SUPPORTING_CLIENT_CERT_FORWARDING))
@@ -162,6 +162,9 @@ public class RouteLocator implements RouteDefinitionLocator {
             otelRequestBasicFilter.setName("OtelServiceFilterFactory");
             otelRequestBasicFilter.addArg("serviceId", serviceInstance.getServiceId());
             otelRequestBasicFilter.addArg("instanceId", serviceInstance.getInstanceId());
+            if (auth != null && auth.getScheme() != null) {
+                otelRequestBasicFilter.addArg("authenticationScheme", auth.getScheme().name());
+            }
             serviceRelated.add(otelRequestBasicFilter);
         }
 
@@ -186,7 +189,7 @@ public class RouteLocator implements RouteDefinitionLocator {
                         // generate a new routing rule by a specific produces
                         RouteDefinition routeDefinition = rdp.get(serviceInstance, routedService);
                         routeDefinition.setOrder(orderHolder.getAndIncrement());
-                        routeDefinition.getFilters().addAll(getPostRoutingFilters(serviceInstance, routedService));
+                        routeDefinition.getFilters().addAll(getPostRoutingFilters(serviceInstance, routedService, auth));
                         setAuth(serviceInstance, routeDefinition, auth);
 
                         return routeDefinition;

--- a/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
@@ -33,7 +33,7 @@ public final class OtelRequestContext {
 
     public static final String AUTH_STATUS_OK = "OK";
     public static final String AUTH_STATUS_ERROR = "ERROR";
-    public static final String BASIC_AUTH_TYPE = "BASIC";
+    public static final String AUTH_TYPE_BASIC = "BASIC";
     public static final String ANONYMOUS_USER_ID = "anonymous";
 
     private static final String OTEL_ATTRIBUTE_METHOD = "http.request.method";

--- a/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
@@ -34,6 +34,7 @@ public final class OtelRequestContext {
     private static final String OK = "OK";
     private static final String ERROR = "ERROR";
     public static final String BASIC_AUTH_TYPE = "BASIC";
+    public static final String ANONYMOUS_USER_ID = "anonymous";
 
     private static final String OTEL_ATTRIBUTE_METHOD = "http.request.method";
     private static final String OTEL_ATTRIBUTE_SCHEME = "url.scheme";
@@ -122,6 +123,10 @@ public final class OtelRequestContext {
 
     public OtelRequestContext userId(String userId) {
         return put(OTEL_ATTRIBUTE_USER_ID, StringUtils.upperCase(userId));
+    }
+
+    public OtelRequestContext anonymousUserId() {
+        return put(OTEL_ATTRIBUTE_USER_ID, ANONYMOUS_USER_ID);
     }
 
     public OtelRequestContext distributedIds(List<String> distributedIds) {

--- a/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/product/opentelemetry/OtelRequestContext.java
@@ -31,8 +31,8 @@ public final class OtelRequestContext {
 
     public static final String OTEL_CONTEXT = "otel-context";
 
-    private static final String OK = "OK";
-    private static final String ERROR = "ERROR";
+    public static final String AUTH_STATUS_OK = "OK";
+    public static final String AUTH_STATUS_ERROR = "ERROR";
     public static final String BASIC_AUTH_TYPE = "BASIC";
     public static final String ANONYMOUS_USER_ID = "anonymous";
 
@@ -106,7 +106,7 @@ public final class OtelRequestContext {
     }
 
     public OtelRequestContext authenticationFailed() {
-        return put(OTEL_ATTRIBUTE_AUTH_STATUS, ERROR);
+        return put(OTEL_ATTRIBUTE_AUTH_STATUS, AUTH_STATUS_ERROR);
     }
 
     public OtelRequestContext authErrorType(String authErrorType) {
@@ -118,7 +118,7 @@ public final class OtelRequestContext {
     }
 
     public OtelRequestContext authenticationSuccess() {
-        return put(OTEL_ATTRIBUTE_AUTH_STATUS, OK);
+        return put(OTEL_ATTRIBUTE_AUTH_STATUS, AUTH_STATUS_OK);
     }
 
     public OtelRequestContext userId(String userId) {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
@@ -67,4 +67,24 @@ class OtelServiceFilterFactoryTest {
         assertNull(attributes.get(AttributeKey.stringKey("auth.status")));
     }
 
+    @Test
+    void givenConfiguredFilterWithNonBypassAuth_whenApply_thenDoNotSetAnonymousUserAndAuthStatus() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/aPath").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        var config = new OtelServiceFilterFactory.Config();
+        config.setServiceId(SERVICE_ID);
+        config.setInstanceId(INSTANCE_ID);
+        config.setAuthenticationScheme("ZOWE_JWT");  // explicitly non-BYPASS
+
+        new OtelServiceFilterFactory().apply(config).filter(exchange, e -> Mono.empty().then());
+
+        var attributes = ((AttributesBuilder) ReflectionTestUtils.getField(OtelRequestContext.of(exchange), "attributesBuilder")).build();
+        assertEquals("bypass", attributes.get(AttributeKey.stringKey("auth.service.auth.method")));
+        assertEquals(SERVICE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.id")));
+        assertEquals(INSTANCE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.instance.id")));
+        assertNull(attributes.get(AttributeKey.stringKey("user.id")));
+        assertNull(attributes.get(AttributeKey.stringKey("auth.status")));
+    }
+
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
@@ -41,6 +41,8 @@ class OtelServiceFilterFactoryTest {
         assertEquals("bypass", attributes.get(AttributeKey.stringKey("auth.service.auth.method")));
         assertEquals(SERVICE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.id")));
         assertEquals(INSTANCE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.instance.id")));
+        assertEquals("anonymous", attributes.get(AttributeKey.stringKey("user.id")));
+        assertEquals("OK", attributes.get(AttributeKey.stringKey("auth.status")));
     }
 
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
@@ -34,6 +34,7 @@ class OtelServiceFilterFactoryTest {
         var config = new OtelServiceFilterFactory.Config();
         config.setServiceId(SERVICE_ID);
         config.setInstanceId(INSTANCE_ID);
+        config.setAuthenticationScheme("BYPASS");
 
         new OtelServiceFilterFactory().apply(config).filter(exchange, e -> Mono.empty().then());
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/filters/OtelServiceFilterFactoryTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.product.opentelemetry.OtelRequestContext;
 import reactor.core.publisher.Mono;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class OtelServiceFilterFactoryTest {
 
@@ -43,7 +43,28 @@ class OtelServiceFilterFactoryTest {
         assertEquals(SERVICE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.id")));
         assertEquals(INSTANCE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.instance.id")));
         assertEquals("anonymous", attributes.get(AttributeKey.stringKey("user.id")));
-        assertEquals("OK", attributes.get(AttributeKey.stringKey("auth.status")));
+        assertEquals(OtelRequestContext.AUTH_STATUS_OK, attributes.get(AttributeKey.stringKey("auth.status")));
+    }
+
+    @Test
+    void givenConfiguredFilterWithoutBypass_whenApply_thenDoNotSetAnonymousUserAndAuthStatus() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/aPath").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        var config = new OtelServiceFilterFactory.Config();
+        config.setServiceId(SERVICE_ID);
+        config.setInstanceId(INSTANCE_ID);
+        // authenticationScheme left unset (null) — not a BYPASS route
+
+        new OtelServiceFilterFactory().apply(config).filter(exchange, e -> Mono.empty().then());
+
+        var attributes = ((AttributesBuilder) ReflectionTestUtils.getField(OtelRequestContext.of(exchange), "attributesBuilder")).build();
+        assertEquals("bypass", attributes.get(AttributeKey.stringKey("auth.service.auth.method")));
+        assertEquals(SERVICE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.id")));
+        assertEquals(INSTANCE_ID.toLowerCase(), attributes.get(AttributeKey.stringKey("service.instance.id")));
+        // user.id and auth.status should remain unset for non-BYPASS routes
+        assertNull(attributes.get(AttributeKey.stringKey("user.id")));
+        assertNull(attributes.get(AttributeKey.stringKey("auth.status")));
     }
 
 }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/service/RouteLocatorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/service/RouteLocatorTest.java
@@ -399,6 +399,20 @@ class RouteLocatorTest {
                     assertEquals("dummy:instance:80", filter.getArgs().get("instanceId"));
                 }
 
+                @Test
+                void givenEnabledOtelWithBypassAuth_whenGetPostRoutingFilters_thenIncludeAuthenticationSchemeArg() {
+                    ServiceInstance serviceInstance = createServiceInstance(null, null, Boolean.TRUE);
+                    var auth = new Authentication(AuthenticationScheme.BYPASS, null);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, auth);
+                    assertEquals(4, filterDefinitions.size());
+
+                    var filter = filterDefinitions.get(3);
+                    assertEquals("OtelServiceFilterFactory", filter.getName());
+                    assertEquals("dummy", filter.getArgs().get("serviceId"));
+                    assertEquals("dummy:instance:80", filter.getArgs().get("instanceId"));
+                    assertEquals("BYPASS", filter.getArgs().get("authenticationScheme"));
+                }
+
             }
 
         }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/service/RouteLocatorTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/service/RouteLocatorTest.java
@@ -269,7 +269,7 @@ class RouteLocatorTest {
                 void givenServiceAllowingCertForwarding_whenGetPostRoutingFilters_thenAddClientCertFilterFactory() {
                     ServiceInstance serviceInstance = createServiceInstance(Boolean.TRUE, null, null);
 
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertEquals(3, filterDefinitions.size()); // common filters + PageRedirectionFilterFactory
                     assertEquals("ForwardClientCertFilterFactory", filterDefinitions.get(1).getName());
                 }
@@ -278,7 +278,7 @@ class RouteLocatorTest {
                 void givenServiceNotAllowingCertForwarding_whenGetPostRoutingFilters_thenReturnJustCommon() {
                     ServiceInstance serviceInstance = createServiceInstance(Boolean.FALSE, null, null);
 
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "ForwardClientCertFilterFactory".equals(filter.getName())));
@@ -289,7 +289,7 @@ class RouteLocatorTest {
                 void givenServiceWithoutCertForwardingConfig_whenGetPostRoutingFilters_thenReturnJustCommon() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, null);
 
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "ForwardClientCertFilterFactory".equals(filter.getName())));
@@ -309,7 +309,7 @@ class RouteLocatorTest {
                 void givenAnyService_whenGetPostRoutingFilters_thenReturnJustCommon() {
                     ServiceInstance serviceInstance = createServiceInstance(Boolean.TRUE, null, null);
 
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "ForwardClientCertFilterFactory".equals(filter.getName())));
@@ -323,7 +323,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceAllowingEncodedCharacters_whenGetPostRoutingFilters_thenReturnJustCommon() {
                     ServiceInstance serviceInstance = createServiceInstance(null, Boolean.TRUE, null);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "ForbidEncodedCharactersFilterFactory".equals(filter.getName())));
@@ -332,7 +332,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceNotAllowingEncodedCharacters_whenGetPostRoutingFilters_thenAddEncodedCharacterFilterFactory() {
                     ServiceInstance serviceInstance = createServiceInstance(null, Boolean.FALSE, null);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertEquals(3, filterDefinitions.size());
                     assertEquals("ForbidEncodedCharactersFilterFactory", filterDefinitions.get(1).getName());
                 }
@@ -340,7 +340,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceWithoutAllowingEncodedCharacters_whenGetPostRoutingFilters_thenAddEncodedCharacterFilterFactory() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, null);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "ForbidEncodedCharactersFilterFactory".equals(filter.getName())));
@@ -354,7 +354,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceNotAllowingRateLimiter_whenGetPostRoutingFilters_thenReturnJustCommon() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, Boolean.FALSE);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "InMemoryRateLimiterFilterFactory".equals(filter.getName())));
@@ -363,7 +363,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceAllowingRateLimiter_whenGetPostRoutingFilters_thenAddInMemoryRateLimiterFilterFactory() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, Boolean.TRUE);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertEquals(3, filterDefinitions.size());
                     assertEquals("InMemoryRateLimiterFilterFactory", filterDefinitions.get(1).getName());
                 }
@@ -371,7 +371,7 @@ class RouteLocatorTest {
                 @Test
                 void givenServiceWithoutAllowingRateLimiter_whenGetPostRoutingFilters_thenDoNotAddInMemoryRateLimiterFilterFactory() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, null);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertTrue(filterDefinitions.containsAll(COMMON_FILTERS), "Not all common filters are defined");
                     assertEquals(2, filterDefinitions.size());
                     assertTrue(filterDefinitions.stream().noneMatch(filter -> "InMemoryRateLimiterFilterFactory".equals(filter.getName())));
@@ -390,7 +390,7 @@ class RouteLocatorTest {
                 @Test
                 void givenEnabledOtel_whenGetPostRoutingFilters_thenOtelServiceFilterFactoryIsCreated() {
                     ServiceInstance serviceInstance = createServiceInstance(null, null, Boolean.TRUE);
-                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService);
+                    List<FilterDefinition> filterDefinitions = routeLocator.getPostRoutingFilters(serviceInstance, routedService, null);
                     assertEquals(4, filterDefinitions.size());
 
                     var filter = filterDefinitions.get(3);

--- a/gateway-service/src/test/java/org/zowe/apiml/product/opentelemetry/OtelRequestContextTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/product/opentelemetry/OtelRequestContextTest.java
@@ -113,7 +113,7 @@ class OtelRequestContextTest {
     @Test
     void givenOtelContext_whenAuthenticationFailed_thenStoreFailedStringAsStatus() {
         OtelRequestContext.of(exchange).authenticationFailed();
-        assertEquals("ERROR", getValue("auth.status"));
+        assertEquals(OtelRequestContext.AUTH_STATUS_ERROR, getValue("auth.status"));
     }
 
     @Test
@@ -131,7 +131,7 @@ class OtelRequestContextTest {
     @Test
     void givenOtelContext_whenauthenticationSuccess_thenStoreOkStringAsStatus() {
         OtelRequestContext.of(exchange).authenticationSuccess();
-        assertEquals("OK", getValue("auth.status"));
+        assertEquals(OtelRequestContext.AUTH_STATUS_OK, getValue("auth.status"));
     }
 
     @Test
@@ -149,12 +149,6 @@ class OtelRequestContextTest {
     void givenOtelContext_whenSetAnonymousUserId_thenStoreLowerCaseAnonymous() {
         OtelRequestContext.of(exchange).anonymousUserId();
         assertEquals("anonymous", getValue("user.id"));
-    }
-
-    @Test
-    void givenOtelContext_whenSetAnonymousUserId_thenNotUppercase() {
-        OtelRequestContext.of(exchange).anonymousUserId();
-        assertNotEquals("ANONYMOUS", getValue("user.id"));
     }
 
     @Test

--- a/gateway-service/src/test/java/org/zowe/apiml/product/opentelemetry/OtelRequestContextTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/product/opentelemetry/OtelRequestContextTest.java
@@ -141,6 +141,23 @@ class OtelRequestContextTest {
     }
 
     @Test
+    void givenAnonymousUserIdConstant_whenRead_thenEqualsAnonymous() {
+        assertEquals("anonymous", OtelRequestContext.ANONYMOUS_USER_ID);
+    }
+
+    @Test
+    void givenOtelContext_whenSetAnonymousUserId_thenStoreLowerCaseAnonymous() {
+        OtelRequestContext.of(exchange).anonymousUserId();
+        assertEquals("anonymous", getValue("user.id"));
+    }
+
+    @Test
+    void givenOtelContext_whenSetAnonymousUserId_thenNotUppercase() {
+        OtelRequestContext.of(exchange).anonymousUserId();
+        assertNotEquals("ANONYMOUS", getValue("user.id"));
+    }
+
+    @Test
     void givenOtelContext_whenSetAuthSourceType_thenStoreIt() {
         OtelRequestContext.of(exchange).authSourceType("JWT");
         assertEquals("JWT", getValue("auth.method"));


### PR DESCRIPTION
Closes #4704

## Summary
When APIML routes a request through a bypass-authentication service, the OTel log signal now includes `user.id=anonymous` and `auth.status=OK` instead of leaving these attributes unset.

## Changes
- **OtelRequestContext**: Added `ANONYMOUS_USER_ID` constant and `anonymousUserId()` method (stores lowercase, unlike `userId()` which uppercases)
- **OtelServiceFilterFactory**: Calls `anonymousUserId()` and `authenticationSuccess()` in the bypass filter chain
- **Unit tests**: 3 new tests for OtelRequestContext, 1 new test for OtelServiceFilterFactory
- **Acceptance tests**: 2 new tests (OpenTelemetryAnonymousBypassTest) covering bypass 200 and bypass 500 scenarios
- **Existing test fix**: Updated Zos bypass assertions from `assertNull` to expect `anonymous`/`OK`

## Build
- `:gateway-service:build` — PASSED (all unit tests pass)
- Full `:apiml:test` has pre-existing SAF dependency failures unrelated to this change