### PR TITLE
fix: set Zowe repository for onboarding-enabler-nodejs

### DIFF
--- a/onboarding-enabler-nodejs/.npmrc
+++ b/onboarding-enabler-nodejs/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+registry=https://zowe.jfrog.io/artifactory/api/npm/npm-org/


### PR DESCRIPTION
# Description

Fix to the repository held in .npmrc in onboarding-enabler-nodejs. It needs to default to https://zowe.jfrog.io/artifactory/api/npm/npm-org/

## Type of change

Please delete options that are not relevant.

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
