### PR TITLE
fix[@ai-claude]: metadata validation on intermediate segments

### DIFF
--- a/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
+++ b/discovery-service/src/main/java/org/zowe/apiml/discovery/metadata/MetadataFilterService.java
@@ -50,6 +50,12 @@ public class MetadataFilterService implements InitializingBean {
 
     private static final String ORG_ZOWE_APIML_COMMON_URL_NOT_ALLOWED = "org.zowe.apiml.common.urlNotAllowed";
     private static final String ORG_ZOWE_APIML_COMMON_SCHEME_NOT_ALLOWED = "org.zowe.apiml.common.schemeNotAllowed";
+    private static final List<String> METADATA_KEYS_TO_VERIFY = List.of(
+        "swaggerUrl",
+        "graphqlUrl",
+        "documentationUrl",
+        "externalUrl"
+    );
 
     private final Cache<String, InetAddress[]> domainToIpAddresses = Caffeine.newBuilder()
         .maximumSize(100)
@@ -247,17 +253,10 @@ public class MetadataFilterService implements InitializingBean {
     }
 
     private boolean validateMetadataEntry(String key, String value, String instanceId) {
-        var metadataKeysToVerify = List.of(
-            "swaggerUrl",
-            "graphqlUrl",
-            "documentationUrl",
-            "externalUrl");
-
-        if (metadataKeysToVerify.stream().anyMatch(metadataKey -> key.startsWith("apiml.") && key.endsWith(metadataKey))) {
-            return validateEntry(key, value, instanceId);
-        }
-        return true;
-
+        if (!key.startsWith("apiml.")) return true;
+        var segments = key.split("\\.", -1);   // -1 keeps the empty trailing segment
+        boolean sensitive = Arrays.stream(segments).anyMatch(METADATA_KEYS_TO_VERIFY::contains);
+        return !sensitive || validateEntry(key, value, instanceId);
     }
 
     private boolean verifyCorsAllowedOrigins(String allowedOrigins, String instanceId) {

--- a/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
+++ b/discovery-service/src/test/java/org/zowe/apiml/discovery/metadata/MetadataFilterServiceTest.java
@@ -88,7 +88,11 @@ class MetadataFilterServiceTest {
             "apiml.externalUrl, httpsBlah://localhost:8080, false, org.zowe.apiml.common.urlNotAllowed",
             "apiml.externalUrl, http://localhost:8080, false, org.zowe.apiml.common.schemeNotAllowed",
             "apiml.externalUrl, https://invalid.org:8080null, false, org.zowe.apiml.common.urlNotAllowed",
-            "apiml.externalUrl, https://localhost:8080null, true, ''"
+            "apiml.externalUrl, https://localhost:8080null, true, ''",
+            "apiml.swaggerUrl.anothersegment, https://localhost:8080, true, ''",
+            "apiml.swaggerUrl.anothersegment, https://example.com:8080, false, org.zowe.apiml.common.urlNotAllowed",
+            "apiml.swaggerUrl.anothersegment.yetanother, https://localhost:8080, true, ''",
+            "apiml.swaggerUrl.anothersegment.yetanother, https://example.com:8080, false, org.zowe.apiml.common.urlNotAllowed",
         })
         void shouldVerifyMetadataKeysAndDomains(String metadataKey, String metadataValue, boolean isAllowed, String expectedLogKey) {
             Map<String, String> metadata = new HashMap<>();


### PR DESCRIPTION
# Description

Validate metadata entries with looked-after keys in intermediate segments, as the consumer does in API Catalog `ApiDocRetrievalServiceRest`

## Type of change

- [ ] fix: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] PR title conforms to commit message guideline ## [Commit Message Structure Guideline](../CONTRIBUTING.md)
- [ ] I have commented my code, particularly in hard-to-understand areas. In JS I did provide JSDoc
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The java tests in the area I was working on leverage @Nested annotations
- [ ] Any dependent changes have been merged and published in downstream modules

