### PR TITLE
chore: prevent websocket client test hang on failure

### DIFF
--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/acceptance/WebSocketTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/acceptance/WebSocketTest.java
@@ -42,7 +42,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import static org.awaitility.Awaitility.await;
@@ -224,21 +224,23 @@ class WebSocketTest {
         }
 
         @Test
-        void whenConnectToServerWithWrongCert_thenReject() throws URISyntaxException, InterruptedException {
+        void whenConnectToServerWithWrongCert_thenReject() throws InterruptedException {
             webSocketClientStrict.connectBlocking();
-            var reasonValid = new AtomicBoolean(false);
+            var statusOnCose = new AtomicReference<Integer>();
+            var reasonOnClose = new AtomicReference<String>();
+
             webSocketClientStrict.setOnClose((status, reason) -> {
-                assertEquals(1011, status);
-                assertNotNull(reason);
-                // assertTrue(reason.contains("No name matching localhost found"), "reason was: " + reason); On Netty client
-                assertTrue(reason.contains("HTTP request to initiate the WebSocket connection to [wss://localhost:" + serviceStrictness.getPort() + "/websocketservicessl/ws] failed")); // On Tomcat client
-                reasonValid.set(true);
+                statusOnCose.set(status);
+                reasonOnClose.set(reason);
             });
 
             await()
                 .atMost(Duration.ofSeconds(10))
                 .untilAsserted(() -> {
-                    assertTrue(reasonValid.get());
+                    assertEquals(1011, statusOnCose.get());
+                    assertNotNull(reasonOnClose.get());
+                    // assertTrue(reasonOnClose.get().contains("No name matching localhost found"), "reason was: " + reason); On Netty client
+                    assertTrue(reasonOnClose.get().contains("HTTP request to initiate the WebSocket connection to [wss://localhost:" + serviceStrictness.getPort() + "/websocketservicessl/ws] failed")); // On Tomcat client
                 });
         }
 
@@ -297,6 +299,9 @@ class WebSocketTest {
         @Setter
         private BiConsumer<Integer, String> onClose;
 
+        @Getter
+        private final AtomicReference<Exception> error = new AtomicReference<>();
+
         public WebSocketTestClient(URI serverUri) {
             super(serverUri);
         }
@@ -323,9 +328,30 @@ class WebSocketTest {
             }
         }
 
+        /**
+         * Must not throw: this runs on the client's read/write thread, and
+         * {@link org.java_websocket.WebSocketImpl#closeConnection} only catches {@link RuntimeException}.
+         * An {@link AssertionError} escaping from here kills that thread before it counts down the
+         * connect/close latches, leaving the untimed connectBlocking()/closeBlocking() waiting forever.
+         * Record the error instead and let the test assert on it.
+         */
         @Override
         public void onError(Exception ex) {
-            fail(ex);
+            error.compareAndSet(null, ex);
+        }
+
+        /**
+         * Reports an error captured by {@link #onError(Exception)} on the calling (test) thread, so tests do not
+         * have to check for it explicitly. Note this only runs when the caller actually closes the client - a
+         * client that never opened is skipped by the {@code isOpen()} guard in {@code tearDown()}.
+         */
+        @Override
+        public void closeBlocking() throws InterruptedException {
+            super.closeBlocking();
+            var ex = error.get();
+            if (ex != null) {
+                fail("WebSocket client reported an error", ex);
+            }
         }
 
     }


### PR DESCRIPTION
# Description

The whenConnectToServerWithWrongCert_thenReject test hung on failure. When the assertion in onClose handler fails, it throws an error (not an exception) that kills the websocket client thread resulting in the client not being able to close so the closeBlocking in @AfterEach waits forever.

The PR moves assertions from the websocket client thread allowing the client to be closed on assertion failure.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
