### PR TITLE
fix: Replace Input with outlined TextField in WizardInputs — GH#4752

### DIFF
--- a/api-catalog-ui/frontend/src/components/Wizard/WizardComponents/WizardInputs.jsx
+++ b/api-catalog-ui/frontend/src/components/Wizard/WizardComponents/WizardInputs.jsx
@@ -13,7 +13,6 @@ import {
     Checkbox,
     FormControl,
     FormControlLabel,
-    FormHelperText,
     InputLabel,
     MenuItem,
     Select,

--- a/api-catalog-ui/frontend/src/components/Wizard/WizardComponents/WizardInputs.jsx
+++ b/api-catalog-ui/frontend/src/components/Wizard/WizardComponents/WizardInputs.jsx
@@ -18,6 +18,7 @@ import {
     MenuItem,
     Select,
     Input,
+    TextField,
     Tooltip,
 } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -444,17 +445,20 @@ class WizardInputs extends Component {
         const captionId = `my-helper${itemKey}`;
         return (
             <Tooltip className="wizardTooltip" title={finalTooltip}>
-                <FormControl className="wizardFormFields" disabled={disabled}>
-                    <InputLabel shrink>{question}</InputLabel>
-                    <Input
-                        id={itemKey}
-                        name={itemKey}
-                        value={value}
-                        onChange={(event) => this.handleInputChange(event, index)}
-                        aria-describedby={captionId}
-                    />
-                    <FormHelperText id={captionId}>{caption}</FormHelperText>
-                </FormControl>
+                <TextField
+                    variant="outlined"
+                    fullWidth
+                    className="wizardFormFields"
+                    label={question}
+                    value={value}
+                    onChange={(event) => this.handleInputChange(event, index)}
+                    helperText={caption}
+                    disabled={disabled}
+                    InputLabelProps={{ shrink: true }}
+                    id={itemKey}
+                    name={itemKey}
+                    FormHelperTextProps={{ id: captionId }}
+                />
             </Tooltip>
         );
     }


### PR DESCRIPTION
Closes #4752

Replaces the MUI FormControl+InputLabel+Input+FormHelperText block in WizardInputs.jsx renderInputElement() with TextField variant="outlined". This adds visible borders to the static onboarding wizard fields, making them clearly distinguishable.

**Change:** 1 file, +15/-11 lines in api-catalog-ui/frontend/src/components/Wizard/WizardComponents/WizardInputs.jsx

(architect PR review to follow)