### PR TITLE
fix:  remove unverified LTPA token extraction paths

### DIFF
--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/ComponentsConfiguration.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/config/ComponentsConfiguration.java
@@ -21,7 +21,6 @@ import org.zowe.apiml.security.common.handler.SuccessfulAccessTokenHandler;
 import org.zowe.apiml.zaas.security.login.Providers;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
 import org.zowe.apiml.zaas.security.mapping.X509CommonNameUserMapper;
-import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 import org.zowe.apiml.zaas.security.service.schema.source.X509AuthSourceService;
 import org.zowe.apiml.zaas.security.service.schema.source.X509CNAuthSourceService;
@@ -76,8 +75,8 @@ public class ComponentsConfiguration {
      * This bean performs the mapping between common name from the client certificate and the mainframe user ID.
      */
     @Bean("x509MFAuthSourceService")
-    X509AuthSourceService getX509MFAuthSourceService(@Qualifier("x509Mapper") AuthenticationMapper mapper, TokenCreationService tokenCreationService, AuthenticationService authenticationService) {
-        return new X509AuthSourceService(mapper, tokenCreationService, authenticationService);
+    X509AuthSourceService getX509MFAuthSourceService(@Qualifier("x509Mapper") AuthenticationMapper mapper, TokenCreationService tokenCreationService) {
+        return new X509AuthSourceService(mapper, tokenCreationService);
     }
 
     /**
@@ -86,8 +85,8 @@ public class ComponentsConfiguration {
      * It treats client name from certificate as user ID and uses X509CommonNameUserMapper for validation.
      */
     @Bean("x509CNAuthSourceService")
-    X509AuthSourceService getX509CNAuthSourceService(TokenCreationService tokenCreationService, AuthenticationService authenticationService) {
-        return new X509CNAuthSourceService(new X509CommonNameUserMapper(), tokenCreationService, authenticationService);
+    X509AuthSourceService getX509CNAuthSourceService(TokenCreationService tokenCreationService) {
+        return new X509CNAuthSourceService(new X509CommonNameUserMapper(), tokenCreationService);
     }
 
     @Bean

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
@@ -222,7 +222,7 @@ public class AuthenticationService {
         try {
             switch (queryResponse.getSource()) {
                 case ZOWE:
-                    final String ltpaToken = getLtpaToken(jwtToken);
+                    final String ltpaToken = getLtpaTokenWithValidation(jwtToken);
                     if (ltpaToken != null) zosmfService.invalidate(LTPA, ltpaToken);
                     break;
                 case ZOSMF:
@@ -482,33 +482,15 @@ public class AuthenticationService {
 
     /**
      * This method validates if JWT token is valid and if yes, then get claim from LTPA token.
-     * For purpose, when is not needed validation, you can use method {@link #getLtpaToken(String)}
      *
      * @param jwtToken the JWT token
      * @return LTPA token extracted from JWT
      */
-    public String getLtpaTokenWithValidation(String jwtToken) {
+    public String getLtpaToken(String jwtToken) {
         try {
             var tokenAuthentication = new TokenAuthentication(jwtToken);
             validateLocalJwtToken(tokenAuthentication);
             return tokenAuthentication.getClaimAsString(LTPA_CLAIM_NAME);
-        } catch (ParseException e) {
-            throw new TokenNotValidException(e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Get the LTPA token from the JWT token
-     *
-     * @param jwtToken the JWT token
-     * @return the LTPA token
-     * @throws TokenNotValidException if the JWT token is not valid
-     */
-    public String getLtpaToken(String jwtToken) {
-        var claims = getJwtClaims(jwtToken);
-
-        try {
-            return claims.getClaimAsString(LTPA_CLAIM_NAME);
         } catch (ParseException e) {
             throw new TokenNotValidException(e.getMessage(), e);
         }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/AuthenticationService.java
@@ -222,7 +222,7 @@ public class AuthenticationService {
         try {
             switch (queryResponse.getSource()) {
                 case ZOWE:
-                    final String ltpaToken = getLtpaTokenWithValidation(jwtToken);
+                    final String ltpaToken = getLtpaToken(jwtToken);
                     if (ltpaToken != null) zosmfService.invalidate(LTPA, ltpaToken);
                     break;
                 case ZOSMF:

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/AuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/AuthSourceService.java
@@ -38,12 +38,5 @@ public interface AuthSourceService {
      */
     AuthSource.Parsed parse(AuthSource authSource);
 
-    /**
-     * Generates LTPA token from current source of authentication.
-     * @param authSource AuthSource object which hold original source of authentication (JWT token, client certificate etc.)
-     * @return LTPA token
-     */
-    String getLtpaToken(AuthSource authSource);
-
     String getJWT(AuthSource authSource);
 }

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/DefaultAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/DefaultAuthSourceService.java
@@ -137,18 +137,6 @@ public class DefaultAuthSourceService implements AuthSourceService {
     }
 
     /**
-     * Delegates the generation of the LTPA token based on the authentication source to a corresponding service.
-     *
-     * @param authSource {@link AuthSource} object which hold original source of authentication (JWT token, client certificate etc.)
-     * @return LPTA token
-     */
-    @Override
-    public String getLtpaToken(AuthSource authSource) {
-        AuthSourceService service = getService(authSource);
-        return service != null ? service.getLtpaToken(authSource) : null;
-    }
-
-    /**
      * Choose a service to process authentication source from the map of available services.
      *
      * @param authSource {@link AuthSource} object which hold original source of authentication (JWT token, client certificate etc.)

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/JwtAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/JwtAuthSourceService.java
@@ -94,20 +94,6 @@ public class JwtAuthSourceService extends TokenAuthSourceService {
         return null;
     }
 
-    /**
-     * Generates LTPA token from current source of authentication (JWT token) using method of {@link AuthenticationService}
-     *
-     * @param authSource {@link AuthSource} object which hold original source of authentication (JWT token)
-     * @return LTPA token
-     */
-    public String getLtpaToken(AuthSource authSource) {
-        if (authSource instanceof JwtAuthSource) {
-            String jwtToken = ((JwtAuthSource) authSource).getRawSource();
-            return jwtToken == null ? null : authenticationService.getLtpaTokenWithValidation(jwtToken);
-        }
-        return null;
-    }
-
     @Override
     public String getJWT(AuthSource authSource) {
         return ((JwtAuthSource) authSource).getRawSource();

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceService.java
@@ -167,17 +167,6 @@ public class OIDCAuthSourceService extends TokenAuthSourceService implements Ini
         return new ParsedTokenAuthSource(mappedUser, response.getCreation(), response.getExpiration(), origin);
     }
 
-    //this method should be removed from the unrelated auth sources
-    @Override
-    public String getLtpaToken(AuthSource authSource) {
-        String zosmfToken = getJWT(authSource);
-        AuthSource.Origin origin = authenticationService.getTokenOrigin(zosmfToken);
-        if (AuthSource.Origin.ZOWE.equals(origin)) {
-            zosmfToken = authenticationService.getLtpaToken(zosmfToken);
-        }
-        return zosmfToken;
-    }
-
     @Override
     public String getJWT(AuthSource authSource) {
         AuthSource.Parsed parsed = parse(authSource);

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/PATAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/PATAuthSourceService.java
@@ -111,16 +111,6 @@ public class PATAuthSourceService extends TokenAuthSourceService {
     }
 
     @Override
-    public String getLtpaToken(AuthSource authSource) {
-        String zosmfToken = getJWT(authSource);
-        AuthSource.Origin origin = authenticationService.getTokenOrigin(zosmfToken);
-        if (AuthSource.Origin.ZOWE.equals(origin)) {
-            zosmfToken = authenticationService.getLtpaToken(zosmfToken);
-        }
-        return zosmfToken;
-    }
-
-    @Override
     public String getJWT(AuthSource authSource) {
         ParsedTokenAuthSource parsed = (ParsedTokenAuthSource) parse(authSource);
         return tokenService.createJwtTokenWithoutCredentials(parsed.getUserId());

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/X509AuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/X509AuthSourceService.java
@@ -13,7 +13,6 @@ package org.zowe.apiml.zaas.security.service.schema.source;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
-import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 import org.zowe.apiml.zaas.security.service.schema.source.AuthSource.Origin;
 import org.zowe.apiml.zaas.security.service.schema.source.X509AuthSource.Parsed;
@@ -44,7 +43,6 @@ public class X509AuthSourceService implements AuthSourceService {
     @Qualifier("x509Mapper")
     private final AuthenticationMapper mapper;
     private final TokenCreationService tokenService;
-    private final AuthenticationService authenticationService;
 
     /**
      * Gets client certificate from request.
@@ -101,12 +99,6 @@ public class X509AuthSourceService implements AuthSourceService {
             return isValid(authSource) ? parseClientCert((X509AuthSource) authSource, mapper) : null;
         }
         return null;
-    }
-
-    @Override
-    public String getLtpaToken(AuthSource authSource) {
-        String jwt = getJWT(authSource);
-        return jwt != null ? authenticationService.getLtpaToken(jwt) : null;
     }
 
     // Gets client certificate from request

--- a/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/X509CNAuthSourceService.java
+++ b/zaas-service/src/main/java/org/zowe/apiml/zaas/security/service/schema/source/X509CNAuthSourceService.java
@@ -12,7 +12,6 @@ package org.zowe.apiml.zaas.security.service.schema.source;
 
 import lombok.extern.slf4j.Slf4j;
 import org.zowe.apiml.zaas.security.mapping.X509CommonNameUserMapper;
-import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 import org.zowe.apiml.message.core.MessageType;
 
@@ -30,8 +29,8 @@ import static org.zowe.apiml.security.common.filter.CategorizeCertsFilter.ATTR_N
  */
 @Slf4j
 public class X509CNAuthSourceService extends X509AuthSourceService {
-    public X509CNAuthSourceService(X509CommonNameUserMapper mapper, TokenCreationService tokenService, AuthenticationService authenticationService) {
-        super(mapper, tokenService, authenticationService);
+    public X509CNAuthSourceService(X509CommonNameUserMapper mapper, TokenCreationService tokenService) {
+        super(mapper, tokenService);
     }
 
     /**

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
@@ -509,8 +509,8 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
 
         @Test
         void invalidateZosmfLtpaToken() {
-
             stubJWTSecurityForSign();
+            when(jwtSecurityInitializer.getJwtVerifier()).thenReturn(new RSASSAVerifier((RSAPublicKey) publicKey));
             String token = authService.createJwtToken("user", DOMAIN, LTPA_TOKEN);
 
             assertTrue(authService.invalidateJwtToken(token, false));
@@ -602,6 +602,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
         @Test
         void whenTokenAlreadyInvalidated_thenUseCache() {
             stubJWTSecurityForSign();
+            when(jwtSecurityInitializer.getJwtVerifier()).thenReturn(new RSASSAVerifier((RSAPublicKey) publicKey));
 
             String jwtToken01 = authService.createJwtToken("user01", "domain01", "ltpa01");
             when(invalidatedJwtTokensCache.get(jwtToken01)).thenReturn(null);
@@ -674,9 +675,9 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
 
             authService.invalidateJwtToken(jwtToken01, false);
             assertTrue(authService.validateJwtToken(jwtToken02).isAuthenticated());
-            verify(jwtSecurityInitializer, times(2)).getJwtVerifier();
+            verify(jwtSecurityInitializer, times(3)).getJwtVerifier();
             assertThrows(TokenNotValidException.class, () -> authService.validateJwtToken(jwtToken01));
-            verify(jwtSecurityInitializer, times(2)).getJwtVerifier();
+            verify(jwtSecurityInitializer, times(3)).getJwtVerifier();
         }
     }
 

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/AuthenticationServiceTest.java
@@ -386,7 +386,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             stubJWTSecurityForSign();
             when(jwtSecurityInitializer.getJwtVerifier()).thenReturn(new RSASSAVerifier((RSAPublicKey) publicKey));
             String jwtToken = authService.createJwtToken(USER, DOMAIN, LTPA);
-            assertEquals(LTPA, authService.getLtpaTokenWithValidation(jwtToken));
+            assertEquals(LTPA, authService.getLtpaToken(jwtToken));
         }
 
         @Test
@@ -396,7 +396,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             String brokenToken = jwtToken + "not";
             assertThrows(
                 TokenNotValidException.class,
-                () -> authService.getLtpaTokenWithValidation(brokenToken)
+                () -> authService.getLtpaToken(brokenToken)
             );
         }
 
@@ -406,7 +406,7 @@ public class AuthenticationServiceTest { //NOSONAR, needs to be public
             when(jwtSecurityInitializer.getJwtVerifier()).thenReturn(new RSASSAVerifier((RSAPublicKey) publicKey));
             assertThrows(
                 TokenExpireException.class,
-                () -> authService.getLtpaTokenWithValidation(expiredJwtToken)
+                () -> authService.getLtpaToken(expiredJwtToken)
             );
         }
 

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/DefaultAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/DefaultAuthSourceServiceTest.java
@@ -93,16 +93,6 @@ public class DefaultAuthSourceServiceTest {
             assertEquals(expectedParsedSource, parsedAuthSource);
         }
 
-        @Test
-        void thenLtpaTokenGenerated() {
-            when(jwtAuthSourceService.getLtpaToken(any())).thenReturn("ltpa");
-
-            Assertions.assertNotNull(serviceUnderTest.getLtpaToken(jwtAuthSource));
-            verify(jwtAuthSourceService, times(1)).getLtpaToken(jwtAuthSource);
-            verifyNoInteractions(x509MFAuthSourceService);
-            verifyNoInteractions(patAuthSourceService);
-            verifyNoInteractions(oidcAuthSourceService);
-        }
     }
 
     @Nested
@@ -237,18 +227,6 @@ public class DefaultAuthSourceServiceTest {
             assertEquals(expectedParsedSource, parsedAuthSource);
         }
 
-        @Test
-        void thenLtpaTokenGenerated() {
-            when(patAuthSourceService.getLtpaToken(any())).thenReturn("ltpa");
-
-            assertNotNull(serviceUnderTest.getLtpaToken(patAuthSource));
-
-            verify(patAuthSourceService, times(1)).getLtpaToken(patAuthSource);
-            verifyNoInteractions(jwtAuthSourceService);
-            verifyNoInteractions(oidcAuthSourceService);
-            verifyNoInteractions(x509MFAuthSourceService);
-        }
-
         @Nested
         class WhenPATIsDisabled {
 
@@ -309,18 +287,6 @@ public class DefaultAuthSourceServiceTest {
             verifyNoInteractions(patAuthSourceService);
             verifyNoInteractions(x509MFAuthSourceService);
             assertEquals(expectedParsedSource, parsedAuthSource);
-        }
-
-        @Test
-        void thenLtpaTokenGenerated() {
-            when(oidcAuthSourceService.getLtpaToken(any())).thenReturn("ltpa");
-
-            assertNotNull(serviceUnderTest.getLtpaToken(oidcAuthSource));
-
-            verify(oidcAuthSourceService, times(1)).getLtpaToken(oidcAuthSource);
-            verifyNoInteractions(jwtAuthSourceService);
-            verifyNoInteractions(patAuthSourceService);
-            verifyNoInteractions(x509MFAuthSourceService);
         }
 
         @Nested

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/JwtAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/JwtAuthSourceServiceTest.java
@@ -131,11 +131,6 @@ class JwtAuthSourceServiceTest {
                 verifyNoInteractions(authenticationService);
             }
 
-            @Test
-            void thenNullLtpa() {
-                Assertions.assertNull(serviceUnderTest.getLtpaToken(null));
-                verifyNoInteractions(authenticationService);
-            }
         }
 
         @Nested
@@ -154,11 +149,6 @@ class JwtAuthSourceServiceTest {
                 verifyNoInteractions(authenticationService);
             }
 
-            @Test
-            void givenNullTokenInAuthSource_thenNullLtpa() {
-                Assertions.assertNull(serviceUnderTest.getLtpaToken(authSourceNullToken));
-                verifyNoInteractions(authenticationService);
-            }
         }
     }
 
@@ -178,11 +168,6 @@ class JwtAuthSourceServiceTest {
             verifyNoInteractions(authenticationService);
         }
 
-        @Test
-        void whenGetLtpa_thenNull() {
-            Assertions.assertNull(serviceUnderTest.getLtpaToken(dummyAuthSource));
-            verifyNoInteractions(authenticationService);
-        }
     }
 
     @Nested
@@ -208,14 +193,6 @@ class JwtAuthSourceServiceTest {
             Assertions.assertEquals(expectedParsedSource, parsedSource);
         }
 
-        @Test
-        void thenLtpaGenerated() {
-            String ltpa = "ltpaToken";
-            when(authenticationService.getLtpaTokenWithValidation(anyString())).thenReturn(ltpa);
-
-            Assertions.assertEquals(ltpa, serviceUnderTest.getLtpaToken(jwtAuthSource));
-            verify(authenticationService, times(1)).getLtpaTokenWithValidation(token);
-        }
     }
 
     @Nested
@@ -236,14 +213,6 @@ class JwtAuthSourceServiceTest {
 
             assertThrows(TokenNotValidException.class, () -> serviceUnderTest.parse(jwtAuthSource));
             verify(authenticationService, times(1)).parseJwtToken(token);
-        }
-
-        @Test
-        void whenGetLtpa_thenThrow() {
-            when(authenticationService.getLtpaTokenWithValidation(anyString())).thenThrow(exception);
-
-            assertThrows(TokenNotValidException.class, () -> serviceUnderTest.getLtpaToken(jwtAuthSource));
-            verify(authenticationService, times(1)).getLtpaTokenWithValidation(token);
         }
 
         @Test
@@ -274,14 +243,6 @@ class JwtAuthSourceServiceTest {
 
             assertThrows(TokenExpireException.class, () -> serviceUnderTest.parse(jwtAuthSource));
             verify(authenticationService, times(1)).parseJwtToken(token);
-        }
-
-        @Test
-        void whenGetLtpa_thenThrow() {
-            when(authenticationService.getLtpaTokenWithValidation(anyString())).thenThrow(exception);
-
-            assertThrows(TokenExpireException.class, () -> serviceUnderTest.getLtpaToken(jwtAuthSource));
-            verify(authenticationService, times(1)).getLtpaTokenWithValidation(token);
         }
 
         @Test

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/OIDCAuthSourceServiceTest.java
@@ -130,21 +130,6 @@ class OIDCAuthSourceServiceTest {
         }
 
         @Test
-        void givenValidAuthSource_thenReturnLTPAToken() {
-            OIDCAuthSource authSource = mockValidAuthSource();
-            String expectedToken = "ltpa-token";
-            when(mapper.mapToMainframeUserId(any())).thenReturn(MF_USER);
-            String zoweToken = "zowe-token";
-            when(tokenCreationService.createJwtTokenWithoutCredentials(MF_USER)).thenReturn(zoweToken);
-            when(authenticationService.getTokenOrigin(zoweToken)).thenReturn(AuthSource.Origin.ZOWE);
-            when(authenticationService.getLtpaToken(zoweToken)).thenReturn(expectedToken);
-
-            String ltpaResult = service.getLtpaToken(authSource);
-            assertEquals(expectedToken, ltpaResult);
-            assertEquals(SUB_USER, authSource.getDistributedId().get(0));
-        }
-
-        @Test
         void givenValidAuthSource_thenReturnJWT() {
             OIDCAuthSource authSource = mockValidAuthSource();
             when(mapper.mapToMainframeUserId(any())).thenReturn(MF_USER);

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/PATAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/PATAuthSourceServiceTest.java
@@ -170,19 +170,6 @@ class PATAuthSourceServiceTest {
         }
 
         @Test
-        void givenValidAuthSource_thenReturnLTPAToken() {
-            String ltpa = "ltpa";
-            PATAuthSource authSource = new PATAuthSource(TOKEN);
-            QueryResponse response = new QueryResponse(null, "user", new Date(), new Date(), "issuer", null, QueryResponse.Source.ZOWE);
-            when(authenticationService.parseJwtWithSignature(TOKEN)).thenReturn(response);
-            when(tokenCreationService.createJwtTokenWithoutCredentials(response.getUserId())).thenReturn(TOKEN);
-            when(authenticationService.getTokenOrigin(TOKEN)).thenReturn(AuthSource.Origin.ZOWE);
-            when(authenticationService.getLtpaToken(TOKEN)).thenReturn(ltpa);
-            String ltpaResult = patAuthSourceService.getLtpaToken(authSource);
-            assertEquals(ltpa, ltpaResult);
-        }
-
-        @Test
         void givenValidAuthSource_thenReturnJWT() {
             PATAuthSource authSource = new PATAuthSource(TOKEN);
             QueryResponse response = new QueryResponse(null, "user", new Date(), new Date(), "issuer", null, QueryResponse.Source.ZOWE_PAT);

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/X509AuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/X509AuthSourceServiceTest.java
@@ -16,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.web.client.ResourceAccessException;
 import org.zowe.apiml.zaas.security.mapping.AuthenticationMapper;
-import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 import org.zowe.apiml.zaas.security.service.schema.source.AuthSource.Origin;
 import org.zowe.apiml.zaas.security.service.schema.source.AuthSource.Parsed;
@@ -50,22 +49,13 @@ class X509AuthSourceServiceTest {
 
         TokenCreationService tokenCreationService;
         X509AuthSourceService service;
-        AuthenticationService authenticationService;
         AuthenticationMapper mapper;
 
         @BeforeEach
         void setup() {
-            authenticationService = mock(AuthenticationService.class);
             tokenCreationService = mock(TokenCreationService.class);
             mapper = mock(AuthenticationMapper.class);
-            service = new X509AuthSourceService(mapper, tokenCreationService, authenticationService);
-        }
-
-        @Test
-        void givenX509Source_returnNullLtpa() {
-
-            X509AuthSource source = new X509AuthSource(null);
-            assertThrows(AuthSchemeException.class, () -> service.getLtpaToken(source));
+            service = new X509AuthSourceService(mapper, tokenCreationService);
         }
 
         @Test
@@ -88,7 +78,7 @@ class X509AuthSourceServiceTest {
         @BeforeEach
         void init() {
             mapper = mock(AuthenticationMapper.class);
-            serviceUnderTest = spy(new X509AuthSourceService(mapper, null, null));
+            serviceUnderTest = spy(new X509AuthSourceService(mapper, null));
         }
 
         @Nested
@@ -113,11 +103,6 @@ class X509AuthSourceServiceTest {
             void whenParse_thenNull() {
                 assertNull(serviceUnderTest.parse(null));
                 verifyNoInteractions(mapper);
-            }
-
-            @Test
-            void whenGetLTPA_thenNull() {
-                assertNull(serviceUnderTest.getLtpaToken(null));
             }
 
         }

--- a/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/X509CNAuthSourceServiceTest.java
+++ b/zaas-service/src/test/java/org/zowe/apiml/zaas/security/service/schema/source/X509CNAuthSourceServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.zowe.apiml.zaas.security.mapping.X509CommonNameUserMapper;
-import org.zowe.apiml.zaas.security.service.AuthenticationService;
 import org.zowe.apiml.zaas.security.service.TokenCreationService;
 
 import java.security.cert.X509Certificate;
@@ -41,7 +40,7 @@ class X509CNAuthSourceServiceTest {
             request = mock(HttpServletRequest.class);
             x509Certificate = mock(X509Certificate.class);
             mapper = mock(X509CommonNameUserMapper.class);
-            serviceUnderTest = new X509CNAuthSourceService(mapper, mock(TokenCreationService.class), mock(AuthenticationService.class));
+            serviceUnderTest = new X509CNAuthSourceService(mapper, mock(TokenCreationService.class));
         }
 
         @Test


### PR DESCRIPTION
# Description

**Summary**

Removes unused and unverified LTPA-token code paths from the ZAAS security layer. LTPA extraction now goes through a single, validated path; the dead interface method and the claim-parsing method that skipped token validation are gone.

**Changes**

1. Remove unverified getLtpaToken(String) claim parsing (AuthenticationService)
- Deleted getLtpaToken(String), which read the LTPA claim straight out of the JWT via getJwtClaims(...) without validating the token first.
- Renamed the validating getLtpaTokenWithValidation(String) → getLtpaToken(String), so the only remaining LTPA extraction path validates the JWT before returning the claim.
- Updated callers and tests to the single method.

2. Remove dead getLtpaToken(AuthSource) from the AuthSourceService hierarchy
- The getLtpaToken(AuthSource) interface method had no production callers — it was only exercised by unit tests and its own delegation chain. Runtime LTPA generation uses AuthenticationService#getLtpaToken(String) (see change 1), which is unaffected.
- Removed the interface method and all implementations: Default, X509, OIDC, PAT, Jwt.
- Removed the now-orphaned AuthenticationService dependency from X509AuthSourceService, along with the cascading constructor/@Bean wiring in X509CNAuthSourceService and ComponentsConfiguration.
- Removed the associated tests.

**Impact**

- No behavioral change to production flows; only unused code and an unvalidated extraction path are removed.
- API surface: AuthSourceService (public interface) loses getLtpaToken(AuthSource), and AuthenticationService loses the unverified getLtpaToken(String) overload while getLtpaTokenWithValidation is renamed to getLtpaToken. Worth a check for any out-of-tree consumers.


Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
