### PR TITLE
fix[@AI-Claude]: run turbofilters only when they should

### DIFF
--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDuplicateMessagesFilter.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDuplicateMessagesFilter.java
@@ -37,12 +37,9 @@ public class ApimlDuplicateMessagesFilter extends DuplicateMessageFilter {
             return FilterReply.NEUTRAL;
         }
         if (!level.isGreaterOrEqual(logger.getEffectiveLevel())) {
-            // logback drops the event on its own, so there is no need to format and hash a message
-            // nobody will read; abstaining rather than denying keeps the rest of the chain in play
             return FilterReply.NEUTRAL;
         }
         String formattedMessage = getLogMessage(format, params, t);
-        // Sent the entire formatted message to the parent to ensure exact duplicates are filtered out
         return super.decide(marker, logger, level, getMessageHash(formattedMessage), params, t);
     }
 

--- a/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDuplicateMessagesFilter.java
+++ b/apiml-utility/src/main/java/org/zowe/apiml/product/logging/ApimlDuplicateMessagesFilter.java
@@ -33,12 +33,29 @@ public class ApimlDuplicateMessagesFilter extends DuplicateMessageFilter {
 
     @Override
     public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
-        if (level.isGreaterOrEqual(logger.getEffectiveLevel())) {
-            String formattedMessage = getLogMessage(format, params, t);
-            // Sent the entire formatted message to the parent to ensure exact duplicates are filtered out
-            return super.decide(marker, logger, level, getMessageHash(formattedMessage), params, t);
+        if (isLevelProbe(format, params, t)) {
+            return FilterReply.NEUTRAL;
         }
-        return FilterReply.DENY;
+        if (!level.isGreaterOrEqual(logger.getEffectiveLevel())) {
+            // logback drops the event on its own, so there is no need to format and hash a message
+            // nobody will read; abstaining rather than denying keeps the rest of the chain in play
+            return FilterReply.NEUTRAL;
+        }
+        String formattedMessage = getLogMessage(format, params, t);
+        // Sent the entire formatted message to the parent to ensure exact duplicates are filtered out
+        return super.decide(marker, logger, level, getMessageHash(formattedMessage), params, t);
+    }
+
+    /**
+     * Logback consults the turbo filter chain from {@code Logger#isDebugEnabled()} and its siblings,
+     * passing no message at all - format, params and throwable are all null. Such a probe carries
+     * nothing to de-duplicate and must not consume a cache entry: with allowedRepetitions set to 0 the
+     * first probe would exhaust the only allowed repetition and every later isXxxEnabled() call in the
+     * whole application would be answered with false, silencing all logging guarded that way
+     * (reactor-netty and Netty's LoggingHandler guard every statement like this).
+     */
+    private boolean isLevelProbe(String format, Object[] params, Throwable t) {
+        return format == null && params == null && t == null;
     }
 
     private String getMessageHash(String message) {

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/ApimlDuplicateMessageFilterTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/ApimlDuplicateMessageFilterTest.java
@@ -48,11 +48,9 @@ class ApimlDuplicateMessageFilterTest {
             apimlDuplicateMessagesFilter.setAllowedRepetitions(0);
             apimlDuplicateMessagesFilter.start();
 
-            // logback drops such an event on its own, this filter only de-duplicates and abstains
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.DEBUG,
                 "Message", null, null), "Expected FilterReply.NEUTRAL");
 
-            // and the skipped event must not have consumed the allowed repetition of the same message
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "Message", null, null), "Expected FilterReply.NEUTRAL");
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
@@ -72,7 +70,6 @@ class ApimlDuplicateMessageFilterTest {
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.WARN,
                 null, null, exception), "Expected FilterReply.NEUTRAL");
 
