### PR TITLE
chore: Hotfix of version to procceed binary release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ artifactoryPublishingMavenRepo=https://zowe.jfrog.io/zowe/libs-release-local
 artifactoryPublishingMavenSnapshotRepo=https://zowe.jfrog.io/zowe/libs-snapshot-local
 
 # Artifacts version
-version=3.5.22-SNAPSHOT
+version=3.5.23-SNAPSHOT
 
 cleanNodeModules=false
 cleanNode=false


### PR DESCRIPTION
# Description

There is an issue durting releasing (https://github.com/zowe/api-layer/actions/runs/31757452986/job/94636258815) when GH action is trying to upload an artifact that already exists. This change should move numbering to avoid this issue.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] chore: Chore, repository cleanup, updates the dependencies.

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
