### PR TITLE
chore: Improve messages during static definition loading

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
@@ -15,7 +15,6 @@ import com.netflix.eureka.EurekaServerContext;
 import com.netflix.eureka.EurekaServerContextHolder;
 import com.netflix.eureka.registry.InstanceRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.discovery.ApimlInstanceRegistry;

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
@@ -15,6 +15,7 @@ import com.netflix.eureka.EurekaServerContext;
 import com.netflix.eureka.EurekaServerContextHolder;
 import com.netflix.eureka.registry.InstanceRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.zowe.apiml.discovery.ApimlInstanceRegistry;
@@ -81,6 +82,23 @@ public class StaticServicesRegistrationService implements StaticServicesRegistra
         }
     }
 
+    private String getAllMessages(Throwable throwable) {
+        Throwable lastThrowable = null;
+        var messages = new StringBuilder();
+        while ((throwable != null) && (lastThrowable != throwable)) {
+            if (!messages.isEmpty()) {
+                messages.append(": ");
+            }
+
+            messages.append(throwable.getMessage());
+
+            lastThrowable = throwable;
+            throwable = throwable.getCause();
+        }
+
+        return messages.toString();
+    }
+
     /**
      * Reloads all statically defined APIs in locations specified by configuration
      * by reading the definitions again.
@@ -98,7 +116,7 @@ public class StaticServicesRegistrationService implements StaticServicesRegistra
                 try {
                     registry.cancel(info.getAppName(), info.getId(), false);
                 } catch (Exception e) {
-                    final Message msg = apimlLog.log("org.zowe.apiml.discovery.staticDefinitionRegistration", staticApiDefinitionsDirectories, e.getMessage());
+                    final Message msg = apimlLog.log("org.zowe.apiml.discovery.staticDefinitionRegistration", staticApiDefinitionsDirectories, getAllMessages(e));
                     result.getErrors().add(msg);
                 }
             }
@@ -112,7 +130,7 @@ public class StaticServicesRegistrationService implements StaticServicesRegistra
             var registry = getRegistry();
             registry.registerStatically(instanceInfo, false, false);
         } catch (Exception e) {
-            final Message msg = apimlLog.log("org.zowe.apiml.discovery.staticDefinitionRegistration", staticApiDefinitionsDirectories, e.getMessage());
+            final Message msg = apimlLog.log("org.zowe.apiml.discovery.staticDefinitionRegistration", staticApiDefinitionsDirectories, getAllMessages(e));
             result.getErrors().add(msg);
         }
     }

--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationService.java
@@ -82,7 +82,7 @@ public class StaticServicesRegistrationService implements StaticServicesRegistra
         }
     }
 
-    private String getAllMessages(Throwable throwable) {
+    String getAllMessages(Throwable throwable) {
         Throwable lastThrowable = null;
         var messages = new StringBuilder();
         while ((throwable != null) && (lastThrowable != throwable)) {

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationServiceTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/staticdef/StaticServicesRegistrationServiceTest.java
@@ -234,6 +234,25 @@ class StaticServicesRegistrationServiceTest {
     }
 
     @Nested
+    class Messages {
+
+        @Test
+        void givenException_whenGetAllMessages_thenGenerateFullMessage() {
+            var service = new StaticServicesRegistrationService(new ServiceDefinitionProcessor(), new MetadataDefaultsService());
+            var root = new Exception("root") {
+                @Override
+                public Throwable getCause() {
+                    return this;
+                }
+            };
+            var middle = new Exception("middle", root);
+            var leaf = new Exception("leaf", middle);
+            assertEquals("leaf: middle: root", service.getAllMessages(leaf));
+        }
+
+    }
+
+    @Nested
     class UnexpectedErrors {
 
         @Mock


### PR DESCRIPTION
# Description

When an error happen during loading static definition the displayed message is very poor. For example when URL is not allowed (see allowed-domain-list), Then there is no message about (unless debug is enabled).

Linked to # (issue)
Part of the # (epic)

## Type of change

- [x] chore: Chore, repository cleanup, updates the dependencies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules
