### PR TITLE
chore: give each Node project its own tools directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,7 @@ deploy-apiml.sh
 */*.trc
 
 tools/*
+# Node/npm toolchains, one per project that applies the Node plugin
+*/tools/
+
 otel/otel-collector/export/*.json

--- a/api-catalog-ui/build.gradle
+++ b/api-catalog-ui/build.gradle
@@ -8,9 +8,9 @@ node {
     npmVersion = libs.versions.projectNpm.get()
     distBaseUrl = "https://nodejs.org/dist"
     npmInstallCommand = "ci"
-    workDir = file("${project.rootDir}/tools/nodejs")
-    npmWorkDir = file("${project.rootDir}/tools/npm")
-    yarnWorkDir = file("${project.rootDir}/tools/yarn")
+    workDir = file("${project.projectDir}/tools/nodejs")
+    npmWorkDir = file("${project.projectDir}/tools/npm")
+    yarnWorkDir = file("${project.projectDir}/tools/yarn")
     nodeProjectDir = file("${project.projectDir}/frontend")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -312,8 +312,11 @@ task publishAllSDKVersions {
 task nodejsClean(type: Delete) {
     group = 'npm'
     if (cleanNode == 'true') {
-        delete 'api-catalog-ui/tools/nodejs', 'api-catalog-ui/tools/npm', 'api-catalog-ui/tools/yarn'
-        delete 'onboarding-enabler-nodejs-sample-app/tools/nodejs', 'onboarding-enabler-nodejs-sample-app/tools/npm', 'onboarding-enabler-nodejs-sample-app/tools/yarn'
+        // Every project that applies the Node plugin keeps its toolchain in <project>/tools
+        ['api-catalog-ui', 'zowe-cli-id-federation-plugin',
+         'onboarding-enabler-nodejs', 'onboarding-enabler-nodejs-sample-app'].each { name ->
+            delete "$name/tools/nodejs", "$name/tools/npm", "$name/tools/yarn"
+        }
     }
 }
 

--- a/onboarding-enabler-nodejs-sample-app/build.gradle
+++ b/onboarding-enabler-nodejs-sample-app/build.gradle
@@ -18,9 +18,9 @@ node {
     npmVersion = libs.versions.projectNpm.get()
     distBaseUrl = "https://nodejs.org/dist"
     npmInstallCommand = "ci"
-    workDir = file("${project.rootDir}/tools/nodejs")
-    npmWorkDir = file("${project.rootDir}/tools/npm")
-    yarnWorkDir = file("${project.rootDir}/tools/yarn")
+    workDir = file("${project.projectDir}/tools/nodejs")
+    npmWorkDir = file("${project.projectDir}/tools/npm")
+    yarnWorkDir = file("${project.projectDir}/tools/yarn")
     nodeProjectDir = file("${project.projectDir}")
 }
 

--- a/onboarding-enabler-nodejs/build.gradle
+++ b/onboarding-enabler-nodejs/build.gradle
@@ -18,8 +18,8 @@ node {
     npmVersion = libs.versions.projectNpm.get()
     distBaseUrl = "https://nodejs.org/dist"
     npmInstallCommand = "ci"
-    workDir = file("${project.rootDir}/tools/nodejs")
-    npmWorkDir = file("${project.rootDir}/tools/npm")
+    workDir = file("${project.projectDir}/tools/nodejs")
+    npmWorkDir = file("${project.projectDir}/tools/npm")
     nodeProjectDir = file("${project.projectDir}")
 }
 

--- a/zowe-cli-id-federation-plugin/build.gradle
+++ b/zowe-cli-id-federation-plugin/build.gradle
@@ -8,9 +8,9 @@ node {
     npmVersion = libs.versions.projectNpm.get()
     distBaseUrl = "https://nodejs.org/dist"
     npmInstallCommand = "ci"
-    workDir = file("${project.rootDir}/tools/nodejs")
-    npmWorkDir = file("${project.rootDir}/tools/npm")
-    yarnWorkDir = file("${project.rootDir}/tools/yarn")
+    workDir = file("${project.projectDir}/tools/nodejs")
+    npmWorkDir = file("${project.projectDir}/tools/npm")
+    yarnWorkDir = file("${project.projectDir}/tools/yarn")
     nodeProjectDir = file("${project.projectDir}")
 }
 


### PR DESCRIPTION
# Description
All npm projects pointed to a shared tools directory `${rootDir}/tools` making npmSetup tasks when running in parallel, so they invalidate each other and one project's npmInstall can be executing the npm that another project's npmSetup is replacing — surfacing as an opaque 'exit value 137' failure.

Point each at ${projectDir}/tools instead, extend nodejsClean to cover all four, and ignore */tools/. It has a cost of higher storage consumption but reduce build flakiness.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
