### PR TITLE
fix: restore default allow credentials to true

### DIFF
--- a/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
+++ b/gateway-service/src/main/java/org/zowe/apiml/gateway/config/ConnectionsConfig.java
@@ -320,6 +320,7 @@ public class ConnectionsConfig {
             .defaultAllowedCorsHttpMethods(corsAllowedMethods)
             .defaultAllowedCorsOrigins(Arrays.asList(corsDefaultAllowedOrigins.split(",")))
             .defaultAllowedCorsHeaders(Arrays.asList(corsDefaultAllowedHeaders.split(",")))
+            .defaultAllowCredentials(true)
             .build();
     }
 

--- a/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
+++ b/gateway-service/src/test/java/org/zowe/apiml/gateway/config/ConnectionsConfigTest.java
@@ -69,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -438,12 +439,15 @@ class ConnectionsConfigTest {
             private ConnectionsConfig connectionsConfig;
 
             @Test
-            void validateDefaultCorsAllowedMethods() {
+            void validateDefaultCors() {
                 var corsUtils = connectionsConfig.corsUtils();
 
                 @SuppressWarnings("unchecked")
                 var corsAllowedMethods = (List<String>) ReflectionTestUtils.getField(corsUtils, "defaultAllowedCorsHttpMethods");
                 assertEquals(7, corsAllowedMethods.size());
+                var allowedCredentials = (boolean) ReflectionTestUtils.getField(corsUtils, "defaultAllowCredentials");
+                assertTrue(allowedCredentials);
+
             }
         }
 


### PR DESCRIPTION
# Description

Allow credentials was intended to always default to true, only not with allowedOrigins `*`

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
