### PR TITLE
chore: update npm security dependencies

### DIFF
--- a/api-catalog-ui/frontend/package-lock.json
+++ b/api-catalog-ui/frontend/package-lock.json
@@ -7538,12 +7538,15 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.19",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+            "version": "2.11.15",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+            "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
             "license": "Apache-2.0",
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/bcrypt-pbkdf": {
@@ -7844,9 +7847,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.8",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7863,11 +7866,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -9759,9 +9762,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.302",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-            "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+            "version": "1.5.411",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+            "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
             "license": "ISC"
         },
         "node_modules/elliptic": {
@@ -17421,10 +17424,13 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT"
+            "version": "2.0.53",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/node-releases/-/node-releases-2.0.53.tgz",
+            "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/node-stdlib-browser": {
             "version": "1.3.1",
@@ -22854,9 +22860,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.1",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/api-catalog-ui/frontend/package.json
+++ b/api-catalog-ui/frontend/package.json
@@ -138,6 +138,7 @@
         "yaml": "2.9.0"
     },
     "overrides": {
+        "browserslist": "4.28.8",
         "openapi-snippet": {
             "openapi-sampler": {
                 "fast-xml-parser": "5.11.0"

--- a/onboarding-enabler-nodejs-sample-app/package-lock.json
+++ b/onboarding-enabler-nodejs-sample-app/package-lock.json
@@ -23,7 +23,7 @@
             "license": "(EPL-2.0 OR Apache-2.0)",
             "dependencies": {
                 "async": "3.2.6",
-                "js-yaml": "4.2.0",
+                "js-yaml": "4.3.1",
                 "lodash": "4.18.1"
             },
             "devDependencies": {
@@ -68,21 +68,34 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -829,17 +842,34 @@
             }
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/unpipe": {

--- a/onboarding-enabler-nodejs-sample-app/package.json
+++ b/onboarding-enabler-nodejs-sample-app/package.json
@@ -19,6 +19,7 @@
         "express": "5.2.1"
     },
     "overrides": {
+        "body-parser": "2.3.0",
         "tough-cookie": "5.1.2",
         "path-to-regexp" : "8.4.2",
         "qs"  : "6.15.3"

--- a/zss-sample-service/package-lock.json
+++ b/zss-sample-service/package-lock.json
@@ -25,21 +25,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -783,17 +796,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {

--- a/zss-sample-service/package.json
+++ b/zss-sample-service/package.json
@@ -9,6 +9,7 @@
     "express": "5.2.1"
   },
   "overrides": {
+    "body-parser": "2.3.0",
     "path-to-regexp": "8.4.2",
     "qs" : "6.15.3"
   }


### PR DESCRIPTION
# Description

Refresh npm dependency resolution for the remaining actionable Black Duck findings:

- force API Catalog's transitive `browserslist` to patched version 4.28.8
- force Express's transitive `body-parser` to patched version 2.3.0 in both Node sample services
- regenerate all three npm lockfiles with npm 10.9.9

This intentionally leaves `react-router` at 7.18.2 because that is the authoritative patched version, and does not change `react-is` because the reported React Server advisory does not affect that package.

## Type of change

- [x] chore: Chore, repository cleanup, updates the dependencies.

# Verification

- API Catalog: `npm ci --legacy-peer-deps`
- API Catalog: `npm ls browserslist --all` — all paths resolve 4.28.8
- API Catalog: lint passed with five pre-existing warnings
- API Catalog: 69 test suites / 351 tests passed
- API Catalog: production build passed
- both Node samples: `npm ci`, `npm ls body-parser --all`, and Express import smoke checks passed
- both Node samples report zero npm audit findings
- independent dependency/lockfile review — passed with no blocking issues
- `npm run test` reached the integration startup check but could not run because no API Mediation Layer instance was started locally; both worktrees produced the same startup timeout

# Checklist

- [x] My code follows the style guidelines of this project
- [x] PR title conforms to commit message guideline
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
