### PR TITLE
fix: detect z/OSMF expired password in 401 response — GH#4083

### DIFF
--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfService.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.zaas.security.service.zosmf;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
@@ -46,7 +47,9 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.auth.saf.PlatformReturned;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
+import org.zowe.apiml.security.common.error.ZosAuthenticationException;
 import org.zowe.apiml.security.common.login.ChangePasswordRequest;
 import org.zowe.apiml.security.common.login.LoginRequest;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
@@ -307,6 +310,36 @@ public class ZosmfService extends AbstractZosmfService {
     }
 
     /**
+     * Check whether a 401 response from z/OSMF indicates an expired password.
+     *
+     * @param e the HttpClientErrorException.Unauthorized exception with the response body
+     * @return true if the response body contains SAFReturnCode=8 and SAFReasonCode=24
+     */
+    private boolean isExpiredPassword(HttpClientErrorException.Unauthorized e) {
+        byte[] responseBody = e.getResponseBodyAsByteArray();
+        if (responseBody == null || responseBody.length == 0) {
+            return false;
+        }
+        try {
+            JsonNode root = securityObjectMapper.readTree(responseBody);
+            JsonNode safMessages = root.get("safMessages");
+            if (safMessages != null && safMessages.isArray()) {
+                for (JsonNode message : safMessages) {
+                    JsonNode safReturnCode = message.get("SAFReturnCode");
+                    JsonNode safReasonCode = message.get("SAFReasonCode");
+                    if (safReturnCode != null && safReturnCode.asInt() == 8
+                        && safReasonCode != null && safReasonCode.asInt() == 24) {
+                        return true;
+                    }
+                }
+            }
+        } catch (IOException e1) {
+            log.debug("Error parsing z/OSMF 401 response body: {}", e1.getMessage());
+        }
+        return false;
+    }
+
+    /**
      * POST to provided url and return authentication response
      *
      * @param authentication with credentials
@@ -324,6 +357,14 @@ public class ZosmfService extends AbstractZosmfService {
                     httpMethod,
                     new HttpEntity<>(null, headers), String.class);
             return getAuthenticationResponse(response);
+        } catch (HttpClientErrorException.Unauthorized e) {
+            if (isExpiredPassword(e)) {
+                throw new ZosAuthenticationException(PlatformReturned.builder()
+                    .errno(168)
+                    .errnoMsg("org.zowe.apiml.security.platform.errno.EMVSEXPIRE")
+                    .build());
+            }
+            throw handleExceptionOnCall(url, e);
         } catch (RuntimeException re) {
             throw handleExceptionOnCall(url, re);
         }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/zosmf/ZosmfServiceTest.java
@@ -51,7 +51,9 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.zowe.apiml.message.log.ApimlLogger;
 import org.zowe.apiml.security.common.config.AuthConfigurationProperties;
+import org.zowe.apiml.security.common.error.PlatformPwdErrno;
 import org.zowe.apiml.security.common.error.ServiceNotAccessibleException;
+import org.zowe.apiml.security.common.error.ZosAuthenticationException;
 import org.zowe.apiml.security.common.login.ChangePasswordRequest;
 import org.zowe.apiml.security.common.login.LoginRequest;
 import org.zowe.apiml.security.common.token.TokenNotValidException;
@@ -1046,6 +1048,116 @@ class ZosmfServiceTest {
             assertThrows(ServiceNotFoundException.class, () -> underTest.exchangeAuthenticationForZosmfToken("OidcToken", authParsedSource));
         }
 
+    }
+
+    @Nested
+    class GivenExpiredPasswordResponse {
+
+        private ZosmfService zosmfService;
+        private Authentication authentication;
+
+        @BeforeEach
+        void setUp() {
+            zosmfService = getZosmfServiceSpy();
+            doReturn(true).when(zosmfService).loginEndpointExists();
+            authentication = new UsernamePasswordAuthenticationToken("user", "pass");
+        }
+
+        @Test
+        void whenZosmfReturnsExpiredPassword_thenThrowZosAuthenticationException() {
+            String responseBody = """
+                {
+                    "safMessages": [
+                        {
+                            "SAFReturnCode": 8,
+                            "SAFReasonCode": 24,
+                            "SAFMessageText": "ICH408I USER(user) EXPIRED PASSWORD"
+                        }
+                    ]
+                }
+                """;
+            HttpClientErrorException.Unauthorized exception = (HttpClientErrorException.Unauthorized)
+                HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized", null,
+                responseBody.getBytes(), null);
+
+            doThrow(exception).when(restTemplate).exchange(
+                anyString(),
+                any(HttpMethod.class),
+                any(HttpEntity.class),
+                (Class<?>) any()
+            );
+
+            ZosAuthenticationException thrown = assertThrows(ZosAuthenticationException.class,
+                () -> zosmfService.authenticate(authentication));
+            assertEquals(PlatformPwdErrno.EMVSEXPIRE, thrown.getPlatformError());
+        }
+
+        @Test
+        void whenZosmfReturnsInvalidCredentials_thenThrowBadCredentialsException() {
+            String responseBody = """
+                {
+                    "safMessages": [
+                        {
+                            "SAFReturnCode": 8,
+                            "SAFReasonCode": 16,
+                            "SAFMessageText": "ICH408I USER(user) INVALID PASSWORD"
+                        }
+                    ]
+                }
+                """;
+            HttpClientErrorException.Unauthorized exception = (HttpClientErrorException.Unauthorized)
+                HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized", null,
+                responseBody.getBytes(), null);
+
+            doThrow(exception).when(restTemplate).exchange(
+                anyString(),
+                any(HttpMethod.class),
+                any(HttpEntity.class),
+                (Class<?>) any()
+            );
+
+            assertThrows(BadCredentialsException.class,
+                () -> zosmfService.authenticate(authentication));
+        }
+
+        @Test
+        void whenZosmfReturnsEmptyBody_thenThrowBadCredentialsException() {
+            HttpClientErrorException.Unauthorized exception = (HttpClientErrorException.Unauthorized)
+                HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized", null,
+                new byte[0], null);
+
+            doThrow(exception).when(restTemplate).exchange(
+                anyString(),
+                any(HttpMethod.class),
+                any(HttpEntity.class),
+                (Class<?>) any()
+            );
+
+            assertThrows(BadCredentialsException.class,
+                () -> zosmfService.authenticate(authentication));
+        }
+
+        @Test
+        void whenZosmfReturnsMalformedJson_thenThrowBadCredentialsException() {
+            String malformedJson = "{ not valid json }";
+            HttpClientErrorException.Unauthorized exception = (HttpClientErrorException.Unauthorized)
+                HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized", null,
+                malformedJson.getBytes(), null);
+
+            doThrow(exception).when(restTemplate).exchange(
+                anyString(),
+                any(HttpMethod.class),
+                any(HttpEntity.class),
+                (Class<?>) any()
+            );
+
+            assertThrows(BadCredentialsException.class,
+                () -> zosmfService.authenticate(authentication));
+        }
     }
 
 }


### PR DESCRIPTION
Closes #4083

## Summary
When z/OSMF returns HTTP 401 for an expired password, the response body now contains SAF indicators (SAFReturnCode=8, SAFReasonCode=24) when z/OSMF is configured for detailed auth messages. Previously, all 401s were blindly mapped to BadCredentialsException (ZWEAG120E). This fix inspects the 401 response body and throws ZosAuthenticationException with EMVSEXPIRE (ZWEAT412E) when expired password is detected.

## Changes
- Added  private helper in ZosmfService.java — parses 401 response body for SAF expired-password indicators
- Modified  to catch HttpClientErrorException.Unauthorized before generic RuntimeException
- 4 unit tests: expired password → ZosAuthenticationException, invalid credentials → BadCredentialsException, empty body → BadCredentialsException, malformed JSON → BadCredentialsException

## QA review + CI gate to follow