### PR TITLE
fix: stamp real project version into API Catalog UI .env

### DIFF
--- a/api-catalog-ui/build.gradle
+++ b/api-catalog-ui/build.gradle
@@ -86,6 +86,36 @@ task npmLint(type: NpmTask) {
 }
 npmLint.dependsOn npmInstall
 
+// Stamps the real project version (from gradle.properties) into the frontend's
+// .env file before every build, so the API Catalog UI displays the same
+// version as the rest of API ML instead of a hand-copied, stale value.
+// See: https://github.com/zowe/api-layer/issues/4703
+task updateEnvVersion {
+    group = 'npm'
+    description = "Updates VITE_ZOWE_BUILD_INFO in .env with the current project version"
+
+    def envFile = file('frontend/.env')
+    inputs.property('projectVersion', project.version.toString())
+    outputs.file(envFile)
+
+    doLast {
+        def lines = envFile.readLines()
+        def versionLine = "VITE_ZOWE_BUILD_INFO=${project.version}"
+        def found = false
+        def updatedLines = lines.collect { line ->
+            if (line.startsWith('VITE_ZOWE_BUILD_INFO=')) {
+                found = true
+                return versionLine
+            }
+            return line
+        }
+        if (!found) {
+            updatedLines << versionLine
+        }
+        envFile.text = updatedLines.join('\n') + '\n'
+    }
+}
+
 task npmBuild(type: NpmTask) {
 
     group = 'npm'
@@ -107,6 +137,7 @@ task npmBuild(type: NpmTask) {
 
 npmBuild.dependsOn npmInstall
 npmBuild.dependsOn npmLint
+npmBuild.dependsOn updateEnvVersion
 build.dependsOn npmBuild
 
 npmBuild.dependsOn npmTest


### PR DESCRIPTION
The API Catalog login page displayed a stale, hand-copied SNAPSHOT version string from api-catalog-ui/frontend/.env, while every other version display in API ML (Gateway homepage, /gateway/version) reads live from VersionService -> build-info.properties, which Gradle regenerates every build.

Adds an updateEnvVersion task that stamps the real project.version (from gradle.properties) into VITE_ZOWE_BUILD_INFO before npmBuild runs, so the Catalog UI stays in sync with actual releases.

Fixes #4703

# Description

The `VITE_ZOWE_BUILD_INFO` value in `api-catalog-ui/frontend/.env` was a static string, manually set at some point and never kept in sync with releases. The new `updateEnvVersion` Gradle task rewrites that value from `project.version` (sourced from `gradle.properties`) immediately before `npmBuild` runs, mirroring the pattern the backend modules already use via `springBoot { buildInfo { ... } }`.

**Note on testing:** the task's line-replacement logic was verified in isolation against a copy of the real `.env` file, confirming it updates only the `VITE_ZOWE_BUILD_INFO` line and leaves all other variables untouched. It has not yet been run through a full `./gradlew :api-catalog-ui:npmBuild` locally — flagging this so reviewers know what has and hasn't been exercised end-to-end.

Linked to #4703

## Type of change

- [x] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline
- [x] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