-            // With args - a null format with args is a real event, not a level probe, so it is de-duplicated
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 null, new Object[]{1}, null), "Expected FilterReply.NEUTRAL");
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
@@ -90,13 +87,11 @@ class ApimlDuplicateMessageFilterTest {
 
             RuntimeException exception = new RuntimeException("my exception");
 
-            // No args
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.WARN,
                 "", null, null), "Expected FilterReply.NEUTRAL");
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.ERROR,
                 "", null, exception), "Expected FilterReply.NEUTRAL");
 
-            // With args
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "", new Object[]{1}, null), "Expected FilterReply.DENY");
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
@@ -112,7 +107,6 @@ class ApimlDuplicateMessageFilterTest {
 
             RuntimeException exception = new RuntimeException("my exception");
 
-            // No exception
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "First Message", null, null), "Expected FilterReply.NEUTRAL");
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
@@ -120,7 +114,6 @@ class ApimlDuplicateMessageFilterTest {
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "First Message", new Object[0], null), "Expected FilterReply.DENY");
 
-            // With Exception
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "Second Message", new Object[]{}, exception), "Expected FilterReply.NEUTRAL");
         }
@@ -180,13 +173,11 @@ class ApimlDuplicateMessageFilterTest {
             apimlDuplicateMessagesFilter.setAllowedRepetitions(0);
             apimlDuplicateMessagesFilter.start();
 
-            // Logback probes the turbo filter chain from Logger#isXxxEnabled() with no message at all
             for (int i = 0; i < 3; i++) {
                 assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                     null, null, null), "Expected FilterReply.NEUTRAL for a repeated level probe");
             }
 
-            // the probes must not have consumed the allowed repetition of a real message
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "Message", null, null), "Expected FilterReply.NEUTRAL");
         }
@@ -203,7 +194,6 @@ class ApimlDuplicateMessageFilterTest {
             Logger guardedLogger = context.getLogger("reactor.netty.http.client.HttpClientConnect");
             guardedLogger.setLevel(Level.DEBUG);
 
-            // reactor-netty and Netty's LoggingHandler wrap every statement in such a check
             for (int i = 0; i < 3; i++) {
                 assertTrue(guardedLogger.isDebugEnabled(), "isDebugEnabled() must keep reporting the configured level");
             }

--- a/apiml-utility/src/test/java/org/zowe/apiml/product/logging/ApimlDuplicateMessageFilterTest.java
+++ b/apiml-utility/src/test/java/org/zowe/apiml/product/logging/ApimlDuplicateMessageFilterTest.java
@@ -12,6 +12,7 @@ package org.zowe.apiml.product.logging;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.spi.FilterReply;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ApimlDuplicateMessageFilterTest {
 
@@ -42,12 +44,18 @@ class ApimlDuplicateMessageFilterTest {
         }
 
         @Test
-        void whenLevelIsLowerThanLoggerEffectiveLevel_thenDeny() {
+        void whenLevelIsLowerThanLoggerEffectiveLevel_thenNeutral() {
             apimlDuplicateMessagesFilter.setAllowedRepetitions(0);
             apimlDuplicateMessagesFilter.start();
 
-            // No args
-            assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.DEBUG,
+            // logback drops such an event on its own, this filter only de-duplicates and abstains
+            assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.DEBUG,
+                "Message", null, null), "Expected FilterReply.NEUTRAL");
+
+            // and the skipped event must not have consumed the allowed repetition of the same message
+            assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
+                "Message", null, null), "Expected FilterReply.NEUTRAL");
+            assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 "Message", null, null), "Expected FilterReply.DENY");
         }
 
@@ -64,9 +72,11 @@ class ApimlDuplicateMessageFilterTest {
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.WARN,
                 null, null, exception), "Expected FilterReply.NEUTRAL");
 
-            // With args
+            // With args - a null format with args is a real event, not a level probe, so it is de-duplicated
+            assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
+                null, new Object[]{1}, null), "Expected FilterReply.NEUTRAL");
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
-                null, new Object[]{1}, null), "Expected FilterReply.DENY");
+                null, new Object[]{2}, null), "Expected FilterReply.DENY");
             assertEquals(FilterReply.DENY, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
                 null, new Object[]{1, exception}, null), "Expected FilterReply.DENY");
             assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
