### PR TITLE
fix: require basic auth for eureka endpoints when TLS validation is disabled

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -416,7 +416,7 @@ jobs:
 
             -   name: Run Discovery Basic Auth Tests
                 run: >
-                    ./gradlew :integration-tests:runDiscoveryBasicAuthTests -Denvironment.config=-docker -Dapiml.discovery.userid=eureka -Dapiml.discovery.password=password
+                    ./gradlew :integration-tests:runDiscoveryBasicAuthTests --info -Denvironment.config=-docker -Dapiml.discovery.userid=eureka -Dapiml.discovery.password=password
 
             -   name: Store results
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -416,7 +416,7 @@ jobs:
 
             -   name: Run Discovery Basic Auth Tests
                 run: >
-                    ./gradlew :integration-tests:runDiscoveryBasicAuthTests -Denvironment.config=-docker
+                    ./gradlew :integration-tests:runDiscoveryBasicAuthTests -Denvironment.config=-docker -Dapiml.discovery.userid=eureka -Dapiml.discovery.password=password
 
             -   name: Store results
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -365,6 +365,70 @@ jobs:
 
             -   uses: ./.github/actions/teardown
 
+
+    CITestsDiscoveryBasicAuth:
+        needs: PublishJibContainers
+        runs-on: ubuntu-latest
+        container: ubuntu:latest
+        timeout-minutes: 15
+
+        services:
+            api-catalog-services:
+                image: ghcr.io/balhar-jakub/api-catalog-services:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_DISCOVERY_USERID: eureka
+                    APIML_DISCOVERY_PASSWORD: password
+            discovery-service:
+                image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_DISCOVERY_USERID: eureka
+                    APIML_DISCOVERY_PASSWORD: password
+            gateway-service:
+                image: ghcr.io/balhar-jakub/gateway-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_DISCOVERY_USERID: eureka
+                    APIML_DISCOVERY_PASSWORD: password
+            discoverable-client:
+                image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_DISCOVERY_USERID: eureka
+                    APIML_DISCOVERY_PASSWORD: password
+            cloud-gateway-service:
+                image: ghcr.io/balhar-jakub/cloud-gateway-service:${{ github.run_id }}-${{ github.run_number }}
+                env:
+                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_DISCOVERY_USERID: eureka
+                    APIML_DISCOVERY_PASSWORD: password
+            mock-services:
+                image: ghcr.io/balhar-jakub/mock-services:${{ github.run_id }}-${{ github.run_number }}
+
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.head_ref }}
+
+            -   uses: ./.github/actions/setup
+
+            -   name: Run Discovery Basic Auth Tests
+                run: >
+                    ./gradlew :integration-tests:runDiscoveryBasicAuthTests -Denvironment.config=-docker
+
+            -   name: Store results
+                uses: actions/upload-artifact@v4
+                if: always()
+                with:
+                    name: CITestsDiscoveryBasicAuth-${{ env.JOB_ID }}
+                    path: |
+                        integration-tests/build/test-results/runStartUpCheck/binary/**
+                        integration-tests/build/reports/**
+                        results/**
+
+            -   uses: ./.github/actions/teardown
+
     CITestsZaas:
         needs: PublishJibContainers
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -383,6 +383,7 @@ jobs:
                 image: ghcr.io/balhar-jakub/discovery-service:${{ github.run_id }}-${{ github.run_number }}
                 env:
                     APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_SECURITY_SSL_NONSTRICTVERIFYSSLCERTIFICATESOFSERVICES: true
                     APIML_DISCOVERY_USERID: eureka
                     APIML_DISCOVERY_PASSWORD: password
             gateway-service:
@@ -423,7 +424,6 @@ jobs:
                 with:
                     name: CITestsDiscoveryBasicAuth-${{ env.JOB_ID }}
                     path: |
-                        integration-tests/build/test-results/runStartUpCheck/binary/**
                         integration-tests/build/reports/**
                         results/**
 
@@ -1739,6 +1739,10 @@ jobs:
                 with:
                     name: CloudGatewayServiceRouting-${{ env.JOB_ID }}
                     path: cloudgatewayservicerouting
+            -   uses: actions/download-artifact@v4
+                with:
+                    name: CITestsDiscoveryBasicAuth-${{ env.JOB_ID }}
+                    path: citestsdiscoverybasicauth
 
             -   name: Code coverage and publish results
                 run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -395,7 +395,7 @@ jobs:
             discoverable-client:
                 image: ghcr.io/balhar-jakub/discoverable-client:${{ github.run_id }}-${{ github.run_number }}
                 env:
-                    APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
+                    APIML_SERVICE_SSL_VERIFYSSLCERTIFICATESOFSERVICES: false
                     APIML_DISCOVERY_USERID: eureka
                     APIML_DISCOVERY_PASSWORD: password
             cloud-gateway-service:

--- a/.run/GatewayApplication.run.xml
+++ b/.run/GatewayApplication.run.xml
@@ -8,12 +8,6 @@
       </param>
     </additionalParameters>
     <option name="ALTERNATIVE_JRE_PATH" value="1.8 (2)" />
-    <envs>
-      <env name="APIML_DISCOVERY_PASSWORD" value="password" />
-      <env name="APIML_DISCOVERY_USERID" value="eureka" />
-      <env name="APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES" value="false" />
-      <env name="APIML_SECURITY_SSL_NONSTRICTVERIFYSSLCERTIFICATESOFSERVICES" value="true" />
-    </envs>
     <module name="api-layer.gateway-service.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.zowe.apiml.gateway.GatewayApplication" />

--- a/.run/GatewayApplication.run.xml
+++ b/.run/GatewayApplication.run.xml
@@ -8,6 +8,12 @@
       </param>
     </additionalParameters>
     <option name="ALTERNATIVE_JRE_PATH" value="1.8 (2)" />
+    <envs>
+      <env name="APIML_DISCOVERY_PASSWORD" value="password" />
+      <env name="APIML_DISCOVERY_USERID" value="eureka" />
+      <env name="APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES" value="false" />
+      <env name="APIML_SECURITY_SSL_NONSTRICTVERIFYSSLCERTIFICATESOFSERVICES" value="true" />
+    </envs>
     <module name="api-layer.gateway-service.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.zowe.apiml.gateway.GatewayApplication" />

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -271,6 +271,14 @@ if [ -z $ZWE_GATEWAY_HOST ]; then
     ZWE_GATEWAY_HOST="$ZWE_haInstance_hostname:$ZWE_components_gateway_port"
 fi
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 CATALOG_CODE=AC
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
@@ -292,6 +300,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \
     -Dapiml.service.eurekaUserName=${ZWE_configs_apiml_service_http_userId:-} \
     -Dapiml.service.eurekaUserPassword=${ZWE_configs_apiml_service_http_password:-} \
     -Dapiml.service.internalProtocol=${internalProtocol:-https} \
+    -Dapiml.discovery.password=${discoveryPassword} \
+    -Dapiml.discovery.userid=${discoveryUserid} \
     -Dapiml.logs.location=${ZWE_zowe_logDirectory} \
     -Dapiml.health.protected=${ZWE_configs_apiml_health_protected:-false} \
     -Dapiml.service.externalUrl="${externalProtocol}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}" \

--- a/api-catalog-package/src/main/resources/bin/start.sh
+++ b/api-catalog-package/src/main/resources/bin/start.sh
@@ -274,11 +274,6 @@ fi
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 CATALOG_CODE=AC
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CATALOG_CODE} java \

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
-import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -39,18 +38,22 @@ public class StaticAPIService {
     private static final String REFRESH_ENDPOINT = "discovery/api/v1/staticApi";
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String eurekaUserid;
+    private String discoveryUserid;
 
     @Value("${apiml.discovery.password:#{null}}")
-    private String eurekaPassword;
+    private String discoveryPassword;
 
     @Qualifier("secureHttpClientWithKeystore")
     private final CloseableHttpClient httpClient;
 
-    @Value("${server.attlsServer.enabled:false}")
-    private boolean isServerAttlsEnabled;
+    @Value("${server.attlsClient.enabled:false}")
+    private boolean isClientAttlsEnabled;
 
-    private final DiscoveryConfigProperties discoveryConfigProperties;
+    @Value("${apiml.security.ssl.verifySslCertificatesOfServices:true}")
+    private boolean verifySslCertificatesOfServices;
+
+    @Value("${apiml.service.discoveryServiceUrls}")
+    private String[] discoveryUrls;
 
     public StaticAPIResponse refresh() {
         List<String> discoveryServiceUrls = getDiscoveryServiceUrls();
@@ -83,10 +86,10 @@ public class StaticAPIService {
     }
 
     void setAuthorization(AbstractHttpMessage request) {
-        if (StringUtils.isEmpty(eurekaUserid) || StringUtils.isEmpty(eurekaPassword)) {
+        if (StringUtils.isEmpty(discoveryUserid) || StringUtils.isEmpty(discoveryPassword)) {
             log.warn("Eureka userid or password not set");
         } else {
-            String basicToken = "Basic " + Base64.getEncoder().encodeToString((eurekaUserid + ":" + eurekaPassword).getBytes());
+            String basicToken = "Basic " + Base64.getEncoder().encodeToString((discoveryUserid + ":" + discoveryPassword).getBytes());
             request.addHeader(HttpHeaders.AUTHORIZATION, basicToken);
         }
     }
@@ -95,18 +98,17 @@ public class StaticAPIService {
         boolean isHttp = discoveryServiceUrl.startsWith("http://");
         HttpPost post = new HttpPost(discoveryServiceUrl);
         post.addHeader("Accept", "application/json");
-        if (isHttp && !isServerAttlsEnabled) {
-            String basicToken = "Basic " + Base64.getEncoder().encodeToString((eurekaUserid + ":" + eurekaPassword).getBytes());
-            post.addHeader("Authorization", basicToken);
+        boolean clientCertificateUnavailable = isHttp || !verifySslCertificatesOfServices;
+        if (clientCertificateUnavailable && !isClientAttlsEnabled) {
+            setAuthorization(post);
         }
         return post;
     }
 
     private List<String> getDiscoveryServiceUrls() {
-        String[] discoveryServiceLocations = discoveryConfigProperties.getLocations();
 
         List<String> discoveryServiceUrls = new ArrayList<>();
-        for (String location : discoveryServiceLocations) {
+        for (String location : discoveryUrls) {
             discoveryServiceUrls.add(location.replace("/eureka", "") + REFRESH_ENDPOINT);
         }
         return discoveryServiceUrls;

--- a/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
+++ b/api-catalog-services/src/main/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIService.java
@@ -38,7 +38,7 @@ public class StaticAPIService {
     private static final String REFRESH_ENDPOINT = "discovery/api/v1/staticApi";
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String discoveryUserid;
+    private String discoveryUserId;
 
     @Value("${apiml.discovery.password:#{null}}")
     private String discoveryPassword;
@@ -86,10 +86,10 @@ public class StaticAPIService {
     }
 
     void setAuthorization(AbstractHttpMessage request) {
-        if (StringUtils.isEmpty(discoveryUserid) || StringUtils.isEmpty(discoveryPassword)) {
+        if (StringUtils.isEmpty(discoveryUserId) || StringUtils.isEmpty(discoveryPassword)) {
             log.warn("Eureka userid or password not set");
         } else {
-            String basicToken = "Basic " + Base64.getEncoder().encodeToString((discoveryUserid + ":" + discoveryPassword).getBytes());
+            String basicToken = "Basic " + Base64.getEncoder().encodeToString((discoveryUserId + ":" + discoveryPassword).getBytes());
             request.addHeader(HttpHeaders.AUTHORIZATION, basicToken);
         }
     }

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -196,7 +196,7 @@ class StaticAPIServiceTest {
         @Test
         void givenCredentials_whenSetCredentials_thenSetAuthorizationHeader() {
             StaticAPIService service = new StaticAPIService(null);
-            ReflectionTestUtils.setField(service, "discoveryUserid", "user");
+            ReflectionTestUtils.setField(service, "discoveryUserId", "user");
             ReflectionTestUtils.setField(service, "discoveryPassword", "password");
 
             AbstractHttpMessage request = mock(AbstractHttpMessage.class);
@@ -213,7 +213,7 @@ class StaticAPIServiceTest {
         })
         void givenIncompleteCredentials_whenSetCredentials_thenDoNotSetAuthorization(String userId, String password) {
             StaticAPIService service = new StaticAPIService(null);
-            ReflectionTestUtils.setField(service, "discoveryUserid", userId);
+            ReflectionTestUtils.setField(service, "discoveryUserId", userId);
             ReflectionTestUtils.setField(service, "discoveryPassword", password);
 
             AbstractHttpMessage request = mock(AbstractHttpMessage.class);

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -92,7 +92,8 @@ class StaticAPIServiceTest {
             @Test
             void givenRefreshAPIWithSecureDiscoveryService_thenReturnApiResponseCodeWithBody() throws IOException {
 
-                when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{DISCOVERY_LOCATION});
+                ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", new String[]{DISCOVERY_LOCATION});
+
                 mockRestTemplateExchange(DISCOVERY_URL);
 
                 StaticAPIResponse actualResponse = staticAPIService.refresh();
@@ -102,7 +103,8 @@ class StaticAPIServiceTest {
 
             @Test
             void givenRefreshAPIWithUnSecureDiscoveryService_thenReturnApiResponseCodeWithBody() throws IOException {
-                when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{DISCOVERY_LOCATION_HTTP});
+
+                ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", new String[]{DISCOVERY_LOCATION_HTTP});
 
                 mockRestTemplateExchange(DISCOVERY_URL_HTTP);
                 StaticAPIResponse actualResponse = staticAPIService.refresh();
@@ -127,7 +129,8 @@ class StaticAPIServiceTest {
 
                 @Test
                 void whenFirstSucceeds_thenReturnResponseFromFirst() throws IOException {
-                    when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+
+                    ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", discoveryLocations);
                     mockRestTemplateExchange(DISCOVERY_LOCATION);
                     StaticAPIResponse actualResponse = staticAPIService.refresh();
                     StaticAPIResponse expectedResponse = new StaticAPIResponse(200, BODY);
@@ -136,7 +139,7 @@ class StaticAPIServiceTest {
 
                 @Test
                 void whenFirstFails_thenReturnResponseFromSecond() throws IOException {
-                    when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+                    ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", discoveryLocations);
                     when(notFoundResponse.getStatusLine()).thenReturn(notFoundStatusLine);
                     when(notFoundStatusLine.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
                     mockRestTemplateExchange(DISCOVERY_LOCATION_2);
@@ -150,7 +153,7 @@ class StaticAPIServiceTest {
             class WhenBothFailsTest {
                 @Test
                 void whenBothFail_thenReturnResponseFromSecond() throws IOException {
-                    when(discoveryConfigProperties.getLocations()).thenReturn(discoveryLocations);
+                    ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", discoveryLocations);
                     when(notFoundResponse.getStatusLine()).thenReturn(notFoundStatusLine);
                     when(notFoundStatusLine.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
                     when(notFoundResponse.getEntity()).thenReturn(entity);
@@ -168,7 +171,8 @@ class StaticAPIServiceTest {
 
     @Test
     void givenNoDiscoveryLocations_whenAttemptRefresh_thenReturn500() {
-        when(discoveryConfigProperties.getLocations()).thenReturn(new String[]{});
+
+        ReflectionTestUtils.setField(staticAPIService, "discoveryUrls", new String[]{});
 
         StaticAPIResponse actualResponse = staticAPIService.refresh();
         StaticAPIResponse expectedResponse = new StaticAPIResponse(500, "Error making static API refresh request to the Discovery Service");
@@ -195,9 +199,9 @@ class StaticAPIServiceTest {
 
         @Test
         void givenCredentials_whenSetCredentials_thenSetAuthorizationHeader() {
-            StaticAPIService service = new StaticAPIService(null, null);
-            ReflectionTestUtils.setField(service, "eurekaUserid", "user");
-            ReflectionTestUtils.setField(service, "eurekaPassword", "password");
+            StaticAPIService service = new StaticAPIService(null);
+            ReflectionTestUtils.setField(service, "discoveryUserid", "user");
+            ReflectionTestUtils.setField(service, "discoveryPassword", "password");
 
             AbstractHttpMessage request = mock(AbstractHttpMessage.class);
             service.setAuthorization(request);
@@ -212,9 +216,9 @@ class StaticAPIServiceTest {
             ",,"
         })
         void givenIncompleteCredentials_whenSetCredentials_thenDoNotSetAuthorization(String userId, String password) {
-            StaticAPIService service = new StaticAPIService(null, null);
-            ReflectionTestUtils.setField(service, "eurekaUserid", userId);
-            ReflectionTestUtils.setField(service, "eurekaPassword", password);
+            StaticAPIService service = new StaticAPIService(null);
+            ReflectionTestUtils.setField(service, "discoveryUserid", userId);
+            ReflectionTestUtils.setField(service, "discoveryPassword", password);
 
             AbstractHttpMessage request = mock(AbstractHttpMessage.class);
             service.setAuthorization(request);

--- a/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
+++ b/api-catalog-services/src/test/java/org/zowe/apiml/apicatalog/staticapi/StaticAPIServiceTest.java
@@ -28,7 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.zowe.apiml.apicatalog.discovery.DiscoveryConfigProperties;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -66,9 +65,6 @@ class StaticAPIServiceTest {
     private StatusLine notFoundStatusLine;
     @Mock
     private HttpEntity entity;
-
-    @Mock
-    private DiscoveryConfigProperties discoveryConfigProperties;
 
     private final String[] discoveryLocations = {DISCOVERY_LOCATION, DISCOVERY_LOCATION_2};
     private static final String BODY = "This is body";

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/EurekaBasicAuthEnvironmentPostProcessor.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/EurekaBasicAuthEnvironmentPostProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.zowe.apiml.product.eureka.EurekaServiceUrlUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * When TLS validation of services is disabled ({@code apiml.security.ssl.verifySslCertificatesOfServices=false}) the
+ * client certificate of a service cannot be trusted, therefore the Discovery Service requires HTTP basic authentication
+ * instead of client certificate authentication. The Netflix Eureka client performs basic authentication only when the
+ * credentials are present in the service URL, so this post processor embeds the configured Discovery Service
+ * credentials ({@code apiml.discovery.userid} / {@code apiml.discovery.password}) into
+ * {@code eureka.client.serviceUrl.defaultZone}.
+ * <p>
+ * When TLS validation is enabled (the default) or the credentials are not configured, the environment is left untouched.
+ */
+@Slf4j
+public class EurekaBasicAuthEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    static final String VERIFY_CERTIFICATES_PROPERTY = "apiml.security.ssl.verifySslCertificatesOfServices";
+    static final String EUREKA_USERID_PROPERTY = "apiml.discovery.userid";
+    static final String EUREKA_PASSWORD_PROPERTY = "apiml.discovery.password";
+    static final String DEFAULT_ZONE_PROPERTY = "eureka.client.serviceUrl.defaultZone";
+    static final String PROPERTY_SOURCE_NAME = "apimlEurekaBasicAuth";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (!"false".equalsIgnoreCase(environment.getProperty(VERIFY_CERTIFICATES_PROPERTY, "true"))) {
+            log.debug("TLS certificate verification is enabled; Eureka basic auth credential injection skipped");
+            return;
+        }
+
+        String userid = environment.getProperty(EUREKA_USERID_PROPERTY);
+        String password = environment.getProperty(EUREKA_PASSWORD_PROPERTY);
+        String defaultZone = environment.getProperty(DEFAULT_ZONE_PROPERTY);
+        if (StringUtils.isAnyBlank(defaultZone, userid, password)) {
+            log.debug("Skipping Eureka basic auth credential injection: one or more of {}, {}, {} is not set",
+                DEFAULT_ZONE_PROPERTY, EUREKA_USERID_PROPERTY, EUREKA_PASSWORD_PROPERTY);
+            return;
+        }
+
+        String updatedDefaultZone = Arrays.stream(defaultZone.split(","))
+            .map(url -> EurekaServiceUrlUtils.addCredentials(url.trim(), userid, password))
+            .collect(Collectors.joining(","));
+
+        if (!updatedDefaultZone.equals(defaultZone)) {
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(DEFAULT_ZONE_PROPERTY, updatedDefaultZone);
+            environment.getPropertySources().addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+            log.debug("Injected basic auth credentials for user '{}' into Eureka service URLs: {}", userid, defaultZone);
+        } else {
+            log.debug("All Eureka service URLs in {} already contain credentials; no update applied", DEFAULT_ZONE_PROPERTY);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        // run after the configuration data (application.yml) has been loaded so the properties are resolvable
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/apiml-common/src/main/resources/META-INF/spring.factories
+++ b/apiml-common/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+org.zowe.apiml.product.web.EurekaBasicAuthEnvironmentPostProcessor

--- a/apiml-common/src/test/java/org/zowe/apiml/product/web/EurekaBasicAuthEnvironmentPostProcessorTest.java
+++ b/apiml-common/src/test/java/org/zowe/apiml/product/web/EurekaBasicAuthEnvironmentPostProcessorTest.java
@@ -1,0 +1,94 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EurekaBasicAuthEnvironmentPostProcessorTest {
+
+    private final EurekaBasicAuthEnvironmentPostProcessor postProcessor = new EurekaBasicAuthEnvironmentPostProcessor();
+    private MockEnvironment environment;
+
+    @BeforeEach
+    void setUp() {
+        environment = new MockEnvironment();
+        environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY, "https://localhost:10011/eureka/");
+        environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.EUREKA_USERID_PROPERTY, "eureka");
+        environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.EUREKA_PASSWORD_PROPERTY, "password");
+    }
+
+    private String defaultZone() {
+        return environment.getProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY);
+    }
+
+    @Nested
+    class GivenVerificationDisabled {
+
+        @BeforeEach
+        void disableVerification() {
+            environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.VERIFY_CERTIFICATES_PROPERTY, "false");
+        }
+
+        @Test
+        void thenCredentialsAreEmbedded() {
+            postProcessor.postProcessEnvironment(environment, null);
+            assertEquals("https://eureka:password@localhost:10011/eureka/", defaultZone());
+        }
+
+        @Test
+        void givenMultipleUrls_thenAllAreRewritten() {
+            environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY,
+                "https://host1:10011/eureka/,https://host2:10011/eureka/");
+            postProcessor.postProcessEnvironment(environment, null);
+            assertEquals(
+                "https://eureka:password@host1:10011/eureka/,https://eureka:password@host2:10011/eureka/",
+                defaultZone()
+            );
+        }
+
+        @Test
+        void givenUrlWithCredentials_thenItIsLeftUntouchedAndNoSourceAdded() {
+            environment.setProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY,
+                "https://eureka:password@localhost:10011/eureka/");
+            postProcessor.postProcessEnvironment(environment, null);
+            assertEquals("https://eureka:password@localhost:10011/eureka/", defaultZone());
+            assertFalse(environment.getPropertySources().contains(EurekaBasicAuthEnvironmentPostProcessor.PROPERTY_SOURCE_NAME));
+        }
+
+        @Test
+        void givenNoCredentials_thenDefaultZoneIsUnchanged() {
+            environment.getPropertySources().remove("mockProperties");
+            MockEnvironment noCreds = new MockEnvironment();
+            noCreds.setProperty(EurekaBasicAuthEnvironmentPostProcessor.VERIFY_CERTIFICATES_PROPERTY, "false");
+            noCreds.setProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY, "https://localhost:10011/eureka/");
+            postProcessor.postProcessEnvironment(noCreds, null);
+            assertEquals("https://localhost:10011/eureka/",
+                noCreds.getProperty(EurekaBasicAuthEnvironmentPostProcessor.DEFAULT_ZONE_PROPERTY));
+        }
+    }
+
+    @Nested
+    class GivenVerificationEnabled {
+
+        @Test
+        void thenDefaultZoneIsUnchanged() {
+            postProcessor.postProcessEnvironment(environment, null);
+            assertEquals("https://localhost:10011/eureka/", defaultZone());
+            assertFalse(environment.getPropertySources().contains(EurekaBasicAuthEnvironmentPostProcessor.PROPERTY_SOURCE_NAME));
+        }
+    }
+}

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/eureka/EurekaServiceUrlUtils.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/eureka/EurekaServiceUrlUtils.java
@@ -1,0 +1,78 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.eureka;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * Helper for embedding basic authentication credentials into Eureka discovery service URLs.
+ * <p>
+ * The Netflix Eureka client (used both by the onboarding enablers and the internal API ML services)
+ * performs HTTP basic authentication only when the credentials are present in the service URL as
+ * {@code scheme://userid:password@host:port/path}. When TLS validation is disabled
+ * ({@code apiml.security.ssl.verifySslCertificatesOfServices=false}) the client certificate cannot be
+ * trusted, so the Discovery Service requires basic authentication instead. This helper rewrites the
+ * configured discovery URLs to carry the credentials in that situation.
+ */
+public final class EurekaServiceUrlUtils {
+
+    private EurekaServiceUrlUtils() {
+    }
+
+    /**
+     * Embeds the given credentials into the authority part of the URL if they are not already present.
+     *
+     * @param url      the discovery service URL (e.g. {@code https://host:10011/eureka/})
+     * @param userid   the eureka user id; if blank the URL is returned unchanged
+     * @param password the eureka password; if blank the URL is returned unchanged
+     * @return the URL with {@code userid:password@} inserted after the scheme, or the original URL when
+     * the credentials are missing, the URL has no scheme, or it already contains user information
+     */
+    public static String addCredentials(String url, String userid, String password) {
+        if (url == null || isBlank(userid) || isBlank(password)) {
+            return url;
+        }
+
+        // Do not touch unresolved placeholders or SpEL expressions (e.g. the http-profile allPeersUrls
+        // that already conditionally embeds credentials); only fully resolved URLs are rewritten.
+        if (url.contains("{")) {
+            return url;
+        }
+
+        URI uri = URI.create(url);
+        if (uri.getScheme() == null || uri.getHost() == null || uri.getUserInfo() != null) {
+            return url;
+        }
+        try {
+            return new URI(uri.getScheme(), userid + ':' + password, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Failed to construct URL with credentials", e);
+        }
+    }
+
+    /**
+     * Applies {@link #addCredentials(String, String, String)} to every URL in the list.
+     */
+    public static List<String> addCredentials(List<String> urls, String userid, String password) {
+        if (urls == null) {
+            return new ArrayList<>();
+        }
+        return urls.stream()
+            .map(url -> addCredentials(url, userid, password)).collect(Collectors.toList());
+    }
+
+}

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/eureka/EurekaServiceUrlUtilsTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/eureka/EurekaServiceUrlUtilsTest.java
@@ -1,0 +1,116 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.product.eureka;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EurekaServiceUrlUtilsTest {
+
+    @Nested
+    class WhenCredentialsAreUsable {
+
+        @Test
+        void givenUrlWithoutCredentials_thenCredentialsAreEmbedded() {
+            assertEquals(
+                "https://eureka:password@localhost:10011/eureka/",
+                EurekaServiceUrlUtils.addCredentials("https://localhost:10011/eureka/", "eureka", "password")
+            );
+        }
+
+        @Test
+        void givenHttpUrl_thenCredentialsAreEmbedded() {
+            assertEquals(
+                "http://eureka:password@localhost:10011/eureka",
+                EurekaServiceUrlUtils.addCredentials("http://localhost:10011/eureka", "eureka", "password")
+            );
+        }
+
+        @Test
+        void givenUrlWithoutPath_thenCredentialsAreEmbedded() {
+            assertEquals(
+                "https://user:pass@localhost:10011",
+                EurekaServiceUrlUtils.addCredentials("https://localhost:10011", "user", "pass")
+            );
+        }
+
+        @Test
+        void givenListOfUrls_thenAllAreRewritten() {
+            List<String> result = EurekaServiceUrlUtils.addCredentials(
+                Arrays.asList("https://host1:10011/eureka/", "https://host2:10011/eureka/"),
+                "eureka", "password"
+            );
+            assertEquals(
+                Arrays.asList("https://eureka:password@host1:10011/eureka/", "https://eureka:password@host2:10011/eureka/"),
+                result
+            );
+        }
+    }
+
+    @Nested
+    class WhenUrlShouldRemainUnchanged {
+
+        @Test
+        void givenUrlThatAlreadyHasCredentials_thenItIsNotModified() {
+            String url = "https://someoneelse:secret@localhost:10011/eureka/";
+            assertEquals(url, EurekaServiceUrlUtils.addCredentials(url, "eureka", "password"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"localhost:10011/eureka", "not-a-url", ""})
+        void givenUrlWithoutScheme_thenItIsNotModified(String url) {
+            assertEquals(url, EurekaServiceUrlUtils.addCredentials(url, "eureka", "password"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "http://#{T(condition) ? '' : 'u:p@'}localhost:10011/eureka/",
+            "https://${apiml.service.hostname}:${apiml.service.port}/eureka/"
+        })
+        void givenUrlWithSpelOrPlaceholder_thenItIsNotModified(String url) {
+            assertEquals(url, EurekaServiceUrlUtils.addCredentials(url, "eureka", "password"));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void givenBlankUserid_thenUrlIsNotModified(String userid) {
+            String url = "https://localhost:10011/eureka/";
+            assertEquals(url, EurekaServiceUrlUtils.addCredentials(url, userid, "password"));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void givenBlankPassword_thenUrlIsNotModified(String password) {
+            String url = "https://localhost:10011/eureka/";
+            assertEquals(url, EurekaServiceUrlUtils.addCredentials(url, "eureka", password));
+        }
+
+        @Test
+        void givenNullUrl_thenNullIsReturned() {
+            assertNull(EurekaServiceUrlUtils.addCredentials((String) null, "eureka", "password"));
+        }
+
+        @Test
+        void givenNullList_thenEmptyListIsReturned() {
+            assertTrue(EurekaServiceUrlUtils.addCredentials((List<String>) null, "eureka", "password").isEmpty());
+        }
+    }
+}

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -258,6 +258,14 @@ fi
 CERTIFICATES_URL=${internalProtocol:-https}://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_gateway_port:-7554}/gateway/certificates
 CERTIFICATES_URL=${ZWE_configs_apiml_security_x509_certificatesUrl:-${CERTIFICATES_URL}}
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 CACHING_CODE=CS
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java \
@@ -280,6 +288,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java \
   -Dapiml.service.customMetadata.apiml.gatewayPort=${ZWE_components_gateway_port:-7554} \
   -Dapiml.service.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \
   -Dapiml.service.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
+  -Dapiml.discovery.userid=${discoveryUserid} \
+  -Dapiml.discovery.password=${discoveryPassword} \
   -Dapiml.security.x509.certificatesUrls=${CERTIFICATES_URL} \
   -Dcaching.storage.evictionStrategy=${ZWE_configs_storage_evictionStrategy:-reject} \
   -Dcaching.storage.size=${ZWE_configs_storage_size:-10000} \

--- a/caching-service-package/src/main/resources/bin/start.sh
+++ b/caching-service-package/src/main/resources/bin/start.sh
@@ -261,11 +261,6 @@ CERTIFICATES_URL=${ZWE_configs_apiml_security_x509_certificatesUrl:-${CERTIFICAT
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 CACHING_CODE=CS
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CACHING_CODE} java \

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -208,6 +208,14 @@ if [ "${ATTLS_SERVER_ENABLED}" = "true" -a "${APIML_ATTLS_LOAD_KEYRING:-false}" 
   keystore_location=
 fi
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 CLOUD_GATEWAY_CODE=CG
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
@@ -229,6 +237,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \
     -Dapiml.service.forwardClientCertEnabled=${ZWE_configs_apiml_service_forwardClientCertEnabled:-false} \
     -Dapiml.service.corsEnabled=${ZWE_configs_apiml_service_corsEnabled:-false} \
     -Dapiml.service.corsAllowedMethods=${ZWE_configs_apiml_service_corsAllowedMethods:-} \
+    -Dapiml.discovery.password=${discoveryPassword} \
+    -Dapiml.discovery.userid=${discoveryUserid} \
     -Dapiml.security.x509.registry.allowedUsers=${ZWE_configs_apiml_security_x509_registry_allowedUsers:-} \
     -Dapiml.logs.location=${ZWE_zowe_logDirectory} \
     -Dapiml.zoweManifest=${ZWE_zowe_runtimeDirectory}/manifest.json \

--- a/cloud-gateway-package/src/main/resources/bin/start.sh
+++ b/cloud-gateway-package/src/main/resources/bin/start.sh
@@ -211,11 +211,6 @@ fi
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 CLOUD_GATEWAY_CODE=CG
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${CLOUD_GATEWAY_CODE} java \

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -63,6 +63,7 @@ import org.zowe.apiml.config.AdditionalRegistrationParser;
 import org.zowe.apiml.message.core.MessageService;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
+import org.zowe.apiml.product.eureka.EurekaServiceUrlUtils;
 import org.zowe.apiml.product.gateway.AdditionalRegistrationGatewayRegistry;
 import org.zowe.apiml.security.HttpsConfig;
 import org.zowe.apiml.security.HttpsConfigError;
@@ -77,6 +78,7 @@ import javax.net.ssl.TrustManagerFactory;
 import java.security.KeyStore;
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.springframework.cloud.netflix.eureka.EurekaClientConfigBean.DEFAULT_ZONE;
 
@@ -141,6 +143,12 @@ public class ConnectionsConfig {
 
     @Value("${apiml.service.corsAllowedMethods:GET,HEAD,POST,PATCH,DELETE,PUT,OPTIONS}")
     private List<String> corsAllowedMethods;
+
+    @Value("${apiml.discovery.userid:#{null}}")
+    private String discoveryUserid;
+
+    @Value("${apiml.discovery.password:#{null}}")
+    private char[] discoveryPassword;
 
     private final ApplicationContext context;
 
@@ -307,7 +315,7 @@ public class ConnectionsConfig {
 
         log.debug("additional registration: {}", apimlRegistration.getDiscoveryServiceUrls());
         Map<String, String> urls = new HashMap<>();
-        urls.put(DEFAULT_ZONE, apimlRegistration.getDiscoveryServiceUrls());
+        urls.put(DEFAULT_ZONE, withBasicAuthFallback(apimlRegistration.getDiscoveryServiceUrls()));
 
         EurekaClientConfigBean configBean = new EurekaClientConfigBean();
         BeanUtils.copyProperties(config, configBean);
@@ -321,6 +329,21 @@ public class ConnectionsConfig {
         InstanceInfo newInfo = eurekaFactory.createInstanceInfo(eurekaInstanceConfig);
 
         return eurekaFactory.createCloudEurekaClient(eurekaInstanceConfig, newInfo, configBean, args, context);
+    }
+
+    /**
+     * When TLS validation is disabled the client certificate cannot be trusted by the Discovery Service, so the
+     * additional registration falls back to basic authentication by embedding the configured Discovery Service
+     * credentials into the discovery service URLs.
+     */
+    private String withBasicAuthFallback(String discoveryServiceUrls) {
+        if (discoveryServiceUrls == null || verifySslCertificatesOfServices) {
+            return discoveryServiceUrls;
+        }
+        String password = (discoveryPassword == null) ? null : new String(discoveryPassword);
+        return Arrays.stream(discoveryServiceUrls.split(","))
+            .map(url -> EurekaServiceUrlUtils.addCredentials(url.trim(), discoveryUserid, password))
+            .collect(Collectors.joining(","));
     }
 
     @Bean

--- a/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
+++ b/cloud-gateway-service/src/main/java/org/zowe/apiml/cloudgatewayservice/config/ConnectionsConfig.java
@@ -274,7 +274,13 @@ public class ConnectionsConfig {
         AbstractDiscoveryClientOptionalArgs<?> args = new MutableDiscoveryClientOptionalArgs();
         args.setEurekaJerseyClient(eurekaJerseyClient);
 
-        final CloudEurekaClient cloudEurekaClient = new CloudEurekaClient(appManager, config, args, this.context);
+        EurekaClientConfigBean configBean = new EurekaClientConfigBean();
+        BeanUtils.copyProperties(config, configBean);
+        Map<String, String> urls = new HashMap<>();
+        urls.put(DEFAULT_ZONE, withBasicAuthFallback(eurekaServerUrl));
+        configBean.setServiceUrl(urls);
+
+        final CloudEurekaClient cloudEurekaClient = new CloudEurekaClient(appManager, configBean, args, this.context);
         cloudEurekaClient.registerHealthCheck(healthCheckHandler);
         return cloudEurekaClient;
     }

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -272,11 +272,6 @@ export ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED=${ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED:-true
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 DISCOVERY_CODE=AD
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java \

--- a/discovery-package/src/main/resources/bin/start.sh
+++ b/discovery-package/src/main/resources/bin/start.sh
@@ -269,6 +269,14 @@ fi
 # TODO Remove for 2.18.6 release
 ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED=${ZWE_ONLY_WARN_ON_URL_NOT_ALLOWED:-true}
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 DISCOVERY_CODE=AD
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java \
@@ -285,8 +293,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${DISCOVERY_CODE} java \
     -Dspring.profiles.active=${ZWE_configs_spring_profiles_active:-https} \
     -Dspring.profiles.include=$LOG_LEVEL \
     -Dserver.address=0.0.0.0 \
-    -Dapiml.discovery.userid=${ZWE_configs_apiml_service_http_userId:-} \
-    -Dapiml.discovery.password=${ZWE_configs_apiml_service_http_password:-} \
+    -Dapiml.discovery.userid=${discoveryUserid} \
+    -Dapiml.discovery.password=${discoveryPassword} \
     -Dapiml.discovery.allPeersUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
     -Dapiml.discovery.serviceIdPrefixReplacer=${ZWE_configs_apiml_discovery_serviceIdPrefixReplacer} \
     -Dapiml.discovery.staticApiDefinitionsDirectories=${ZWE_STATIC_DEFINITIONS_DIR} \

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
@@ -61,7 +61,7 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     private static final String DISCOVERY_REALM = "API Mediation Discovery Service realm";
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String discoveryUserid;
+    private String discoveryUserId;
 
     @Value("${apiml.discovery.password:#{null}}")
     private char[] discoveryPassword;
@@ -75,7 +75,7 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) {
         // we cannot use `auth.inMemoryAuthentication()` because it does not support char array
-        auth.authenticationProvider(new EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword));
+        auth.authenticationProvider(new EurekaBasicAuthenticationProvider(discoveryUserId, discoveryPassword));
     }
 
     private final HandlerInitializer handlerInitializer;

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpWebSecurityConfig.java
@@ -61,10 +61,10 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     private static final String DISCOVERY_REALM = "API Mediation Discovery Service realm";
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String eurekaUserid;
+    private String discoveryUserid;
 
     @Value("${apiml.discovery.password:#{null}}")
-    private char[] eurekaPassword;
+    private char[] discoveryPassword;
 
     @Value("${apiml.metrics.enabled:false}")
     private boolean isMetricsEnabled;
@@ -75,7 +75,7 @@ public class HttpWebSecurityConfig extends AbstractWebSecurityConfigurer {
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) {
         // we cannot use `auth.inMemoryAuthentication()` because it does not support char array
-        auth.authenticationProvider(new EurekaBasicAuthenticationProvider(eurekaUserid, eurekaPassword));
+        auth.authenticationProvider(new EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword));
     }
 
     private final HandlerInitializer handlerInitializer;

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.zowe.apiml.filter.AttlsFilter;
 import org.zowe.apiml.filter.SecureConnectionFilter;
 import org.zowe.apiml.security.client.EnableApimlAuth;
@@ -80,23 +81,22 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
 
     @Bean
     public WebSecurityCustomizer httpsWebSecurityCustomizer() {
-        String[] noSecurityAntMatchers = {
-            "/eureka/css/**",
-            "/eureka/js/**",
-            "/eureka/fonts/**",
-            "/eureka/images/**",
-            "/application/info",
-            "/favicon.ico"
-        };
         return web -> {
-            web.ignoring().requestMatchers(noSecurityAntMatchers);
+            web.ignoring().requestMatchers(
+                new AntPathRequestMatcher("/eureka/css/**"),
+                new AntPathRequestMatcher("/eureka/js/**"),
+                new AntPathRequestMatcher("/eureka/fonts/**"),
+                new AntPathRequestMatcher("/eureka/images/**"),
+                new AntPathRequestMatcher("/application/info"),
+                new AntPathRequestMatcher("/favicon.ico")
+            );
 
             if (!isHealthEndpointProtected) {
-                web.ignoring().requestMatchers("/application/health");
+                web.ignoring().requestMatchers(new AntPathRequestMatcher("/application/health"));
             }
 
             if (isMetricsEnabled) {
-                web.ignoring().requestMatchers("/application/hystrixstream");
+                web.ignoring().requestMatchers(new AntPathRequestMatcher("/application/hystrixstream"));
             }
         };
     }
@@ -108,13 +108,13 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
     @Order(3)
     public SecurityFilterChain basicAuthOrTokenFilterChain(HttpSecurity http) throws Exception {
         baseConfigure(http.securityMatchers(matchers -> matchers.requestMatchers(
-            "/application/**",
-            "/*"
+            new AntPathRequestMatcher("/application/**"),
+            new AntPathRequestMatcher("/*")
         )))
             .authenticationProvider(gatewayLoginProvider)
             .authenticationProvider(gatewayTokenProvider)
             .authorizeHttpRequests(requests -> requests
-                .requestMatchers("/**").authenticated())
+                .requestMatchers(new AntPathRequestMatcher("/**")).authenticated())
             .httpBasic(basic -> basic.realmName(DISCOVERY_REALM));
         if (isServerAttlsEnabled) {
             http.addFilterBefore(new SecureConnectionFilter(), UsernamePasswordAuthenticationFilter.class);
@@ -164,8 +164,7 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
                 http.addFilterBefore(new SecureConnectionFilter(), AttlsFilter.class);
             }
         } else {
-            http.authenticationProvider(new HttpWebSecurityConfig.EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword))
-                .authorizeHttpRequests(requests -> requests.anyRequest().authenticated());
+            http.authorizeHttpRequests(requests -> requests.anyRequest().authenticated());
         }
 
         return http.apply(new CustomSecurityFilters()).and().build();

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -71,6 +71,13 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
     @Value("${apiml.health.protected:false}")
     private boolean isHealthEndpointProtected;
 
+    @Value("${apiml.discovery.userid:#{null}}")
+    private String discoveryUserid;
+
+    @Value("${apiml.discovery.password:#{null}}")
+    private char[] discoveryPassword;
+
+
     @Bean
     public WebSecurityCustomizer httpsWebSecurityCustomizer() {
         String[] noSecurityAntMatchers = {
@@ -131,7 +138,10 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
                 http.addFilterBefore(new SecureConnectionFilter(), AttlsFilter.class);
             }
         } else {
-            http.authorizeHttpRequests(requests -> requests.anyRequest().permitAll());
+            http.authenticationProvider(new HttpWebSecurityConfig.EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword))
+                .authorizeHttpRequests(requests -> requests.anyRequest().authenticated())
+                .httpBasic(basic -> basic.realmName(DISCOVERY_REALM));
+
         }
         return http.build();
     }
@@ -153,6 +163,9 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
                 http.addFilterBefore(new AttlsFilter(), X509AuthenticationFilter.class);
                 http.addFilterBefore(new SecureConnectionFilter(), AttlsFilter.class);
             }
+        } else {
+            http.authenticationProvider(new HttpWebSecurityConfig.EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword))
+                .authorizeHttpRequests(requests -> requests.anyRequest().authenticated());
         }
 
         return http.apply(new CustomSecurityFilters()).and().build();

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/config/HttpsWebSecurityConfig.java
@@ -73,7 +73,7 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
     private boolean isHealthEndpointProtected;
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String discoveryUserid;
+    private String discoveryUserId;
 
     @Value("${apiml.discovery.password:#{null}}")
     private char[] discoveryPassword;
@@ -138,7 +138,7 @@ public class HttpsWebSecurityConfig extends AbstractWebSecurityConfigurer {
                 http.addFilterBefore(new SecureConnectionFilter(), AttlsFilter.class);
             }
         } else {
-            http.authenticationProvider(new HttpWebSecurityConfig.EurekaBasicAuthenticationProvider(discoveryUserid, discoveryPassword))
+            http.authenticationProvider(new HttpWebSecurityConfig.EurekaBasicAuthenticationProvider(discoveryUserId, discoveryPassword))
                 .authorizeHttpRequests(requests -> requests.anyRequest().authenticated())
                 .httpBasic(basic -> basic.realmName(DISCOVERY_REALM));
 

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -343,6 +343,14 @@ if [ -n "${externalProtocol}" ] && [ -n "${ZWE_zowe_externalDomains_0}" ] && [ -
     EXTERNAL_URL="-Dapiml.service.externalUrl=${externalProtocol}://${ZWE_zowe_externalDomains_0}:${ZWE_zowe_externalPort}"
 fi
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 GATEWAY_CODE=AG
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
@@ -405,6 +413,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \
     -Dapiml.service.discoveryServiceUrls=${ZWE_DISCOVERY_SERVICES_LIST} \
     -Dapiml.service.hostname=${ZWE_haInstance_hostname:-localhost} \
     -Dapiml.service.port=${ZWE_configs_port:-7554} \
+    -Dapiml.discovery.password=${discoveryPassword} \
+    -Dapiml.discovery.userid=${discoveryUserid} \
     -Dapiml.zoweManifest=${ZWE_zowe_runtimeDirectory}/manifest.json \
     -Dfile.encoding=UTF-8 \
     -Dibm.serversocket.recover=true \

--- a/gateway-package/src/main/resources/bin/start.sh
+++ b/gateway-package/src/main/resources/bin/start.sh
@@ -346,11 +346,6 @@ fi
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 GATEWAY_CODE=AG
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${GATEWAY_CODE} java \

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -78,7 +78,7 @@ public class DiscoveryClientConfig {
     private boolean verifySslCertificatesOfServices;
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String discoveryUserid;
+    private String discoveryUserId;
 
     @Value("${apiml.discovery.password:#{null}}")
     private char[] discoveryPassword;
@@ -161,7 +161,7 @@ public class DiscoveryClientConfig {
         }
         String password = (discoveryPassword == null) ? null : new String(discoveryPassword);
         return Arrays.stream(discoveryServiceUrls.split(","))
-            .map(url -> EurekaServiceUrlUtils.addCredentials(url.trim(), discoveryUserid, password))
+            .map(url -> EurekaServiceUrlUtils.addCredentials(url.trim(), discoveryUserId, password))
             .collect(Collectors.joining(","));
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/DiscoveryClientConfig.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
 import org.springframework.cloud.netflix.eureka.MutableDiscoveryClientOptionalArgs;
@@ -36,9 +37,11 @@ import org.zowe.apiml.config.AdditionalRegistrationParser;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClient;
 import org.zowe.apiml.gateway.discovery.ApimlDiscoveryClientFactory;
 import org.zowe.apiml.gateway.filters.pre.ApimlPreDecorationFilter;
+import org.zowe.apiml.product.eureka.EurekaServiceUrlUtils;
 import org.zowe.apiml.product.gateway.AdditionalRegistrationGatewayRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +73,15 @@ public class DiscoveryClientConfig {
     private final ApplicationContext context;
     private final Supplier<EurekaJerseyClientImpl.EurekaJerseyClientBuilder> eurekaJerseyClientBuilder;
     private final AdditionalRegistrationGatewayRegistry additionalRegistrationGatewayRegistry;
+
+    @Value("${apiml.security.ssl.verifySslCertificatesOfServices:true}")
+    private boolean verifySslCertificatesOfServices;
+
+    @Value("${apiml.discovery.userid:#{null}}")
+    private String discoveryUserid;
+
+    @Value("${apiml.discovery.password:#{null}}")
+    private char[] discoveryPassword;
 
     @Bean
     public List<AdditionalRegistration> additionalRegistration() {
@@ -121,7 +133,7 @@ public class DiscoveryClientConfig {
 
         Map<String, String> urls = new HashMap<>();
         log.debug("additional registration: {}", apimlRegistration.getDiscoveryServiceUrls());
-        urls.put(DEFAULT_ZONE, apimlRegistration.getDiscoveryServiceUrls());
+        urls.put(DEFAULT_ZONE, withBasicAuthFallback(apimlRegistration.getDiscoveryServiceUrls()));
 
         configBean.setServiceUrl(urls);
 
@@ -136,6 +148,21 @@ public class DiscoveryClientConfig {
         discoveryClientClient.registerHealthCheck(healthCheckHandler);
 
         return discoveryClientClient;
+    }
+
+    /**
+     * When TLS validation is disabled the client certificate cannot be trusted by the Discovery Service, so the
+     * additional registration falls back to basic authentication by embedding the configured Discovery Service
+     * credentials into the discovery service URLs.
+     */
+    private String withBasicAuthFallback(String discoveryServiceUrls) {
+        if (discoveryServiceUrls == null || verifySslCertificatesOfServices) {
+            return discoveryServiceUrls;
+        }
+        String password = (discoveryPassword == null) ? null : new String(discoveryPassword);
+        return Arrays.stream(discoveryServiceUrls.split(","))
+            .map(url -> EurekaServiceUrlUtils.addCredentials(url.trim(), discoveryUserid, password))
+            .collect(Collectors.joining(","));
     }
 
     private InstanceInfo rewriteInstanceInfoRoutes(AdditionalRegistration apimlRegistration, InstanceInfo newInfo) {

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -216,7 +216,8 @@ task runAllIntegrationTestsForZoweNonHaTestingOnZos(type: Test) {
             'CloudGatewayAuthTest',
             'CloudGatewayCentralRegistry',
             'SafIdTokenTest',
-            'InfinispanJGroupStabilityTest'
+            'InfinispanJGroupStabilityTest',
+            'DiscoveryBasicAuthTest'
         )
     }
 
@@ -262,7 +263,8 @@ task runAllIntegrationTestsForZoweHaTestingOnZos(type: Test) {
             'SafIdTokenTest',
             'ChaoticHATest',
             'GraphQLTest',
-            'InfinispanJGroupStabilityTest'
+            'InfinispanJGroupStabilityTest',
+            'DiscoveryBasicAuthTest'
         )
     }
 
@@ -359,7 +361,8 @@ task runContainerTests(type: Test) {
             'CloudGatewayCentralRegistry',
             'ZaasTest',
             'HealthEndpointProtectionDisabledTest',
-            'InfinispanJGroupStabilityTest'
+            'InfinispanJGroupStabilityTest',
+            'DiscoveryBasicAuthTest'
         )
     }
 }
@@ -412,6 +415,20 @@ task runRegistrationTests(type: Test) {
     useJUnitPlatform {
         includeTags(
             'RegistrationTest'
+        )
+    }
+}
+
+task runDiscoveryBasicAuthTests(type: Test) {
+    group "integration tests"
+    description "Run tests verifying discovery service basic auth protection when SSL certificate verification is disabled"
+
+    outputs.cacheIf { false }
+
+    systemProperties System.getProperties()
+    useJUnitPlatform {
+        includeTags(
+            'DiscoveryBasicAuthTest'
         )
     }
 }

--- a/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/DiscoveryBasicAuthProtectionTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/integration/discovery/DiscoveryBasicAuthProtectionTest.java
@@ -1,0 +1,94 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.integration.discovery;
+
+import io.restassured.RestAssured;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zowe.apiml.util.TestWithStartedInstances;
+import org.zowe.apiml.util.categories.DiscoveryBasicAuthTest;
+import org.zowe.apiml.util.config.ConfigReader;
+import org.zowe.apiml.util.config.DiscoveryServiceConfiguration;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
+import static org.zowe.apiml.util.requests.Endpoints.APPLICATIONS;
+
+/**
+ * Verifies that the Discovery Service protects the Eureka registration endpoint with HTTP basic
+ * authentication when {@code apiml.security.ssl.verifySslCertificatesOfServices=false}.
+ * <p>
+ * Requires the discovery service to be started with:
+ * <ul>
+ *   <li>{@code APIML_SECURITY_SSL_VERIFYSSLCERTIFICATESOFSERVICES=false}</li>
+ *   <li>{@code APIML_DISCOVERY_USERID=eureka}</li>
+ *   <li>{@code APIML_DISCOVERY_PASSWORD=password}</li>
+ * </ul>
+ */
+@DiscoveryBasicAuthTest
+class DiscoveryBasicAuthProtectionTest implements TestWithStartedInstances {
+
+    private static final String EUREKA_USERID = "eureka";
+    private static final String EUREKA_PASSWORD = "password";
+
+    private String scheme;
+    private String host;
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        DiscoveryServiceConfiguration config = ConfigReader.environmentConfiguration().getDiscoveryServiceConfiguration();
+        scheme = config.getScheme();
+        host = config.getHost();
+        port = config.getPort();
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @Test
+    void givenNoCredentials_thenReturnUnauthorized() throws URISyntaxException {
+        given()
+            .get(eurekaAppsUri())
+        .then()
+            .statusCode(is(HttpStatus.SC_UNAUTHORIZED));
+    }
+
+    @Test
+    void givenValidEurekaCredentials_thenReturnOk() throws URISyntaxException {
+        given()
+            .auth().preemptive().basic(EUREKA_USERID, EUREKA_PASSWORD)
+            .get(eurekaAppsUri())
+        .then()
+            .statusCode(is(HttpStatus.SC_OK));
+    }
+
+    @Test
+    void givenWrongEurekaCredentials_thenReturnUnauthorized() throws URISyntaxException {
+        given()
+            .auth().preemptive().basic(EUREKA_USERID, "wrongPassword")
+            .get(eurekaAppsUri())
+        .then()
+            .statusCode(is(HttpStatus.SC_UNAUTHORIZED));
+    }
+
+    private URI eurekaAppsUri() throws URISyntaxException {
+        return new URIBuilder()
+            .setScheme(scheme)
+            .setHost(host)
+            .setPort(port)
+            .setPath(APPLICATIONS)
+            .build();
+    }
+}

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -15,6 +15,8 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
@@ -26,6 +28,7 @@ import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -41,6 +44,12 @@ public class ApiMediationLayerStartupChecker {
     private final List<Service> servicesToCheck = new ArrayList<>();
     private final String healthEndpoint = "/application/health";
 
+    private static final boolean VERIFY_SSL_CERTIFICATES = Boolean.parseBoolean(
+        System.getProperty("apiml.security.ssl.verifySslCertificatesOfServices", "true")
+    );
+    private static final String EUREKA_CREDENTIALS_HEADER = buildEurekaCredentialsHeader();
+
+
     public ApiMediationLayerStartupChecker() {
         gatewayConfiguration = ConfigReader.environmentConfiguration().getGatewayServiceConfiguration();
 
@@ -48,6 +57,15 @@ public class ApiMediationLayerStartupChecker {
         servicesToCheck.add(new Service("Api Catalog", "$.components.gateway.details.apicatalog"));
         servicesToCheck.add(new Service("Discovery Service", "$.components.gateway.details.discovery"));
         servicesToCheck.add(new Service("Authentication Service", "$.components.gateway.details.auth"));
+    }
+
+    private static String buildEurekaCredentialsHeader() {
+        String userid = System.getProperty("apiml.discovery.userid");
+        String password = System.getProperty("apiml.discovery.password");
+        if (StringUtils.isAnyBlank(userid, password)) {
+            return null;
+        }
+        return "Basic " + Base64.getEncoder().encodeToString((userid + ":" + password).getBytes());
     }
 
     public void waitUntilReady() {
@@ -59,9 +77,12 @@ public class ApiMediationLayerStartupChecker {
         .until(this::areAllServicesUp);
     }
 
-    private DocumentContext getDocumentAsContext() {
+    private DocumentContext getDocumentAsContext(String authorizationHeader) {
         try {
             HttpGet request = HttpRequestUtils.getRequest(healthEndpoint);
+            if (authorizationHeader != null) {
+                request.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+            }
             final HttpResponse response = HttpClientUtils.client().execute(request);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                 log.warn("Unexpected HTTP status code: {}", response.getStatusLine().getStatusCode());
@@ -79,7 +100,10 @@ public class ApiMediationLayerStartupChecker {
 
     private boolean areAllServicesUp() {
         try {
-            DocumentContext context = getDocumentAsContext();
+            String header = VERIFY_SSL_CERTIFICATES
+                ? null
+                : EUREKA_CREDENTIALS_HEADER;
+            DocumentContext context = getDocumentAsContext(header);
             if (context == null) {
                 return false;
             }

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -63,12 +63,12 @@ public class ApiMediationLayerStartupChecker {
     }
 
     private static String buildEurekaCredentialsHeader() {
-        String userid = System.getProperty("apiml.discovery.userid");
+        String userId = System.getProperty("apiml.discovery.userid");
         String password = System.getProperty("apiml.discovery.password");
-        if (StringUtils.isAnyBlank(userid, password)) {
+        if (StringUtils.isAnyBlank(userId, password)) {
             return null;
         }
-        return "Basic " + Base64.getEncoder().encodeToString((userid + ":" + password).getBytes());
+        return "Basic " + Base64.getEncoder().encodeToString((userId + ":" + password).getBytes());
     }
 
     public void waitUntilReady() {

--- a/integration-tests/src/test/java/org/zowe/apiml/util/categories/DiscoveryBasicAuthTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/util/categories/DiscoveryBasicAuthTest.java
@@ -1,0 +1,26 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.util.categories;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Tag("DiscoveryBasicAuthTest")
+@Target({ TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DiscoveryBasicAuthTest {
+}

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -223,11 +223,6 @@ fi
 discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
 discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
 
-if [ "${verifySslCertificatesOfServices}" = "false" ]; then
-    discoveryUserid=${discoveryUserid:-eureka}
-    discoveryPassword=${discoveryPassword:-password}
-fi
-
 METRICS_CODE=MS
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java \

--- a/metrics-service-package/src/main/resources/bin/start.sh
+++ b/metrics-service-package/src/main/resources/bin/start.sh
@@ -220,6 +220,14 @@ if [ -n "${ZWE_configs_logging_config}" ]; then
     LOGBACK="-Dlogging.config=${ZWE_configs_logging_config}"
 fi
 
+discoveryUserid=${ZWE_configs_apiml_discovery_userid:-${ZWE_components_discovery_apiml_discovery_userid:-}}
+discoveryPassword=${ZWE_configs_apiml_discovery_password:-${ZWE_components_discovery_apiml_discovery_password:-}}
+
+if [ "${verifySslCertificatesOfServices}" = "false" ]; then
+    discoveryUserid=${discoveryUserid:-eureka}
+    discoveryPassword=${discoveryPassword:-password}
+fi
+
 METRICS_CODE=MS
 _BPXK_AUTOCVT=OFF
 _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java \
@@ -241,6 +249,8 @@ _BPX_JOBNAME=${ZWE_zowe_job_prefix}${METRICS_CODE} java \
   -Dapiml.service.customMetadata.apiml.gatewayPort=${ZWE_components_gateway_port:-7554} \
   -Dapiml.service.ssl.verifySslCertificatesOfServices=${verifySslCertificatesOfServices:-false} \
   -Dapiml.service.ssl.nonStrictVerifySslCertificatesOfServices=${nonStrictVerifySslCertificatesOfServices:-false} \
+  -Dapiml.discovery.password=${discoveryPassword} \
+  -Dapiml.discovery.userid=${discoveryUserid} \
   -Dapiml.httpclient.ssl.enabled-protocols=${ZWE_components_gateway_apiml_httpclient_ssl_enabled_protocols:-"TLSv1.2"} \
   -Dserver.address=0.0.0.0 \
   -Dserver.ssl.enabled=${ZWE_components_gateway_server_ssl_enabled:-true} \

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/ApiMediationServiceConfig.java
@@ -29,6 +29,20 @@ public class ApiMediationServiceConfig {
     private List<String> discoveryServiceUrls;
 
     /**
+     * Eureka basic authentication user id. It is used only as a fallback when TLS validation is disabled
+     * ({@code ssl.verifySslCertificatesOfServices=false}); in that case the client certificate cannot be trusted by the
+     * Discovery Service, so the credentials are embedded into the discovery service URLs to authenticate with basic
+     * authentication instead. The value has to match the Discovery Service {@code apiml.discovery.userid}.
+     */
+    private String discoveryUserid;
+
+    /**
+     * Eureka basic authentication password, see {@link #discoveryUserid}. The value has to match the Discovery Service
+     * {@code apiml.discovery.password}.
+     */
+    private char[] discoveryPassword;
+
+    /**
      *     Uniquely identifies instances of a microservice in the API ML.
      *     The service developer specifies a default value during the design of the service.
      *

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfiguration.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfiguration.java
@@ -49,7 +49,10 @@ public class EurekaClientConfiguration extends DefaultEurekaClientConfig {
 
     @Override
     public List<String> getEurekaServerServiceUrls(String s) {
-        String password = (config.getDiscoveryPassword() == null) ? null : new String(config.getDiscoveryPassword());
+        String password = null;
+        if (config.getSsl() != null && !config.getSsl().getVerifySslCertificatesOfServices()) {
+            password = (config.getDiscoveryPassword() == null) ? null : new String(config.getDiscoveryPassword());
+        }
         return EurekaServiceUrlUtils.addCredentials(config.getDiscoveryServiceUrls(), config.getDiscoveryUserid(), password);
     }
 

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfiguration.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfiguration.java
@@ -11,6 +11,7 @@
 package org.zowe.apiml.eurekaservice.client.config;
 
 import com.netflix.discovery.DefaultEurekaClientConfig;
+import org.zowe.apiml.product.eureka.EurekaServiceUrlUtils;
 
 import java.util.List;
 
@@ -48,7 +49,8 @@ public class EurekaClientConfiguration extends DefaultEurekaClientConfig {
 
     @Override
     public List<String> getEurekaServerServiceUrls(String s) {
-        return config.getDiscoveryServiceUrls();
+        String password = (config.getDiscoveryPassword() == null) ? null : new String(config.getDiscoveryPassword());
+        return EurekaServiceUrlUtils.addCredentials(config.getDiscoveryServiceUrls(), config.getDiscoveryUserid(), password);
     }
 
     @Override

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfigurationTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfigurationTest.java
@@ -43,9 +43,9 @@ class EurekaClientConfigurationTest {
     class GivenSslVerificationEnabled {
 
         @Test
-        void thenCredentialsAreStillEmbedded() {
+        void thenCredentialsAreNotEmbedded() {
             ssl.setVerifySslCertificatesOfServices(true);
-            assertEquals(Collections.singletonList("https://eureka:password@localhost:10011/eureka/"), serviceUrls());
+            assertEquals(Collections.singletonList("https://localhost:10011/eureka/"), serviceUrls());
         }
     }
 
@@ -74,9 +74,9 @@ class EurekaClientConfigurationTest {
     class GivenNoSslConfiguration {
 
         @Test
-        void thenCredentialsAreEmbedded() {
+        void thenCredentialsAreNotEmbedded() {
             config.setSsl(null);
-            assertEquals(Collections.singletonList("https://eureka:password@localhost:10011/eureka/"), serviceUrls());
+            assertEquals(Collections.singletonList("https://localhost:10011/eureka/"), serviceUrls());
         }
     }
 }

--- a/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfigurationTest.java
+++ b/onboarding-enabler-java/src/test/java/org/zowe/apiml/eurekaservice/client/config/EurekaClientConfigurationTest.java
@@ -1,0 +1,82 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.eurekaservice.client.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EurekaClientConfigurationTest {
+
+    private ApiMediationServiceConfig config;
+    private Ssl ssl;
+
+    @BeforeEach
+    void setUp() {
+        ssl = new Ssl();
+        config = ApiMediationServiceConfig.builder()
+            .discoveryServiceUrls(Collections.singletonList("https://localhost:10011/eureka/"))
+            .discoveryUserid("eureka")
+            .discoveryPassword("password".toCharArray())
+            .ssl(ssl)
+            .build();
+    }
+
+    private List<String> serviceUrls() {
+        return new EurekaClientConfiguration(config).getEurekaServerServiceUrls("default");
+    }
+
+    @Nested
+    class GivenSslVerificationEnabled {
+
+        @Test
+        void thenCredentialsAreStillEmbedded() {
+            ssl.setVerifySslCertificatesOfServices(true);
+            assertEquals(Collections.singletonList("https://eureka:password@localhost:10011/eureka/"), serviceUrls());
+        }
+    }
+
+    @Nested
+    class GivenSslVerificationDisabled {
+
+        @BeforeEach
+        void disableVerification() {
+            ssl.setVerifySslCertificatesOfServices(false);
+        }
+
+        @Test
+        void thenCredentialsAreEmbedded() {
+            assertEquals(Collections.singletonList("https://eureka:password@localhost:10011/eureka/"), serviceUrls());
+        }
+
+        @Test
+        void givenNoCredentials_thenUrlIsUnchanged() {
+            config.setDiscoveryUserid(null);
+            config.setDiscoveryPassword(null);
+            assertEquals(Collections.singletonList("https://localhost:10011/eureka/"), serviceUrls());
+        }
+    }
+
+    @Nested
+    class GivenNoSslConfiguration {
+
+        @Test
+        void thenCredentialsAreEmbedded() {
+            config.setSsl(null);
+            assertEquals(Collections.singletonList("https://eureka:password@localhost:10011/eureka/"), serviceUrls());
+        }
+    }
+}

--- a/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
+++ b/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
@@ -45,6 +45,12 @@ public class RegisterToApiLayer {
     @Value("${apiml.enabled:true}")
     private boolean apimlEnabled;
 
+    @Value("${apiml.discovery.userid:#{null}}")
+    private String discoveryUserid;
+
+    @Value("${apiml.discovery.password:#{null}}")
+    private char[] discoveryPassword;
+
     @InjectApimlLogger
     private final ApimlLogger logger = ApimlLogger.empty();
 
@@ -82,6 +88,12 @@ public class RegisterToApiLayer {
     }
 
     private void register(ApiMediationServiceConfig newConfig) {
+        if (newConfig.getDiscoveryUserid() == null) {
+            newConfig.setDiscoveryUserid(discoveryUserid);
+        }
+        if (newConfig.getDiscoveryPassword() == null) {
+            newConfig.setDiscoveryPassword(discoveryPassword);
+        }
 
         this.config = newConfig;
 

--- a/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
+++ b/onboarding-enabler-spring/src/main/java/org/zowe/apiml/enable/register/RegisterToApiLayer.java
@@ -46,7 +46,7 @@ public class RegisterToApiLayer {
     private boolean apimlEnabled;
 
     @Value("${apiml.discovery.userid:#{null}}")
-    private String discoveryUserid;
+    private String discoveryUserId;
 
     @Value("${apiml.discovery.password:#{null}}")
     private char[] discoveryPassword;
@@ -89,7 +89,7 @@ public class RegisterToApiLayer {
 
     private void register(ApiMediationServiceConfig newConfig) {
         if (newConfig.getDiscoveryUserid() == null) {
-            newConfig.setDiscoveryUserid(discoveryUserid);
+            newConfig.setDiscoveryUserid(discoveryUserId);
         }
         if (newConfig.getDiscoveryPassword() == null) {
             newConfig.setDiscoveryPassword(discoveryPassword);


### PR DESCRIPTION
# Description

Disabling certificate validation silently disables authentication against eureka endpoints. This change fallbacks to basic authentication when digital certificates are not an option for authentication.
cherry-pick https://github.com/zowe/api-layer/pull/4734

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
