### PR TITLE
fix: use explicit SnakeYAML constructors for security

### DIFF
--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/saf/SafResourceAccessDummy.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/auth/saf/SafResourceAccessDummy.java
@@ -13,7 +13,9 @@ package org.zowe.apiml.security.common.auth.saf;
 import lombok.Builder;
 import lombok.Value;
 import org.springframework.security.core.Authentication;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.*;
 import java.util.HashMap;
@@ -108,7 +110,7 @@ public class SafResourceAccessDummy implements SafResourceAccessVerifying {
      * @param inputStream stream to be loaded
      */
     private void loadDefinition(InputStream inputStream) {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         Map<String, Object> data = yaml.load(inputStream);
         loadDefinition(data);
     }

--- a/common-service-core/src/main/java/org/zowe/apiml/message/yaml/YamlMessageService.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/yaml/YamlMessageService.java
@@ -10,7 +10,9 @@
 
 package org.zowe.apiml.message.yaml;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.zowe.apiml.message.core.AbstractMessageService;
 import org.zowe.apiml.message.core.DuplicateMessageException;
@@ -55,7 +57,7 @@ public class YamlMessageService extends AbstractMessageService {
     @Override
     public void loadMessages(String messagesFilePath) {
         try (InputStream in = YamlMessageService.class.getResourceAsStream(messagesFilePath)) {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new Constructor(MessageTemplates.class, new LoaderOptions()));
             MessageTemplates messageTemplates = yaml.loadAs(in, MessageTemplates.class);
             if (messageTemplates.getMessages() != null && !messageTemplates.getMessages().isEmpty()) {
                 super.addMessageTemplates(messageTemplates);


### PR DESCRIPTION
## What

Replace bare `new Yaml()` with targeted constructors for explicit security:

| Class | Before | After | Why |
|-------|--------|-------|-----|
| **YamlMessageService** | `new Yaml()` | `new Yaml(new Constructor(MessageTemplates.class, new LoaderOptions()))` | `loadAs()` needs full Constructor to map YAML → custom POJO |
| **SafResourceAccessDummy** | `new Yaml()` | `new Yaml(new SafeConstructor(new LoaderOptions()))` | `load()` only returns Map — SafeConstructor is sufficient |

## Why not SafeConstructor everywhere

The previous attempt (`new SafeConstructor()` for both) broke `YamlMessageService.loadAs()`: SafeConstructor only handles `Map`/`List`/`String`/primitives — it cannot construct arbitrary Java types like `MessageTemplates`. `Constructor(MessageTemplates.class)` locks construction to ONLY that target type, providing the same security benefit.

## Verification

- `:common-service-core:compileJava` — passes
- `:apiml-security-common:compileJava` — passes