### PR TITLE
feat: define local address binding for outbound connections

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2980,5 +2980,6 @@ jobs:
                         build/reports/problems/problems-report.html
                         results/**
                         apiml/build/reports/tests/**
+                        apiml-security-common/build/reports/tests/**
 
             -   uses: ./.github/actions/teardown

--- a/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
+++ b/apiml-common/src/main/java/org/zowe/apiml/product/web/HttpConfig.java
@@ -53,6 +53,9 @@ public class HttpConfig implements InitializingBean {
 
     private static final char[] KEYRING_PASSWORD = "password".toCharArray();
 
+    @Value("${server.address:0.0.0.0}")
+    private String address;
+
     @Value("${apiml.service.ssl.protocol:${server.ssl.protocol:TLSv1.2}}")
     private String protocol;
 
@@ -179,12 +182,12 @@ public class HttpConfig implements InitializingBean {
 
             log.debug("Using HTTPS configuration: {}", httpsConfig.toString());
 
-            httpsFactory = new HttpsFactory(httpsConfig);
+            httpsFactory = new HttpsFactory(httpsConfig, address);
             ApimlPoolingHttpClientConnectionManager secureConnectionManager = getConnectionManager(httpsFactory);
             secureHttpClient = httpsFactory.buildHttpClient(secureConnectionManager);
             secureSslContext = httpsFactory.getSslContext();
             secureHostnameVerifier = httpsFactory.getHostnameVerifier();
-            HttpsFactory factoryWithoutKeystore = new HttpsFactory(httpsConfigWithoutKeystore);
+            HttpsFactory factoryWithoutKeystore = new HttpsFactory(httpsConfigWithoutKeystore, address);
             ApimlPoolingHttpClientConnectionManager connectionManagerWithoutKeystore = getConnectionManager(factoryWithoutKeystore);
             secureHttpClientWithoutKeystore = factoryWithoutKeystore.buildHttpClient(connectionManagerWithoutKeystore);
             secureSslContextWithoutKeystore = factoryWithoutKeystore.getSslContext();

--- a/apiml-security-common/build.gradle
+++ b/apiml-security-common/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testCompileOnly libs.lombok
     testImplementation libs.netty.reactor.http
     testImplementation libs.reactor.test
+    testImplementation libs.spring.cloud.gateway.server
     testAnnotationProcessor libs.lombok
 
     testFixturesImplementation libs.nimbus.jose.jwt

--- a/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
+++ b/apiml-security-common/src/main/java/org/zowe/apiml/security/common/config/WebClientConfig.java
@@ -10,8 +10,10 @@
 
 package org.zowe.apiml.security.common.config;
 
-import java.util.List;
-
+import io.netty.handler.ssl.SslContext;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,12 +32,10 @@ import org.zowe.apiml.message.yaml.YamlMessageServiceInstance;
 import org.zowe.apiml.product.web.HttpConfig;
 import org.zowe.apiml.security.HttpsConfigError;
 import org.zowe.apiml.security.common.util.ConnectionUtil;
-
-import io.netty.handler.ssl.SslContext;
-import io.netty.resolver.DefaultAddressResolverGroup;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.netty.http.client.HttpClient;
+
+import java.net.InetSocketAddress;
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -49,6 +49,9 @@ public class WebClientConfig {
 
     @Value("${server.attlsClient.enabled:false}")
     private boolean isClientAttlsEnabled;
+
+    @Value("${server.address:0.0.0.0}")
+    private String listenAddress;
 
     @Bean
     HttpClientFactory gatewayHttpClientFactory(
@@ -68,6 +71,7 @@ public class WebClientConfig {
             @Override
             protected HttpClient createInstance() {
                 return super.createInstance()
+                    .bindAddress(() -> new InetSocketAddress(listenAddress, 0))
                     .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
                     .resolver(DefaultAddressResolverGroup.INSTANCE);
             }

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/config/WebClientConfigTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/config/WebClientConfigTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.zowe.apiml.product.web.HttpConfig;
 import org.zowe.apiml.security.common.util.ConnectionUtil;
 import reactor.core.publisher.Mono;
+import reactor.netty.ChannelBindException;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
@@ -39,8 +40,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -132,7 +133,8 @@ class WebClientConfigTest {
 
             var connectionAttempt = assertThrows(Exception.class, () -> connect(httpClient).block(Duration.ofSeconds(5)));
 
-            assertInstanceOf(BindException.class, ExceptionUtils.getRootCause(connectionAttempt));
+            var rootCause = ExceptionUtils.getRootCause(connectionAttempt);
+            assertTrue(rootCause instanceof BindException || rootCause instanceof ChannelBindException);
         }
     }
 

--- a/apiml-security-common/src/test/java/org/zowe/apiml/security/common/config/WebClientConfigTest.java
+++ b/apiml-security-common/src/test/java/org/zowe/apiml/security/common/config/WebClientConfigTest.java
@@ -1,0 +1,156 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.apiml.security.common.config;
+
+import com.sun.net.httpserver.HttpServer;
+import io.netty.handler.ssl.SslContext;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.gateway.config.HttpClientProperties;
+import org.springframework.cloud.gateway.config.HttpClientSslConfigurer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.zowe.apiml.product.web.HttpConfig;
+import org.zowe.apiml.security.common.util.ConnectionUtil;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientResponse;
+
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebClientConfigTest {
+
+    private static final String OWNED_ADDRESS = "127.0.0.1";
+    private static final String NOT_OWNED_ADDRESS = "192.0.2.1";
+
+    @Mock
+    private NetworkInterface interface0;
+    @Mock
+    private NetworkInterface interface1;
+    @Mock
+    private InterfaceAddress interfaceAddress0;
+    @Mock
+    private InterfaceAddress interfaceAddress1;
+
+    @Mock
+    private HttpConfig httpConfig;
+    @Mock
+    private HttpClientSslConfigurer sslConfigurer;
+
+    private WebClientConfig webClientConfig;
+    private HttpServer localServer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lenient().when(interface0.getInterfaceAddresses()).thenReturn(List.of(interfaceAddress0));
+        lenient().when(interface1.getInterfaceAddresses()).thenReturn(List.of(interfaceAddress1));
+        lenient().when(interfaceAddress0.getAddress()).thenReturn(InetAddress.getByName(NOT_OWNED_ADDRESS));
+        lenient().when(interfaceAddress1.getAddress()).thenReturn(InetAddress.getByName(OWNED_ADDRESS));
+
+        webClientConfig = new WebClientConfig(httpConfig);
+        when(sslConfigurer.configureSsl(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        localServer = HttpServer.create(new InetSocketAddress(OWNED_ADDRESS, 0), 0);
+        localServer.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        localServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        localServer.stop(0);
+    }
+
+    @Test
+    void givenSpecificAddress_whenHttpClientConnects_thenItBindsToTheMatchingInterfaceAndConnects() throws Exception {
+        try (
+            var mockedNetworkInterface = mockStatic(NetworkInterface.class);
+            var mockedConnectionUtil = mockStatic(ConnectionUtil.class)
+        ) {
+            mockedNetworkInterface.when(NetworkInterface::getNetworkInterfaces)
+                .thenReturn(Collections.enumeration(List.of(interface0, interface1)));
+            mockedConnectionUtil.when(() -> ConnectionUtil.getSslContext(httpConfig, false))
+                .thenReturn(mock(SslContext.class));
+
+            var selectedAddress = OWNED_ADDRESS;
+            ReflectionTestUtils.setField(webClientConfig, "listenAddress", selectedAddress);
+
+            var httpClient = buildClientWithFactory();
+            var response = connect(httpClient).block(Duration.ofSeconds(5));
+
+            assertEquals(200, response.status().code());
+        }
+    }
+
+    @Test
+    void givenAddressNotOwnedByThisHost_whenHttpClientConnects_thenBindFails() throws Exception {
+        try (
+            var mockedNetworkInterface = mockStatic(NetworkInterface.class);
+            var mockedConnectionUtil = mockStatic(ConnectionUtil.class)
+        ) {
+            mockedNetworkInterface.when(NetworkInterface::getNetworkInterfaces)
+                .thenReturn(Collections.enumeration(List.of(interface0, interface1)));
+            mockedConnectionUtil.when(() -> ConnectionUtil.getSslContext(httpConfig, false))
+                .thenReturn(mock(SslContext.class));
+
+            var otherAddress = NOT_OWNED_ADDRESS;
+            ReflectionTestUtils.setField(webClientConfig, "listenAddress", otherAddress);
+
+            var httpClient = buildClientWithFactory();
+
+            var connectionAttempt = assertThrows(Exception.class, () -> connect(httpClient).block(Duration.ofSeconds(5)));
+
+            assertInstanceOf(BindException.class, ExceptionUtils.getRootCause(connectionAttempt));
+        }
+    }
+
+    private Mono<HttpClientResponse> connect(HttpClient httpClient) {
+        return httpClient.get()
+            .uri("http://" + OWNED_ADDRESS + ":" + localServer.getAddress().getPort() + "/")
+            .response();
+    }
+
+    private HttpClient buildClientWithFactory() throws Exception {
+        var properties = new HttpClientProperties();
+        properties.getPool().setType(HttpClientProperties.Pool.PoolType.DISABLED);
+
+        var factory = webClientConfig.gatewayHttpClientFactory(
+            properties, new ServerProperties(), Collections.emptyList(), sslConfigurer
+        );
+        factory.afterPropertiesSet();
+        return (HttpClient) factory.getObject();
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,7 @@ configure(subprojects.findAll {it.name != 'platform'}) {
     }
 
     test {
+        maxHeapSize = '2g'
         useJUnitPlatform()
         jvmArgs '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,6 @@ configure(subprojects.findAll {it.name != 'platform'}) {
     test {
         maxHeapSize = '2g'
         useJUnitPlatform()
-        maxHeapSize = '2g'
         jvmArgs '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/java.io=ALL-UNNAMED'

--- a/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/security/HttpsFactory.java
@@ -15,14 +15,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.UserTokenHandler;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
 import org.apache.hc.client5.http.impl.LaxRedirectStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.HttpsSupport;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.PrivateKeyStrategy;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.Timeout;
@@ -36,7 +40,9 @@ import javax.net.ssl.TrustManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -50,14 +56,16 @@ import java.util.Collection;
 @Data
 public class HttpsFactory {
 
+    private String address;
     private HttpsConfig config;
     private SSLContext secureSslContext;
     private KeyStore usedKeyStore = null;
     private ApimlLogger apimlLog;
     private Collection<TrustManager> trustManagers;
 
-    public HttpsFactory(HttpsConfig httpsConfig) {
+    public HttpsFactory(HttpsConfig httpsConfig, String address) {
         this.config = httpsConfig;
+        this.address = address;
         this.apimlLog = ApimlLogger.of(HttpsFactory.class, YamlMessageServiceInstance.getInstance());
     }
 
@@ -75,6 +83,17 @@ public class HttpsFactory {
             .evictIdleConnections(Timeout.ofSeconds(config.getIdleConnTimeoutSeconds()))
             .disableAuthCaching()
             .setRedirectStrategy(new LaxRedirectStrategy())
+            .setRoutePlanner(new DefaultRoutePlanner(DefaultSchemePortResolver.INSTANCE) {
+                @Override
+                protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context) {
+                    try {
+                        return InetAddress.getByName(address);
+                    } catch (UnknownHostException e) {
+                        log.warn("Failed to resolve local address {}, using default", address, e);
+                        return null;
+                    }
+                }
+        })
             .build();
     }
 

--- a/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
@@ -10,20 +10,46 @@
 
 package org.zowe.apiml.security;
 
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
 import java.security.KeyStoreException;
+import java.util.Collections;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
 
+@ExtendWith(MockitoExtension.class)
 class HttpsFactoryTest {
+
     private static final String INCORRECT_PARAMETER_VALUE = "WRONG";
 
     private HttpsConfig.HttpsConfigBuilder httpsConfigBuilder;
@@ -121,4 +147,95 @@ class HttpsFactoryTest {
         HostnameVerifier hostnameVerifier = httpsFactory.getHostnameVerifier();
         assertEquals(NoopHostnameVerifier.class, hostnameVerifier.getClass());
     }
+
+    @Nested
+    class OverrideLocalAddress {
+
+        private static final String OWNED_ADDRESS = "127.0.0.1";
+        private static final String NOT_OWNED_ADDRESS = "192.0.2.1";
+
+        @Mock
+        private NetworkInterface interface0;
+        @Mock
+        private NetworkInterface interface1;
+        @Mock
+        private InterfaceAddress interfaceAddress0;
+        @Mock
+        private InterfaceAddress interfaceAddress1;
+
+        private HttpServer localServer;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            lenient().when(interface0.getInterfaceAddresses()).thenReturn(List.of(interfaceAddress0));
+            lenient().when(interface1.getInterfaceAddresses()).thenReturn(List.of(interfaceAddress1));
+            lenient().when(interfaceAddress0.getAddress()).thenReturn(InetAddress.getByName(NOT_OWNED_ADDRESS));
+            lenient().when(interfaceAddress1.getAddress()).thenReturn(InetAddress.getByName(OWNED_ADDRESS));
+
+            localServer = HttpServer.create(new InetSocketAddress(OWNED_ADDRESS, 0), 0);
+            localServer.createContext("/", exchange -> {
+                exchange.sendResponseHeaders(200, -1);
+                exchange.close();
+            });
+            localServer.start();
+        }
+
+        @AfterEach
+        void tearDown() {
+            localServer.stop(0);
+        }
+
+        @Test
+        void givenSpecificAddress_whenHttpClientConnects_thenItBindsToTheMatchingInterfaceAndConnects() {
+            try (
+                var mockedNetworkInterface = mockStatic(NetworkInterface.class);
+            ) {
+                mockedNetworkInterface.when(NetworkInterface::getNetworkInterfaces)
+                    .thenReturn(Collections.enumeration(List.of(interface0, interface1)));
+
+                var httpClient = buildHttpClient(OWNED_ADDRESS);
+                var status = connect(httpClient);
+                assertEquals(200, status);
+            }
+        }
+
+        private int connect(CloseableHttpClient httpClient) {
+            var get = new HttpGet("http://" + OWNED_ADDRESS + ":" + localServer.getAddress().getPort() + "/");
+            try {
+                return httpClient.execute(get, r -> {
+                    return r.getCode();
+                });
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        void givenAddressNotOwnedByThisHost_whenHttpClientConnects_thenBindFails() {
+            try (
+                var mockedNetworkInterface = mockStatic(NetworkInterface.class);
+            ) {
+                mockedNetworkInterface.when(NetworkInterface::getNetworkInterfaces)
+                    .thenReturn(Collections.enumeration(List.of(interface0, interface1)));
+
+                var httpClient = buildHttpClient(NOT_OWNED_ADDRESS);
+
+                var connectionAttempt = assertThrows(Exception.class, () -> connect(httpClient));
+
+                assertInstanceOf(BindException.class, ExceptionUtils.getRootCause(connectionAttempt));
+            }
+        }
+
+        private CloseableHttpClient buildHttpClient(String selectedAddress) {
+            var httpsConfig = httpsConfigBuilder.build();
+            var httpsFactory = new HttpsFactory(httpsConfig, selectedAddress);
+
+            var httpClient = httpsFactory.buildHttpClient(null);
+            assertEquals("org.apache.hc.client5.http.impl.classic.InternalHttpClient", httpClient.getClass().getName());
+
+            return httpClient;
+        }
+
+    }
+
 }

--- a/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/security/HttpsFactoryTest.java
@@ -36,7 +36,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateSecureSslSocketFactory() {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         ConnectionSocketFactory socketFactory = httpsFactory.createSslSocketFactory();
         assertEquals(SSLConnectionSocketFactory.class, socketFactory.getClass());
     }
@@ -44,7 +44,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateIgnoringSslSocketFactory() throws KeyStoreException {
         HttpsConfig httpsConfig = httpsConfigBuilder.verifySslCertificatesOfServices(false).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         ConnectionSocketFactory socketFactory = httpsFactory.createSslSocketFactory();
         assertEquals(SSLConnectionSocketFactory.class, socketFactory.getClass());
         assertFalse(httpsFactory.getUsedKeyStore().aliases().hasMoreElements());
@@ -53,7 +53,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateSecureSslContextWithEmptyKeystoreWhenNoKeystoreIsProvided() throws KeyStoreException {
         HttpsConfig httpsConfig = HttpsConfig.builder().protocol("TLSv1.2").verifySslCertificatesOfServices(true).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         httpsFactory.getSslContext();
         assertFalse(httpsFactory.getUsedKeyStore().aliases().hasMoreElements());
     }
@@ -61,7 +61,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateSecureHttpClient() {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
 
         var httpClient = httpsFactory.buildHttpClient(null);
         assertEquals("org.apache.hc.client5.http.impl.classic.InternalHttpClient", httpClient.getClass().getName());
@@ -70,7 +70,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateSecureSslContext() {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         SSLContext sslContext = httpsFactory.getSslContext();
         assertNotNull(sslContext);
         assertEquals(SSLContext.class, sslContext.getClass());
@@ -79,7 +79,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateIgnoringSslContext() {
         HttpsConfig httpsConfig = httpsConfigBuilder.verifySslCertificatesOfServices(false).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         SSLContext sslContext = httpsFactory.getSslContext();
         assertNotNull(sslContext);
         assertEquals(SSLContext.class, sslContext.getClass());
@@ -88,28 +88,28 @@ class HttpsFactoryTest {
     @Test
     void wrongKeyPasswordConfigurationShouldFail() {
         HttpsConfig httpsConfig = httpsConfigBuilder.keyPassword(INCORRECT_PARAMETER_VALUE.toCharArray()).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         assertThrows(HttpsConfigError.class, () -> httpsFactory.getSslContext());
     }
 
     @Test
     void specificIncorrectAliasShouldFail() {
         HttpsConfig httpsConfig = httpsConfigBuilder.trustStorePassword(INCORRECT_PARAMETER_VALUE.toCharArray()).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         assertThrows(HttpsConfigError.class, () -> httpsFactory.getSslContext());
     }
 
     @Test
     void incorrectProtocolShouldFail() {
         HttpsConfig httpsConfig = httpsConfigBuilder.verifySslCertificatesOfServices(false).protocol(INCORRECT_PARAMETER_VALUE).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         assertThrows(HttpsConfigError.class, () -> httpsFactory.getSslContext());
     }
 
     @Test
     void shouldCreateDefaultHostnameVerifier() {
         HttpsConfig httpsConfig = httpsConfigBuilder.build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         HostnameVerifier hostnameVerifier = httpsFactory.getHostnameVerifier();
         assertEquals(DefaultHostnameVerifier.class, hostnameVerifier.getClass());
     }
@@ -117,7 +117,7 @@ class HttpsFactoryTest {
     @Test
     void shouldCreateNoopHostnameVerifier() {
         HttpsConfig httpsConfig = httpsConfigBuilder.verifySslCertificatesOfServices(false).build();
-        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig);
+        HttpsFactory httpsFactory = new HttpsFactory(httpsConfig, "0.0.0.0");
         HostnameVerifier hostnameVerifier = httpsFactory.getHostnameVerifier();
         assertEquals(NoopHostnameVerifier.class, hostnameVerifier.getClass());
     }

--- a/common-service-core/src/test/java/org/zowe/apiml/tomcat/TomcatHttpsTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/tomcat/TomcatHttpsTest.java
@@ -123,7 +123,7 @@ class TomcatHttpsTest {
     private void startTomcatAndDoHttpsRequest(HttpsConfig serverConfig, HttpsConfig clientConfig) throws IOException, LifecycleException {
         Tomcat tomcat = new TomcatServerFactory().startTomcat(serverConfig);
         try {
-            HttpsFactory clientHttpsFactory = new HttpsFactory(clientConfig);
+            HttpsFactory clientHttpsFactory = new HttpsFactory(clientConfig, "0.0.0.0");
             RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder = RegistryBuilder
                 .<ConnectionSocketFactory>create().register("http", PlainConnectionSocketFactory.getSocketFactory());
             socketFactoryRegistryBuilder.register("https", clientHttpsFactory.createSslSocketFactory());

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/eureka/RefreshablePeerEurekaNodes.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/eureka/RefreshablePeerEurekaNodes.java
@@ -29,6 +29,7 @@ import com.netflix.eureka.transport.Jersey3ReplicationClient;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.params.ClientPNames;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
@@ -66,6 +67,9 @@ public class RefreshablePeerEurekaNodes extends PeerEurekaNodes
 
     @Value("${apiml.security.ssl.nonStrictVerifySslCertificatesOfServices:false}")
     private boolean nonStrictVerifySslCertificatesOfServices;
+
+    @Value("${server.address:0.0.0.0}")
+    private String address;
 
     private Collection<ClientRequestFilter> replicationClientAdditionalFilters;
     private SSLContext secureSslContext;
@@ -160,7 +164,6 @@ public class RefreshablePeerEurekaNodes extends PeerEurekaNodes
         } catch (UnknownHostException e) {
             log.warn("Cannot find localhost ip", e);
         }
-
         Client jerseyApacheClient = jerseyClient.getClient();
         jerseyApacheClient.register(new Jersey3DynamicGZIPContentEncodingFilter(config));
 
@@ -258,11 +261,22 @@ public class RefreshablePeerEurekaNodes extends PeerEurekaNodes
                 String fullUserAgentName = USER_AGENT + "/v" + buildVersion();
                 property(CoreProtocolPNames.USER_AGENT, fullUserAgentName);
 
+                try {
+                    property(ApacheClientProperties.REQUEST_CONFIG, RequestConfig.custom()
+                        .setLocalAddress(InetAddress.getByName(address))
+                        .build());
+                } catch (UnknownHostException e) {
+                    log.warn("Failed to resolve host {}. Using default 0.0.0.0", address, e);
+                }
+
                 // To pin a client to specific server in case redirect happens, we handle redirects directly
                 // (see DiscoveryClient.makeRemoteCall methods).
                 property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE);
                 property(ClientPNames.HANDLE_REDIRECTS, Boolean.FALSE);
             }
+
         }
+
     }
+
 }

--- a/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
+++ b/onboarding-enabler-java/src/main/java/org/zowe/apiml/eurekaservice/client/impl/ApiMediationClientImpl.java
@@ -155,7 +155,7 @@ public class ApiMediationClientImpl implements ApiMediationClient {
         }
         HttpsConfig httpsConfig = builder.build();
 
-        HttpsFactory factory = new HttpsFactory(httpsConfig);
+        HttpsFactory factory = new HttpsFactory(httpsConfig, "0.0.0.0");
 
         AbstractDiscoveryClientOptionalArgs<?> args = new Jersey3DiscoveryClientOptionalArgs();
         args.setSSLContext(factory.getSslContext());


### PR DESCRIPTION
# Description

When running on z/OS API ML allows overriding the bound IP address where the server listens to (by default 0.0.0.0)
This setting however was not applied to outbound connections. In some cases due to incorrect network configuration it can lead to assign to an unintended LINK.

This PR uses the same `listenAddress` setting to apply to outbound connections in Http Clients.

## Type of change

- [ ] feat: New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