@@ -163,6 +173,42 @@ class ApimlDuplicateMessageFilterTest {
                 assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO, "Message " + i, null, null),
                     "Expected FilterReply.NEUTRAL");
             }
+        }
+
+        @Test
+        void whenLevelProbeIsRepeated_thenNeutralAndCacheUntouched() {
+            apimlDuplicateMessagesFilter.setAllowedRepetitions(0);
+            apimlDuplicateMessagesFilter.start();
+
+            // Logback probes the turbo filter chain from Logger#isXxxEnabled() with no message at all
+            for (int i = 0; i < 3; i++) {
+                assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
+                    null, null, null), "Expected FilterReply.NEUTRAL for a repeated level probe");
+            }
+
+            // the probes must not have consumed the allowed repetition of a real message
+            assertEquals(FilterReply.NEUTRAL, apimlDuplicateMessagesFilter.decide(null, logger, Level.INFO,
+                "Message", null, null), "Expected FilterReply.NEUTRAL");
+        }
+
+        @Test
+        void whenFilterIsRegisteredInContext_thenIsEnabledChecksKeepWorking() {
+            LoggerContext context = new LoggerContext();
+            context.start();
+            apimlDuplicateMessagesFilter.setAllowedRepetitions(0);
+            apimlDuplicateMessagesFilter.setContext(context);
+            apimlDuplicateMessagesFilter.start();
+            context.addTurboFilter(apimlDuplicateMessagesFilter);
+
+            Logger guardedLogger = context.getLogger("reactor.netty.http.client.HttpClientConnect");
+            guardedLogger.setLevel(Level.DEBUG);
+
+            // reactor-netty and Netty's LoggingHandler wrap every statement in such a check
+            for (int i = 0; i < 3; i++) {
+                assertTrue(guardedLogger.isDebugEnabled(), "isDebugEnabled() must keep reporting the configured level");
+            }
+            assertTrue(context.getLogger("org.zowe.apiml.other").isInfoEnabled(),
+                "a probe on one logger must not disable another one");
         }
 
         @Test

