### PR TITLE
chore: increase forked test JVM heap to 2g to prevent OOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ configure(subprojects.findAll {it.name != 'platform'}) {
 
     test {
         useJUnitPlatform()
+        maxHeapSize = '2g'
         jvmArgs '--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/java.io=ALL-UNNAMED'


### PR DESCRIPTION
## Summary
Forked Gradle test executors default to `-Xmx512m`, which exhausts the heap for Spring-context tests (e.g. `HttpConfig`'s HTTP connection manager / `idle-connection-evictor` threads) and fails with `java.lang.OutOfMemoryError: Java heap space`.

`org.gradle.jvmargs=-Xmx2048m` only sizes the Gradle **daemon**, not the forked test JVMs, so it does not help here.

## Change
Set `maxHeapSize = '2g'` on the shared `test {}` task in the root `build.gradle`, so every subproject's forked test JVM gets an adequate heap.

## Impact
- Build-only change; no production code affected.
- 2 GB per fork is comfortable given `org.gradle.parallel=true` may fork several module test tasks concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)