### PR TITLE
chore: verify that mock-services rejects encoded characters

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
@@ -44,11 +44,11 @@ import static org.zowe.apiml.util.SecurityUtils.assertValidAuthToken;
 class ZosmfLoginTest implements TestWithStartedInstances {
 
     private final static boolean ZOS_TARGET = Boolean.parseBoolean(System.getProperty("environment.zos.target", "false"));
+    private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getClientUser();
     private final static String ZOSMF_SERVICE_ID = ConfigReader.environmentConfiguration().getZosmfServiceConfiguration().getServiceId();
     private static final String ZOSMF_CONTEXT_ROOT = ConfigReader.environmentConfiguration().getZosmfServiceConfiguration().getContextRoot();
-    private final static String ZOSMF_ENDPOINT_GW = "/" + ZOSMF_SERVICE_ID + "/api/v1/" + (StringUtils.hasText(ZOSMF_CONTEXT_ROOT) ? ZOSMF_CONTEXT_ROOT + "/" : "") + "restfiles/ds";
-    private final static String USERNAME = ConfigReader.environmentConfiguration().getCredentials().getClientUser();
-    private final static String ZOSMF_ENDPOINT_MOCK = "/" + ZOSMF_SERVICE_ID + "/api/zosmf/restfiles/ds";
+    private final static String ZOSMF_ENDPOINT_GW = "/" + ZOSMF_SERVICE_ID + "/api/v1/" + (StringUtils.hasText(ZOSMF_CONTEXT_ROOT) ? ZOSMF_CONTEXT_ROOT + "/" : "") + "restfiles/";
+    private final static String ZOSMF_ENDPOINT_MOCK = "/" + ZOSMF_SERVICE_ID + "/api/zosmf/restfiles/";
     private final static String ZOSMF_ENDPOINT = ZOS_TARGET ? ZOSMF_ENDPOINT_GW : ZOSMF_ENDPOINT_MOCK;
 
     @BeforeAll
@@ -66,7 +66,7 @@ class ZosmfLoginTest implements TestWithStartedInstances {
             String dsname1 = "SYS1.PARMLIB";
             String dsname2 = "SYS1.PROCLIB";
 
-            URI uri = HttpRequestUtils.getUriFromGateway(ZOSMF_ENDPOINT, new BasicNameValuePair("dslevel", "sys1.p*"));
+            URI uri = HttpRequestUtils.getUriFromGateway(ZOSMF_ENDPOINT + "ds", new BasicNameValuePair("dslevel", "sys1.p*"));
 
             given()
                 .config(SslContext.clientCertUser)
@@ -81,7 +81,7 @@ class ZosmfLoginTest implements TestWithStartedInstances {
 
         @Test
         void givenValidCertificate_whenPathContainsEncodedCharacters_thenReturnBadRequest() {
-            URI uri = HttpRequestUtils.getRawUriFromGateway("/" + ZOSMF_SERVICE_ID + "/api/v1/zosmf/restfiles/fs%2Fc%2Fuser%2Ffile.txt");
+            URI uri = HttpRequestUtils.getRawUriFromGateway(ZOSMF_ENDPOINT + "fs%2Fc%2Fuser%2Ffile.txt");
             RequestSpecification mySpec = new RequestSpecBuilder().setUrlEncodingEnabled(false).build();
             given()
                 .config(SslContext.clientCertUser)
@@ -98,7 +98,7 @@ class ZosmfLoginTest implements TestWithStartedInstances {
 
         @Test
         void givenValidCertificate_whenQueryParamsEncoded_thenReturnFile() {
-            URI uri = HttpRequestUtils.getRawUriFromGateway("/" + ZOSMF_SERVICE_ID + "/api/v1/zosmf/restfiles/fs?path=c%2Fuser%2Ffile.txt");
+            URI uri = HttpRequestUtils.getRawUriFromGateway(ZOSMF_ENDPOINT + "fs?path=c%2Fuser%2Ffile.txt");
             RequestSpecification mySpec = new RequestSpecBuilder().setUrlEncodingEnabled(false).build();
             given()
                 .config(SslContext.clientCertUser)

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
@@ -71,16 +71,16 @@ class ZosmfLoginTest implements TestWithStartedInstances {
             given()
                 .config(SslContext.clientCertUser)
                 .header("X-CSRF-ZOSMF-HEADER", "")
-            .when()
+                .when()
                 .get(uri)
-            .then()
+                .then()
                 .statusCode(is(SC_OK))
                 .body("items.dsname", hasItems(dsname1, dsname2))
                 .onFailMessage("Accessing " + uri);
         }
 
         @Test
-        void givenValidCertificate_thenReturnExistingFile() {
+        void givenValidCertificate_whenPathContainsEncodedCharacters_thenReturnBadRequest() {
             URI uri = HttpRequestUtils.getRawUriFromGateway("/" + ZOSMF_SERVICE_ID + "/api/v1/zosmf/restfiles/fs%2Fc%2Fuser%2Ffile.txt");
             RequestSpecification mySpec = new RequestSpecBuilder().setUrlEncodingEnabled(false).build();
             given()
@@ -88,10 +88,26 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                 .log().all()
                 .spec(mySpec)
                 .header("X-CSRF-ZOSMF-HEADER", "")
-            .when()
+                .when()
                 .get(uri)
-            .then()
+                .then()
                 .statusCode(is(SC_BAD_REQUEST))
+                .onFailMessage("Accessing " + uri);
+        }
+
+        @Test
+        void givenValidCertificate_whenQueryParamsEncoded_thenReturnFile() {
+            URI uri = HttpRequestUtils.getRawUriFromGateway("/" + ZOSMF_SERVICE_ID + "/api/v1/zosmf/restfiles/fs?path=c%2Fuser%2Ffile.txt");
+            RequestSpecification mySpec = new RequestSpecBuilder().setUrlEncodingEnabled(false).build();
+            given()
+                .config(SslContext.clientCertUser)
+                .log().all()
+                .spec(mySpec)
+                .header("X-CSRF-ZOSMF-HEADER", "")
+                .when()
+                .get(uri)
+                .then()
+                .statusCode(is(SC_OK))
                 .onFailMessage("Accessing " + uri);
         }
 
@@ -108,9 +124,9 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                     given()
                         .config(SslContext.clientCertValid)
                         .noContentType()
-                    .when()
+                        .when()
                         .post(loginUrl)
-                    .then()
+                        .then()
                         .statusCode(is(SC_NO_CONTENT))
                         .cookie(COOKIE_NAME, not(is(emptyString())))
                         .onFailMessage("Accessing " + loginUrl)
@@ -128,9 +144,9 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                         .config(SslContext.clientCertValid)
                         .auth().basic("Bob", "The Builder")
                         .noContentType()
-                    .when()
+                        .when()
                         .post(loginUrl)
-                    .then()
+                        .then()
                         .statusCode(is(SC_NO_CONTENT))
                         .cookie(COOKIE_NAME, not(is(emptyString())))
                         .onFailMessage("Accessing " + loginUrl)

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
@@ -91,6 +91,7 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                 .when()
                 .get(uri)
                 .then()
+                .log().all()
                 .statusCode(is(SC_BAD_REQUEST))
                 .onFailMessage("Accessing " + uri);
         }
@@ -107,8 +108,8 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                 .when()
                 .get(uri)
                 .then()
-                .statusCode(is(SC_OK))
-                .onFailMessage("Accessing " + uri);
+                .log().all()
+                .statusCode(is(SC_OK));
         }
 
     }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/authentication/providers/ZosmfLoginTest.java
@@ -11,7 +11,9 @@
 package org.zowe.apiml.integration.authentication.providers;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.Cookie;
+import io.restassured.specification.RequestSpecification;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -30,8 +32,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.SC_NO_CONTENT;
-import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.*;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.core.Is.is;
@@ -74,11 +75,26 @@ class ZosmfLoginTest implements TestWithStartedInstances {
                 .get(uri)
             .then()
                 .statusCode(is(SC_OK))
-                .body(
-                    "items.dsname", hasItems(dsname1, dsname2)
-                )
+                .body("items.dsname", hasItems(dsname1, dsname2))
                 .onFailMessage("Accessing " + uri);
         }
+
+        @Test
+        void givenValidCertificate_thenReturnExistingFile() {
+            URI uri = HttpRequestUtils.getRawUriFromGateway("/" + ZOSMF_SERVICE_ID + "/api/v1/zosmf/restfiles/fs%2Fc%2Fuser%2Ffile.txt");
+            RequestSpecification mySpec = new RequestSpecBuilder().setUrlEncodingEnabled(false).build();
+            given()
+                .config(SslContext.clientCertUser)
+                .log().all()
+                .spec(mySpec)
+                .header("X-CSRF-ZOSMF-HEADER", "")
+            .when()
+                .get(uri)
+            .then()
+                .statusCode(is(SC_BAD_REQUEST))
+                .onFailMessage("Accessing " + uri);
+        }
+
     }
 
     @Nested

--- a/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
@@ -74,7 +74,7 @@ public class HttpRequestUtils {
         return new HttpGet(uri);
     }
 
-    public static URI getUri(ServiceConfiguration serviceConfiguration, String endpoint, NameValuePair...arguments) {
+    public static URI getUri(ServiceConfiguration serviceConfiguration, String endpoint, NameValuePair... arguments) {
         var host = serviceConfiguration.getHost();
         if (serviceConfiguration instanceof GatewayServiceConfiguration s && StringUtils.isNotBlank(s.getDvipaHost())) {
             host = s.getDvipaHost();
@@ -82,7 +82,7 @@ public class HttpRequestUtils {
         return getUri(serviceConfiguration.getScheme(), host, serviceConfiguration.getPort(), endpoint, arguments);
     }
 
-    public static URI getUri(String scheme, String host, int port, String endpoint, NameValuePair...arguments) {
+    public static URI getUri(String scheme, String host, int port, String endpoint, NameValuePair... arguments) {
         URI uri = null;
         try {
             uri = new URIBuilder()
@@ -100,7 +100,7 @@ public class HttpRequestUtils {
         return uri;
     }
 
-    public static URI getUriFromService(ServiceConfiguration serviceConfiguration, String endpoint, NameValuePair...arguments) {
+    public static URI getUriFromService(ServiceConfiguration serviceConfiguration, String endpoint, NameValuePair... arguments) {
         return getUriFromService(serviceConfiguration, endpoint, sc -> {
             var host = sc.getHost();
             var hostnameTokenizer = new StringTokenizer(host, ",");
@@ -112,14 +112,14 @@ public class HttpRequestUtils {
         }, arguments);
     }
 
-    public static URI getUriFromService(ServiceConfiguration serviceConfiguration, String endpoint, Function<ServiceConfiguration, String> hostSelector, NameValuePair...arguments) {
+    public static URI getUriFromService(ServiceConfiguration serviceConfiguration, String endpoint, Function<ServiceConfiguration, String> hostSelector, NameValuePair... arguments) {
         var scheme = serviceConfiguration.getScheme();
         var host = hostSelector.apply(serviceConfiguration);
         int port = serviceConfiguration.getPort();
         return getUri(scheme, host, port, endpoint, arguments);
     }
 
-    public static URI getUriFromGateway(String endpoint, NameValuePair...arguments) {
+    public static URI getUriFromGateway(String endpoint, NameValuePair... arguments) {
         return getUriFromService(ConfigReader.environmentConfiguration().getGatewayServiceConfiguration(), endpoint, arguments);
     }
 
@@ -140,11 +140,11 @@ public class HttpRequestUtils {
             return new URI(config.getScheme() + "://" + host + ":" + config.getPort() + rawPath);
         } catch (URISyntaxException e) {
             log.error("Can't create raw URI for path '{}'", rawPath);
-            return null;
+            throw new RuntimeException("Invalid raw path: " + rawPath, e);
         }
     }
 
-    public static URI getUriFromGateway(String endpoint, String gatewayHostname, NameValuePair...arguments) {
+    public static URI getUriFromGateway(String endpoint, String gatewayHostname, NameValuePair... arguments) {
         return getUriFromService(ConfigReader.environmentConfiguration().getGatewayServiceConfiguration(), endpoint, s -> gatewayHostname, arguments);
     }
 
@@ -152,16 +152,16 @@ public class HttpRequestUtils {
      * Get a zaas-based URL
      * ZAAS is no longer a separate entity in single-service deployment mode, so the URL is optional
      *
-     * @param endpoint Which zaas endpoint
+     * @param endpoint  Which zaas endpoint
      * @param arguments Arguments
      * @return An optional URI object
      */
-    public static Optional<URI> getUriFromZaas(String endpoint, NameValuePair...arguments) {
+    public static Optional<URI> getUriFromZaas(String endpoint, NameValuePair... arguments) {
         return Optional.ofNullable(ConfigReader.environmentConfiguration().getZaasConfiguration()) // on modulith zaas is not defined
             .map(zaasConfig -> getUriFromService(zaasConfig, endpoint, arguments));
     }
 
-    public static URI getUriFromZaas(String endpoint, String zaasHostname, NameValuePair...arguments) {
+    public static URI getUriFromZaas(String endpoint, String zaasHostname, NameValuePair... arguments) {
         return getUriFromService(ConfigReader.environmentConfiguration().getZaasConfiguration(), endpoint, s -> zaasHostname, arguments);
     }
 

--- a/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/http/HttpRequestUtils.java
@@ -123,6 +123,27 @@ public class HttpRequestUtils {
         return getUriFromService(ConfigReader.environmentConfiguration().getGatewayServiceConfiguration(), endpoint, arguments);
     }
 
+    /**
+     * Build a gateway URI from a raw (already percent-encoded) path without re-encoding.
+     * Use this instead of {@link #getUriFromGateway} when the path contains encoded characters
+     * like {@code %2F} that must not be double-encoded.
+     */
+    public static URI getRawUriFromGateway(String rawPath) {
+        var config = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
+        var host = config.getHost();
+        var hostnameTokenizer = new StringTokenizer(host, ",");
+        host = hostnameTokenizer.nextToken();
+        if (StringUtils.isNotBlank(config.getDvipaHost())) {
+            host = config.getDvipaHost();
+        }
+        try {
+            return new URI(config.getScheme() + "://" + host + ":" + config.getPort() + rawPath);
+        } catch (URISyntaxException e) {
+            log.error("Can't create raw URI for path '{}'", rawPath);
+            return null;
+        }
+    }
+
     public static URI getUriFromGateway(String endpoint, String gatewayHostname, NameValuePair...arguments) {
         return getUriFromService(ConfigReader.environmentConfiguration().getGatewayServiceConfiguration(), endpoint, s -> gatewayHostname, arguments);
     }

--- a/mock-services/src/main/java/org/zowe/apiml/client/api/FilesController.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/api/FilesController.java
@@ -10,6 +10,7 @@
 
 package org.zowe.apiml.client.api;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.zowe.apiml.client.services.AparBasedService;
 
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 
 @RestController
@@ -27,11 +27,20 @@ public class FilesController {
     private final AparBasedService files;
 
     @GetMapping(value = "/zosmf/restfiles/ds", produces = "application/json; charset=utf-8")
-    public ResponseEntity<?> readFiles(
+    public ResponseEntity<?> readDatasets(
         HttpServletResponse response,
         @RequestHeader Map<String, String> headers
     ) {
         return files.process("files", "read", response, headers);
     }
+
+    @GetMapping(value = "/zosmf/restfiles/fs/**", produces = "application/json; charset=utf-8")
+    public ResponseEntity<?> readFile(
+        HttpServletResponse response,
+        @RequestHeader Map<String, String> headers
+    ) {
+        return files.process("files", "readFile", response, headers);
+    }
+
 }
 

--- a/mock-services/src/main/java/org/zowe/apiml/client/api/FilesController.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/api/FilesController.java
@@ -34,7 +34,7 @@ public class FilesController {
         return files.process("files", "read", response, headers);
     }
 
-    @GetMapping(value = "/zosmf/restfiles/fs/**", produces = "application/json; charset=utf-8")
+    @GetMapping(value = {"/zosmf/restfiles/fs/**", "/zosmf/restfiles/fs"}, produces = "application/json; charset=utf-8")
     public ResponseEntity<?> readFile(
         HttpServletResponse response,
         @RequestHeader Map<String, String> headers

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -23,6 +23,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.HashMap;
 
 @SuppressWarnings({"squid:S1452", "squid:S1172"})
 public class FunctionalApar implements Apar {
@@ -168,7 +169,9 @@ public class FunctionalApar implements Apar {
      * Override to provide a response entity when a specific file content is requested.
      */
     protected ResponseEntity<?> handleFileContent(Map<String, String> headers) {
-        return null;
+        var body = new HashMap<String, String>();
+        body.put("file", "content");
+        return new ResponseEntity<>(body, HttpStatus.OK);
     }
 
     protected boolean noAuthentication(Map<String, String> headers) {

--- a/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
+++ b/mock-services/src/main/java/org/zowe/apiml/client/services/apars/FunctionalApar.java
@@ -89,7 +89,11 @@ public class FunctionalApar implements Apar {
         }
 
         if (calledService.equals("files")) {
-            result = handleFiles(headers);
+            if ("readFile".equals(calledMethod)) {
+                result = handleFileContent(headers);
+            } else {
+                result = handleFiles(headers);
+            }
         }
 
         if (calledService.equals("jwtKeys")) {
@@ -157,6 +161,13 @@ public class FunctionalApar implements Apar {
      * Override to provide a response entity when the files service is called with proper authorization.
      */
     protected ResponseEntity<?> handleFiles(Map<String, String> headers) {
+        return null;
+    }
+
+    /**
+     * Override to provide a response entity when a specific file content is requested.
+     */
+    protected ResponseEntity<?> handleFileContent(Map<String, String> headers) {
         return null;
     }
 


### PR DESCRIPTION
# Description

Add integration tests to verify that mock-services aligns with Jakarta EE 10 specification with regards to the encoded characters in the URL path.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [x] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