--- a/common-service-core/src/main/java/org/zowe/apiml/message/log/ApimlLogger.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/log/ApimlLogger.java
@@ -142,7 +142,9 @@ public final class ApimlLogger {
     }
 
     private void logInvalidArguments(IllegalArgumentException e, Object... arguments) {
-        if (logger.isDebugEnabled()) {
+        // the marker has to be part of the check, the guarded call carries it and log filters such as
+        // LogLevelInfoFilter decide by marker - an unmarked check would answer for a different event
+        if (logger.isDebugEnabled(marker)) {
             logger.debug(marker, "Invalid log message cannot be logged: {}", arguments, e);
         } else {
             logger.warn(marker, "Invalid log message cannot be logged: {}, enable debug for stack trace: {}", arguments, e.getMessage());

--- a/common-service-core/src/main/java/org/zowe/apiml/message/log/ApimlLogger.java
+++ b/common-service-core/src/main/java/org/zowe/apiml/message/log/ApimlLogger.java
@@ -142,8 +142,6 @@ public final class ApimlLogger {
     }
 
     private void logInvalidArguments(IllegalArgumentException e, Object... arguments) {
-        // the marker has to be part of the check, the guarded call carries it and log filters such as
-        // LogLevelInfoFilter decide by marker - an unmarked check would answer for a different event
         if (logger.isDebugEnabled(marker)) {
             logger.debug(marker, "Invalid log message cannot be logged: {}", arguments, e);
         } else {

--- a/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
@@ -81,8 +81,6 @@ class ApimlLoggerTest {
         ReflectionTestUtils.setField(apimlLogger, "logger", logger);
         Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
 
-        // the guarded call carries the APIML-LOGGER marker, so the check has to carry it too - log
-        // filters such as LogLevelInfoFilter decide by marker and would deny an unmarked check
         when(logger.isDebugEnabled(marker)).thenReturn(true);
 
         apimlLogger.log((MessageType) null, "text");

--- a/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
@@ -23,7 +23,10 @@ import org.zowe.apiml.message.template.MessageTemplate;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -68,6 +71,39 @@ class ApimlLoggerTest {
         verify(logger, times(1)).info((Marker) any(), anyString(), (Object[]) any());
         verify(logger, times(1)).warn((Marker) any(), anyString(), (Object[]) any());
         verify(logger, times(1)).error((Marker) any(), anyString(), (Object[]) any());
+    }
+
+    @Test
+    void whenArgumentsAreInvalidAndDebugIsEnabledForTheMarker_thenStackTraceIsLogged() {
+        ApimlLogger apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
+
+        Logger logger = mock(Logger.class);
+        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
+        Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
+
+        // the guarded call carries the APIML-LOGGER marker, so the check has to carry it too - log
+        // filters such as LogLevelInfoFilter decide by marker and would deny an unmarked check
+        when(logger.isDebugEnabled(marker)).thenReturn(true);
+
+        apimlLogger.log((MessageType) null, "text");
+
+        verify(logger, times(1)).debug(eq(marker), anyString(), any(), any());
+        verify(logger, never()).warn(eq(marker), anyString(), any(), any());
+        verify(logger, never()).isDebugEnabled();
+    }
+
+    @Test
+    void whenArgumentsAreInvalidAndDebugIsDisabledForTheMarker_thenHintIsLogged() {
+        ApimlLogger apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
+
+        Logger logger = mock(Logger.class);
+        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
+        Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
+
+        apimlLogger.log((MessageType) null, "text");
+
+        verify(logger, times(1)).warn(eq(marker), anyString(), any(), any());
+        verify(logger, never()).debug(eq(marker), anyString(), any(), any());
     }
 
     @Nested

--- a/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
@@ -62,20 +62,20 @@ class ApimlLoggerTest {
 
     @Test
     void testLogLevel() {
-        apimlLogger.log(MessageType.TRACE, "traceLog", new Object[]{"param1"});
-        verify(logger, times(1)).trace(MARKER, "traceLog", new Object[]{"param1"});
+        apimlLogger.log(MessageType.TRACE, "traceLog {}", new Object[]{"param1"});
+        verify(logger, times(1)).trace(MARKER, "traceLog {}", new Object[]{"param1"});
 
-        apimlLogger.log(MessageType.DEBUG, "debugLog", new Object[]{"param2"});
-        verify(logger, times(1)).debug(MARKER, "debugLog", new Object[]{"param2"});
+        apimlLogger.log(MessageType.DEBUG, "debugLog {}", new Object[]{"param2"});
+        verify(logger, times(1)).debug(MARKER, "debugLog {}", new Object[]{"param2"});
 
-        apimlLogger.log(MessageType.INFO, "infoLog", new Object[]{"param3"});
-        verify(logger, times(1)).info(MARKER, "infoLog", new Object[]{"param3"});
+        apimlLogger.log(MessageType.INFO, "infoLog {}", new Object[]{"param3"});
+        verify(logger, times(1)).info(MARKER, "infoLog {}", new Object[]{"param3"});
 
-        apimlLogger.log(MessageType.WARNING, "warningLog", new Object[]{"param4"});
-        verify(logger, times(1)).warn(MARKER, "warningLog", new Object[]{"param4"});
+        apimlLogger.log(MessageType.WARNING, "warningLog {}", new Object[]{"param4"});
+        verify(logger, times(1)).warn(MARKER, "warningLog {}", new Object[]{"param4"});
 
-        apimlLogger.log(MessageType.ERROR, "errorLog", new Object[]{"param5"});
-        verify(logger, times(1)).error(MARKER, "errorLog", new Object[]{"param5"});
+        apimlLogger.log(MessageType.ERROR, "errorLog {}", new Object[]{"param5"});
+        verify(logger, times(1)).error(MARKER, "errorLog {}", new Object[]{"param5"});
 
         verify(logger, times(1)).trace((Marker) any(), anyString(), (Object[]) any());
         verify(logger, times(1)).debug((Marker) any(), anyString(), (Object[]) any());

--- a/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
+++ b/common-service-core/src/test/java/org/zowe/apiml/message/log/ApimlLoggerTest.java
@@ -10,61 +10,72 @@
 
 package org.zowe.apiml.message.log;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
-import org.zowe.apiml.message.core.Message;
-import org.zowe.apiml.message.core.MessageType;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.zowe.apiml.message.core.Message;
+import org.zowe.apiml.message.core.MessageType;
 import org.zowe.apiml.message.template.MessageTemplate;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ApimlLoggerTest {
+
+    private static final Marker MARKER = (Marker) ReflectionTestUtils.getField(ApimlLogger.class, "marker");
+
+    @Mock
+    private Logger logger;
+
+    private ApimlLogger apimlLogger;
+
+    @BeforeEach
+    void setUp() {
+        apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
+        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
+    }
 
     @Test
     void testEmpty() {
-        ApimlLogger apimlLogger = ApimlLogger.empty();
-        Logger logger = (Logger) ReflectionTestUtils.getField(apimlLogger, "logger");
-        assertEquals(ApimlLogger.class.getName(), logger.getName());
-        assertNull(ReflectionTestUtils.getField(apimlLogger, "messageService"));
+        ApimlLogger emptyLogger = ApimlLogger.empty();
+        Logger defaultLogger = (Logger) ReflectionTestUtils.getField(emptyLogger, "logger");
+        assertEquals(ApimlLogger.class.getName(), defaultLogger.getName());
+        assertNull(ReflectionTestUtils.getField(emptyLogger, "messageService"));
 
-        assertNull(apimlLogger.log("someKey"));
+        assertNull(emptyLogger.log("someKey"));
     }
 
     @Test
     void testLogLevel() {
-        ApimlLogger apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
-
-        Logger logger = mock(Logger.class);
-        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
-
-        Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
-
         apimlLogger.log(MessageType.TRACE, "traceLog", new Object[]{"param1"});
-        verify(logger, times(1)).trace(marker, "traceLog", new Object[]{"param1"});
+        verify(logger, times(1)).trace(MARKER, "traceLog", new Object[]{"param1"});
 
         apimlLogger.log(MessageType.DEBUG, "debugLog", new Object[]{"param2"});
-        verify(logger, times(1)).debug(marker, "debugLog", new Object[]{"param2"});
+        verify(logger, times(1)).debug(MARKER, "debugLog", new Object[]{"param2"});
 
         apimlLogger.log(MessageType.INFO, "infoLog", new Object[]{"param3"});
-        verify(logger, times(1)).info(marker, "infoLog", new Object[]{"param3"});
+        verify(logger, times(1)).info(MARKER, "infoLog", new Object[]{"param3"});
 
         apimlLogger.log(MessageType.WARNING, "warningLog", new Object[]{"param4"});
-        verify(logger, times(1)).warn(marker, "warningLog", new Object[]{"param4"});
+        verify(logger, times(1)).warn(MARKER, "warningLog", new Object[]{"param4"});
 
         apimlLogger.log(MessageType.ERROR, "errorLog", new Object[]{"param5"});
-        verify(logger, times(1)).error(marker, "errorLog", new Object[]{"param5"});
+        verify(logger, times(1)).error(MARKER, "errorLog", new Object[]{"param5"});
 
         verify(logger, times(1)).trace((Marker) any(), anyString(), (Object[]) any());
         verify(logger, times(1)).debug((Marker) any(), anyString(), (Object[]) any());
@@ -75,38 +86,25 @@ class ApimlLoggerTest {
 
     @Test
     void whenArgumentsAreInvalidAndDebugIsEnabledForTheMarker_thenStackTraceIsLogged() {
-        ApimlLogger apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
-
-        Logger logger = mock(Logger.class);
-        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
-        Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
-
-        when(logger.isDebugEnabled(marker)).thenReturn(true);
+        when(logger.isDebugEnabled(MARKER)).thenReturn(true);
 
         apimlLogger.log((MessageType) null, "text");
 
-        verify(logger, times(1)).debug(eq(marker), anyString(), any(), any());
-        verify(logger, never()).warn(eq(marker), anyString(), any(), any());
+        verify(logger, times(1)).debug(eq(MARKER), anyString(), any(), any());
+        verify(logger, never()).warn(eq(MARKER), anyString(), any(), any());
         verify(logger, never()).isDebugEnabled();
     }
 
     @Test
     void whenArgumentsAreInvalidAndDebugIsDisabledForTheMarker_thenHintIsLogged() {
-        ApimlLogger apimlLogger = new ApimlLogger(ApimlLoggerTest.class, null);
-
-        Logger logger = mock(Logger.class);
-        ReflectionTestUtils.setField(apimlLogger, "logger", logger);
-        Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
-
         apimlLogger.log((MessageType) null, "text");
 
-        verify(logger, times(1)).warn(eq(marker), anyString(), any(), any());
-        verify(logger, never()).debug(eq(marker), anyString(), any(), any());
+        verify(logger, times(1)).warn(eq(MARKER), anyString(), any(), any());
+        verify(logger, never()).debug(eq(MARKER), anyString(), any(), any());
     }
 
     @Nested
     class GivenNullMessageService {
-        ApimlLogger apimlLogger = ApimlLogger.empty();
 
         @Test
         void when_nullMessageService_return_nullMessage() {
@@ -118,11 +116,6 @@ class ApimlLoggerTest {
         void when_nullKey_return_invalidKeyMessage() {
             assertNull(ReflectionTestUtils.getField(apimlLogger, "messageService"));
 
-            Logger logger = mock(Logger.class);
-            ReflectionTestUtils.setField(apimlLogger, "logger", logger);
-
-            Marker marker = (Marker) ReflectionTestUtils.getField(apimlLogger, "marker");
-
             Message message = apimlLogger.log(null, new Object[]{});
             MessageTemplate messageTemplate = (MessageTemplate) ReflectionTestUtils.getField(message, "messageTemplate");
             String invalidKeyMessageText = "Internal error: Invalid message key '%s' provided. " +
@@ -133,7 +126,7 @@ class ApimlLoggerTest {
             assertEquals(MessageType.ERROR, messageTemplate.getType());
             assertEquals(invalidKeyMessageText, messageTemplate.getText());
 
-            verify(logger, times(1)).error(marker, "ZWEAM102E Internal error: Invalid message key " +
+            verify(logger, times(1)).error(MARKER, "ZWEAM102E Internal error: Invalid message key " +
                 "'null' provided. No default message found. Please contact support of further assistance.", new Object[0]);
         }
 


### PR DESCRIPTION
# Description

Duplicate filter is silently hinding all logs that are gated behine isXxEnabled(). This change checks whether it's level probe and allow other filters to decide if it is.

Linked to # (issue)
Part of the # (epic)

## Type of change

Please delete options that are not relevant.

- [x] fix: Bug fix (non-breaking change which fixes an issue)
- [ ] feat: New feature (non-breaking change which adds functionality)
- [ ] docs: Change in a documentation
- [ ] refactor: Refactor the code 
- [ ] chore: Chore, repository cleanup, updates the dependencies.
- [ ] BREAKING CHANGE or !: Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

For more details about how should the code look like read the [Contributing guideline](https://github.com/zowe/api-layer/blob/master/CONTRIBUTING.md)
