### PR TITLE
fix: v2 restore allowcredentials default

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/CorsBeans.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/security/config/CorsBeans.java
@@ -115,6 +115,7 @@ public class CorsBeans implements InitializingBean {
             .defaultAllowedCorsHttpMethods(corsAllowedMethods)
             .defaultAllowedCorsHeaders(Arrays.asList(corsDefaultAllowedHeaders.split(",")))
             .defaultAllowedCorsOrigins(getDefaultAllowedOrigins(new ArrayList<>(Arrays.asList(externalUrl))))
+            .defaultAllowCredentials(true)
             .build();
 
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
@@ -75,12 +75,14 @@ class CorsEnabledAcceptanceTest extends AcceptanceTestWithBasePath {
         private CorsBeans corsBeans;
 
         @Test
-        void validateDefaultCorsAllowedMethods() throws URISyntaxException {
+        void validateDefaultCors() throws URISyntaxException {
             CorsUtils corsUtils = corsBeans.corsUtils(environment, "https://dvipahost:10010", "lparhost", 10010);
 
             @SuppressWarnings("unchecked")
             List<String> corsAllowedMethods = (List<String>) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCorsHttpMethods");
             assertEquals(7, corsAllowedMethods.size());
+            Boolean allowCredentials = (Boolean) ReflectionTestUtils.getField(corsUtils, additionalGatewayAddress);
+            assertTrue(allowCredentials);
         }
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
@@ -81,7 +81,7 @@ class CorsEnabledAcceptanceTest extends AcceptanceTestWithBasePath {
             @SuppressWarnings("unchecked")
             List<String> corsAllowedMethods = (List<String>) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCorsHttpMethods");
             assertEquals(7, corsAllowedMethods.size());
-            Boolean allowCredentials = (Boolean) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCredentials");
+            Boolean allowCredentials = (Boolean) ReflectionTestUtils.getField(corsUtils, "defaultAllowCredentials");
             assertTrue(allowCredentials);
         }
     }

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/security/config/CorsBeanTest.java
@@ -81,7 +81,7 @@ class CorsEnabledAcceptanceTest extends AcceptanceTestWithBasePath {
             @SuppressWarnings("unchecked")
             List<String> corsAllowedMethods = (List<String>) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCorsHttpMethods");
             assertEquals(7, corsAllowedMethods.size());
-            Boolean allowCredentials = (Boolean) ReflectionTestUtils.getField(corsUtils, additionalGatewayAddress);
+            Boolean allowCredentials = (Boolean) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCredentials");
             assertTrue(allowCredentials);
         }
     }


### PR DESCRIPTION
# Description

Allow credentials was intended to always default to true, only not with allowedOrigins `*`

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
