### PR TITLE
fix: update markdown-it to 14.3.0 and linkify-it to 5.0.2 (CVE-2026-48988, CVE-2026-59887)

### DIFF
--- a/api-catalog-ui/frontend/package-lock.json
+++ b/api-catalog-ui/frontend/package-lock.json
@@ -8840,15 +8840,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/cosmiconfig/node_modules/yaml": {
-            "version": "1.10.3",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/yaml/-/yaml-1.10.3.tgz",
-            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/create-ecdh": {
             "version": "4.0.4",
             "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -16357,9 +16348,19 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.2",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -16905,14 +16906,24 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.3.0",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/markdown-it/-/markdown-it-14.3.0.tgz",
+            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -23547,7 +23558,6 @@
             "version": "2.9.0",
             "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"


### PR DESCRIPTION
## Description

Resolves the two remaining open findings from the latest vulnerability scan. Both are transitive dependencies of `@graphiql/react` in the API Catalog UI:

| Advisory | Was | Now | Issue |
|---|---|---|---|
| CVE-2026-48988 | markdown-it 14.1.1 | **14.3.0** | Quadratic-complexity DoS in the smartquotes rule (fixed in 14.2.0) |
| CVE-2026-59887 | linkify-it 5.0.0 | **5.0.2** | Quadratic-complexity DoS via the `mailto:` validator scan loop |

Both fixed versions fall inside the already declared semver ranges (`markdown-it: ^14.1.0`, `linkify-it: ^5.0.0`), so only `package-lock.json` changes — no `package.json` or version-catalog edit needed.

The lockfile diff also contains two incidental normalizations from npm re-resolving the tree: a stale duplicate `cosmiconfig/node_modules/yaml@1.10.3` entry is dropped (the existing `cosmiconfig > yaml: 2.9.0` override already governs it) and `yaml@2.9.0` loses its `dev` flag.

## Context

The rest of the scan's findings are already remediated on `v3.x.x` — Netty is at 4.2.17.Final (fix: 4.2.15/4.2.16), Spring Security 6.5.11, Spring Framework 6.2.19, spring-cloud-gateway 4.3.5, jackson-core 2.22.1, httpcore5 5.4.3, Logback 1.6.1, DOMPurify 3.4.12, immutable 4.3.9/5.1.9. The HTTPComponents Core 4.4.16 findings (BDSA-2026-17708/17734) appear to be false positives: both advisories target `HPackDecoder` and `Http1Config`, which are 5.x-only classes and are not present in the `httpcore-4.4.16` jar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)