### PR TITLE
fix: sanitize OIDC returnUrl to prevent open redirect

### DIFF
--- a/common-service-core/src/main/java/org/zowe/apiml/constants/ApimlConstants.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/constants/ApimlConstants.java
@@ -28,5 +28,6 @@ public final class ApimlConstants {
     public static final String SAF_TOKEN_HEADER = "X-SAF-Token";
     public static final String HEADER_OIDC_TOKEN = "OIDC-token";
     public static final String X_INSTANCEID = "X-InstanceId";
+    public static final String[] DEFAULT_ALLOWED_DOMAINS = { "www.ibm.com", "zowe.github.io", "www.zowe.org", "techdocs.broadcom.com" };
 
 }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
@@ -38,7 +38,7 @@ public class MetadataFilterService implements InitializingBean {
 
     private static final String ORG_ZOWE_APIML_COMMON_URL_NOT_ALLOWED = "org.zowe.apiml.common.urlNotAllowed";
 
-    @Value("${apiml.security.allowedDomains:${apiml.service.hostname}}")
+    @Value("${apiml.security.allowedDomains:${apiml.service.hostname:localhost}}")
     private String allowedDomains;
 
     private boolean onlyWarn = false;

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
@@ -30,12 +30,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.zowe.apiml.constants.ApimlConstants.DEFAULT_ALLOWED_DOMAINS;
+
 @Service
 @Slf4j
 public class MetadataFilterService implements InitializingBean {
 
     private static final String ORG_ZOWE_APIML_COMMON_URL_NOT_ALLOWED = "org.zowe.apiml.common.urlNotAllowed";
-    private static final String[] DEFAULT_ALLOWED_DOMAINS = { "www.ibm.com", "zowe.github.io", "www.zowe.org", "techdocs.broadcom.com" };
 
     @Value("${apiml.security.allowedDomains:${apiml.service.hostname}}")
     private String allowedDomains;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
@@ -7,6 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
+
 package org.zowe.apiml.gateway.config;
 
 public class InvalidForwardException extends RuntimeException {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
@@ -11,7 +11,13 @@
 package org.zowe.apiml.gateway.config;
 
 public class InvalidForwardException extends RuntimeException {
+    
+    private static final long serialVersionUID = 2717623179179277677L;
+
     public InvalidForwardException(String message) {
         super(message);
+    }
+    public InvalidForwardException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/InvalidForwardException.java
@@ -1,0 +1,16 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.apiml.gateway.config;
+
+public class InvalidForwardException extends RuntimeException {
+    public InvalidForwardException(String message) {
+        super(message);
+    }
+}

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -626,8 +626,11 @@ public class WebSecurity {
                 .orElse(exchange.getRequest().getHeaders().getFirst(HttpHeaders.ORIGIN));
         }
 
-        // Only a same-origin relative path or an absolute URL matching apiml.service.externalUrl is trusted;
-        // anything else falls back to the gateway's own root to prevent open-redirect/phishing via returnUrl.
+        /**
+         * Sanitize the return URL
+         * @param exchange the exchange
+         * @return the sanitized return URL
+         */
         private String getSafeReturnUrl(ServerWebExchange exchange) {
             return sanitizeReturnUrl(getReturnUrl(exchange));
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -248,7 +248,6 @@ public class WebSecurity {
 
             if (forwardUrl.isAbsolute()) {
                 if (forwardUrl.getHost() == null ||
-                    forwardUrl.getRawUserInfo() != null ||
                      allowedDomainsSet.stream()
                     .noneMatch(allowed -> StringUtils.equalsIgnoreCase(allowed, forwardUrl.getHost())
                 )) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -246,29 +246,24 @@ public class WebSecurity {
         }
 
         try {
-            var forwardUrl = UriComponentsBuilder
-                .fromUriString(decodedUrl)
-                .build()
+            var uriBuilder =
+                UriComponentsBuilder.fromUriString(decodedUrl)
+                .build();
+            var forwardUrl = uriBuilder
                 .toUri();
 
-            if (forwardUrl.isAbsolute()) {
-                if (forwardUrl.getHost() == null ||
-                     allowedDomainsSet.stream()
+            if (forwardUrl.getScheme() != null || forwardUrl.getHost() != null) {
+                if (allowedDomainsSet.stream()
                     .noneMatch(allowed -> StringUtils.equalsIgnoreCase(allowed, forwardUrl.getHost())
-                )) {
+                    )) {
                     throw new InvalidForwardException(decodedUrl);
                 }
             } else {
-                var path = forwardUrl.getRawPath();
-
-                if (forwardUrl.getRawAuthority() != null ||
-                    !path.startsWith("/") ||
-                    path.startsWith("//")) {
+                if (decodedUrl.contains("//")) {
                     throw new InvalidForwardException(decodedUrl);
                 }
             }
-
-            return decodedUrl;
+            return uriBuilder.toUriString();
         } catch (IllegalArgumentException | IllegalStateException e) {
             throw new InvalidForwardException(decodedUrl, e);
         }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -254,17 +254,15 @@ public class WebSecurity {
                 )) {
                     throw new InvalidForwardException(forwardUrlString);
                 }
+            } else {
+                var path = forwardUrl.getRawPath();
 
-                return forwardUrlString;
-            }
-
-            var path = forwardUrl.getRawPath();
-
-            if (forwardUrl.getRawAuthority() != null ||
-                StringUtils.isEmpty(path) ||
-                !path.startsWith("/") ||
-                path.startsWith("//")) {
-                throw new InvalidForwardException(forwardUrlString);
+                if (forwardUrl.getRawAuthority() != null ||
+                    StringUtils.isEmpty(path) ||
+                    !path.startsWith("/") ||
+                    path.startsWith("//")) {
+                    throw new InvalidForwardException(forwardUrlString);
+                }
             }
 
             return forwardUrlString;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -133,7 +133,7 @@ public class WebSecurity {
     @Value("${apiml.security.enableStrictUrlValidation:false}")
     private boolean isStrictUrlValidationEnabled;
 
-    @Value("${apiml.service.externalUrl}")
+    @Value("${apiml.service.externalUrl:}")
     private String externalUrl;
 
     private final ClientConfiguration clientConfiguration;
@@ -332,6 +332,7 @@ public class WebSecurity {
             return CONTEXT_PATH;
         }
     }
+
     public Mono<Object> updateCookies(WebFilterExchange webFilterExchange, OAuth2AuthorizedClient oAuth2AuthorizedClient) {
         ServerWebExchange exchange = webFilterExchange.getExchange();
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -365,7 +365,7 @@ public class WebSecurity {
         var location = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
 
         if (!HAS_NO_VALUE.test(location)) {
-            redirect(webFilterExchange.getExchange().getResponse(), sanitizeReturnUrl(location.getValue()));
+            redirect(exchange.getResponse(), sanitizeReturnUrl(location.getValue()));
         }
         clearCookies(webFilterExchange);
         return Mono.empty();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -362,7 +362,7 @@ public class WebSecurity {
 
         exchange.getResponse().addCookie(defaultCookieAttr(ResponseCookie.from(COOKIE_AUTH_NAME, oAuth2AuthorizedClient.getAccessToken().getTokenValue())).build());
 
-        HttpCookie location = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
+        var location = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
 
         if (!HAS_NO_VALUE.test(location)) {
             redirect(webFilterExchange.getExchange().getResponse(), sanitizeReturnUrl(location.getValue()));

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -235,14 +235,19 @@ public class WebSecurity {
      */
     private String getSafeReturnUrl(String forwardUrlString) throws InvalidForwardException {
 
-        if (StringUtils.isBlank(forwardUrlString)
-            || forwardUrlString.contains("\\")) {
+        if (StringUtils.isBlank(forwardUrlString)) {
             throw new InvalidForwardException(forwardUrlString);
+        }
+
+        var decodedUrl = URLDecoder.decode(forwardUrlString, StandardCharsets.UTF_8);
+
+        if (decodedUrl.contains("\\")) {
+            throw new InvalidForwardException(decodedUrl);
         }
 
         try {
             var forwardUrl = UriComponentsBuilder
-                .fromUriString(forwardUrlString)
+                .fromUriString(decodedUrl)
                 .build()
                 .toUri();
 
@@ -251,7 +256,7 @@ public class WebSecurity {
                      allowedDomainsSet.stream()
                     .noneMatch(allowed -> StringUtils.equalsIgnoreCase(allowed, forwardUrl.getHost())
                 )) {
-                    throw new InvalidForwardException(forwardUrlString);
+                    throw new InvalidForwardException(decodedUrl);
                 }
             } else {
                 var path = forwardUrl.getRawPath();
@@ -260,13 +265,13 @@ public class WebSecurity {
                     StringUtils.isBlank(path) ||
                     !path.startsWith("/") ||
                     path.startsWith("//")) {
-                    throw new InvalidForwardException(forwardUrlString);
+                    throw new InvalidForwardException(decodedUrl);
                 }
             }
 
-            return forwardUrlString;
+            return decodedUrl;
         } catch (IllegalArgumentException e) {
-            throw new InvalidForwardException(forwardUrlString, e);
+            throw new InvalidForwardException(decodedUrl, e);
         }
     }
 
@@ -279,8 +284,7 @@ public class WebSecurity {
 
         if (!HAS_NO_VALUE.test(location) && location != null) {
             try {
-                String decodedLocation = URLDecoder.decode(location.getValue(), StandardCharsets.UTF_8);
-                redirect(exchange.getResponse(), getSafeReturnUrl(decodedLocation));
+                redirect(exchange.getResponse(), getSafeReturnUrl(location.getValue()));
             } catch (InvalidForwardException e) {
                 return Mono.error(e);
             }
@@ -537,9 +541,6 @@ public class WebSecurity {
             String targetUrl = null;
             try {
                 targetUrl = getReturnUrl(exchange);
-                if (targetUrl != null) {
-                    targetUrl = URLDecoder.decode(targetUrl, StandardCharsets.UTF_8);
-                }
                 var safeCookieUrl = getSafeReturnUrl(targetUrl);
                 exchange.getResponse().addCookie(createCookie(COOKIE_RETURN_URL, safeCookieUrl));
             } catch (InvalidForwardException e) {

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -64,6 +64,7 @@ import org.springframework.security.web.server.util.matcher.PathPatternParserSer
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.zowe.apiml.config.ApplicationInfo;
 import org.zowe.apiml.gateway.config.oidc.ClientConfiguration;
 import org.zowe.apiml.gateway.controllers.GatewayExceptionHandler;
@@ -83,8 +84,7 @@ import org.zowe.apiml.security.common.util.X509Util;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -94,6 +94,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.zowe.apiml.gateway.services.ServicesInfoController.SERVICES_FULL_URL;
 import static org.zowe.apiml.gateway.services.ServicesInfoController.SERVICES_SHORT_URL;
@@ -133,8 +134,11 @@ public class WebSecurity {
     @Value("${apiml.security.enableStrictUrlValidation:true}")
     private boolean isStrictUrlValidationEnabled;
 
-    @Value("${apiml.service.externalUrl:}")
-    private String externalUrl;
+    @Value("${apiml.security.allowedDomains:${apiml.service.hostname}}")
+    private String allowedDomains;
+
+    private Set<String> allowedDomainsSet;
+    private static final String[] DEFAULT_ALLOWED_DOMAINS = { "www.ibm.com", "zowe.github.io", "www.zowe.org", "techdocs.broadcom.com" };
 
     private final ClientConfiguration clientConfiguration;
 
@@ -148,6 +152,7 @@ public class WebSecurity {
     @PostConstruct
     void initScopes() {
         boolean authorizeAnyUsers = "*".equals(allowedUsers);
+        allowedDomainsSet = Stream.concat(Arrays.stream(allowedDomains.split(",")).map(String::trim), Arrays.stream(DEFAULT_ALLOWED_DOMAINS)).map(String::toLowerCase).collect(Collectors.toSet());
 
         Set<String> users = Optional.ofNullable(allowedUsers)
             .map(line -> line.split("[,;]"))
@@ -166,6 +171,10 @@ public class WebSecurity {
 
     private ResponseCookie createCookie(String name, String value) {
         return defaultCookieAttr(ResponseCookie.from(name, value)).build();
+    }
+
+    private GatewayExceptionHandler gatewayExceptionHandler() {
+        return applicationContext.getBean("gatewayExceptionHandler", GatewayExceptionHandler.class);
     }
 
     /**
@@ -201,8 +210,7 @@ public class WebSecurity {
                     reactiveOAuth2AuthorizedClientService
                         .orElseThrow(() -> new NoSuchBeanDefinitionException(ReactiveOAuth2AuthorizedClientService.class))
                         .loadAuthorizedClient(getClientRegistrationId(webFilterExchange.getExchange()), authentication.getName())
-                        .map(oAuth2AuthorizedClient -> updateCookies(webFilterExchange, oAuth2AuthorizedClient)
-                        ).flatMap(x -> Mono.empty())
+                        .flatMap(oAuth2AuthorizedClient -> updateCookies(webFilterExchange, oAuth2AuthorizedClient))
                 )
                 .authenticationFailureHandler((webFilterExchange, exception) -> {
                         var clientRegistrationId = getClientRegistrationId(webFilterExchange.getExchange());
@@ -219,153 +227,66 @@ public class WebSecurity {
     }
 
     /**
+     * Sanitize the return URL
      * Validates a relative return URI.
-     * Only root-relative paths are accepted. Protocol-relative URLs,
-     * paths with an authority component, and other ambiguous forms are rejected.
-     *
-     * @param uri the relative URI to validate
-     * @return a safe relative location or {@link #CONTEXT_PATH} if invalid
+     * Only relative paths are accepted, paths with an authority component, and other ambiguous forms are rejected.
+     * @param forwardUrlString the return URL to check
+     * @return the sanitized return URL
      */
-    private String sanitizeRelativeUri(URI uri) {
-        if (uri.getRawAuthority() != null) {
-            return CONTEXT_PATH;
-        }
+    private String getSafeReturnUrl(String forwardUrlString) throws InvalidForwardException {
 
-        String path = uri.getRawPath();
-
-        if (StringUtils.isEmpty(path)
-            || !path.startsWith("/")
-            || path.startsWith("//")) {
-            return CONTEXT_PATH;
-        }
-
-        return toRelativeLocation(uri);
-    }
-
-    /**
-     * Checks whether the supplied absolute URI matches the configured Gateway origin.
-     *
-     * @param candidate the URI provided by the client
-     * @param configuredExternalUri the configured Gateway external URL
-     * @return true if both URIs share the same origin, false otherwise
-     */
-    private boolean isSameOrigin(URI candidate, URI configuredExternalUri) {
-        if (candidate.getScheme() == null
-            || candidate.getHost() == null
-            || configuredExternalUri.getScheme() == null
-            || configuredExternalUri.getHost() == null
-            || candidate.getRawUserInfo() != null) {
-            return false;
-        }
-
-        return candidate.getScheme().equalsIgnoreCase(configuredExternalUri.getScheme())
-            && candidate.getHost().equalsIgnoreCase(configuredExternalUri.getHost())
-            && effectivePort(candidate) == effectivePort(configuredExternalUri);
-    }
-
-    /**
-     * Returns the effective port of the URI.
-     * If the URI does not explicitly specify a port, the default port for
-     * the URI scheme is returned (80 for HTTP, 443 for HTTPS).
-     *
-     * @param uri the URI
-     * @return the effective port
-     */
-    private int effectivePort(URI uri) {
-        if (uri.getPort() >= 0) {
-            return uri.getPort();
-        }
-
-        if ("https".equalsIgnoreCase(uri.getScheme())) {
-            return 443;
-        }
-
-        if ("http".equalsIgnoreCase(uri.getScheme())) {
-            return 80;
-        }
-
-        return -1;
-    }
-
-    /**
-     * Converts an absolute or relative URI into a relative redirect location.
-     * The returned value contains only the path, query, and fragment.
-     *
-     * @param uri the URI to normalize
-     * @return the relative redirect location
-     */
-    private String toRelativeLocation(URI uri) {
-        String path = StringUtils.defaultIfEmpty(uri.getRawPath(), "/");
-
-        StringBuilder location = new StringBuilder(path);
-
-        if (uri.getRawQuery() != null) {
-            location.append('?').append(uri.getRawQuery());
-        }
-
-        if (uri.getRawFragment() != null) {
-            location.append('#').append(uri.getRawFragment());
-        }
-
-        return location.toString();
-    }
-
-    /**
-     * Validates and normalizes a return URL.
-     * Only root-relative paths or absolute URLs matching the configured
-     * Gateway origin are accepted. Any invalid or untrusted value falls back
-     * to {@link #CONTEXT_PATH} to prevent open redirect attacks.
-     *
-     * @param candidate the return URL supplied by the client
-     * @return a safe redirect target
-     */
-    private String sanitizeReturnUrl(String candidate) {
-        if (StringUtils.isBlank(candidate)) {
-            return CONTEXT_PATH;
-        }
-
-        String lowercaseCandidate = candidate.toLowerCase(Locale.ROOT);
-
-        // Backslashes can be interpreted as slashes by some clients.
-        // Also reject encoded backslashes and CR/LF characters, to avoid CRLF Injection.
-        if (candidate.contains("\\")
-            || lowercaseCandidate.contains("%5c")
-            || lowercaseCandidate.contains("%0d")
-            || lowercaseCandidate.contains("%0a")) {
-            return CONTEXT_PATH;
+        if (StringUtils.isBlank(forwardUrlString)
+            || forwardUrlString.contains("\\")) {
+            throw new InvalidForwardException(forwardUrlString);
         }
 
         try {
-            URI candidateUri = new URI(candidate);
+            var forwardUrl = UriComponentsBuilder
+                .fromUriString(forwardUrlString)
+                .build()
+                .toUri();
 
-            if (!candidateUri.isAbsolute()) {
-                return sanitizeRelativeUri(candidateUri);
+            if (forwardUrl.isAbsolute()) {
+                if (forwardUrl.getHost() == null ||
+                    forwardUrl.getRawUserInfo() != null ||
+                     allowedDomainsSet.stream()
+                    .noneMatch(allowed -> StringUtils.equalsIgnoreCase(allowed, forwardUrl.getHost())
+                )) {
+                    throw new InvalidForwardException(forwardUrlString);
+                }
+
+                return forwardUrlString;
             }
 
-            if (StringUtils.isBlank(externalUrl)) {
-                return CONTEXT_PATH;
-            }
-            URI configuredExternalUri = new URI(externalUrl);
+            var path = forwardUrl.getRawPath();
 
-            if (!isSameOrigin(candidateUri, configuredExternalUri)) {
-                return CONTEXT_PATH;
+            if (forwardUrl.getRawAuthority() != null ||
+                StringUtils.isEmpty(path) ||
+                !path.startsWith("/") ||
+                path.startsWith("//")) {
+                throw new InvalidForwardException(forwardUrlString);
             }
 
-            return toRelativeLocation(candidateUri);
-        } catch (URISyntaxException | IllegalArgumentException e) {
-            return CONTEXT_PATH;
+            return forwardUrlString;
+        } catch (IllegalArgumentException e) {
+            throw new InvalidForwardException(forwardUrlString);
         }
     }
 
-    public Mono<Object> updateCookies(WebFilterExchange webFilterExchange, OAuth2AuthorizedClient oAuth2AuthorizedClient) {
+    public Mono<Void> updateCookies(WebFilterExchange webFilterExchange, OAuth2AuthorizedClient oAuth2AuthorizedClient) {
         ServerWebExchange exchange = webFilterExchange.getExchange();
 
         exchange.getResponse().addCookie(defaultCookieAttr(ResponseCookie.from(COOKIE_AUTH_NAME, oAuth2AuthorizedClient.getAccessToken().getTokenValue())).build());
 
         var location = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
 
-        if (!HAS_NO_VALUE.test(location)) {
-            redirect(exchange.getResponse(), sanitizeReturnUrl(location.getValue()));
+        if (!HAS_NO_VALUE.test(location) && location != null) {
+            try {
+                String decodedLocation = URLDecoder.decode(location.getValue(), StandardCharsets.UTF_8);
+                redirect(exchange.getResponse(), getSafeReturnUrl(decodedLocation));
+            } catch (InvalidForwardException e) {
+                return Mono.error(e);
+            }
         }
         clearCookies(webFilterExchange);
         return Mono.empty();
@@ -477,11 +398,11 @@ public class WebSecurity {
     }
 
     public ServerHttpSecurity defaultSecurityConfig(ServerHttpSecurity http) {
-        var gatewayExceptionHandler = applicationContext.getBean("gatewayExceptionHandler", GatewayExceptionHandler.class);
+        var gatewayExceptionHandler = gatewayExceptionHandler();
 
         return http
             .headers(headers -> headers
-                .hsts(hsts -> hsts.disable())
+                .hsts(ServerHttpSecurity.HeaderSpec.HstsSpec::disable)
                 .writer(new CustomHstsServerHttpHeadersWriter())
                 .frameOptions(spec -> spec.mode(XFrameOptionsServerHttpHeadersWriter.Mode.SAMEORIGIN)))
             .x509(x509 -> x509
@@ -616,7 +537,19 @@ public class WebSecurity {
             exchange.getResponse().addCookie(
                 createCookie(COOKIE_NONCE, String.valueOf(authorizationRequest.getAttributes().get(OidcParameterNames.NONCE)))
             );
-            exchange.getResponse().addCookie(createCookie(COOKIE_RETURN_URL, getSafeReturnUrl(exchange)));
+            String targetUrl = null;
+            try {
+                targetUrl = getReturnUrl(exchange);
+                if (targetUrl != null) {
+                    targetUrl = URLDecoder.decode(targetUrl, StandardCharsets.UTF_8);
+                }
+                var safeCookieUrl = getSafeReturnUrl(targetUrl);
+                exchange.getResponse().addCookie(createCookie(COOKIE_RETURN_URL, safeCookieUrl));
+            } catch (InvalidForwardException e) {
+                return Mono.error(e);
+            } catch (IllegalArgumentException e) {
+                return Mono.error(new InvalidForwardException(targetUrl));
+            }
             exchange.getResponse().addCookie(createCookie(COOKIE_STATE, authorizationRequest.getState()));
             return Mono.empty();
         }
@@ -626,15 +559,6 @@ public class WebSecurity {
                 .orElse(exchange.getRequest().getHeaders().getFirst(HttpHeaders.ORIGIN));
         }
 
-        /**
-         * Sanitize the return URL
-         * @param exchange the exchange
-         * @return the sanitized return URL
-         */
-        private String getSafeReturnUrl(ServerWebExchange exchange) {
-            return sanitizeReturnUrl(getReturnUrl(exchange));
-        }
-
         @Override
         public Mono<OAuth2AuthorizationRequest> removeAuthorizationRequest(ServerWebExchange exchange) {
             Mono<OAuth2AuthorizationRequest> requestMono = loadAuthorizationRequest(exchange);
@@ -642,6 +566,18 @@ public class WebSecurity {
             return requestMono;
         }
 
+    }
+
+    /**
+     * InvalidForwardException is thrown from within the Spring Security filter chain (e.g. while saving the
+     * OAuth2 authorization request), which runs before the GatewayExceptionHandler
+     * resolution. This filter is to turn it into an actual response.
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    WebFilter invalidForwardExceptionHandlingFilter() {
+        return (exchange, chain) -> chain.filter(exchange)
+            .onErrorResume(InvalidForwardException.class, e -> gatewayExceptionHandler().handleInvalidForwardException(exchange, e));
     }
 
     @Bean
@@ -701,10 +637,8 @@ public class WebSecurity {
             "/v3/api-docs"
         };
 
-        private static final String[] BASE_PATHS_MODULITH = ArrayUtils.addAll(BASE_PATH_MICROSERVICES, new String[]{
-            "/apicatalog",
-            "/cachingservice"
-        });
+        private static final String[] BASE_PATHS_MODULITH = ArrayUtils.addAll(BASE_PATH_MICROSERVICES, "/apicatalog",
+            "/cachingservice");
 
         @Value("${server.port}")
         private int gatewayPort;

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -96,6 +96,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.zowe.apiml.constants.ApimlConstants.DEFAULT_ALLOWED_DOMAINS;
 import static org.zowe.apiml.gateway.services.ServicesInfoController.SERVICES_FULL_URL;
 import static org.zowe.apiml.gateway.services.ServicesInfoController.SERVICES_SHORT_URL;
 import static org.zowe.apiml.security.SecurityUtils.COOKIE_AUTH_NAME;
@@ -138,7 +139,6 @@ public class WebSecurity {
     private String allowedDomains;
 
     private Set<String> allowedDomainsSet;
-    private static final String[] DEFAULT_ALLOWED_DOMAINS = { "www.ibm.com", "zowe.github.io", "www.zowe.org", "techdocs.broadcom.com" };
 
     private final ClientConfiguration clientConfiguration;
 
@@ -258,7 +258,7 @@ public class WebSecurity {
                 var path = forwardUrl.getRawPath();
 
                 if (forwardUrl.getRawAuthority() != null ||
-                    StringUtils.isEmpty(path) ||
+                    StringUtils.isBlank(path) ||
                     !path.startsWith("/") ||
                     path.startsWith("//")) {
                     throw new InvalidForwardException(forwardUrlString);
@@ -267,7 +267,7 @@ public class WebSecurity {
 
             return forwardUrlString;
         } catch (IllegalArgumentException e) {
-            throw new InvalidForwardException(forwardUrlString);
+            throw new InvalidForwardException(forwardUrlString, e);
         }
     }
 
@@ -546,7 +546,7 @@ public class WebSecurity {
             } catch (InvalidForwardException e) {
                 return Mono.error(e);
             } catch (IllegalArgumentException e) {
-                return Mono.error(new InvalidForwardException(targetUrl));
+                return Mono.error(new InvalidForwardException(targetUrl, e));
             }
             exchange.getResponse().addCookie(createCookie(COOKIE_STATE, authorizationRequest.getState()));
             return Mono.empty();

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -83,6 +83,8 @@ import org.zowe.apiml.security.common.util.X509Util;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -130,6 +132,9 @@ public class WebSecurity {
 
     @Value("${apiml.security.enableStrictUrlValidation:false}")
     private boolean isStrictUrlValidationEnabled;
+
+    @Value("${apiml.service.externalUrl}")
+    private String externalUrl;
 
     private final ClientConfiguration clientConfiguration;
 
@@ -213,13 +218,134 @@ public class WebSecurity {
             .build();
     }
 
-    public Mono<Object> updateCookies(WebFilterExchange webFilterExchange, OAuth2AuthorizedClient oAuth2AuthorizedClient) {
-        webFilterExchange.getExchange().getResponse().addCookie(defaultCookieAttr(ResponseCookie.from(COOKIE_AUTH_NAME, oAuth2AuthorizedClient.getAccessToken().getTokenValue())).build());
-        var location = webFilterExchange.getExchange().getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
-        if (!HAS_NO_VALUE.test(location)) {
-            redirect(webFilterExchange.getExchange().getResponse(), location.getValue());
+    private String sanitizeRelativeUri(URI uri) {
+        /*
+         * Reject:
+         *   //attacker.example
+         *   attacker.example/path
+         *   gateway:foo
+         *
+         * Only root-relative paths are allowed.
+         */
+        if (uri.getRawAuthority() != null
+            || uri.getRawUserInfo() != null) {
+            return CONTEXT_PATH;
         }
+
+        String path = uri.getRawPath();
+
+        if (StringUtils.isEmpty(path)
+            || !path.startsWith("/")
+            || path.startsWith("//")) {
+            return CONTEXT_PATH;
+        }
+
+        return toRelativeLocation(uri);
+    }
+
+    private boolean isSameOrigin(URI candidate, URI configuredExternalUri) {
+        if (candidate.getScheme() == null
+            || candidate.getHost() == null
+            || configuredExternalUri.getScheme() == null
+            || configuredExternalUri.getHost() == null
+            || candidate.getRawUserInfo() != null) {
+            return false;
+        }
+
+        return candidate.getScheme().equalsIgnoreCase(configuredExternalUri.getScheme())
+            && candidate.getHost().equalsIgnoreCase(configuredExternalUri.getHost())
+            && effectivePort(candidate) == effectivePort(configuredExternalUri);
+    }
+
+    private int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) {
+            return uri.getPort();
+        }
+
+        if ("https".equalsIgnoreCase(uri.getScheme())) {
+            return 443;
+        }
+
+        if ("http".equalsIgnoreCase(uri.getScheme())) {
+            return 80;
+        }
+
+        return -1;
+    }
+
+    // defense-in-depth
+    private String toRelativeLocation(URI uri) {
+        String path = StringUtils.defaultIfEmpty(uri.getRawPath(), "/");
+
+        StringBuilder location = new StringBuilder(path);
+
+        if (uri.getRawQuery() != null) {
+            location.append('?').append(uri.getRawQuery());
+        }
+
+        if (uri.getRawFragment() != null) {
+            location.append('#').append(uri.getRawFragment());
+        }
+
+        return location.toString();
+    }
+
+    private String sanitizeReturnUrl(String candidate) {
+        if (StringUtils.isBlank(candidate)) {
+            return CONTEXT_PATH;
+        }
+
+        String lowercaseCandidate = candidate.toLowerCase(Locale.ROOT);
+
+        // Backslashes can be interpreted as slashes by some clients.
+        // Also reject encoded backslashes and CR/LF characters.
+        if (candidate.contains("\\")
+            || lowercaseCandidate.contains("%5c")
+            || lowercaseCandidate.contains("%0d")
+            || lowercaseCandidate.contains("%0a")) {
+            return CONTEXT_PATH;
+        }
+
+        try {
+            URI candidateUri = new URI(candidate);
+
+            if (!candidateUri.isAbsolute()) {
+                return sanitizeRelativeUri(candidateUri);
+            }
+
+            if (StringUtils.isBlank(externalUrl)) {
+                return CONTEXT_PATH;
+            }
+            URI configuredExternalUri = new URI(externalUrl);
+
+            if (!isSameOrigin(candidateUri, configuredExternalUri)) {
+                return CONTEXT_PATH;
+            }
+
+            /*
+             * Even for an accepted absolute same-origin URL, return only its
+             * path/query/fragment. This guarantees that Location never contains
+             * a user-controlled authority.
+             */
+            return toRelativeLocation(candidateUri);
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            return CONTEXT_PATH;
+        }
+    }
+    public Mono<Object> updateCookies(WebFilterExchange webFilterExchange, OAuth2AuthorizedClient oAuth2AuthorizedClient) {
+        ServerWebExchange exchange = webFilterExchange.getExchange();
+
+        exchange.getResponse().addCookie(defaultCookieAttr(ResponseCookie.from(COOKIE_AUTH_NAME, oAuth2AuthorizedClient.getAccessToken().getTokenValue())).build());
+
+        HttpCookie locationCookie = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
+
+        String location = HAS_NO_VALUE.test(locationCookie)
+            ? CONTEXT_PATH
+            : sanitizeReturnUrl(locationCookie.getValue());
+
+        redirect(exchange.getResponse(), location);
         clearCookies(webFilterExchange);
+
         return Mono.empty();
     }
 
@@ -468,7 +594,7 @@ public class WebSecurity {
             exchange.getResponse().addCookie(
                 createCookie(COOKIE_NONCE, String.valueOf(authorizationRequest.getAttributes().get(OidcParameterNames.NONCE)))
             );
-            exchange.getResponse().addCookie(createCookie(COOKIE_RETURN_URL, getReturnUrl(exchange)));
+            exchange.getResponse().addCookie(createCookie(COOKIE_RETURN_URL, getSafeReturnUrl(exchange)));
             exchange.getResponse().addCookie(createCookie(COOKIE_STATE, authorizationRequest.getState()));
             return Mono.empty();
         }
@@ -476,6 +602,12 @@ public class WebSecurity {
         String getReturnUrl(ServerWebExchange exchange) {
             return Optional.ofNullable(exchange.getRequest().getQueryParams().getFirst("returnUrl"))
                 .orElse(exchange.getRequest().getHeaders().getFirst(HttpHeaders.ORIGIN));
+        }
+
+        // Only a same-origin relative path or an absolute URL matching apiml.service.externalUrl is trusted;
+        // anything else falls back to the gateway's own root to prevent open-redirect/phishing via returnUrl.
+        private String getSafeReturnUrl(ServerWebExchange exchange) {
+            return sanitizeReturnUrl(getReturnUrl(exchange));
         }
 
         @Override

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -135,7 +135,7 @@ public class WebSecurity {
     @Value("${apiml.security.enableStrictUrlValidation:true}")
     private boolean isStrictUrlValidationEnabled;
 
-    @Value("${apiml.security.allowedDomains:${apiml.service.hostname}}")
+    @Value("${apiml.security.allowedDomains:${apiml.service.hostname:localhost}}")
     private String allowedDomains;
 
     private Set<String> allowedDomainsSet;
@@ -262,7 +262,6 @@ public class WebSecurity {
                 var path = forwardUrl.getRawPath();
 
                 if (forwardUrl.getRawAuthority() != null ||
-                    StringUtils.isBlank(path) ||
                     !path.startsWith("/") ||
                     path.startsWith("//")) {
                     throw new InvalidForwardException(decodedUrl);
@@ -270,7 +269,7 @@ public class WebSecurity {
             }
 
             return decodedUrl;
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             throw new InvalidForwardException(decodedUrl, e);
         }
     }

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/WebSecurity.java
@@ -218,17 +218,16 @@ public class WebSecurity {
             .build();
     }
 
+    /**
+     * Validates a relative return URI.
+     * Only root-relative paths are accepted. Protocol-relative URLs,
+     * paths with an authority component, and other ambiguous forms are rejected.
+     *
+     * @param uri the relative URI to validate
+     * @return a safe relative location or {@link #CONTEXT_PATH} if invalid
+     */
     private String sanitizeRelativeUri(URI uri) {
-        /*
-         * Reject:
-         *   //attacker.example
-         *   attacker.example/path
-         *   gateway:foo
-         *
-         * Only root-relative paths are allowed.
-         */
-        if (uri.getRawAuthority() != null
-            || uri.getRawUserInfo() != null) {
+        if (uri.getRawAuthority() != null) {
             return CONTEXT_PATH;
         }
 
@@ -243,6 +242,13 @@ public class WebSecurity {
         return toRelativeLocation(uri);
     }
 
+    /**
+     * Checks whether the supplied absolute URI matches the configured Gateway origin.
+     *
+     * @param candidate the URI provided by the client
+     * @param configuredExternalUri the configured Gateway external URL
+     * @return true if both URIs share the same origin, false otherwise
+     */
     private boolean isSameOrigin(URI candidate, URI configuredExternalUri) {
         if (candidate.getScheme() == null
             || candidate.getHost() == null
@@ -257,6 +263,14 @@ public class WebSecurity {
             && effectivePort(candidate) == effectivePort(configuredExternalUri);
     }
 
+    /**
+     * Returns the effective port of the URI.
+     * If the URI does not explicitly specify a port, the default port for
+     * the URI scheme is returned (80 for HTTP, 443 for HTTPS).
+     *
+     * @param uri the URI
+     * @return the effective port
+     */
     private int effectivePort(URI uri) {
         if (uri.getPort() >= 0) {
             return uri.getPort();
@@ -273,7 +287,13 @@ public class WebSecurity {
         return -1;
     }
 
-    // defense-in-depth
+    /**
+     * Converts an absolute or relative URI into a relative redirect location.
+     * The returned value contains only the path, query, and fragment.
+     *
+     * @param uri the URI to normalize
+     * @return the relative redirect location
+     */
     private String toRelativeLocation(URI uri) {
         String path = StringUtils.defaultIfEmpty(uri.getRawPath(), "/");
 
@@ -290,6 +310,15 @@ public class WebSecurity {
         return location.toString();
     }
 
+    /**
+     * Validates and normalizes a return URL.
+     * Only root-relative paths or absolute URLs matching the configured
+     * Gateway origin are accepted. Any invalid or untrusted value falls back
+     * to {@link #CONTEXT_PATH} to prevent open redirect attacks.
+     *
+     * @param candidate the return URL supplied by the client
+     * @return a safe redirect target
+     */
     private String sanitizeReturnUrl(String candidate) {
         if (StringUtils.isBlank(candidate)) {
             return CONTEXT_PATH;
@@ -298,7 +327,7 @@ public class WebSecurity {
         String lowercaseCandidate = candidate.toLowerCase(Locale.ROOT);
 
         // Backslashes can be interpreted as slashes by some clients.
-        // Also reject encoded backslashes and CR/LF characters.
+        // Also reject encoded backslashes and CR/LF characters, to avoid CRLF Injection.
         if (candidate.contains("\\")
             || lowercaseCandidate.contains("%5c")
             || lowercaseCandidate.contains("%0d")
@@ -322,11 +351,6 @@ public class WebSecurity {
                 return CONTEXT_PATH;
             }
 
-            /*
-             * Even for an accepted absolute same-origin URL, return only its
-             * path/query/fragment. This guarantees that Location never contains
-             * a user-controlled authority.
-             */
             return toRelativeLocation(candidateUri);
         } catch (URISyntaxException | IllegalArgumentException e) {
             return CONTEXT_PATH;
@@ -338,15 +362,12 @@ public class WebSecurity {
 
         exchange.getResponse().addCookie(defaultCookieAttr(ResponseCookie.from(COOKIE_AUTH_NAME, oAuth2AuthorizedClient.getAccessToken().getTokenValue())).build());
 
-        HttpCookie locationCookie = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
+        HttpCookie location = exchange.getRequest().getCookies().getFirst(COOKIE_RETURN_URL);
 
-        String location = HAS_NO_VALUE.test(locationCookie)
-            ? CONTEXT_PATH
-            : sanitizeReturnUrl(locationCookie.getValue());
-
-        redirect(exchange.getResponse(), location);
+        if (!HAS_NO_VALUE.test(location)) {
+            redirect(webFilterExchange.getExchange().getResponse(), sanitizeReturnUrl(location.getValue()));
+        }
         clearCookies(webFilterExchange);
-
         return Mono.empty();
     }
 

--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/controllers/GatewayExceptionHandler.java
@@ -33,6 +33,7 @@ import org.springframework.web.server.adapter.DefaultServerWebExchange;
 import org.springframework.web.server.i18n.LocaleContextResolver;
 import org.springframework.web.server.session.DefaultWebSessionManager;
 import org.zowe.apiml.exception.MetadataValidationException;
+import org.zowe.apiml.gateway.config.InvalidForwardException;
 import org.zowe.apiml.gateway.filters.ForbidCharacterException;
 import org.zowe.apiml.gateway.filters.ForbidSlashException;
 import org.zowe.apiml.gateway.filters.ZaasInternalErrorException;
@@ -179,6 +180,12 @@ public class GatewayExceptionHandler {
     public Mono<Void> handleZaasInternalErrorException(ServerWebExchange exchange, ZaasInternalErrorException ex) {
         log.debug("The ZAAS instance {} return internal server error for request {}: {}", ex.getInstanceId(), exchange.getRequest().getURI(), ex.getMessage());
         return setBodyResponse(exchange, SC_INTERNAL_SERVER_ERROR, "org.zowe.apiml.gateway.zaas.internalServerError", ex.getInstanceId());
+    }
+
+    @ExceptionHandler(InvalidForwardException.class)
+    public Mono<Void> handleInvalidForwardException(ServerWebExchange exchange, InvalidForwardException ex) {
+        log.debug("Invalid or not allowed return URL on {}: {}", exchange.getRequest().getURI(), ex.getMessage());
+        return setBodyResponse(exchange, SC_BAD_REQUEST, "org.zowe.apiml.gateway.invalidOidcReturnUrl");
     }
 
     @ExceptionHandler(ServerWebInputException.class)

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -56,8 +56,8 @@ messages:
       number: ZWEAG703
       type: ERROR
       text: "The OIDC return URL is invalid, malformed, or untrusted."
-      reason: "The requested return URL is absolute but its domain is not present in the allowed domains whitelist, or the URL is relative but malformed."
-      action: "Whitelist the domain in 'apiml.security.allowedDomains' or use a valid relative path."
+      reason: "The requested return URL is absolute but its domain is not present in the allowed domains allowedlist, or the URL is relative but malformed."
+      action: "Add the domain to 'apiml.security.allowedDomains' or use a valid relative path."
 
     # Legacy messages
 

--- a/gateway-service/src/main/resources/gateway-log-messages.yml
+++ b/gateway-service/src/main/resources/gateway-log-messages.yml
@@ -52,6 +52,13 @@ messages:
       reason: "The provided service does not satisfy the conformance criteria and is therefore not valid."
       action: "Verify the conformance criteria."
 
+    - key: org.zowe.apiml.gateway.invalidOidcReturnUrl
+      number: ZWEAG703
+      type: ERROR
+      text: "The OIDC return URL is invalid, malformed, or untrusted."
+      reason: "The requested return URL is absolute but its domain is not present in the allowed domains whitelist, or the URL is relative but malformed."
+      action: "Whitelist the domain in 'apiml.security.allowedDomains' or use a valid relative path."
+
     # Legacy messages
 
     - key: org.zowe.apiml.security.authRequired

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -92,6 +92,7 @@ class WebSecurityTest {
         void setUp() {
             webSecurity = new WebSecurity(new ClientConfiguration(), tokenProvider, basicAuthProvider, applicationContext);
             ReflectionTestUtils.setField(webSecurity, "allowedUsers", "registryUser,registryAdmin");
+            ReflectionTestUtils.setField(webSecurity, "allowedDomains", "");
             webSecurity.initScopes();
             reactiveUserDetailsService = webSecurity.userDetailsService();
         }
@@ -175,6 +176,7 @@ class WebSecurityTest {
         void setUp() {
             var webSecurity = new WebSecurity(new ClientConfiguration(), tokenProvider, basicAuthProvider, applicationContext);
             ReflectionTestUtils.setField(webSecurity, "allowedUsers", "*");
+            ReflectionTestUtils.setField(webSecurity, "allowedDomains", "");
             webSecurity.initScopes();
             reactiveUserDetailsService = webSecurity.userDetailsService();
         }
@@ -465,7 +467,9 @@ class WebSecurityTest {
         var request = mock(ServerHttpRequest.class);
         var headers = new HttpHeaders();
         when(request.getHeaders()).thenReturn(headers);
-        when(request.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+        var queryParams = new LinkedMultiValueMap<String, String>();
+        queryParams.add("returnUrl", "/gateway/foo");
+        when(request.getQueryParams()).thenReturn(queryParams);
 
         var exchange = mock(ServerWebExchange.class);
         when(exchange.getRequest()).thenReturn(request);
@@ -496,19 +500,21 @@ class WebSecurityTest {
     @Nested
     class SanitizeReturnUrl {
 
-        private static final String EXTERNAL_URL = "https://gateway.zowe.example:10010";
+        private static final String ALLOWED_HOST = "gateway.zowe.example";
+        private static final String EXTERNAL_URL = "https://" + ALLOWED_HOST + ":10010";
 
         WebSecurity.ApimlServerAuthorizationRequestRepository requestRepository;
 
         @BeforeEach
         void setUp() {
             var webSecurity = new WebSecurity(null, tokenProvider, basicAuthProvider, applicationContext);
-            ReflectionTestUtils.setField(webSecurity, "externalUrl", EXTERNAL_URL);
+            ReflectionTestUtils.setField(webSecurity, "allowedDomains", ALLOWED_HOST);
+            webSecurity.initScopes();
             var resolver = mock(ServerOAuth2AuthorizationRequestResolver.class);
             requestRepository = webSecurity.new ApimlServerAuthorizationRequestRepository(resolver);
         }
 
-        private String sanitize(String returnUrlQueryParam, String originHeader) {
+        private Mono<Void> save(String returnUrlQueryParam, String originHeader, LinkedMultiValueMap<String, ResponseCookie> cookies) {
             var request = mock(ServerHttpRequest.class);
             var headers = new HttpHeaders();
             if (originHeader != null) {
@@ -527,7 +533,6 @@ class WebSecurityTest {
             var response = mock(ServerHttpResponse.class);
             when(exchange.getResponse()).thenReturn(response);
 
-            var cookies = new LinkedMultiValueMap<String, ResponseCookie>();
             doAnswer(invocation -> {
                 var cookie = invocation.getArgument(0, ResponseCookie.class);
                 cookies.add(cookie.getName(), cookie);
@@ -541,54 +546,75 @@ class WebSecurityTest {
                 .attributes(attrs -> attrs.put(OidcParameterNames.NONCE, "test-nonce"))
                 .build();
 
-            requestRepository.saveAuthorizationRequest(oauth2AuthReq, exchange).block();
+            return requestRepository.saveAuthorizationRequest(oauth2AuthReq, exchange);
+        }
 
+        private String sanitize(String returnUrlQueryParam, String originHeader) {
+            var cookies = new LinkedMultiValueMap<String, ResponseCookie>();
+            save(returnUrlQueryParam, originHeader, cookies).block();
             return Objects.requireNonNull(cookies.getFirst(WebSecurity.COOKIE_RETURN_URL)).getValue();
         }
 
-        static Stream<Arguments> safeAndUnsafeReturnUrls() {
+        private void assertRejected(String returnUrlQueryParam, String originHeader) {
+            var cookies = new LinkedMultiValueMap<String, ResponseCookie>();
+            StepVerifier.create(save(returnUrlQueryParam, originHeader, cookies))
+                .verifyErrorSatisfies(e -> assertThat(e).isInstanceOf(InvalidForwardException.class));
+            assertThat(cookies.getFirst(WebSecurity.COOKIE_RETURN_URL)).isNull();
+        }
+
+        static Stream<Arguments> safeReturnUrls() {
             return Stream.of(
-                // no returnUrl and no Origin header at all
-                Arguments.of(null, WebSecurity.CONTEXT_PATH),
-                Arguments.of("", WebSecurity.CONTEXT_PATH),
                 // plain relative paths are passed through untouched
                 Arguments.of("/gateway/foo", "/gateway/foo"),
                 Arguments.of("/gateway/foo?bar=1#frag", "/gateway/foo?bar=1#frag"),
-                // protocol-relative and backslash tricks that resolve to a different host
-                Arguments.of("//attacker.example/x", WebSecurity.CONTEXT_PATH),
-                Arguments.of("/\\attacker.example", WebSecurity.CONTEXT_PATH),
-                Arguments.of("/foo%5Cattacker.example", WebSecurity.CONTEXT_PATH),
-                Arguments.of("/foo%0D%0ASet-Cookie:evil=1", WebSecurity.CONTEXT_PATH),
-                // absolute URLs matching the configured externalUrl are accepted, authority stripped
-                Arguments.of(EXTERNAL_URL + "/gateway/foo?x=1#frag", "/gateway/foo?x=1#frag"),
-                Arguments.of(EXTERNAL_URL, "/"),
-                Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "/gateway/foo"),
-                // absolute URLs that differ from externalUrl in host, port, scheme or userinfo
-                Arguments.of("https://attacker.example/x", WebSecurity.CONTEXT_PATH),
-                Arguments.of("https://gateway.zowe.example:9999/x", WebSecurity.CONTEXT_PATH),
-                Arguments.of("http://gateway.zowe.example:10010/x", WebSecurity.CONTEXT_PATH),
-                Arguments.of("https://user@gateway.zowe.example:10010/x", WebSecurity.CONTEXT_PATH),
-                // non-http(s) schemes and malformed URIs
-                Arguments.of("javascript:alert(1)", WebSecurity.CONTEXT_PATH),
-                Arguments.of("mailto:foo@bar.com", WebSecurity.CONTEXT_PATH),
-                Arguments.of("http://exa mple.com", WebSecurity.CONTEXT_PATH)
+                // absolute URLs whose host is allow-listed are accepted unchanged
+                Arguments.of(EXTERNAL_URL + "/gateway/foo?x=1#frag", EXTERNAL_URL + "/gateway/foo?x=1#frag"),
+                Arguments.of(EXTERNAL_URL, EXTERNAL_URL),
+                Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo"),
+                Arguments.of("http://gateway.zowe.example:10010/x", "http://gateway.zowe.example:10010/x"),
+                Arguments.of("https://www.ibm.com/docs", "https://www.ibm.com/docs")
+            );
+        }
+
+        static Stream<String> unsafeReturnUrls() {
+            return Stream.of(
+                "",
+                "//attacker.example/x",
+                "/\\attacker.example",
+                "/foo%5Cattacker.example",
+                "/foo%0D%0ASet-Cookie:evil=1",
+                "https://attacker.example/x",
+                "https://user@gateway.zowe.example:10010/x",
+                "mailto:foo@bar.com",
+                "http://exa mple.com"
             );
         }
 
         @ParameterizedTest
-        @MethodSource("safeAndUnsafeReturnUrls")
+        @MethodSource("safeReturnUrls")
         void sanitizesReturnUrlQueryParam(String returnUrl, String expected) {
             assertThat(sanitize(returnUrl, null)).isEqualTo(expected);
         }
 
+        @ParameterizedTest
+        @MethodSource("unsafeReturnUrls")
+        void rejectsUnsafeReturnUrlQueryParam(String returnUrl) {
+            assertRejected(returnUrl, null);
+        }
+
+        @Test
+        void whenNoReturnUrlParamAndNoOriginHeader_thenRejected() {
+            assertRejected(null, null);
+        }
+
         @Test
         void whenNoReturnUrlParam_thenFallsBackToOriginHeader_sameOrigin() {
-            assertThat(sanitize(null, EXTERNAL_URL)).isEqualTo("/");
+            assertThat(sanitize(null, EXTERNAL_URL)).isEqualTo(EXTERNAL_URL);
         }
 
         @Test
         void whenNoReturnUrlParam_thenFallsBackToOriginHeader_crossOrigin() {
-            assertThat(sanitize(null, "https://attacker.example")).isEqualTo(WebSecurity.CONTEXT_PATH);
+            assertRejected(null, "https://attacker.example");
         }
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +66,7 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,7 +114,7 @@ class WebSecurityTest {
         @Test
         void whenAccessTokenIsAvailable_thenAddItAsCookie() {
             var token = "thisIsToken";
-            var location = "localhost:10010";
+            var location = "/gateway/some/path";
             var webFilterExchange = mock(WebFilterExchange.class);
             var exchange = mock(ServerWebExchange.class);
             when(webFilterExchange.getExchange()).thenReturn(exchange);
@@ -488,6 +491,106 @@ class WebSecurityTest {
 
         assertThat(cookies.getFirst(WebSecurity.COOKIE_NONCE).getValue()).isEqualTo("test-nonce");
         assertThat(cookies.getFirst(WebSecurity.COOKIE_STATE).getValue()).isEqualTo("test-state");
+
+    }
+
+    @Nested
+    class SanitizeReturnUrl {
+
+        private static final String EXTERNAL_URL = "https://gateway.zowe.example:10010";
+
+        WebSecurity.ApimlServerAuthorizationRequestRepository requestRepository;
+
+        @BeforeEach
+        void setUp() {
+            var webSecurity = new WebSecurity(null, tokenProvider, basicAuthProvider, applicationContext);
+            ReflectionTestUtils.setField(webSecurity, "externalUrl", EXTERNAL_URL);
+            var resolver = mock(ServerOAuth2AuthorizationRequestResolver.class);
+            requestRepository = webSecurity.new ApimlServerAuthorizationRequestRepository(resolver);
+        }
+
+        private String sanitize(String returnUrlQueryParam, String originHeader) {
+            var request = mock(ServerHttpRequest.class);
+            var headers = new HttpHeaders();
+            if (originHeader != null) {
+                headers.set(HttpHeaders.ORIGIN, originHeader);
+            }
+            when(request.getHeaders()).thenReturn(headers);
+
+            var queryParams = new LinkedMultiValueMap<String, String>();
+            if (returnUrlQueryParam != null) {
+                queryParams.add("returnUrl", returnUrlQueryParam);
+            }
+            when(request.getQueryParams()).thenReturn(queryParams);
+
+            var exchange = mock(ServerWebExchange.class);
+            when(exchange.getRequest()).thenReturn(request);
+            var response = mock(ServerHttpResponse.class);
+            when(exchange.getResponse()).thenReturn(response);
+
+            var cookies = new LinkedMultiValueMap<String, ResponseCookie>();
+            doAnswer(invocation -> {
+                var cookie = invocation.getArgument(0, ResponseCookie.class);
+                cookies.add(cookie.getName(), cookie);
+                return null;
+            }).when(response).addCookie(any(ResponseCookie.class));
+
+            var oauth2AuthReq = OAuth2AuthorizationRequest.authorizationCode()
+                .clientId("test-client")
+                .state("test-state")
+                .authorizationUri("https://test.auth.server/oauth/authorize")
+                .attributes(attrs -> attrs.put(OidcParameterNames.NONCE, "test-nonce"))
+                .build();
+
+            requestRepository.saveAuthorizationRequest(oauth2AuthReq, exchange).block();
+
+            return cookies.getFirst(WebSecurity.COOKIE_RETURN_URL).getValue();
+        }
+
+        static Stream<Arguments> safeAndUnsafeReturnUrls() {
+            return Stream.of(
+                // no returnUrl and no Origin header at all
+                Arguments.of(null, WebSecurity.CONTEXT_PATH),
+                Arguments.of("", WebSecurity.CONTEXT_PATH),
+                // plain relative paths are passed through untouched
+                Arguments.of("/gateway/foo", "/gateway/foo"),
+                Arguments.of("/gateway/foo?bar=1#frag", "/gateway/foo?bar=1#frag"),
+                // protocol-relative and backslash tricks that resolve to a different host
+                Arguments.of("//attacker.example/x", WebSecurity.CONTEXT_PATH),
+                Arguments.of("/\\attacker.example", WebSecurity.CONTEXT_PATH),
+                Arguments.of("/foo%5Cattacker.example", WebSecurity.CONTEXT_PATH),
+                Arguments.of("/foo%0D%0ASet-Cookie:evil=1", WebSecurity.CONTEXT_PATH),
+                // absolute URLs matching the configured externalUrl are accepted, authority stripped
+                Arguments.of(EXTERNAL_URL + "/gateway/foo?x=1#frag", "/gateway/foo?x=1#frag"),
+                Arguments.of(EXTERNAL_URL, "/"),
+                Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "/gateway/foo"),
+                // absolute URLs that differ from externalUrl in host, port, scheme or userinfo
+                Arguments.of("https://attacker.example/x", WebSecurity.CONTEXT_PATH),
+                Arguments.of("https://gateway.zowe.example:9999/x", WebSecurity.CONTEXT_PATH),
+                Arguments.of("http://gateway.zowe.example:10010/x", WebSecurity.CONTEXT_PATH),
+                Arguments.of("https://user@gateway.zowe.example:10010/x", WebSecurity.CONTEXT_PATH),
+                // non-http(s) schemes and malformed URIs
+                Arguments.of("javascript:alert(1)", WebSecurity.CONTEXT_PATH),
+                Arguments.of("mailto:foo@bar.com", WebSecurity.CONTEXT_PATH),
+                Arguments.of("http://exa mple.com", WebSecurity.CONTEXT_PATH)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("safeAndUnsafeReturnUrls")
+        void sanitizesReturnUrlQueryParam(String returnUrl, String expected) {
+            assertThat(sanitize(returnUrl, null)).isEqualTo(expected);
+        }
+
+        @Test
+        void whenNoReturnUrlParam_thenFallsBackToOriginHeader_sameOrigin() {
+            assertThat(sanitize(null, EXTERNAL_URL)).isEqualTo("/");
+        }
+
+        @Test
+        void whenNoReturnUrlParam_thenFallsBackToOriginHeader_crossOrigin() {
+            assertThat(sanitize(null, "https://attacker.example")).isEqualTo(WebSecurity.CONTEXT_PATH);
+        }
 
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -573,6 +573,9 @@ class WebSecurityTest {
                 Arguments.of(EXTERNAL_URL, EXTERNAL_URL),
                 Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo"),
                 Arguments.of("http://gateway.zowe.example:10010/x", "http://gateway.zowe.example:10010/x"),
+                Arguments.of("https://www.ibm.com/docs", "https://www.ibm.com/docs"),
+                Arguments.of("/gateway/foo%2Bmore?bar=%2f1#frag", "/gateway/foo+more?bar=/1#frag"),
+                Arguments.of("https://user:password@gateway.zowe.example:10010/x", "https://user:password@gateway.zowe.example:10010/x"),
                 Arguments.of("https://www.ibm.com/docs", "https://www.ibm.com/docs")
             );
         }
@@ -587,7 +590,15 @@ class WebSecurityTest {
                 "https://attacker.example/x",
                 "https://user@attacker.example:10010/x",
                 "mailto:foo@bar.com",
-                "http://exa mple.com"
+                "//gateway.zowe.example",
+                "http://exa mple.com",
+                "%2f%2fatacker/unknow",
+                "https://user:password@attacker.example:10010/x",
+                "//user:password@attacker.example:10010/x",
+                "https://",
+                "//gateway.zowe.example",
+                "//:80/",
+                "relative//invalid"
             );
         }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -567,6 +567,7 @@ class WebSecurityTest {
                 // plain relative paths are passed through untouched
                 Arguments.of("/gateway/foo", "/gateway/foo"),
                 Arguments.of("/gateway/foo?bar=1#frag", "/gateway/foo?bar=1#frag"),
+                Arguments.of("https://user@gateway.zowe.example:10010/x", "https://user@gateway.zowe.example:10010/x"),
                 // absolute URLs whose host is allow-listed are accepted unchanged
                 Arguments.of(EXTERNAL_URL + "/gateway/foo?x=1#frag", EXTERNAL_URL + "/gateway/foo?x=1#frag"),
                 Arguments.of(EXTERNAL_URL, EXTERNAL_URL),
@@ -584,7 +585,7 @@ class WebSecurityTest {
                 "/foo%5Cattacker.example",
                 "/foo%0D%0ASet-Cookie:evil=1",
                 "https://attacker.example/x",
-                "https://user@gateway.zowe.example:10010/x",
+                "https://user@attacker.example:10010/x",
                 "mailto:foo@bar.com",
                 "http://exa mple.com"
             );

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -64,6 +64,7 @@ import reactor.test.StepVerifier;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -133,9 +134,9 @@ class WebSecurityTest {
             when(accessToken.getTokenValue()).thenReturn(token);
 
             webSecurity.updateCookies(webFilterExchange, oAuth2AuthorizedClient);
-            assertEquals(token, serverHttpResponse.getCookies().getFirst("apimlAuthenticationToken").getValue());
-            assertEquals("", serverHttpResponse.getCookies().getFirst(WebSecurity.COOKIE_NONCE).getValue());
-            assertEquals("", serverHttpResponse.getCookies().getFirst(WebSecurity.COOKIE_STATE).getValue());
+            assertEquals(token, Objects.requireNonNull(serverHttpResponse.getCookies().getFirst("apimlAuthenticationToken")).getValue());
+            assertEquals("", Objects.requireNonNull(serverHttpResponse.getCookies().getFirst(WebSecurity.COOKIE_NONCE)).getValue());
+            assertEquals("", Objects.requireNonNull(serverHttpResponse.getCookies().getFirst(WebSecurity.COOKIE_STATE)).getValue());
             assertEquals(location, serverHttpResponse.getHeaders().getFirst(HttpHeaders.LOCATION));
         }
 
@@ -246,8 +247,6 @@ class WebSecurityTest {
 
         ServerHttpSecurity.AuthorizeExchangeSpec authorizeExchangeSpec = mock(ServerHttpSecurity.AuthorizeExchangeSpec.class);
         ServerHttpSecurity.AuthorizeExchangeSpec.Access access = mock(ServerHttpSecurity.AuthorizeExchangeSpec.Access.class);
-        ServerHttpSecurity.OAuth2LoginSpec oauth2LoginSpec = mock(ServerHttpSecurity.OAuth2LoginSpec.class);
-        ServerHttpSecurity.HeaderSpec headerSpec = mock(ServerHttpSecurity.HeaderSpec.class);
 
         when(http.headers(any())).thenReturn(http);
         when(http.securityContextRepository(any())).thenReturn(http);
@@ -489,8 +488,8 @@ class WebSecurityTest {
 
         requestRepository.saveAuthorizationRequest(oauth2AuthReq, exchange).block();
 
-        assertThat(cookies.getFirst(WebSecurity.COOKIE_NONCE).getValue()).isEqualTo("test-nonce");
-        assertThat(cookies.getFirst(WebSecurity.COOKIE_STATE).getValue()).isEqualTo("test-state");
+        assertThat(Objects.requireNonNull(cookies.getFirst(WebSecurity.COOKIE_NONCE)).getValue()).isEqualTo("test-nonce");
+        assertThat(Objects.requireNonNull(cookies.getFirst(WebSecurity.COOKIE_STATE)).getValue()).isEqualTo("test-state");
 
     }
 
@@ -544,7 +543,7 @@ class WebSecurityTest {
 
             requestRepository.saveAuthorizationRequest(oauth2AuthReq, exchange).block();
 
-            return cookies.getFirst(WebSecurity.COOKIE_RETURN_URL).getValue();
+            return Objects.requireNonNull(cookies.getFirst(WebSecurity.COOKIE_RETURN_URL)).getValue();
         }
 
         static Stream<Arguments> safeAndUnsafeReturnUrls() {
@@ -603,7 +602,7 @@ class WebSecurityTest {
         @Mock
         private StrictServerWebExchangeFirewall nonRoutingFirewall;
         private WebSecurity.ApimlStrictServerWebExchangeFirewall apimlStrictServerWebExchangeFirewall;
-        private ApplicationInfo applicationInfo = ApplicationInfo.builder().build();
+        private final ApplicationInfo applicationInfo = ApplicationInfo.builder().build();
 
         @BeforeEach
         void setUp() {

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/WebSecurityTest.java
@@ -571,7 +571,8 @@ class WebSecurityTest {
                 // absolute URLs whose host is allow-listed are accepted unchanged
                 Arguments.of(EXTERNAL_URL + "/gateway/foo?x=1#frag", EXTERNAL_URL + "/gateway/foo?x=1#frag"),
                 Arguments.of(EXTERNAL_URL, EXTERNAL_URL),
-                Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo"),
+                Arguments.of("//gateway.zowe.example", "//gateway.zowe.example"),
+                Arguments.of("HTTPS://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo", "https://GATEWAY.ZOWE.EXAMPLE:10010/gateway/foo"),
                 Arguments.of("http://gateway.zowe.example:10010/x", "http://gateway.zowe.example:10010/x"),
                 Arguments.of("https://www.ibm.com/docs", "https://www.ibm.com/docs"),
                 Arguments.of("/gateway/foo%2Bmore?bar=%2f1#frag", "/gateway/foo+more?bar=/1#frag"),
@@ -590,13 +591,11 @@ class WebSecurityTest {
                 "https://attacker.example/x",
                 "https://user@attacker.example:10010/x",
                 "mailto:foo@bar.com",
-                "//gateway.zowe.example",
                 "http://exa mple.com",
                 "%2f%2fatacker/unknow",
                 "https://user:password@attacker.example:10010/x",
                 "//user:password@attacker.example:10010/x",
                 "https://",
-                "//gateway.zowe.example",
                 "//:80/",
                 "relative//invalid"
             );


### PR DESCRIPTION
# Description

Sanitize OIDC returnUrl to prevent open redirect after OIDC login via unvalidated returnUrl

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
