### PR TITLE
chore: Validate port is reachable before check. 

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -20,11 +20,14 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.zowe.apiml.util.config.ConfigReader;
+import org.zowe.apiml.util.config.DiscoveryServiceConfiguration;
 import org.zowe.apiml.util.config.GatewayServiceConfiguration;
 import org.zowe.apiml.util.http.HttpClientUtils;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,6 +55,12 @@ public class ApiMediationLayerStartupChecker {
 
     public void waitUntilReady() {
         long poolInterval = 5;
+        await()
+            .atMost(30, SECONDS)
+            .pollDelay(1, SECONDS)
+            .pollInterval(1, SECONDS)
+        .until(this::areDiscoveryPortsReachable);
+
         await()
             .atMost(10, MINUTES)
             .pollDelay(0, SECONDS)
@@ -134,6 +143,17 @@ public class ApiMediationLayerStartupChecker {
 
     private void logDebug(String logMessage, boolean state) {
         log.debug(logMessage, state ? "UP" : "DOWN");
+    }
+
+    private boolean areDiscoveryPortsReachable() {
+        DiscoveryServiceConfiguration discoveryConfig = ConfigReader.environmentConfiguration().getDiscoveryServiceConfiguration();
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(discoveryConfig.getHost(), discoveryConfig.getPort()), 5000);
+        } catch (IOException e) {
+            log.debug("Discovery service {}:{} is not yet reachable: {}", discoveryConfig.getHost(), discoveryConfig.getPort(), e.getMessage());
+            return false;
+        }
+        return true;
     }
 
     @AllArgsConstructor

--- a/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/startup/impl/ApiMediationLayerStartupChecker.java
@@ -56,7 +56,7 @@ public class ApiMediationLayerStartupChecker {
     public void waitUntilReady() {
         long poolInterval = 5;
         await()
-            .atMost(30, SECONDS)
+            .atMost(2, MINUTES)
             .pollDelay(1, SECONDS)
             .pollInterval(1, SECONDS)
         .until(this::areDiscoveryPortsReachable);


### PR DESCRIPTION
# Description

Cherry-picked from PR #4708 — adds a TCP-level reachability check for the Discovery service port before starting the HTTP health endpoint polling. This prevents the startup checker from flooding the health endpoint with requests before the Discovery service has bound its port, which reduces flaky integration test failures on slow CI runners.

## Type of change

Please delete options that are not relevant.

- [x] chore: Chore, repository cleanup, updates the dependencies.