### PR TITLE
fix: add negative tests for saf resource check 

### DIFF
--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/SafAuthCheckTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/SafAuthCheckTest.java
@@ -26,6 +26,7 @@ import org.zowe.apiml.util.config.SslContext;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.hamcrest.core.Is.is;
@@ -50,25 +51,43 @@ class SafAuthCheckTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    private final SafCheckRequest request = new SafCheckRequest(
+    private final SafCheckRequest requestRead = new SafCheckRequest(
         "ZOWE",
         "APIML.SERVICES",
         "READ"
+    );
+
+    private final SafCheckRequest requestControl = new SafCheckRequest(
+        "ZOWE",
+        "APIML.SERVICES",
+        "CONTROL"
     );
 
     @Nested
     class GivenClientCertAuthentication {
 
         @Test
-        void returnReturn204() {
+        void return204() {
             given()
                 .config(SslContext.clientCertUser)
                 .contentType(ContentType.JSON)
-                .body(request)
+                .body(requestRead)
             .when()
                 .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
             .then()
                 .statusCode(SC_NO_CONTENT);
+        }
+
+        @Test
+        void return403WhenDontHaveAccess() {
+            given()
+                .config(SslContext.clientCertUser)
+                .contentType(ContentType.JSON)
+                .body(requestControl)
+            .when()
+                .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
+            .then()
+                .statusCode(is(SC_FORBIDDEN));
         }
     }
 
@@ -80,12 +99,25 @@ class SafAuthCheckTest {
             String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
             given()
                 .contentType(ContentType.JSON)
-                .body(request)
+                .body(requestRead)
                 .header("Authorization", "Bearer " + token)
             .when()
                 .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
             .then()
                 .statusCode(is(SC_NO_CONTENT));
+        }
+
+        @Test
+        void return403WhenDontHaveAccess() {
+            String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
+            given()
+                .contentType(ContentType.JSON)
+                .body(requestControl)
+                .header("Authorization", "Bearer " + token)
+            .when()
+                .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
+            .then()
+                .statusCode(is(SC_FORBIDDEN));
         }
     }
 
@@ -96,7 +128,7 @@ class SafAuthCheckTest {
         void return401() {
             given()
                 .contentType(ContentType.JSON)
-                .body(request)
+                .body(requestRead)
                 .header("Authorization", "Bearer invalidToken")
             .when()
                 .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))

--- a/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/SafAuthCheckTest.java
+++ b/integration-tests/src/test/java/org/zowe/apiml/functional/gateway/SafAuthCheckTest.java
@@ -26,7 +26,6 @@ import org.zowe.apiml.util.config.SslContext;
 import org.zowe.apiml.util.http.HttpRequestUtils;
 
 import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.hamcrest.core.Is.is;
@@ -79,7 +78,7 @@ class SafAuthCheckTest {
         }
 
         @Test
-        void return403WhenDontHaveAccess() {
+        void return401WhenDontHaveAccess() {
             given()
                 .config(SslContext.clientCertUser)
                 .contentType(ContentType.JSON)
@@ -87,7 +86,7 @@ class SafAuthCheckTest {
             .when()
                 .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
             .then()
-                .statusCode(is(SC_FORBIDDEN));
+                .statusCode(is(SC_UNAUTHORIZED));
         }
     }
 
@@ -108,7 +107,7 @@ class SafAuthCheckTest {
         }
 
         @Test
-        void return403WhenDontHaveAccess() {
+        void return401WhenDontHaveAccess() {
             String token = SecurityUtils.gatewayToken(USERNAME, PASSWORD);
             given()
                 .contentType(ContentType.JSON)
@@ -117,7 +116,7 @@ class SafAuthCheckTest {
             .when()
                 .post(HttpRequestUtils.getUriFromGateway(SAF_AUTH_CHECK))
             .then()
-                .statusCode(is(SC_FORBIDDEN));
+                .statusCode(is(SC_UNAUTHORIZED));
         }
     }
 


### PR DESCRIPTION
# Description

Added negative tests to SafAuthCheckTest, so we can be sure that the testing user doesn't have more permissions then it should have.

## Type of change

- [X] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
