### PR TITLE
fix: set frame options to same origin 

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/NewSecurityConfiguration.java
@@ -650,7 +650,7 @@ public class NewSecurityConfiguration {
             .headers(headers -> headers
                 .httpStrictTransportSecurity(HeadersConfigurer.HstsConfig::disable)
                 .addHeaderWriter(new CustomHstsHeadersWriter())
-                .frameOptions().disable())
+                .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
             .exceptionHandling(handling -> handling
                 .authenticationEntryPoint(handlerInitializer.getBasicAuthUnauthorizedHandler()))
             .sessionManagement(management -> management


### PR DESCRIPTION
# Description

Enable frame options and set header to same origin.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
