### PR TITLE
fix: use explicit SafeConstructor with LoaderOptions in SnakeYAML

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/saf/SafResourceAccessDummy.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/saf/SafResourceAccessDummy.java
@@ -13,7 +13,9 @@ package org.zowe.apiml.security.common.auth.saf;
 import lombok.Builder;
 import lombok.Value;
 import org.springframework.security.core.Authentication;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.*;
 import java.util.HashMap;
@@ -108,7 +110,7 @@ public class SafResourceAccessDummy implements SafResourceAccessVerifying {
      * @param inputStream stream to be loaded
      */
     private void loadDefinition(InputStream inputStream) {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         Map<String, Object> data = yaml.load(inputStream);
         loadDefinition(data);
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/message/yaml/YamlMessageService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/yaml/YamlMessageService.java
@@ -10,7 +10,9 @@
 
 package org.zowe.apiml.message.yaml;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.zowe.apiml.message.core.AbstractMessageService;
 import org.zowe.apiml.message.core.DuplicateMessageException;
@@ -55,7 +57,7 @@ public class YamlMessageService extends AbstractMessageService {
     @Override
     public void loadMessages(String messagesFilePath) {
         try (InputStream in = YamlMessageService.class.getResourceAsStream(messagesFilePath)) {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
             MessageTemplates messageTemplates = yaml.loadAs(in, MessageTemplates.class);
             if (messageTemplates.getMessages() != null && !messageTemplates.getMessages().isEmpty()) {
                 super.addMessageTemplates(messageTemplates);


### PR DESCRIPTION
## What

Replace bare `new Yaml()` with `new Yaml(new SafeConstructor(new LoaderOptions()))` in two classes:

- **YamlMessageService** — message YAML loading
- **SafResourceAccessDummy** — SAF resource access definition loading

## Why

While SnakeYAML 2.0+ already defaults to `SafeConstructor` implicitly, making it explicit eliminates any ambiguity and aligns with security best practices. An empty `LoaderOptions` provides a clean, documented starting point.

## Verification

- `:common-service-core:compileJava` — passes
- `:apiml-security-common:compileJava` — passes